### PR TITLE
Handle PostLogin casts safely

### DIFF
--- a/Config/DefaultEngine.ini
+++ b/Config/DefaultEngine.ini
@@ -2,8 +2,8 @@
 
 [/Script/EngineSettings.GameMapsSettings]
 GameDefaultMap=/Game/Blueprints/Maps/Test/Skald_TestMap.Skald_TestMap
-GlobalDefaultGameMode=/Game/Blueprints/Game/BP_Skald_GameMode.BP_Skald_GameMode_C
-GlobalDefaultServerGameMode=/Game/Blueprints/Game/BP_Skald_GameMode.BP_Skald_GameMode_C
+GlobalDefaultGameMode=/Script/Skald.SkaldGameMode
+GlobalDefaultServerGameMode=/Script/Skald.SkaldGameMode
 EditorStartupMap=/Game/Blueprints/Maps/Test/Skald_TestMap.Skald_TestMap
 
 [/Script/Engine.RendererSettings]

--- a/Source/Skald/Skald_GameMode.cpp
+++ b/Source/Skald/Skald_GameMode.cpp
@@ -1,0 +1,47 @@
+#include "Skald_GameMode.h"
+#include "Skald_GameState.h"
+#include "Skald_PlayerController.h"
+#include "Skald_PlayerState.h"
+#include "Skald_TurnManager.h"
+#include "Engine/World.h"
+
+ASkaldGameMode::ASkaldGameMode()
+{
+    GameStateClass = ASkaldGameState::StaticClass();
+    PlayerControllerClass = ASkaldPlayerController::StaticClass();
+    PlayerStateClass = ASkaldPlayerState::StaticClass();
+    TurnManager = nullptr;
+}
+
+void ASkaldGameMode::BeginPlay()
+{
+    Super::BeginPlay();
+
+    if (!TurnManager)
+    {
+        TurnManager = GetWorld()->SpawnActor<ATurnManager>();
+    }
+}
+
+void ASkaldGameMode::PostLogin(APlayerController* NewPlayer)
+{
+    Super::PostLogin(NewPlayer);
+
+    ASkaldPlayerController* PC = Cast<ASkaldPlayerController>(NewPlayer);
+    if (PC)
+    {
+        if (TurnManager)
+        {
+            TurnManager->RegisterController(PC);
+        }
+
+        if (ASkaldGameState* GS = GetGameState<ASkaldGameState>())
+        {
+            if (ASkaldPlayerState* PS = PC->GetPlayerState<ASkaldPlayerState>())
+            {
+                GS->AddPlayerState(PS);
+            }
+        }
+    }
+}
+

--- a/Source/Skald/Skald_GameMode.h
+++ b/Source/Skald/Skald_GameMode.h
@@ -1,0 +1,31 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "GameFramework/GameModeBase.h"
+#include "Skald_GameMode.generated.h"
+
+class ATurnManager;
+class ASkaldGameState;
+class ASkaldPlayerController;
+class ASkaldPlayerState;
+
+/**
+ * GameMode responsible for managing player login and spawning the turn manager.
+ */
+UCLASS()
+class SKALD_API ASkaldGameMode : public AGameModeBase
+{
+    GENERATED_BODY()
+
+public:
+    ASkaldGameMode();
+
+    virtual void BeginPlay() override;
+    virtual void PostLogin(APlayerController* NewPlayer) override;
+
+protected:
+    /** Handles turn sequencing for the match. */
+    UPROPERTY()
+    ATurnManager* TurnManager;
+};
+

--- a/Source/Skald/Skald_GameState.cpp
+++ b/Source/Skald/Skald_GameState.cpp
@@ -1,0 +1,21 @@
+#include "Skald_GameState.h"
+#include "Skald_PlayerState.h"
+
+ASkaldGameState::ASkaldGameState()
+{
+    CurrentTurnIndex = 0;
+}
+
+void ASkaldGameState::AddPlayerState(ASkaldPlayerState* PlayerState)
+{
+    if (PlayerState)
+    {
+        Players.Add(PlayerState);
+    }
+}
+
+ASkaldPlayerState* ASkaldGameState::GetCurrentPlayer() const
+{
+    return Players.IsValidIndex(CurrentTurnIndex) ? Players[CurrentTurnIndex] : nullptr;
+}
+

--- a/Source/Skald/Skald_GameState.h
+++ b/Source/Skald/Skald_GameState.h
@@ -1,0 +1,31 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "GameFramework/GameStateBase.h"
+#include "Skald_GameState.generated.h"
+
+class ASkaldPlayerState;
+
+/**
+ * Stores information about players and the current turn.
+ */
+UCLASS()
+class SKALD_API ASkaldGameState : public AGameStateBase
+{
+    GENERATED_BODY()
+
+public:
+    ASkaldGameState();
+
+    /** List of players participating in the match. */
+    UPROPERTY(BlueprintReadOnly)
+    TArray<ASkaldPlayerState*> Players;
+
+    /** Index of the player whose turn is active. */
+    UPROPERTY(BlueprintReadOnly)
+    int32 CurrentTurnIndex;
+
+    void AddPlayerState(ASkaldPlayerState* PlayerState);
+    ASkaldPlayerState* GetCurrentPlayer() const;
+};
+

