### PR TITLE
Fix module include path and resolve build errors

### DIFF
--- a/Source/Skald/Skald.Build.cs
+++ b/Source/Skald/Skald.Build.cs
@@ -27,6 +27,11 @@ public class Skald : ModuleRules
                         "OnlineSubsystem"
                 });
 
+                PrivateIncludePaths.AddRange(new string[]
+                {
+                        ModuleDirectory
+                });
+
                 // To include OnlineSubsystemSteam, add it to the plugins section in your uproject file with the Enabled attribute set to true
         }
 }

--- a/Source/Skald/Skald_GameState.cpp
+++ b/Source/Skald/Skald_GameState.cpp
@@ -6,11 +6,13 @@ ASkaldGameState::ASkaldGameState()
 {
 }
 
-void ASkaldGameState::AddPlayerState(ASkaldPlayerState* PlayerState)
+void ASkaldGameState::AddPlayerState(APlayerState* PlayerState)
 {
-    if (PlayerState)
+    Super::AddPlayerState(PlayerState);
+
+    if (ASkaldPlayerState* SkaldPlayer = Cast<ASkaldPlayerState>(PlayerState))
     {
-        Players.Add(PlayerState);
+        Players.Add(SkaldPlayer);
     }
 }
 

--- a/Source/Skald/Skald_GameState.h
+++ b/Source/Skald/Skald_GameState.h
@@ -25,8 +25,7 @@ public:
     UPROPERTY(BlueprintReadOnly, Category="GameState")
     int32 CurrentTurnIndex;
 
-    UFUNCTION(BlueprintCallable, Category="GameState")
-    void AddPlayerState(ASkaldPlayerState* PlayerState);
+    virtual void AddPlayerState(APlayerState* PlayerState) override;
 
     UFUNCTION(BlueprintCallable, BlueprintPure, Category="GameState")
     ASkaldPlayerState* GetCurrentPlayer() const;

--- a/Source/Skald/StartGameWidget.cpp
+++ b/Source/Skald/StartGameWidget.cpp
@@ -36,9 +36,9 @@ void UStartGameWidget::OnSingleplayer()
 {
     if (UWorld* World = GetWorld())
     {
-        TSubclassOf<UPlayerSetupWidget> ClassToUse = PlayerSetupWidgetClass
+        const TSubclassOf<UPlayerSetupWidget> ClassToUse = PlayerSetupWidgetClass
             ? PlayerSetupWidgetClass
-            : UPlayerSetupWidget::StaticClass();
+            : TSubclassOf<UPlayerSetupWidget>(UPlayerSetupWidget::StaticClass());
         if (UPlayerSetupWidget* Widget = CreateWidget<UPlayerSetupWidget>(World, ClassToUse))
         {
             Widget->bMultiplayer = false;
@@ -51,9 +51,9 @@ void UStartGameWidget::OnMultiplayer()
 {
     if (UWorld* World = GetWorld())
     {
-        TSubclassOf<UPlayerSetupWidget> ClassToUse = PlayerSetupWidgetClass
+        const TSubclassOf<UPlayerSetupWidget> ClassToUse = PlayerSetupWidgetClass
             ? PlayerSetupWidgetClass
-            : UPlayerSetupWidget::StaticClass();
+            : TSubclassOf<UPlayerSetupWidget>(UPlayerSetupWidget::StaticClass());
         if (UPlayerSetupWidget* Widget = CreateWidget<UPlayerSetupWidget>(World, ClassToUse))
         {
             Widget->bMultiplayer = true;

--- a/Source/Skald/WorldMap.cpp
+++ b/Source/Skald/WorldMap.cpp
@@ -91,7 +91,7 @@ void AWorldMap::RegisterTerritory(ATerritory *Territory) {
 }
 
 ATerritory *AWorldMap::GetTerritoryById(int32 TerritoryId) const {
-  if (ATerritory **Found = Territories.FindByPredicate(
+  if (ATerritory * const* Found = Territories.FindByPredicate(
           [TerritoryId](ATerritory *Territory) {
             return Territory && Territory->TerritoryID == TerritoryId;
           })) {


### PR DESCRIPTION
## Summary
- add module directory to private include paths to allow SkaldTypes.h to be included from subfolders
- resolve conditional expression ambiguity in StartGameWidget by explicitly wrapping StaticClass() in `TSubclassOf`
- override `AddPlayerState` with base `APlayerState` parameter and cast to `ASkaldPlayerState`
- correct constness when retrieving territories in `WorldMap`

## Testing
- `g++ -fsyntax-only -I Source/Skald Source/Skald/StartGameWidget.cpp Source/Skald/Skald_GameState.cpp Source/Skald/WorldMap.cpp` *(fails: CoreMinimal.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a9d4d6e414832490c7143352d3c0be