### PR TITLE
Add native save game support

### DIFF
--- a/Source/Skald/SkaldSaveGame.cpp
+++ b/Source/Skald/SkaldSaveGame.cpp
@@ -1,0 +1,7 @@
+#include "SkaldSaveGame.h"
+
+USkaldSaveGame::USkaldSaveGame()
+{
+    SaveDate = FDateTime::Now();
+}
+

--- a/Source/Skald/SkaldSaveGame.h
+++ b/Source/Skald/SkaldSaveGame.h
@@ -1,0 +1,59 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "GameFramework/SaveGame.h"
+#include "SkaldTypes.h"
+#include "SkaldSaveGame.generated.h"
+
+/**
+ * Native save game object storing persistent game data.
+ */
+UCLASS(BlueprintType)
+class SKALD_API USkaldSaveGame : public USaveGame
+{
+    GENERATED_BODY()
+
+public:
+    USkaldSaveGame();
+
+    /** Name of the save slot. */
+    UPROPERTY(BlueprintReadWrite, Category="SaveGame", SaveGame)
+    FString SaveName;
+
+    /** Date the save was created. */
+    UPROPERTY(BlueprintReadWrite, Category="SaveGame", SaveGame)
+    FDateTime SaveDate;
+
+    /** Current turn number in the campaign. */
+    UPROPERTY(BlueprintReadWrite, Category="SaveGame", SaveGame)
+    int32 TurnNumber = 0;
+
+    /** Index of the player whose turn is active. */
+    UPROPERTY(BlueprintReadWrite, Category="SaveGame", SaveGame)
+    int32 CurrentPlayerIndex = 0;
+
+    /** Stored territory state data. */
+    UPROPERTY(BlueprintReadWrite, Category="SaveGame", SaveGame)
+    TArray<FS_Territory> Territories;
+
+    /** Stored player data. */
+    UPROPERTY(BlueprintReadWrite, Category="SaveGame", SaveGame)
+    TArray<FPlayerSaveStruct> Players;
+
+    /** Stored siege equipment data. */
+    UPROPERTY(BlueprintReadWrite, Category="SaveGame", SaveGame)
+    TArray<FS_Siege> Sieges;
+
+    /** Random seed used for procedural elements. */
+    UPROPERTY(BlueprintReadWrite, Category="SaveGame", SaveGame)
+    int32 RandomSeed = 0;
+
+    /** Camera view offset at the time of saving. */
+    UPROPERTY(BlueprintReadWrite, Category="SaveGame", SaveGame)
+    FVector2D SavedViewOffset = FVector2D::ZeroVector;
+
+    /** Camera zoom level at the time of saving. */
+    UPROPERTY(BlueprintReadWrite, Category="SaveGame", SaveGame)
+    float SavedZoomAmount = 0.f;
+};
+

--- a/Source/Skald/SkaldSaveGameLibrary.cpp
+++ b/Source/Skald/SkaldSaveGameLibrary.cpp
@@ -1,0 +1,27 @@
+#include "SkaldSaveGameLibrary.h"
+#include "SkaldSaveGame.h"
+#include "Kismet/GameplayStatics.h"
+
+bool USkaldSaveGameLibrary::SaveSkaldGame(USkaldSaveGame* SaveGameObject, const FString& SlotName, int32 UserIndex)
+{
+    if (!SaveGameObject)
+    {
+        return false;
+    }
+
+    SaveGameObject->SaveName = SlotName;
+    SaveGameObject->SaveDate = FDateTime::Now();
+
+    return UGameplayStatics::SaveGameToSlot(SaveGameObject, SlotName, UserIndex);
+}
+
+USkaldSaveGame* USkaldSaveGameLibrary::LoadSkaldGame(const FString& SlotName, int32 UserIndex)
+{
+    USkaldSaveGame* LoadedGame = Cast<USkaldSaveGame>(UGameplayStatics::LoadGameFromSlot(SlotName, UserIndex));
+    if (LoadedGame)
+    {
+        LoadedGame->SaveName = SlotName;
+    }
+    return LoadedGame;
+}
+

--- a/Source/Skald/SkaldSaveGameLibrary.h
+++ b/Source/Skald/SkaldSaveGameLibrary.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Kismet/BlueprintFunctionLibrary.h"
+#include "SkaldSaveGameLibrary.generated.h"
+
+class USkaldSaveGame;
+
+/**
+ * Blueprint-callable helpers for saving and loading Skald game data.
+ */
+UCLASS()
+class SKALD_API USkaldSaveGameLibrary : public UBlueprintFunctionLibrary
+{
+    GENERATED_BODY()
+
+public:
+    /** Save the provided game object to the given slot. */
+    UFUNCTION(BlueprintCallable, Category="Skald|SaveGame")
+    static bool SaveSkaldGame(USkaldSaveGame* SaveGameObject, const FString& SlotName, int32 UserIndex);
+
+    /** Load a game object from the given slot. */
+    UFUNCTION(BlueprintCallable, Category="Skald|SaveGame")
+    static USkaldSaveGame* LoadSkaldGame(const FString& SlotName, int32 UserIndex);
+};
+


### PR DESCRIPTION
## Summary
- add USkaldSaveGame derived from USaveGame with fields from BP_SaveGame
- provide blueprint-callable helpers to save and load using UGameplayStatics
- refresh save metadata before saving and after loading

## Testing
- `g++ -fsyntax-only Source/Skald/SkaldSaveGame.cpp Source/Skald/SkaldSaveGameLibrary.cpp 2>&1 | head -n 20` *(fails: CoreMinimal.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a64d6c30ec8324adb86a1e153e05fd