### PR TITLE
Validate save game before loading level

### DIFF
--- a/Source/Skald/LoadGameWidget.cpp
+++ b/Source/Skald/LoadGameWidget.cpp
@@ -4,6 +4,7 @@
 #include "Components/VerticalBox.h"
 #include "Blueprint/WidgetTree.h"
 #include "Kismet/GameplayStatics.h"
+#include "GameFramework/SaveGame.h"
 
 static const TCHAR* SlotNames[3] = { TEXT("Slot0"), TEXT("Slot1"), TEXT("Slot2") };
 
@@ -46,19 +47,29 @@ void ULoadGameWidget::NativeConstruct()
 
 void ULoadGameWidget::OnLoadSlot0()
 {
-    UGameplayStatics::LoadGameFromSlot(SlotNames[0], 0);
-    UGameplayStatics::OpenLevel(this, FName("OverviewMap"));
+    HandleLoadSlot(0);
 }
 
 void ULoadGameWidget::OnLoadSlot1()
 {
-    UGameplayStatics::LoadGameFromSlot(SlotNames[1], 0);
-    UGameplayStatics::OpenLevel(this, FName("OverviewMap"));
+    HandleLoadSlot(1);
 }
 
 void ULoadGameWidget::OnLoadSlot2()
 {
-    UGameplayStatics::LoadGameFromSlot(SlotNames[2], 0);
-    UGameplayStatics::OpenLevel(this, FName("OverviewMap"));
+    HandleLoadSlot(2);
+}
+
+void ULoadGameWidget::HandleLoadSlot(int32 SlotIndex)
+{
+    USaveGame* LoadedGame = UGameplayStatics::LoadGameFromSlot(SlotNames[SlotIndex], 0);
+    if (LoadedGame)
+    {
+        UGameplayStatics::OpenLevel(this, FName("OverviewMap"));
+    }
+    else
+    {
+        UE_LOG(LogTemp, Error, TEXT("Failed to load save slot %s"), SlotNames[SlotIndex]);
+    }
 }
 

--- a/Source/Skald/LoadGameWidget.h
+++ b/Source/Skald/LoadGameWidget.h
@@ -23,5 +23,9 @@ protected:
 
     UFUNCTION(BlueprintCallable)
     void OnLoadSlot2();
+
+private:
+    /** Shared implementation for the individual load slot handlers. */
+    void HandleLoadSlot(int32 SlotIndex);
 };
 


### PR DESCRIPTION
## Summary
- Add shared handler for load-slot buttons
- Check that a save game exists before opening the level and log an error if loading fails

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a98c9e0bc083248802618a83a18f02