### PR TITLE
Add C++ equivalents for Blueprint types

### DIFF
--- a/Source/Skald/SkaldTypes.h
+++ b/Source/Skald/SkaldTypes.h
@@ -1,0 +1,233 @@
+#pragma once
+
+#include "CoreMinimal.h"
+
+#include "SkaldTypes.generated.h"
+
+UENUM(BlueprintType)
+enum class SKALD_API E_TurnPhase : uint8
+{
+    Reinforcement UMETA(DisplayName="Reinforcement"),
+    Attack        UMETA(DisplayName="Attack"),
+    Engineering   UMETA(DisplayName="Engineering"),
+    Treasure      UMETA(DisplayName="Treasure"),
+    Movement      UMETA(DisplayName="Movement"),
+    EndTurn       UMETA(DisplayName="EndTurn"),
+    Revolt        UMETA(DisplayName="Revolt"),
+};
+
+UENUM(BlueprintType)
+enum class SKALD_API Enum_SiegeWeapons : uint8
+{
+    BatteringRam UMETA(DisplayName="BatteringRam"),
+    Trebuchet    UMETA(DisplayName="Trebuchet"),
+    SiegeTower   UMETA(DisplayName="SiegeTower"),
+    Catapult     UMETA(DisplayName="Catapult"),
+};
+
+UENUM(BlueprintType)
+enum class SKALD_API Enum_BattleStats : uint8
+{
+    NewEnumerator0 UMETA(DisplayName="NewEnumerator0"),
+    NewEnumerator1 UMETA(DisplayName="NewEnumerator1"),
+    NewEnumerator2 UMETA(DisplayName="NewEnumerator2"),
+};
+
+USTRUCT(BlueprintType)
+struct SKALD_API FS_ArmyUnit
+{
+    GENERATED_BODY()
+
+    UPROPERTY(BlueprintReadWrite, EditAnywhere)
+    int32 UnitID = 0;
+
+    UPROPERTY(BlueprintReadWrite, EditAnywhere)
+    int32 OwnerPlayerID = 0;
+
+    UPROPERTY(BlueprintReadWrite, EditAnywhere)
+    int32 ArmyCount = 0;
+
+    UPROPERTY(BlueprintReadWrite, EditAnywhere)
+    bool HasTreasure = false;
+
+    UPROPERTY(BlueprintReadWrite, EditAnywhere)
+    int32 AssignedSiegeID = 0;
+
+    UPROPERTY(BlueprintReadWrite, EditAnywhere)
+    bool IsSelected = false;
+};
+
+USTRUCT(BlueprintType)
+struct SKALD_API FS_BattlePayload
+{
+    GENERATED_BODY()
+
+    UPROPERTY(BlueprintReadWrite, EditAnywhere)
+    int32 AttackerPlayerID = 0;
+
+    UPROPERTY(BlueprintReadWrite, EditAnywhere)
+    int32 DefenderPlayerID = 0;
+
+    UPROPERTY(BlueprintReadWrite, EditAnywhere)
+    int32 FromTerritoryID = 0;
+
+    UPROPERTY(BlueprintReadWrite, EditAnywhere)
+    int32 TargetTerritoryID = 0;
+
+    UPROPERTY(BlueprintReadWrite, EditAnywhere)
+    int32 ArmyCountSent = 0;
+
+    UPROPERTY(BlueprintReadWrite, EditAnywhere)
+    bool IsCapitalAttack = false;
+
+    UPROPERTY(BlueprintReadWrite, EditAnywhere)
+    TArray<int32> AssignedSiegeIDs;
+
+    UPROPERTY(BlueprintReadWrite, EditAnywhere)
+    bool TreasureFlag = false;
+
+    UPROPERTY(BlueprintReadWrite, EditAnywhere)
+    int32 TurnNumber = 0;
+};
+
+USTRUCT(BlueprintType)
+struct SKALD_API FS_PlayerData
+{
+    GENERATED_BODY()
+
+    UPROPERTY(BlueprintReadWrite, EditAnywhere)
+    int32 PlayerID = 0;
+
+    UPROPERTY(BlueprintReadWrite, EditAnywhere)
+    FString PlayerName;
+
+    UPROPERTY(BlueprintReadWrite, EditAnywhere)
+    bool IsAI = false;
+
+    UPROPERTY(BlueprintReadWrite, EditAnywhere)
+    bool IsEliminated = false;
+
+    UPROPERTY(BlueprintReadWrite, EditAnywhere)
+    int32 CapitalsOwned = 0;
+
+    UPROPERTY(BlueprintReadWrite, EditAnywhere)
+    int32 ColorIndex = 0;
+
+    UPROPERTY(BlueprintReadWrite, EditAnywhere)
+    int32 TroopsCount = 0;
+
+    UPROPERTY(BlueprintReadWrite, EditAnywhere)
+    int32 Resources = 0;
+
+    UPROPERTY(BlueprintReadWrite, EditAnywhere)
+    FString FactionName;
+
+    UPROPERTY(BlueprintReadWrite, EditAnywhere)
+    TArray<int32> CapitalTerritoryIDs;
+
+    UPROPERTY(BlueprintReadWrite, EditAnywhere)
+    bool IsHuman = false;
+
+    UPROPERTY(BlueprintReadWrite, EditAnywhere)
+    bool IsAlive = false;
+};
+
+USTRUCT(BlueprintType)
+struct SKALD_API FS_Siege
+{
+    GENERATED_BODY()
+
+    UPROPERTY(BlueprintReadWrite, EditAnywhere)
+    int32 SiegeID = 0;
+
+    UPROPERTY(BlueprintReadWrite, EditAnywhere)
+    Enum_SiegeWeapons Type = Enum_SiegeWeapons::BatteringRam;
+
+    UPROPERTY(BlueprintReadWrite, EditAnywhere)
+    int32 BuiltAtTerritoryID = 0;
+
+    UPROPERTY(BlueprintReadWrite, EditAnywhere)
+    int32 AssignedToUnitID = 0;
+
+    UPROPERTY(BlueprintReadWrite, EditAnywhere)
+    TArray<int32> BattleStats;
+};
+
+USTRUCT(BlueprintType)
+struct SKALD_API FS_Territory
+{
+    GENERATED_BODY()
+
+    UPROPERTY(BlueprintReadWrite, EditAnywhere)
+    int32 TerritoryID = 0;
+
+    UPROPERTY(BlueprintReadWrite, EditAnywhere)
+    FString TerritoryName;
+
+    UPROPERTY(BlueprintReadWrite, EditAnywhere)
+    int32 OwnerPlayerID = 0;
+
+    UPROPERTY(BlueprintReadWrite, EditAnywhere)
+    bool IsCapital = false;
+
+    UPROPERTY(BlueprintReadWrite, EditAnywhere)
+    int32 CapitalOwner = 0;
+
+    UPROPERTY(BlueprintReadWrite, EditAnywhere)
+    int32 ArmyCount = 0;
+
+    UPROPERTY(BlueprintReadWrite, EditAnywhere)
+    TArray<int32> AdjacentIDs;
+
+    UPROPERTY(BlueprintReadWrite, EditAnywhere)
+    int32 ContinentID = 0;
+
+    UPROPERTY(BlueprintReadWrite, EditAnywhere)
+    bool HasTreasure = false;
+
+    UPROPERTY(BlueprintReadWrite, EditAnywhere)
+    int32 TreasureAttachedUnitID = 0;
+
+    UPROPERTY(BlueprintReadWrite, EditAnywhere)
+    int32 FortificationLevel = 0;
+
+    UPROPERTY(BlueprintReadWrite, EditAnywhere)
+    bool Moat = false;
+
+    UPROPERTY(BlueprintReadWrite, EditAnywhere)
+    int32 WallHealth = 0;
+
+    UPROPERTY(BlueprintReadWrite, EditAnywhere)
+    int32 BuiltSiegeID = 0;
+
+    UPROPERTY(BlueprintReadWrite, EditAnywhere)
+    int32 ConqueredTurn = 0;
+
+    UPROPERTY(BlueprintReadWrite, EditAnywhere)
+    bool IsNeutralSpawn = false;
+};
+
+USTRUCT(BlueprintType)
+struct SKALD_API PlayerSaveStruct
+{
+    GENERATED_BODY()
+
+    UPROPERTY(BlueprintReadWrite, EditAnywhere)
+    int32 PlayerID = 0;
+
+    UPROPERTY(BlueprintReadWrite, EditAnywhere)
+    FString PlayerName;
+
+    UPROPERTY(BlueprintReadWrite, EditAnywhere)
+    bool IsAI = false;
+
+    UPROPERTY(BlueprintReadWrite, EditAnywhere)
+    FString FactionName;
+
+    UPROPERTY(BlueprintReadWrite, EditAnywhere)
+    TArray<int32> CapitalTerritoryIDs;
+
+    UPROPERTY(BlueprintReadWrite, EditAnywhere)
+    bool IsEliminated = false;
+};
+

--- a/Source/Skald/Skald_TurnManager.h
+++ b/Source/Skald/Skald_TurnManager.h
@@ -2,6 +2,7 @@
 
 #include "CoreMinimal.h"
 #include "GameFramework/Actor.h"
+#include "SkaldTypes.h"
 #include "Skald_TurnManager.generated.h"
 
 class ASkaldPlayerController;
@@ -28,5 +29,11 @@ protected:
     TArray<ASkaldPlayerController*> Controllers;
 
     int32 CurrentIndex;
+
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category="Turn")
+    E_TurnPhase CurrentPhase = E_TurnPhase::Reinforcement;
+
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category="Turn")
+    FS_BattlePayload PendingBattle;
 };
 


### PR DESCRIPTION
## Summary
- define gameplay enums and structs in `SkaldTypes.h`
- reference new enums/structs from `ATurnManager`
- export gameplay types with `SKALD_API`

## Testing
- `clang++ -c Source/Skald/Skald.cpp` *(fails: 'CoreMinimal.h' file not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a3f20fc7f88324933517c77ba74192