### PR TITLE
Add faction enum and army placement stub

### DIFF
--- a/Source/Skald/SkaldTypes.h
+++ b/Source/Skald/SkaldTypes.h
@@ -5,6 +5,13 @@
 
 // Keep generated.h last among includes in this header!
 
+// Gameplay-wide constants
+namespace SkaldConstants
+{
+    // Minimum army units required to attack a capital
+    static constexpr int32 CapitalAttackArmyRequirement = 10;
+}
+
 UENUM(BlueprintType)
 enum class ETurnPhase : uint8
 {
@@ -34,6 +41,19 @@ enum class EBattleStats : uint8
     Defense      UMETA(DisplayName = "Defense"),
     Speed        UMETA(DisplayName = "Speed"),
     // ...
+};
+
+// Factions available for players to choose at game start
+UENUM(BlueprintType)
+enum class EFaction : uint8
+{
+    Human       UMETA(DisplayName = "Human Faction"),
+    Orc         UMETA(DisplayName = "Orc Faction"),
+    Dwarf       UMETA(DisplayName = "Dwarf Faction"),
+    Elf         UMETA(DisplayName = "Elf Faction"),
+    LizardFolk  UMETA(DisplayName = "Lizard Folk Faction"),
+    Undead      UMETA(DisplayName = "Undead Faction"),
+    Gnoll       UMETA(DisplayName = "Gnoll Faction"),
 };
 
 USTRUCT(BlueprintType)
@@ -123,7 +143,7 @@ struct SKALD_API FS_PlayerData
     int32 Resources = 0;
 
     UPROPERTY(BlueprintReadWrite, EditAnywhere)
-    FString FactionName;
+    EFaction Faction = EFaction::Human;
 
     UPROPERTY(BlueprintReadWrite, EditAnywhere)
     TArray<int32> CapitalTerritoryIDs;
@@ -225,7 +245,7 @@ struct SKALD_API FPlayerSaveStruct
     bool IsAI = false;
 
     UPROPERTY(BlueprintReadWrite, EditAnywhere)
-    FString FactionName;
+    EFaction Faction = EFaction::Human;
 
     UPROPERTY(BlueprintReadWrite, EditAnywhere)
     TArray<int32> CapitalTerritoryIDs;

--- a/Source/Skald/Skald_GameMode.cpp
+++ b/Source/Skald/Skald_GameMode.cpp
@@ -44,6 +44,7 @@ void ASkaldGameMode::BeginPlay()
     }
 
     InitializeWorld();
+    BeginArmyPlacementPhase();
 
     GetWorldTimerManager().SetTimer(
         StartGameTimerHandle,
@@ -98,6 +99,16 @@ void ASkaldGameMode::PostLogin(APlayerController* NewPlayer)
                 }
             }
         }
+    }
+}
+
+void ASkaldGameMode::BeginArmyPlacementPhase()
+{
+    if (TurnManager)
+    {
+        // Initiative order determines who places armies first. The actual
+        // placement UI is expected to be handled in blueprints.
+        TurnManager->SortControllersByInitiative();
     }
 }
 

--- a/Source/Skald/Skald_GameMode.h
+++ b/Source/Skald/Skald_GameMode.h
@@ -42,5 +42,9 @@ protected:
     /** Setup initial territories, armies, and initiative. */
     UFUNCTION(BlueprintCallable, Category="GameMode")
     void InitializeWorld();
+
+    /** Allow players to position initial armies based on initiative. */
+    UFUNCTION(BlueprintCallable, Category="GameMode")
+    void BeginArmyPlacementPhase();
 };
 


### PR DESCRIPTION
## Summary
- introduce EFaction enum and capital-attack requirement constant
- convert player data to use EFaction
- add game mode hook for pre-game army placement based on initiative

## Testing
- `g++ -fsyntax-only Source/Skald/Skald_GameMode.cpp` *(fails: CoreMinimal.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a9bed0120883248004558d24d24bfd