### PR TITLE
Expose gameplay classes to Blueprints

### DIFF
--- a/Source/Skald/LoadGameWidget.h
+++ b/Source/Skald/LoadGameWidget.h
@@ -7,7 +7,7 @@
 /**
  * Simple load game menu listing a few save slots.
  */
-UCLASS()
+UCLASS(Blueprintable, BlueprintType)
 class SKALD_API ULoadGameWidget : public UUserWidget
 {
     GENERATED_BODY()
@@ -15,13 +15,13 @@ class SKALD_API ULoadGameWidget : public UUserWidget
 protected:
     virtual void NativeConstruct() override;
 
-    UFUNCTION()
+    UFUNCTION(BlueprintCallable)
     void OnLoadSlot0();
 
-    UFUNCTION()
+    UFUNCTION(BlueprintCallable)
     void OnLoadSlot1();
 
-    UFUNCTION()
+    UFUNCTION(BlueprintCallable)
     void OnLoadSlot2();
 };
 

--- a/Source/Skald/LobbyGameMode.h
+++ b/Source/Skald/LobbyGameMode.h
@@ -7,7 +7,7 @@
 /**
  * Game mode used for the lobby map.
  */
-UCLASS()
+UCLASS(Blueprintable, BlueprintType)
 class SKALD_API ALobbyGameMode : public AGameModeBase
 {
     GENERATED_BODY()
@@ -18,7 +18,7 @@ public:
     virtual void BeginPlay() override;
 
 protected:
-    UPROPERTY(EditDefaultsOnly, Category = "UI")
+    UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category = "UI")
     TSubclassOf<class UUserWidget> LobbyWidgetClass;
 };
 

--- a/Source/Skald/LobbyMenuWidget.h
+++ b/Source/Skald/LobbyMenuWidget.h
@@ -7,7 +7,7 @@
 /**
  * Main menu widget shown on the lobby map.
  */
-UCLASS()
+UCLASS(Blueprintable, BlueprintType)
 class SKALD_API ULobbyMenuWidget : public UUserWidget
 {
     GENERATED_BODY()
@@ -15,16 +15,16 @@ class SKALD_API ULobbyMenuWidget : public UUserWidget
 protected:
     virtual void NativeConstruct() override;
 
-    UFUNCTION()
+    UFUNCTION(BlueprintCallable)
     void OnStartGame();
 
-    UFUNCTION()
+    UFUNCTION(BlueprintCallable)
     void OnLoadGame();
 
-    UFUNCTION()
+    UFUNCTION(BlueprintCallable)
     void OnSettings();
 
-    UFUNCTION()
+    UFUNCTION(BlueprintCallable)
     void OnExit();
 };
 

--- a/Source/Skald/SettingsWidget.h
+++ b/Source/Skald/SettingsWidget.h
@@ -7,7 +7,7 @@
 /**
  * Basic settings menu allowing to apply current user settings.
  */
-UCLASS()
+UCLASS(Blueprintable, BlueprintType)
 class SKALD_API USettingsWidget : public UUserWidget
 {
     GENERATED_BODY()
@@ -15,7 +15,7 @@ class SKALD_API USettingsWidget : public UUserWidget
 protected:
     virtual void NativeConstruct() override;
 
-    UFUNCTION()
+    UFUNCTION(BlueprintCallable)
     void OnApply();
 };
 

--- a/Source/Skald/SkaldSaveGameLibrary.h
+++ b/Source/Skald/SkaldSaveGameLibrary.h
@@ -9,7 +9,7 @@ class USkaldSaveGame;
 /**
  * Blueprint-callable helpers for saving and loading Skald game data.
  */
