### PR TITLE
Ensure TurnManager sorts controllers safely

### DIFF
--- a/Source/Skald/Skald_TurnManager.cpp
+++ b/Source/Skald/Skald_TurnManager.cpp
@@ -2,55 +2,46 @@
 #include "Skald_PlayerController.h"
 #include "Skald_PlayerState.h"
 
-ATurnManager::ATurnManager()
-{
-    PrimaryActorTick.bCanEverTick = false;
-    CurrentIndex = 0;
+ATurnManager::ATurnManager() {
+  PrimaryActorTick.bCanEverTick = false;
+  CurrentIndex = 0;
 }
 
-void ATurnManager::BeginPlay()
-{
-    Super::BeginPlay();
+void ATurnManager::BeginPlay() { Super::BeginPlay(); }
+
+void ATurnManager::RegisterController(ASkaldPlayerController *Controller) {
+  if (Controller) {
+    Controllers.Add(Controller);
+    Controller->SetTurnManager(this);
+  }
 }
 
-void ATurnManager::RegisterController(ASkaldPlayerController* Controller)
-{
-    if (Controller)
-    {
-        Controllers.Add(Controller);
-        Controller->SetTurnManager(this);
-    }
-}
-
-void ATurnManager::StartTurns()
-{
-    CurrentIndex = 0;
-    if (Controllers.IsValidIndex(CurrentIndex))
-    {
-        Controllers[CurrentIndex]->StartTurn();
-    }
-}
-
-void ATurnManager::AdvanceTurn()
-{
-    if (Controllers.Num() == 0)
-    {
-        return;
-    }
-
-    CurrentIndex = (CurrentIndex + 1) % Controllers.Num();
+void ATurnManager::StartTurns() {
+  SortControllersByInitiative();
+  CurrentIndex = 0;
+  if (Controllers.IsValidIndex(CurrentIndex)) {
     Controllers[CurrentIndex]->StartTurn();
+  }
 }
 
-void ATurnManager::SortControllersByInitiative()
-{
-    Controllers.Sort([](const ASkaldPlayerController& A, const ASkaldPlayerController& B)
-    {
-        const ASkaldPlayerState* PSA = A.GetPlayerState<ASkaldPlayerState>();
-        const ASkaldPlayerState* PSB = B.GetPlayerState<ASkaldPlayerState>();
-        int32 RollA = PSA ? PSA->InitiativeRoll : 0;
-        int32 RollB = PSB ? PSB->InitiativeRoll : 0;
+void ATurnManager::AdvanceTurn() {
+  if (Controllers.Num() == 0) {
+    return;
+  }
+
+  CurrentIndex = (CurrentIndex + 1) % Controllers.Num();
+  Controllers[CurrentIndex]->StartTurn();
+}
+
+void ATurnManager::SortControllersByInitiative() {
+  Controllers.Sort(
+      [](const ASkaldPlayerController *A, const ASkaldPlayerController *B) {
+        const ASkaldPlayerState *PSA =
+            A ? A->GetPlayerState<ASkaldPlayerState>() : nullptr;
+        const ASkaldPlayerState *PSB =
+            B ? B->GetPlayerState<ASkaldPlayerState>() : nullptr;
+        const int32 RollA = PSA ? PSA->InitiativeRoll : 0;
+        const int32 RollB = PSB ? PSB->InitiativeRoll : 0;
         return RollA > RollB;
-    });
+      });
 }
-


### PR DESCRIPTION
## Summary
- Sort player controllers by initiative before the first turn begins
- Compare controllers via pointers with null checks when sorting

## Testing
- `g++ -std=c++17 -c Source/Skald/Skald_TurnManager.cpp` *(fails: CoreMinimal.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a9b30c6eb0832481ac84873d7bc5bf