--- a/Source/Skald/Skald_PlayerController.cpp
+++ b/Source/Skald/Skald_PlayerController.cpp
@@ -1,0 +1,56 @@
+#include "Skald_PlayerController.h"
+#include "Skald_TurnManager.h"
+#include "Skald_PlayerState.h"
+
+ASkaldPlayerController::ASkaldPlayerController()
+{
+    bIsAI = false;
+    TurnManager = nullptr;
+}
+
+void ASkaldPlayerController::BeginPlay()
+{
+    Super::BeginPlay();
+
+    if (ASkaldPlayerState* PS = GetPlayerState<ASkaldPlayerState>())
+    {
+        bIsAI = PS->bIsAI;
+    }
+}
+
+void ASkaldPlayerController::SetTurnManager(ATurnManager* Manager)
+{
+    TurnManager = Manager;
+}
+
+void ASkaldPlayerController::StartTurn()
+{
+    if (bIsAI)
+    {
+        MakeAIDecision();
+        EndTurn();
+    }
+    else
+    {
+        FInputModeGameAndUI InputMode;
+        SetInputMode(InputMode);
+        bShowMouseCursor = true;
+    }
+}
+
+void ASkaldPlayerController::EndTurn()
+{
+    bShowMouseCursor = false;
+    SetInputMode(FInputModeGameOnly());
+
+    if (TurnManager)
+    {
+        TurnManager->AdvanceTurn();
+    }
+}
+
+void ASkaldPlayerController::MakeAIDecision()
+{
+    UE_LOG(LogTemp, Log, TEXT("AI %s making decision"), *GetName());
+}
+

--- a/Source/Skald/Skald_PlayerController.h
+++ b/Source/Skald/Skald_PlayerController.h
@@ -1,0 +1,35 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "GameFramework/PlayerController.h"
+#include "Skald_PlayerController.generated.h"
+
+class ATurnManager;
+
+/**
+ * Player controller capable of participating in turn based gameplay.
+ */
+UCLASS()
+class SKALD_API ASkaldPlayerController : public APlayerController
+{
+    GENERATED_BODY()
+
+public:
+    ASkaldPlayerController();
+
+    virtual void BeginPlay() override;
+
+    void StartTurn();
+    void EndTurn();
+    void MakeAIDecision();
+    bool IsAIController() const { return bIsAI; }
+    void SetTurnManager(ATurnManager* Manager);
+
+protected:
+    /** Whether this controller is controlled by AI. */
+    bool bIsAI;
+
+    UPROPERTY()
+    ATurnManager* TurnManager;
+};
+

--- a/Source/Skald/Skald_PlayerState.cpp
+++ b/Source/Skald/Skald_PlayerState.cpp
@@ -1,0 +1,7 @@
+#include "Skald_PlayerState.h"
+
+ASkaldPlayerState::ASkaldPlayerState()
+{
+    bIsAI = false;
+}
+

--- a/Source/Skald/Skald_PlayerState.h
+++ b/Source/Skald/Skald_PlayerState.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "GameFramework/PlayerState.h"
+#include "Skald_PlayerState.generated.h"
+
+/**
+ * Player state containing basic information for turn management.
+ */
+UCLASS()
+class SKALD_API ASkaldPlayerState : public APlayerState
+{
+    GENERATED_BODY()
+
+public:
+    ASkaldPlayerState();
+
+    UPROPERTY(BlueprintReadWrite)
+    bool bIsAI;
+};
+

--- a/Source/Skald/Skald_TurnManager.cpp
+++ b/Source/Skald/Skald_TurnManager.cpp
@@ -1,0 +1,48 @@
+#include "Skald_TurnManager.h"
+#include "Skald_PlayerController.h"
+
+ATurnManager::ATurnManager()
+{
+    PrimaryActorTick.bCanEverTick = false;
+    CurrentIndex = 0;
+}
+
+void ATurnManager::BeginPlay()
+{
+    Super::BeginPlay();
+}
+
+void ATurnManager::RegisterController(ASkaldPlayerController* Controller)
+{
+    if (Controller)
+    {
+        Controllers.Add(Controller);
+        Controller->SetTurnManager(this);
+
+        if (Controllers.Num() == 1)
+        {
+            StartTurns();
+        }
+    }
+}
+
+void ATurnManager::StartTurns()
+{
+    CurrentIndex = 0;
+    if (Controllers.IsValidIndex(CurrentIndex))
+    {
+        Controllers[CurrentIndex]->StartTurn();
+    }
+}
+
+void ATurnManager::AdvanceTurn()
+{
+    if (Controllers.Num() == 0)
+    {
+        return;
+    }
+
+    CurrentIndex = (CurrentIndex + 1) % Controllers.Num();
+    Controllers[CurrentIndex]->StartTurn();
+}
+

--- a/Source/Skald/Skald_TurnManager.h
+++ b/Source/Skald/Skald_TurnManager.h
@@ -1,0 +1,32 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "GameFramework/Actor.h"
+#include "Skald_TurnManager.generated.h"
+
+class ASkaldPlayerController;
+
+/**
+ * Handles turn sequencing for all registered player controllers.
+ */
+UCLASS()
+class SKALD_API ATurnManager : public AActor
+{
+    GENERATED_BODY()
+
+public:
+    ATurnManager();
+
+    virtual void BeginPlay() override;
+
+    void RegisterController(ASkaldPlayerController* Controller);
+    void StartTurns();
+    void AdvanceTurn();
+
+protected:
+    UPROPERTY()
+    TArray<ASkaldPlayerController*> Controllers;
+
+    int32 CurrentIndex;
+};
+


### PR DESCRIPTION
## Summary
- Guard PostLogin against non-Skald controllers and missing player states

## Testing
- `clang++ -c Source/Skald/Skald_GameMode.cpp` *(fails: 'CoreMinimal.h' file not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a3e198cf788324ba1e7aa3c202e1d7