### PR TITLE
Handle territory selection and deselection

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,32 @@
 # Skald
 
 Developed with Unreal Engine 5
+
+## Using the world map code
+
+The gameplay classes included in this repository are intended to be used
+from Blueprints and level actors. To hook everything up:
+
+1. **World Map** – Create a Blueprint subclass of `AWorldMap` and place it in
+   your level. This actor keeps track of all `ATerritory` instances and the
+   currently selected territory.
+
+2. **Territories** – Create Blueprint subclasses of `ATerritory` for each
+   province on your map. Assign a static mesh and a material with a
+   `Color` parameter. When a territory is placed in the level it will
+   automatically register itself with the `AWorldMap` and bind its selection
+   events.
+
+3. **Player Character** – Ensure the level uses `ASkald_PlayerCharacter`.
+   The character looks for a `AWorldMap` actor at startup and will call the
+   `Select()` function on territories under the mouse cursor when the
+   `Select` action is triggered.
+
+4. **Input** – Add axis mappings for `MoveForward` and `MoveRight` and action
+   mappings for `Select`, `Ability1`, `Ability2`, and `Ability3` in the
+   project settings. Also enable *Click Events* and *Mouse Over Events* on the
+   player controller so territory meshes can generate the appropriate input
+   callbacks.
+
+With this setup the C++ logic handles selection, deselection, and movement
+between adjacent territories without requiring additional Blueprint wiring.

--- a/Source/Skald/Skald_PlayerCharacter.cpp
+++ b/Source/Skald/Skald_PlayerCharacter.cpp
@@ -82,10 +82,7 @@ void ASkald_PlayerCharacter::Select()
         {
                 if (ATerritory* Territory = Cast<ATerritory>(Hit.GetActor()))
                 {
-                        if (WorldMap)
-                        {
-                                WorldMap->SelectTerritory(Territory);
-                        }
+                        Territory->Select();
                         CurrentSelection = Territory;
                 }
         }

--- a/Source/Skald/Territory.cpp
+++ b/Source/Skald/Territory.cpp
@@ -3,6 +3,8 @@
 #include "Components/StaticMeshComponent.h"
 #include "Materials/MaterialInstanceDynamic.h"
 #include "Components/PrimitiveComponent.h"
+#include "WorldMap.h"
+#include "Kismet/GameplayStatics.h"
 
 ATerritory::ATerritory()
 {
@@ -32,6 +34,14 @@ void ATerritory::BeginPlay()
             DynamicMaterial->GetVectorParameterValue(FName("Color"), DefaultColor);
         }
     }
+
+    // Automatically register this territory with the world map so that
+    // selection and movement logic can be centrally managed without any
+    // additional setup in Blueprints or the level.
+    if (AWorldMap* WorldMap = Cast<AWorldMap>(UGameplayStatics::GetActorOfClass(GetWorld(), AWorldMap::StaticClass())))
+    {
+        WorldMap->RegisterTerritory(this);
+    }
 }
 
 void ATerritory::Select()
@@ -42,6 +52,15 @@ void ATerritory::Select()
         DynamicMaterial->SetVectorParameterValue(FName("Color"), FLinearColor::Yellow);
     }
     OnTerritorySelected.Broadcast(this);
+}
+
+void ATerritory::Deselect()
+{
+    bIsSelected = false;
+    if (DynamicMaterial)
+    {
+        DynamicMaterial->SetVectorParameterValue(FName("Color"), DefaultColor);
+    }
 }
 
 bool ATerritory::IsAdjacentTo(const ATerritory* Other) const

--- a/Source/Skald/Territory.h
+++ b/Source/Skald/Territory.h
@@ -54,6 +54,10 @@ public:
     UFUNCTION(BlueprintCallable, Category = "Territory")
     void Select();
 
+    /** Remove selection state from this territory. */
+    UFUNCTION(BlueprintCallable, Category = "Territory")
+    void Deselect();
+
     /** Check if another territory is adjacent to this one. */
     UFUNCTION(BlueprintCallable, BlueprintPure, Category = "Territory")
     bool IsAdjacentTo(const ATerritory* Other) const;

--- a/Source/Skald/WorldMap.cpp
+++ b/Source/Skald/WorldMap.cpp
@@ -30,10 +30,17 @@ ATerritory* AWorldMap::GetTerritoryById(int32 TerritoryId) const
 
 void AWorldMap::SelectTerritory(ATerritory* Territory)
 {
-    if (Territory)
+    if (Territory == SelectedTerritory)
     {
-        SelectedTerritory = Territory;
+        return;
     }
+
+    if (SelectedTerritory)
+    {
+        SelectedTerritory->Deselect();
+    }
+
+    SelectedTerritory = Territory;
 }
 
 bool AWorldMap::MoveBetween(ATerritory* From, ATerritory* To)
@@ -43,12 +50,6 @@ bool AWorldMap::MoveBetween(ATerritory* From, ATerritory* To)
         return false;
     }
 
-    if (From->MoveTo(To))
-    {
-        SelectedTerritory = To;
-        return true;
-    }
-
-    return false;
+    return From->MoveTo(To);
 }
 


### PR DESCRIPTION
## Summary
- Add deselect support for territories to reset highlight state
- Ensure world map tracks a single selected territory and deselects previous selections
- Use territory selection logic in player character rather than direct world map calls
- Automatically register territories with the world map at runtime and document Blueprint setup

## Testing
- `g++ -fsyntax-only Source/Skald/Territory.cpp` *(fails: CoreMinimal.h: No such file or directory)*
- `g++ -fsyntax-only Source/Skald/WorldMap.cpp` *(fails: CoreMinimal.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a7442a44a88324a268f355943e56d8