### PR TITLE
Fix module include path so SkaldTypes.h is discoverable

### DIFF
--- a/Source/Skald/Skald.Build.cs
+++ b/Source/Skald/Skald.Build.cs
@@ -27,6 +27,11 @@ public class Skald : ModuleRules
                         "OnlineSubsystem"
                 });
 
+                PrivateIncludePaths.AddRange(new string[]
+                {
+                        ModuleDirectory
+                });
+
                 // To include OnlineSubsystemSteam, add it to the plugins section in your uproject file with the Enabled attribute set to true
         }
 }


### PR DESCRIPTION
## Summary
- add module directory to private include paths to allow SkaldTypes.h to be included from subfolders

## Testing
- `g++ -fsyntax-only -I Source/Skald Source/Skald/UI/SkaldMainHUDWidget.cpp` *(fails: CoreMinimal.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a9d4d6e414832490c7143352d3c0be