### PR TITLE
Add C++ territory and world map actors

### DIFF
--- a/Source/Skald/Skald_GameMode.cpp
+++ b/Source/Skald/Skald_GameMode.cpp
@@ -3,6 +3,7 @@
 #include "Skald_PlayerController.h"
 #include "Skald_PlayerState.h"
 #include "Skald_TurnManager.h"
+#include "WorldMap.h"
 #include "Engine/World.h"
 
 ASkaldGameMode::ASkaldGameMode()
@@ -11,6 +12,7 @@ ASkaldGameMode::ASkaldGameMode()
     PlayerControllerClass = ASkaldPlayerController::StaticClass();
     PlayerStateClass = ASkaldPlayerState::StaticClass();
     TurnManager = nullptr;
+    WorldMap = nullptr;
 }
 
 void ASkaldGameMode::BeginPlay()
@@ -20,6 +22,11 @@ void ASkaldGameMode::BeginPlay()
     if (!TurnManager)
     {
         TurnManager = GetWorld()->SpawnActor<ATurnManager>();
+    }
+
+    if (!WorldMap)
+    {
+        WorldMap = GetWorld()->SpawnActor<AWorldMap>();
     }
 }
 

--- a/Source/Skald/Skald_GameMode.h
+++ b/Source/Skald/Skald_GameMode.h
@@ -8,6 +8,7 @@ class ATurnManager;
 class ASkaldGameState;
 class ASkaldPlayerController;
 class ASkaldPlayerState;
+class AWorldMap;
 
 /**
  * GameMode responsible for managing player login and spawning the turn manager.
@@ -27,5 +28,9 @@ protected:
     /** Handles turn sequencing for the match. */
     UPROPERTY()
     ATurnManager* TurnManager;
+
+    /** Holds all territory actors for the current map. */
+    UPROPERTY()
+    AWorldMap* WorldMap;
 };
 

--- a/Source/Skald/Territory.cpp
+++ b/Source/Skald/Territory.cpp
@@ -1,0 +1,49 @@
+#include "Territory.h"
+#include "Skald_PlayerState.h"
+#include "Components/StaticMeshComponent.h"
+
+ATerritory::ATerritory()
+{
+    PrimaryActorTick.bCanEverTick = false;
+    MeshComponent = CreateDefaultSubobject<UStaticMeshComponent>(TEXT("Mesh"));
+    RootComponent = MeshComponent;
+
+    Owner = nullptr;
+    Resources = 0;
+    TerritoryID = 0;
+}
+
+void ATerritory::BeginPlay()
+{
+    Super::BeginPlay();
+}
+
+void ATerritory::Select()
+{
+    OnTerritorySelected.Broadcast(this);
+}
+
+bool ATerritory::IsAdjacentTo(const ATerritory* Other) const
+{
+    for (const ATerritory* Adjacent : AdjacentTerritories)
+    {
+        if (Adjacent == Other)
+        {
+            return true;
+        }
+    }
+    return false;
+}
+
+bool ATerritory::MoveTo(ATerritory* TargetTerritory)
+{
+    if (!TargetTerritory || !IsAdjacentTo(TargetTerritory))
+    {
+        return false;
+    }
+
+    // Movement logic would be handled here. For now we simply select the target.
+    TargetTerritory->Select();
+    return true;
+}
+

--- a/Source/Skald/Territory.h
+++ b/Source/Skald/Territory.h
@@ -1,0 +1,63 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "GameFramework/Actor.h"
+#include "Territory.generated.h"
+
+class ASkaldPlayerState;
+class ATerritory;
+class UStaticMeshComponent;
+
+DECLARE_DYNAMIC_MULTICAST_DELEGATE_OneParam(FTerritorySelectedSignature, ATerritory*, Territory);
+
+/**
+ * Actor representing a single territory on the world map.
+ */
+UCLASS()
+class SKALD_API ATerritory : public AActor
+{
+    GENERATED_BODY()
+
+public:
+    ATerritory();
+
+    virtual void BeginPlay() override;
+
+    /** Owning player of this territory. */
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Territory")
+    ASkaldPlayerState* Owner;
+
+    /** Amount of resources produced by this territory. */
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Territory")
+    int32 Resources;
+
+    /** Unique identifier for this territory. */
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Territory")
+    int32 TerritoryID;
+
+    /** Adjacent territories that units may move to. */
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Territory")
+    TArray<ATerritory*> AdjacentTerritories;
+
+    /** Called when the territory is selected. */
+    UPROPERTY(BlueprintAssignable, Category = "Territory")
+    FTerritorySelectedSignature OnTerritorySelected;
+
+    /** Mark this territory as selected. */
+    UFUNCTION(BlueprintCallable, Category = "Territory")
+    void Select();
+
+    /** Check if another territory is adjacent to this one. */
+    UFUNCTION(BlueprintCallable, BlueprintPure, Category = "Territory")
+    bool IsAdjacentTo(const ATerritory* Other) const;
+
+    /** Attempt to move units to the target territory. */
+    UFUNCTION(BlueprintCallable, Category = "Territory")
+    bool MoveTo(ATerritory* TargetTerritory);
+
+protected:
+    /** Visual representation of the territory. */
+    UPROPERTY(VisibleAnywhere)
+    UStaticMeshComponent* MeshComponent;
+};
+

