### PR TITLE
Rename turn phase enum for Unreal header compatibility

### DIFF
--- a/Source/Skald/SkaldTypes.h
+++ b/Source/Skald/SkaldTypes.h
@@ -6,7 +6,7 @@
 // Keep generated.h last among includes in this header!
 
 UENUM(BlueprintType)
-enum class E_TurnPhase : uint8
+enum class ETurnPhase : uint8
 {
     Reinforcement UMETA(DisplayName = "Reinforcement"),
     Attack        UMETA(DisplayName = "Attack"),
@@ -18,7 +18,7 @@ enum class E_TurnPhase : uint8
 };
 
 UENUM(BlueprintType)
-enum class E_SiegeWeapons : uint8   // (Consider “E” prefix instead of “Enum_” for UE style)
+enum class E_SiegeWeapons : uint8   // (Consider E prefix instead of Enum_ for UE style)
 {
     BatteringRam UMETA(DisplayName = "BatteringRam"),
     Trebuchet    UMETA(DisplayName = "Trebuchet"),

--- a/Source/Skald/Skald_TurnManager.h
+++ b/Source/Skald/Skald_TurnManager.h
@@ -40,7 +40,7 @@ protected:
     int32 CurrentIndex;
 
     UPROPERTY(BlueprintReadWrite, EditAnywhere, Category="Turn")
-    E_TurnPhase CurrentPhase = E_TurnPhase::Reinforcement;
+    ETurnPhase CurrentPhase = ETurnPhase::Reinforcement;
 
     UPROPERTY(BlueprintReadWrite, EditAnywhere, Category="Turn")
     FS_BattlePayload PendingBattle;

--- a/Source/Skald/UI/SkaldMainHUDWidget.h
+++ b/Source/Skald/UI/SkaldMainHUDWidget.h
@@ -5,8 +5,6 @@
 #include "SkaldTypes.h"
 #include "SkaldMainHUDWidget.generated.h"
 
-// Alias existing enum to expected name without underscore
-using ETurnPhase = E_TurnPhase;
 
 // Delegates broadcasting user UI actions to game logic
 DECLARE_DYNAMIC_MULTICAST_DELEGATE_ThreeParams(FSkaldAttackRequested, int32, FromID, int32, ToID, int32, ArmySent);


### PR DESCRIPTION
## Summary
- Rename `E_TurnPhase` enum to `ETurnPhase`
- Update turn manager and HUD widget to use `ETurnPhase` directly

## Testing
- `g++ -std=c++17 -fsyntax-only Source/Skald/SkaldTypes.h` *(fails: CoreMinimal.h: No such file or directory)*
- `g++ -std=c++17 -fsyntax-only Source/Skald/Skald_TurnManager.h` *(fails: CoreMinimal.h: No such file or directory)*
- `g++ -std=c++17 -fsyntax-only Source/Skald/UI/SkaldMainHUDWidget.h` *(fails: CoreMinimal.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a99ff998988324b06a441ef36cdcb4