### PR TITLE
Toggle territory selection on click

### DIFF
--- a/Source/Skald/Territory.cpp
+++ b/Source/Skald/Territory.cpp
@@ -119,10 +119,13 @@ void ATerritory::HandleMouseLeave(UPrimitiveComponent* TouchedComponent)
 
 void ATerritory::HandleClicked(UPrimitiveComponent* TouchedComponent, FKey ButtonPressed)
 {
-    Select();
     if (!bIsSelected)
     {
         Select();
+    }
+    else
+    {
+        Deselect();
     }
 }
 


### PR DESCRIPTION
## Summary
- remove redundant call to `Select()` and toggle selection based on current state

## Testing
- `g++ -c Source/Skald/Territory.cpp` *(fails: CoreMinimal.h: No such file or directory)*
- `make test` *(fails: No rule to make target 'test')*

------
https://chatgpt.com/codex/tasks/task_e_68a773e19bcc8324828ee3d093dfa47a