### PR TITLE
Avoid invalid territory materials

### DIFF
--- a/Source/Skald/Territory.cpp
+++ b/Source/Skald/Territory.cpp
@@ -30,9 +30,14 @@ void ATerritory::BeginPlay() {
                                               &ATerritory::HandleMouseLeave);
     MeshComponent->OnClicked.AddDynamic(this, &ATerritory::HandleClicked);
 
-    DynamicMaterial = MeshComponent->CreateAndSetMaterialInstanceDynamic(0);
-    if (DynamicMaterial) {
-      DynamicMaterial->GetVectorParameterValue(FName("Color"), DefaultColor);
+    if (MeshComponent->GetNumMaterials() > 0) {
+      DynamicMaterial = MeshComponent->CreateAndSetMaterialInstanceDynamic(0);
+      if (DynamicMaterial) {
+        DynamicMaterial->GetVectorParameterValue(FName("Color"), DefaultColor);
+      }
+    } else {
+      UE_LOG(LogTemp, Warning,
+             TEXT("Territory %s has no material at index 0"), *GetName());
     }
   }
 


### PR DESCRIPTION
## Summary
- Guard against missing materials when a territory initializes
- Log a warning if no material is present instead of creating an invalid dynamic material

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68aa15d2c5f883249954621be41bb4f3