### PR TITLE
Expose TurnManager pointer to Blueprints

### DIFF
--- a/Source/Skald/Skald_GameMode.cpp
+++ b/Source/Skald/Skald_GameMode.cpp
@@ -14,6 +14,10 @@ ASkaldGameMode::ASkaldGameMode()
     PlayerStateClass = ASkaldPlayerState::StaticClass();
     TurnManager = nullptr;
     WorldMap = nullptr;
+
+    // Preallocate two slots so blueprint scripts can safely write
+    // player data to indices without hitting "invalid index" warnings.
+    PlayersData.SetNum(2);
 }
 
 void ASkaldGameMode::BeginPlay()
@@ -50,6 +54,14 @@ void ASkaldGameMode::PostLogin(APlayerController* NewPlayer)
             if (ASkaldPlayerState* PS = PC->GetPlayerState<ASkaldPlayerState>())
             {
                 GS->AddPlayerState(PS);
+
+                // Ensure PlayersData can hold at least as many entries as there
+                // are connected players. Never shrink to avoid index issues in
+                // existing blueprint logic.
+                if (PlayersData.Num() < GS->PlayerArray.Num())
+                {
+                    PlayersData.SetNum(GS->PlayerArray.Num());
+                }
             }
         }
     }

--- a/Source/Skald/Skald_GameMode.h
+++ b/Source/Skald/Skald_GameMode.h
@@ -2,6 +2,7 @@
 
 #include "CoreMinimal.h"
 #include "GameFramework/GameModeBase.h"
+#include "SkaldTypes.h"
 #include "Skald_GameMode.generated.h"
 
 class ATurnManager;
@@ -32,6 +33,11 @@ protected:
     /** Holds all territory actors for the current map. */
     UPROPERTY()
     AWorldMap* WorldMap;
+
+    /** Data describing each player in the match. Pre-sized so blueprints can
+     * safely write to indices without hitting invalid array warnings. */
+    UPROPERTY(BlueprintReadOnly, Category="Players")
+    TArray<FS_PlayerData> PlayersData;
 
     /** Setup initial territories, armies, and initiative. */
     void InitializeWorld();

--- a/Source/Skald/Skald_PlayerController.cpp
+++ b/Source/Skald/Skald_PlayerController.cpp
@@ -1,11 +1,13 @@
 #include "Skald_PlayerController.h"
 #include "Skald_TurnManager.h"
 #include "Skald_PlayerState.h"
+#include "Blueprint/UserWidget.h"
 
 ASkaldPlayerController::ASkaldPlayerController()
 {
     bIsAI = false;
     TurnManager = nullptr;
+    HUDRef = nullptr;
 
     bShowMouseCursor = true;
     bEnableClickEvents = true;
@@ -15,6 +17,16 @@ ASkaldPlayerController::ASkaldPlayerController()
 void ASkaldPlayerController::BeginPlay()
 {
     Super::BeginPlay();
+
+    // Create and show the HUD widget if a class has been assigned.
+    if (HUDWidgetClass)
+    {
+        HUDRef = CreateWidget<UUserWidget>(this, HUDWidgetClass);
+        if (HUDRef)
+        {
+            HUDRef->AddToViewport();
+        }
+    }
 
     if (ASkaldPlayerState* PS = GetPlayerState<ASkaldPlayerState>())
     {

--- a/Source/Skald/Skald_PlayerController.h
+++ b/Source/Skald/Skald_PlayerController.h
@@ -5,6 +5,7 @@
 #include "Skald_PlayerController.generated.h"
 
 class ATurnManager;
+class UUserWidget;
 
 /**
  * Player controller capable of participating in turn based gameplay.
@@ -23,13 +24,29 @@ public:
     void EndTurn();
     void MakeAIDecision();
     bool IsAIController() const { return bIsAI; }
+
+    /** Set the turn manager responsible for sequencing play. */
+    UFUNCTION(BlueprintCallable, Category="Turn")
     void SetTurnManager(ATurnManager* Manager);
 
 protected:
     /** Whether this controller is controlled by AI. */
     bool bIsAI;
 
-    UPROPERTY()
-    ATurnManager* TurnManager;
+    /** Widget class to instantiate for the player's HUD. */
+    UPROPERTY(EditDefaultsOnly, Category="UI")
+    TSubclassOf<UUserWidget> HUDWidgetClass;
+
+    /** Reference to the HUD widget instance. */
+    UPROPERTY(BlueprintReadOnly, Category="UI", meta=(AllowPrivateAccess="true"))
+    TObjectPtr<UUserWidget> HUDRef;
+
+    /** Reference to the game's turn manager.
+     *  Exposed to Blueprints so BP_Skald_PlayerController can bind to
+     *  turn events without keeping an external pointer that might be
+     *  uninitialised.
+     */
+    UPROPERTY(BlueprintReadOnly, Category="Turn", meta=(AllowPrivateAccess="true"))
+    TObjectPtr<ATurnManager> TurnManager;
 };
 


### PR DESCRIPTION
## Summary
- Provide a blueprint-readable `TurnManager` property in `ASkaldPlayerController`
- Preallocate player data array and grow it on login to avoid invalid index warnings
- Instantiate the HUD widget in `ASkaldPlayerController` so `HUDRef` is always valid

## Testing
- `npm test` *(fails: ENOENT Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a73a618d2c8324a41d98d93661c514