--- a/Source/Skald/WorldMap.cpp
+++ b/Source/Skald/WorldMap.cpp
@@ -1,0 +1,54 @@
+#include "WorldMap.h"
+#include "Territory.h"
+
+AWorldMap::AWorldMap()
+{
+    PrimaryActorTick.bCanEverTick = false;
+    SelectedTerritory = nullptr;
+}
+
+void AWorldMap::RegisterTerritory(ATerritory* Territory)
+{
+    if (Territory && !Territories.Contains(Territory))
+    {
+        Territories.Add(Territory);
+        Territory->OnTerritorySelected.AddDynamic(this, &AWorldMap::SelectTerritory);
+    }
+}
+
+ATerritory* AWorldMap::GetTerritoryById(int32 TerritoryId) const
+{
+    for (ATerritory* Territory : Territories)
+    {
+        if (Territory && Territory->TerritoryID == TerritoryId)
+        {
+            return Territory;
+        }
+    }
+    return nullptr;
+}
+
+void AWorldMap::SelectTerritory(ATerritory* Territory)
+{
+    if (Territory)
+    {
+        SelectedTerritory = Territory;
+    }
+}
+
+bool AWorldMap::MoveBetween(ATerritory* From, ATerritory* To)
+{
+    if (!From || !To)
+    {
+        return false;
+    }
+
+    if (From->MoveTo(To))
+    {
+        SelectedTerritory = To;
+        return true;
+    }
+
+    return false;
+}
+

--- a/Source/Skald/WorldMap.h
+++ b/Source/Skald/WorldMap.h
@@ -1,0 +1,44 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "GameFramework/Actor.h"
+#include "WorldMap.generated.h"
+
+class ATerritory;
+
+/**
+ * Actor owning and managing all territories in the map.
+ */
+UCLASS()
+class SKALD_API AWorldMap : public AActor
+{
+    GENERATED_BODY()
+
+public:
+    AWorldMap();
+
+    /** All territories contained in this world map. */
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "WorldMap")
+    TArray<ATerritory*> Territories;
+
+    /** Currently selected territory. */
+    UPROPERTY(BlueprintReadOnly, Category = "WorldMap")
+    ATerritory* SelectedTerritory;
+
+    /** Register a territory with the world map. */
+    UFUNCTION(BlueprintCallable, Category = "WorldMap")
+    void RegisterTerritory(ATerritory* Territory);
+
+    /** Get a territory by its identifier. */
+    UFUNCTION(BlueprintCallable, Category = "WorldMap")
+    ATerritory* GetTerritoryById(int32 TerritoryId) const;
+
+    /** Handle territory selection. */
+    UFUNCTION(BlueprintCallable, Category = "WorldMap")
+    void SelectTerritory(ATerritory* Territory);
+
+    /** Move units between territories. */
+    UFUNCTION(BlueprintCallable, Category = "WorldMap")
+    bool MoveBetween(ATerritory* From, ATerritory* To);
+};
+


### PR DESCRIPTION
## Summary
- implement `ATerritory` actor to track owner, resources, adjacency and support selection and movement
- add `AWorldMap` actor to manage territories and selection
- spawn `AWorldMap` from game mode alongside the turn manager
- bind territory selection events to the world map and streamline adjacency checks

## Testing
- `clang++-20 -fsyntax-only Source/Skald/Territory.cpp` *(fails: 'CoreMinimal.h' file not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a3f6fe01708324a8743d6346b8a863