### PR TITLE
Bind lobby menu buttons to native handlers

### DIFF
--- a/Source/Skald/LobbyMenuWidget.cpp
+++ b/Source/Skald/LobbyMenuWidget.cpp
@@ -3,9 +3,6 @@
 #include "LoadGameWidget.h"
 #include "SettingsWidget.h"
 #include "Components/Button.h"
-#include "Components/TextBlock.h"
-#include "Components/VerticalBox.h"
-#include "Blueprint/WidgetTree.h"
 #include "Kismet/GameplayStatics.h"
 #include "Kismet/KismetSystemLibrary.h"
 
@@ -13,27 +10,24 @@ void ULobbyMenuWidget::NativeConstruct()
 {
     Super::NativeConstruct();
 
-    if (WidgetTree)
+    if (StartButton)
     {
-        UVerticalBox* Root = WidgetTree->ConstructWidget<UVerticalBox>(UVerticalBox::StaticClass());
-        WidgetTree->RootWidget = Root;
+        StartButton->OnClicked.AddDynamic(this, &ULobbyMenuWidget::OnStartGame);
+    }
 
-        auto AddButton = [this, Root](const FString& Label, const FName& FuncName)
-        {
-            UButton* Button = WidgetTree->ConstructWidget<UButton>(UButton::StaticClass());
-            UTextBlock* Text = WidgetTree->ConstructWidget<UTextBlock>(UTextBlock::StaticClass());
-            Text->SetText(FText::FromString(Label));
-            Button->AddChild(Text);
-            FScriptDelegate Delegate;
-            Delegate.BindUFunction(this, FuncName);
-            Button->OnClicked.Add(Delegate);
-            Root->AddChild(Button);
-        };
+    if (LoadButton)
+    {
+        LoadButton->OnClicked.AddDynamic(this, &ULobbyMenuWidget::OnLoadGame);
+    }
 
-        AddButton(TEXT("Start Game"), FName("OnStartGame"));
-        AddButton(TEXT("Load Game"), FName("OnLoadGame"));
-        AddButton(TEXT("Settings"), FName("OnSettings"));
-        AddButton(TEXT("Exit"), FName("OnExit"));
+    if (SettingsButton)
+    {
+        SettingsButton->OnClicked.AddDynamic(this, &ULobbyMenuWidget::OnSettings);
+    }
+
+    if (ExitButton)
+    {
+        ExitButton->OnClicked.AddDynamic(this, &ULobbyMenuWidget::OnExit);
     }
 }
 

--- a/Source/Skald/LobbyMenuWidget.h
+++ b/Source/Skald/LobbyMenuWidget.h
@@ -4,6 +4,9 @@
 #include "Blueprint/UserWidget.h"
 #include "LobbyMenuWidget.generated.h"
 
+class UButton;
+class UVerticalBox;
+
 /**
  * Main menu widget shown on the lobby map.
  */
@@ -14,6 +17,21 @@ class SKALD_API ULobbyMenuWidget : public UUserWidget
 
 protected:
     virtual void NativeConstruct() override;
+
+    UPROPERTY(meta=(BindWidget))
+    UVerticalBox* Root;
+
+    UPROPERTY(meta=(BindWidget))
+    UButton* StartButton;
+
+    UPROPERTY(meta=(BindWidget))
+    UButton* LoadButton;
+
+    UPROPERTY(meta=(BindWidget))
+    UButton* SettingsButton;
+
+    UPROPERTY(meta=(BindWidget))
+    UButton* ExitButton;
 
     UFUNCTION(BlueprintCallable)
     void OnStartGame();


### PR DESCRIPTION
## Summary
- Expose lobby menu buttons and layout as `UPROPERTY` members for blueprint binding
- Bind existing lobby menu button clicks to `OnStartGame`, `OnLoadGame`, `OnSettings`, and `OnExit`

## Testing
- `make test` *(fails: No rule to make target 'test')*

------
https://chatgpt.com/codex/tasks/task_e_68aa14d865088324a2951442091932eb