-UCLASS()
+UCLASS(BlueprintType)
 class SKALD_API USkaldSaveGameLibrary : public UBlueprintFunctionLibrary
 {
     GENERATED_BODY()

--- a/Source/Skald/Skald_GameMode.h
+++ b/Source/Skald/Skald_GameMode.h
@@ -14,7 +14,7 @@ class AWorldMap;
 /**
  * GameMode responsible for managing player login and spawning the turn manager.
  */
-UCLASS()
+UCLASS(Blueprintable, BlueprintType)
 class SKALD_API ASkaldGameMode : public AGameModeBase
 {
     GENERATED_BODY()
@@ -27,11 +27,11 @@ public:
 
 protected:
     /** Handles turn sequencing for the match. */
-    UPROPERTY()
+    UPROPERTY(BlueprintReadOnly, Category="GameMode")
     ATurnManager* TurnManager;
 
     /** Holds all territory actors for the current map. */
-    UPROPERTY()
+    UPROPERTY(BlueprintReadOnly, Category="GameMode")
     AWorldMap* WorldMap;
 
     /** Data describing each player in the match. Pre-sized so blueprints can
@@ -40,6 +40,7 @@ protected:
     TArray<FS_PlayerData> PlayersData;
 
     /** Setup initial territories, armies, and initiative. */
+    UFUNCTION(BlueprintCallable, Category="GameMode")
     void InitializeWorld();
 };
 

--- a/Source/Skald/Skald_GameState.h
+++ b/Source/Skald/Skald_GameState.h
@@ -9,7 +9,7 @@ class ASkaldPlayerState;
 /**
  * Stores information about players and the current turn.
  */
-UCLASS()
+UCLASS(Blueprintable, BlueprintType)
 class SKALD_API ASkaldGameState : public AGameStateBase
 {
     GENERATED_BODY()
@@ -18,14 +18,17 @@ public:
     ASkaldGameState();
 
     /** List of players participating in the match. */
-    UPROPERTY(BlueprintReadOnly)
+    UPROPERTY(BlueprintReadOnly, Category="GameState")
     TArray<ASkaldPlayerState*> Players;
 
     /** Index of the player whose turn is active. */
-    UPROPERTY(BlueprintReadOnly)
+    UPROPERTY(BlueprintReadOnly, Category="GameState")
     int32 CurrentTurnIndex;
 
+    UFUNCTION(BlueprintCallable, Category="GameState")
     void AddPlayerState(ASkaldPlayerState* PlayerState);
+
+    UFUNCTION(BlueprintCallable, BlueprintPure, Category="GameState")
     ASkaldPlayerState* GetCurrentPlayer() const;
 };
 

--- a/Source/Skald/Skald_PlayerCharacter.h
+++ b/Source/Skald/Skald_PlayerCharacter.h
@@ -10,7 +10,7 @@ class ATerritory;
 
 #include "Skald_PlayerCharacter.generated.h"
 
-UCLASS()
+UCLASS(Blueprintable, BlueprintType)
 class SKALD_API ASkald_PlayerCharacter : public ACharacter
 {
 	GENERATED_BODY()
@@ -39,16 +39,24 @@ public:
         virtual void SetupPlayerInputComponent(class UInputComponent* PlayerInputComponent) override;
 
         /** Handle forward/backward movement input */
+        UFUNCTION(BlueprintCallable, Category="Input")
         void MoveForward(float Value);
 
         /** Handle right/left movement input */
+        UFUNCTION(BlueprintCallable, Category="Input")
         void MoveRight(float Value);
 
         /** Handle selection action */
+        UFUNCTION(BlueprintCallable, Category="Input")
         void Select();
 
         /** Ability triggers */
+        UFUNCTION(BlueprintCallable, Category="Abilities")
         void AbilityOne();
+
+        UFUNCTION(BlueprintCallable, Category="Abilities")
         void AbilityTwo();
+
+        UFUNCTION(BlueprintCallable, Category="Abilities")
         void AbilityThree();
 };

--- a/Source/Skald/Skald_PlayerController.cpp
+++ b/Source/Skald/Skald_PlayerController.cpp
@@ -68,3 +68,8 @@ void ASkaldPlayerController::MakeAIDecision()
     UE_LOG(LogTemp, Log, TEXT("AI %s making decision"), *GetName());
 }
 
+bool ASkaldPlayerController::IsAIController() const
+{
+    return bIsAI;
+}
+

--- a/Source/Skald/Skald_PlayerController.h
+++ b/Source/Skald/Skald_PlayerController.h
@@ -10,7 +10,7 @@ class UUserWidget;
 /**
  * Player controller capable of participating in turn based gameplay.
  */
