### PR TITLE
Refactor load game slot button binding and fix player character includes

### DIFF
--- a/Source/Skald/LoadGameWidget.cpp
+++ b/Source/Skald/LoadGameWidget.cpp
@@ -7,14 +7,13 @@
 
 static const TCHAR* SlotNames[3] = { TEXT("Slot0"), TEXT("Slot1"), TEXT("Slot2") };
 
-template<typename TFunc>
-static void AddSlotButton(UWidgetTree* Tree, UVerticalBox* Root, const FString& Label, TFunc&& Handler)
+static void AddSlotButton(UWidgetTree* Tree, UVerticalBox* Root, const FString& Label, ULoadGameWidget* Widget, void (ULoadGameWidget::*Handler)())
 {
     UButton* Button = Tree->ConstructWidget<UButton>(UButton::StaticClass());
     UTextBlock* Text = Tree->ConstructWidget<UTextBlock>(UTextBlock::StaticClass());
     Text->SetText(FText::FromString(Label));
     Button->AddChild(Text);
-    Button->OnClicked.AddLambda(Handler);
+    Button->OnClicked.AddDynamic(Widget, Handler);
     Root->AddChild(Button);
 }
 
@@ -30,17 +29,17 @@ void ULoadGameWidget::NativeConstruct()
         // Slot 0
         if (UGameplayStatics::DoesSaveGameExist(SlotNames[0], 0))
         {
-            AddSlotButton(WidgetTree, Root, SlotNames[0], [this]() { OnLoadSlot0(); });
+            AddSlotButton(WidgetTree, Root, SlotNames[0], this, &ULoadGameWidget::OnLoadSlot0);
         }
         // Slot 1
         if (UGameplayStatics::DoesSaveGameExist(SlotNames[1], 0))
         {
-            AddSlotButton(WidgetTree, Root, SlotNames[1], [this]() { OnLoadSlot1(); });
+            AddSlotButton(WidgetTree, Root, SlotNames[1], this, &ULoadGameWidget::OnLoadSlot1);
         }
         // Slot 2
         if (UGameplayStatics::DoesSaveGameExist(SlotNames[2], 0))
         {
-            AddSlotButton(WidgetTree, Root, SlotNames[2], [this]() { OnLoadSlot2(); });
+            AddSlotButton(WidgetTree, Root, SlotNames[2], this, &ULoadGameWidget::OnLoadSlot2);
         }
     }
 }

--- a/Source/Skald/Skald_GameMode.cpp
+++ b/Source/Skald/Skald_GameMode.cpp
@@ -98,8 +98,9 @@ void ASkaldGameMode::InitializeWorld()
     {
         if (Territory && PlayerCount > 0)
         {
-            ASkaldPlayerState* Owner = Cast<ASkaldPlayerState>(GS->PlayerArray[Index % PlayerCount]);
-            Territory->OwningPlayer = Owner;
+            // Rename local variable to avoid hiding AActor::Owner
+            ASkaldPlayerState* TerritoryOwner = Cast<ASkaldPlayerState>(GS->PlayerArray[Index % PlayerCount]);
+            Territory->OwningPlayer = TerritoryOwner;
             Territory->ArmyStrength = 1;
             ++Index;
         }

--- a/Source/Skald/Skald_PlayerCharacter.cpp
+++ b/Source/Skald/Skald_PlayerCharacter.cpp
@@ -7,6 +7,8 @@
 #include "Camera/CameraComponent.h"
 #include "GameFramework/SpringArmComponent.h"
 #include "Kismet/GameplayStatics.h"
+#include "Engine/World.h"
+#include "Components/InputComponent.h"
 
 // Sets default values
 ASkald_PlayerCharacter::ASkald_PlayerCharacter()
@@ -32,7 +34,7 @@ void ASkald_PlayerCharacter::Tick(float DeltaTime)
         Super::Tick(DeltaTime);
 
         // Example tick behavior: keep track of selection validity
-        if (CurrentSelection && CurrentSelection->IsPendingKill())
+        if (!IsValid(CurrentSelection))
         {
                 CurrentSelection = nullptr;
         }


### PR DESCRIPTION
## Summary
- Bind load game buttons via dynamic delegates
- Pass widget and handler pointers when adding load slots
- Rename territory owner variable to avoid hiding AActor::Owner
- Include missing headers and validate selection when caching player character state

## Testing
- `clang++ -c Source/Skald/LoadGameWidget.cpp` *(fails: 'CoreMinimal.h' file not found)*
- `clang++ -c Source/Skald/Skald_GameMode.cpp` *(fails: 'CoreMinimal.h' file not found)*
- `clang++ -c Source/Skald/Skald_PlayerCharacter.cpp` *(fails: 'CoreMinimal.h' file not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a74b88ccfc8324842ac484d0d69f7c