### PR TITLE
Add base C++ HUD widget for Blueprint subclassing

### DIFF
--- a/Source/Skald/Skald.Build.cs
+++ b/Source/Skald/Skald.Build.cs
@@ -8,9 +8,24 @@ public class Skald : ModuleRules
         {
                 PCHUsage = PCHUsageMode.UseExplicitOrSharedPCHs;
 
-                PublicDependencyModuleNames.AddRange(new string[] { "Core", "CoreUObject", "Engine", "InputCore", "UMG" });
+                PublicDependencyModuleNames.AddRange(new string[]
+                {
+                        "Core",
+                        "CoreUObject",
+                        "Engine",
+                        "InputCore",
+                        "UMG",
+                        "Slate",
+                        "SlateCore"
+                });
 
-                PrivateDependencyModuleNames.AddRange(new string[] { "Slate", "SlateCore", "UMG", "OnlineSubsystem" });
+                PrivateDependencyModuleNames.AddRange(new string[]
+                {
+                        "Slate",
+                        "SlateCore",
+                        "UMG",
+                        "OnlineSubsystem"
+                });
 
                 // To include OnlineSubsystemSteam, add it to the plugins section in your uproject file with the Enabled attribute set to true
         }

--- a/Source/Skald/UI/SkaldMainHUDWidget.h
+++ b/Source/Skald/UI/SkaldMainHUDWidget.h
@@ -1,0 +1,144 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Blueprint/UserWidget.h"
+#include "SkaldTypes.h"
+#include "SkaldMainHUDWidget.generated.h"
+
+// Alias existing enum to expected name without underscore
+using ETurnPhase = E_TurnPhase;
+
+// Delegates broadcasting user UI actions to game logic
+DECLARE_DYNAMIC_MULTICAST_DELEGATE_ThreeParams(FSkaldAttackRequested, int32, FromID, int32, ToID, int32, ArmySent);
+DECLARE_DYNAMIC_MULTICAST_DELEGATE_OneParam(FSkaldEndAttackRequested, bool, bConfirmed);
+DECLARE_DYNAMIC_MULTICAST_DELEGATE_TwoParams(FSkaldEngineeringRequested, int32, CapitalID, uint8, UpgradeType);
+DECLARE_DYNAMIC_MULTICAST_DELEGATE_OneParam(FSkaldDigTreasureRequested, int32, TerritoryID);
+DECLARE_DYNAMIC_MULTICAST_DELEGATE_ThreeParams(FSkaldMoveRequested, int32, FromID, int32, ToID, int32, Troops);
+DECLARE_DYNAMIC_MULTICAST_DELEGATE_OneParam(FSkaldEndMovementRequested, bool, bConfirmed);
+
+/**
+ * Base HUD widget that exposes state and events for the game logic.
+ *
+ * Blueprint subclasses are expected to create the visual elements. Typical wiring:
+ *  - Buttons in the BP call the BlueprintCallable functions such as SubmitAttack or SubmitMove.
+ *    (e.g. AttackButton->OnClicked -> SubmitAttack(SourceID, TargetID, ArmySent))
+ *  - PlayerController binds to the multicast delegates to forward actions to server RPCs:
+ *      HUDWidget->OnAttackRequested.AddDynamic(this, &ASKald_PlayerController::Server_RequestAttack);
+ */
+UCLASS(Blueprintable, BlueprintType)
+class SKALD_API USkaldMainHUDWidget : public UUserWidget
+{
+    GENERATED_BODY()
+
+public:
+    // Identity / state (read by BP)
+    UPROPERTY(BlueprintReadWrite, Category="Skald|State")
+    int32 LocalPlayerID = -1;
+
+    UPROPERTY(BlueprintReadWrite, Category="Skald|State")
+    int32 CurrentPlayerID = -1;
+
+    UPROPERTY(BlueprintReadWrite, Category="Skald|State")
+    int32 TurnNumber = 1;
+
+    UPROPERTY(BlueprintReadWrite, Category="Skald|State")
+    ETurnPhase CurrentPhase = ETurnPhase::Reinforcement;
+
+    // Selection helpers used by Attack/Move flows
+    UPROPERTY(BlueprintReadWrite, Category="Skald|Selection")
+    int32 SelectedSourceID = -1;
+
+    UPROPERTY(BlueprintReadWrite, Category="Skald|Selection")
+    int32 SelectedTargetID = -1;
+
+    UPROPERTY(BlueprintReadWrite, Category="Skald|Selection")
+    bool bSelectingForAttack = false;
+
+    UPROPERTY(BlueprintReadWrite, Category="Skald|Selection")
+    bool bSelectingForMove = false;
+
+    // Cached list of players for UI list building
+    UPROPERTY(BlueprintReadWrite, Category="Skald|Data")
+    TArray<FS_PlayerData> CachedPlayers;
+
+    // Delegates (BlueprintAssignable) — UI → game actions
+    UPROPERTY(BlueprintAssignable, Category="Skald|Events")
+    FSkaldAttackRequested OnAttackRequested;
+
+    UPROPERTY(BlueprintAssignable, Category="Skald|Events")
+    FSkaldEndAttackRequested OnEndAttackRequested;
+
+    UPROPERTY(BlueprintAssignable, Category="Skald|Events")
+    FSkaldEngineeringRequested OnEngineeringRequested;
+
+    UPROPERTY(BlueprintAssignable, Category="Skald|Events")
+    FSkaldDigTreasureRequested OnDigTreasureRequested;
+
+    UPROPERTY(BlueprintAssignable, Category="Skald|Events")
+    FSkaldMoveRequested OnMoveRequested;
+
+    UPROPERTY(BlueprintAssignable, Category="Skald|Events")
+    FSkaldEndMovementRequested OnEndMovementRequested;
+
+    // BlueprintCallable functions — game → HUD (push updates)
+    UFUNCTION(BlueprintCallable, Category="Skald|HUD")
+    void UpdateTurnBanner(int32 InCurrentPlayerID, int32 InTurnNumber);
+
+    UFUNCTION(BlueprintCallable, Category="Skald|HUD")
+    void UpdatePhaseBanner(ETurnPhase InPhase);
+
+    UFUNCTION(BlueprintCallable, Category="Skald|HUD")
+    void UpdateTerritoryInfo(const FString& TerritoryName, const FString& OwnerName, int32 ArmyCount);
+
+    UFUNCTION(BlueprintCallable, Category="Skald|HUD")
+    void RefreshPlayerList(const TArray<FS_PlayerData>& Players);
+
+    UFUNCTION(BlueprintCallable, Category="Skald|HUD")
+    void RefreshFromState(int32 InCurrentPlayerID, int32 InTurnNumber, ETurnPhase InPhase, const TArray<FS_PlayerData>& Players);
+
+    // BlueprintCallable functions — selection UX helpers
+    UFUNCTION(BlueprintCallable, Category="Skald|Selection")
+    void BeginAttackSelection();
+
+    UFUNCTION(BlueprintCallable, Category="Skald|Selection")
+    void SubmitAttack(int32 FromID, int32 ToID, int32 ArmySent);
+
+    UFUNCTION(BlueprintCallable, Category="Skald|Selection")
+    void CancelAttackSelection();
+
+    UFUNCTION(BlueprintCallable, Category="Skald|Selection")
+    void BeginMoveSelection();
+
+    UFUNCTION(BlueprintCallable, Category="Skald|Selection")
+    void SubmitMove(int32 FromID, int32 ToID, int32 Troops);
+
+    UFUNCTION(BlueprintCallable, Category="Skald|Selection")
+    void CancelMoveSelection();
+
+    UFUNCTION(BlueprintCallable, Category="Skald|Selection")
+    void OnTerritoryClickedUI(int32 TerritoryID, bool bOwnedByLocal);
+
+    // BlueprintImplementableEvent hooks — BP subclass draws UI
+    UFUNCTION(BlueprintImplementableEvent, Category="Skald|HUD")
+    void BP_SetTurnText(int32 InTurnNumber, int32 InCurrentPlayerID);
+
+    UFUNCTION(BlueprintImplementableEvent, Category="Skald|HUD")
+    void BP_SetPhaseText(ETurnPhase InPhase);
+
+    UFUNCTION(BlueprintImplementableEvent, Category="Skald|HUD")
+    void BP_SetTerritoryPanel(const FString& TerritoryName, const FString& OwnerName, int32 ArmyCount);
+
+    UFUNCTION(BlueprintImplementableEvent, Category="Skald|HUD")
+    void BP_RebuildPlayerList(const TArray<FS_PlayerData>& Players);
+
+    UFUNCTION(BlueprintImplementableEvent, Category="Skald|HUD")
+    void BP_SetPhaseButtons(ETurnPhase InPhase, bool bIsMyTurn);
+
+    // Helper so PlayerController can refresh button enable state after it knows turn ownership
+    UFUNCTION(BlueprintCallable, Category="Skald|HUD")
+    void SyncPhaseButtons(bool bIsMyTurn);
+
+protected:
+    virtual void NativeConstruct() override;
+};
+


### PR DESCRIPTION
## Summary
- Add USkaldMainHUDWidget exposing HUD state, delegates, update functions, and Blueprint hooks
- Implement selection helpers and phase button sync logic
- Expose UMG/Slate modules in build rules

## Testing
- `g++ -std=c++17 -I Source/Skald -c Source/Skald/UI/SkaldMainHUDWidget.cpp` *(fails: CoreMinimal.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a995e3b38c8324a2cbe9f7675c5408