### PR TITLE
Delay turn start until players ready

### DIFF
--- a/Source/Skald/Skald_TurnManager.cpp
+++ b/Source/Skald/Skald_TurnManager.cpp
@@ -19,11 +19,6 @@ void ATurnManager::RegisterController(ASkaldPlayerController* Controller)
     {
         Controllers.Add(Controller);
         Controller->SetTurnManager(this);
-
-        if (Controllers.Num() == 1)
-        {
-            StartTurns();
-        }
     }
 }
 


### PR DESCRIPTION
## Summary
- prevent turn manager from auto-starting turns on first controller
- start turns from game mode only after all players join or a timeout

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a98beb89e88324a6061145ca8a1b21