### PR TITLE
Fix controller sort predicate and update include order

### DIFF
--- a/Source/Skald.Target.cs
+++ b/Source/Skald.Target.cs
@@ -5,11 +5,12 @@ using System.Collections.Generic;
 
 public class SkaldTarget : TargetRules
 {
-	public SkaldTarget(TargetInfo Target) : base(Target)
-	{
-		Type = TargetType.Game;
-		DefaultBuildSettings = BuildSettingsVersion.V5;
+        public SkaldTarget(TargetInfo Target) : base(Target)
+        {
+                Type = TargetType.Game;
+                DefaultBuildSettings = BuildSettingsVersion.V5;
+                IncludeOrderVersion = EngineIncludeOrderVersion.Unreal5_5;
 
-		ExtraModuleNames.AddRange( new string[] { "Skald" } );
-	}
+                ExtraModuleNames.AddRange( new string[] { "Skald" } );
+        }
 }

--- a/Source/Skald/Skald_TurnManager.cpp
+++ b/Source/Skald/Skald_TurnManager.cpp
@@ -36,11 +36,11 @@ void ATurnManager::AdvanceTurn() {
 
 void ATurnManager::SortControllersByInitiative() {
   Controllers.Sort(
-      [](const ASkaldPlayerController *A, const ASkaldPlayerController *B) {
+      [](const ASkaldPlayerController &A, const ASkaldPlayerController &B) {
         const ASkaldPlayerState *PSA =
-            A ? A->GetPlayerState<ASkaldPlayerState>() : nullptr;
+            A.GetPlayerState<ASkaldPlayerState>();
         const ASkaldPlayerState *PSB =
-            B ? B->GetPlayerState<ASkaldPlayerState>() : nullptr;
+            B.GetPlayerState<ASkaldPlayerState>();
         const int32 RollA = PSA ? PSA->InitiativeRoll : 0;
         const int32 RollB = PSB ? PSB->InitiativeRoll : 0;
         return RollA > RollB;

--- a/Source/SkaldEditor.Target.cs
+++ b/Source/SkaldEditor.Target.cs
@@ -5,11 +5,12 @@ using System.Collections.Generic;
 
 public class SkaldEditorTarget : TargetRules
 {
-	public SkaldEditorTarget(TargetInfo Target) : base(Target)
-	{
-		Type = TargetType.Editor;
-		DefaultBuildSettings = BuildSettingsVersion.V5;
+        public SkaldEditorTarget(TargetInfo Target) : base(Target)
+        {
+                Type = TargetType.Editor;
+                DefaultBuildSettings = BuildSettingsVersion.V5;
+                IncludeOrderVersion = EngineIncludeOrderVersion.Unreal5_5;
 
-		ExtraModuleNames.AddRange( new string[] { "Skald" } );
-	}
+                ExtraModuleNames.AddRange( new string[] { "Skald" } );
+        }
 }


### PR DESCRIPTION
## Summary
- fix sorting predicate for controller initiative comparisons
- adopt Unreal 5.5 include order in target files

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a9fb5bda948324b6a997283c2f1ff7