### PR TITLE
Implement player character input and selection logic

### DIFF
--- a/Source/Skald/Skald_PlayerCharacter.cpp
+++ b/Source/Skald/Skald_PlayerCharacter.cpp
@@ -2,33 +2,113 @@
 
 
 #include "Skald_PlayerCharacter.h"
+#include "WorldMap.h"
+#include "Territory.h"
+#include "Camera/CameraComponent.h"
+#include "GameFramework/SpringArmComponent.h"
+#include "Kismet/GameplayStatics.h"
 
 // Sets default values
 ASkald_PlayerCharacter::ASkald_PlayerCharacter()
 {
- 	// Set this character to call Tick() every frame.  You can turn this off to improve performance if you don't need it.
-	PrimaryActorTick.bCanEverTick = true;
+        PrimaryActorTick.bCanEverTick = true;
 
+        WorldMap = nullptr;
+        CurrentSelection = nullptr;
 }
 
 // Called when the game starts or when spawned
 void ASkald_PlayerCharacter::BeginPlay()
 {
-	Super::BeginPlay();
-	
+        Super::BeginPlay();
+
+        // Cache reference to the world map if one exists in the level
+        WorldMap = Cast<AWorldMap>(UGameplayStatics::GetActorOfClass(GetWorld(), AWorldMap::StaticClass()));
 }
 
 // Called every frame
 void ASkald_PlayerCharacter::Tick(float DeltaTime)
 {
-	Super::Tick(DeltaTime);
+        Super::Tick(DeltaTime);
 
+        // Example tick behavior: keep track of selection validity
+        if (CurrentSelection && CurrentSelection->IsPendingKill())
+        {
+                CurrentSelection = nullptr;
+        }
 }
 
 // Called to bind functionality to input
 void ASkald_PlayerCharacter::SetupPlayerInputComponent(UInputComponent* PlayerInputComponent)
 {
-	Super::SetupPlayerInputComponent(PlayerInputComponent);
+        Super::SetupPlayerInputComponent(PlayerInputComponent);
 
+        check(PlayerInputComponent);
+
+        PlayerInputComponent->BindAxis("MoveForward", this, &ASkald_PlayerCharacter::MoveForward);
+        PlayerInputComponent->BindAxis("MoveRight", this, &ASkald_PlayerCharacter::MoveRight);
+
+        PlayerInputComponent->BindAction("Select", IE_Pressed, this, &ASkald_PlayerCharacter::Select);
+        PlayerInputComponent->BindAction("Ability1", IE_Pressed, this, &ASkald_PlayerCharacter::AbilityOne);
+        PlayerInputComponent->BindAction("Ability2", IE_Pressed, this, &ASkald_PlayerCharacter::AbilityTwo);
+        PlayerInputComponent->BindAction("Ability3", IE_Pressed, this, &ASkald_PlayerCharacter::AbilityThree);
+}
+
+void ASkald_PlayerCharacter::MoveForward(float Value)
+{
+        if (Value != 0.0f)
+        {
+                AddMovementInput(GetActorForwardVector(), Value);
+        }
+}
+
+void ASkald_PlayerCharacter::MoveRight(float Value)
+{
+        if (Value != 0.0f)
+        {
+                AddMovementInput(GetActorRightVector(), Value);
+        }
+}
+
+void ASkald_PlayerCharacter::Select()
+{
+        if (!Controller)
+        {
+                return;
+        }
+
+        FHitResult Hit;
+        if (GetWorld()->GetFirstPlayerController()->GetHitResultUnderCursor(ECC_Visibility, false, Hit))
+        {
+                if (ATerritory* Territory = Cast<ATerritory>(Hit.GetActor()))
+                {
+                        if (WorldMap)
+                        {
+                                WorldMap->SelectTerritory(Territory);
+                        }
+                        CurrentSelection = Territory;
+                }
+        }
+}
+
+void ASkald_PlayerCharacter::AbilityOne()
+{
+        if (CurrentSelection)
+        {
+                UE_LOG(LogTemp, Log, TEXT("%s used Ability One on %s"), *GetName(), *CurrentSelection->GetName());
+        }
+}
+
+void ASkald_PlayerCharacter::AbilityTwo()
+{
+        if (CurrentSelection)
+        {
+                UE_LOG(LogTemp, Log, TEXT("%s used Ability Two"), *GetName());
+        }
+}
+
+void ASkald_PlayerCharacter::AbilityThree()
+{
+        UE_LOG(LogTemp, Log, TEXT("%s used Ability Three"), *GetName());
 }
 

--- a/Source/Skald/Skald_PlayerCharacter.h
+++ b/Source/Skald/Skald_PlayerCharacter.h
@@ -4,6 +4,10 @@
 
 #include "CoreMinimal.h"
 #include "GameFramework/Character.h"
+
+class AWorldMap;
+class ATerritory;
+
 #include "Skald_PlayerCharacter.generated.h"
 
 UCLASS()
@@ -12,18 +16,39 @@ class SKALD_API ASkald_PlayerCharacter : public ACharacter
 	GENERATED_BODY()
 
 public:
-	// Sets default values for this character's properties
-	ASkald_PlayerCharacter();
+        /** Sets default values for this character's properties */
+        ASkald_PlayerCharacter();
 
 protected:
-	// Called when the game starts or when spawned
-	virtual void BeginPlay() override;
+        /** Called when the game starts or when spawned */
+        virtual void BeginPlay() override;
 
-public:	
-	// Called every frame
-	virtual void Tick(float DeltaTime) override;
+        /** Reference to the world map actor for selection and movement */
+        UPROPERTY()
+        AWorldMap* WorldMap;
 
-	// Called to bind functionality to input
-	virtual void SetupPlayerInputComponent(class UInputComponent* PlayerInputComponent) override;
+        /** Currently selected territory, if any */
+        UPROPERTY(BlueprintReadOnly, Category="Selection")
+        ATerritory* CurrentSelection;
 
+public:
+        /** Called every frame */
+        virtual void Tick(float DeltaTime) override;
+
+        /** Called to bind functionality to input */
+        virtual void SetupPlayerInputComponent(class UInputComponent* PlayerInputComponent) override;
+
+        /** Handle forward/backward movement input */
+        void MoveForward(float Value);
+
+        /** Handle right/left movement input */
+        void MoveRight(float Value);
+
+        /** Handle selection action */
+        void Select();
+
+        /** Ability triggers */
+        void AbilityOne();
+        void AbilityTwo();
+        void AbilityThree();
 };


### PR DESCRIPTION
## Summary
- add world map reference, movement, selection, and ability stubs to `ASkald_PlayerCharacter`
- bind input axes and actions replicating blueprint setup
- handle selection validity each tick

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a66655b4108324a106ce774766d1b5