### PR TITLE
Handle territory selection and deselection

### DIFF
--- a/Source/Skald/Skald_PlayerCharacter.cpp
+++ b/Source/Skald/Skald_PlayerCharacter.cpp
@@ -82,10 +82,7 @@ void ASkald_PlayerCharacter::Select()
         {
                 if (ATerritory* Territory = Cast<ATerritory>(Hit.GetActor()))
                 {
-                        if (WorldMap)
-                        {
-                                WorldMap->SelectTerritory(Territory);
-                        }
+                        Territory->Select();
                         CurrentSelection = Territory;
                 }
         }

--- a/Source/Skald/Territory.cpp
+++ b/Source/Skald/Territory.cpp
@@ -44,6 +44,15 @@ void ATerritory::Select()
     OnTerritorySelected.Broadcast(this);
 }
 
+void ATerritory::Deselect()
+{
+    bIsSelected = false;
+    if (DynamicMaterial)
+    {
+        DynamicMaterial->SetVectorParameterValue(FName("Color"), DefaultColor);
+    }
+}
+
 bool ATerritory::IsAdjacentTo(const ATerritory* Other) const
 {
     for (const ATerritory* Adjacent : AdjacentTerritories)

--- a/Source/Skald/Territory.h
+++ b/Source/Skald/Territory.h
@@ -54,6 +54,10 @@ public:
     UFUNCTION(BlueprintCallable, Category = "Territory")
     void Select();
 
+    /** Remove selection state from this territory. */
+    UFUNCTION(BlueprintCallable, Category = "Territory")
+    void Deselect();
+
     /** Check if another territory is adjacent to this one. */
     UFUNCTION(BlueprintCallable, BlueprintPure, Category = "Territory")
     bool IsAdjacentTo(const ATerritory* Other) const;

--- a/Source/Skald/WorldMap.cpp
+++ b/Source/Skald/WorldMap.cpp
@@ -30,10 +30,17 @@ ATerritory* AWorldMap::GetTerritoryById(int32 TerritoryId) const
 
 void AWorldMap::SelectTerritory(ATerritory* Territory)
 {
-    if (Territory)
+    if (Territory == SelectedTerritory)
     {
-        SelectedTerritory = Territory;
+        return;
     }
+
+    if (SelectedTerritory)
+    {
+        SelectedTerritory->Deselect();
+    }
+
+    SelectedTerritory = Territory;
 }
 
 bool AWorldMap::MoveBetween(ATerritory* From, ATerritory* To)
@@ -43,12 +50,6 @@ bool AWorldMap::MoveBetween(ATerritory* From, ATerritory* To)
         return false;
     }
 
-    if (From->MoveTo(To))
-    {
-        SelectedTerritory = To;
-        return true;
-    }
-
-    return false;
+    return From->MoveTo(To);
 }
 


### PR DESCRIPTION
## Summary
- Add deselect support for territories to reset highlight state
- Ensure world map tracks a single selected territory and deselects previous selections
- Use territory selection logic in player character rather than direct world map calls

## Testing
- `g++ -fsyntax-only Source/Skald/Territory.cpp` *(fails: CoreMinimal.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a7442a44a88324a268f355943e56d8