-UCLASS()
+UCLASS(Blueprintable, BlueprintType)
 class SKALD_API ASkaldPlayerController : public APlayerController
 {
     GENERATED_BODY()
@@ -20,10 +20,17 @@ public:
 
     virtual void BeginPlay() override;
 
+    UFUNCTION(BlueprintCallable, Category="Turn")
     void StartTurn();
+
+    UFUNCTION(BlueprintCallable, Category="Turn")
     void EndTurn();
+
+    UFUNCTION(BlueprintCallable, Category="Turn")
     void MakeAIDecision();
-    bool IsAIController() const { return bIsAI; }
+
+    UFUNCTION(BlueprintCallable, BlueprintPure, Category="Turn")
+    bool IsAIController() const;
 
     /** Set the turn manager responsible for sequencing play. */
     UFUNCTION(BlueprintCallable, Category="Turn")
@@ -31,6 +38,7 @@ public:
 
 protected:
     /** Whether this controller is controlled by AI. */
+    UPROPERTY(BlueprintReadOnly, Category="Turn")
     bool bIsAI;
 
     /** Widget class to instantiate for the player's HUD. */

--- a/Source/Skald/Skald_PlayerState.h
+++ b/Source/Skald/Skald_PlayerState.h
@@ -7,7 +7,7 @@
 /**
  * Player state containing basic information for turn management.
  */
-UCLASS()
+UCLASS(Blueprintable, BlueprintType)
 class SKALD_API ASkaldPlayerState : public APlayerState
 {
     GENERATED_BODY()
@@ -15,15 +15,15 @@ class SKALD_API ASkaldPlayerState : public APlayerState
 public:
     ASkaldPlayerState();
 
-    UPROPERTY(BlueprintReadWrite)
+    UPROPERTY(BlueprintReadWrite, Category="PlayerState")
     bool bIsAI;
 
     /** Army units available for placement. */
-    UPROPERTY(BlueprintReadWrite)
+    UPROPERTY(BlueprintReadWrite, Category="PlayerState")
     int32 ArmyPool;
 
     /** Initiative roll determining turn order. */
-    UPROPERTY(BlueprintReadWrite)
+    UPROPERTY(BlueprintReadWrite, Category="PlayerState")
     int32 InitiativeRoll;
 };
 

--- a/Source/Skald/Skald_TurnManager.h
+++ b/Source/Skald/Skald_TurnManager.h
@@ -10,7 +10,7 @@ class ASkaldPlayerController;
 /**
  * Handles turn sequencing for all registered player controllers.
  */
-UCLASS()
+UCLASS(Blueprintable, BlueprintType)
 class SKALD_API ATurnManager : public AActor
 {
     GENERATED_BODY()
@@ -20,15 +20,23 @@ public:
 
     virtual void BeginPlay() override;
 
+    UFUNCTION(BlueprintCallable, Category="Turn")
     void RegisterController(ASkaldPlayerController* Controller);
+
+    UFUNCTION(BlueprintCallable, Category="Turn")
     void StartTurns();
+
+    UFUNCTION(BlueprintCallable, Category="Turn")
     void AdvanceTurn();
+
+    UFUNCTION(BlueprintCallable, Category="Turn")
     void SortControllersByInitiative();
 
 protected:
-    UPROPERTY()
+    UPROPERTY(BlueprintReadOnly, Category="Turn")
     TArray<ASkaldPlayerController*> Controllers;
 
+    UPROPERTY(BlueprintReadOnly, Category="Turn")
     int32 CurrentIndex;
 
     UPROPERTY(BlueprintReadWrite, EditAnywhere, Category="Turn")

--- a/Source/Skald/StartGameWidget.h
+++ b/Source/Skald/StartGameWidget.h
@@ -7,7 +7,7 @@
 /**
  * Menu shown after pressing Start Game, to choose single or multiplayer.
  */
-UCLASS()
+UCLASS(Blueprintable, BlueprintType)
 class SKALD_API UStartGameWidget : public UUserWidget
 {
     GENERATED_BODY()
@@ -15,10 +15,10 @@ class SKALD_API UStartGameWidget : public UUserWidget
 protected:
     virtual void NativeConstruct() override;
 
-    UFUNCTION()
+    UFUNCTION(BlueprintCallable)
     void OnSingleplayer();
 
-    UFUNCTION()
+    UFUNCTION(BlueprintCallable)
     void OnMultiplayer();
 };
 

--- a/Source/Skald/Territory.h
+++ b/Source/Skald/Territory.h
@@ -16,7 +16,7 @@ DECLARE_DYNAMIC_MULTICAST_DELEGATE_OneParam(FTerritorySelectedSignature, ATerrit
 /**
  * Actor representing a single territory on the world map.
  */
-UCLASS()
+UCLASS(Blueprintable, BlueprintType)
 class SKALD_API ATerritory : public AActor
 {
     GENERATED_BODY()

--- a/Source/Skald/WorldMap.h
+++ b/Source/Skald/WorldMap.h
@@ -44,7 +44,7 @@ struct FTerritorySpawnData
 /**
  * Actor owning and managing all territories in the map.
  */
-UCLASS()
+UCLASS(Blueprintable, BlueprintType)
 class SKALD_API AWorldMap : public AActor
 {
     GENERATED_BODY()


### PR DESCRIPTION
## Summary
- add Blueprintable UCLASS specifiers and BlueprintCallable functions for menu widgets
- expose game state, player controller, and turn manager APIs to Blueprints
- mark Skald game mode properties and initialization function for Blueprint access

## Testing
- `UnrealBuildTool -Project=Skald.uproject SkaldEditor Linux Development` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a776447c008324ac30fa74c4ef2fe4