### PR TITLE
Fix duplicate EFaction enum definition

### DIFF
--- a/Source/Skald/SkaldTypes.h
+++ b/Source/Skald/SkaldTypes.h
@@ -28,10 +28,15 @@ enum class ETurnPhase : uint8
 UENUM(BlueprintType)
 enum class EFaction : uint8
 {
-    None   UMETA(DisplayName = "None"),
-    Empire UMETA(DisplayName = "Empire"),
-    Orcs   UMETA(DisplayName = "Orcs"),
-    Undead UMETA(DisplayName = "Undead"),
+    None       UMETA(DisplayName = "None"),
+    Human      UMETA(DisplayName = "Human Faction"),
+    Orc        UMETA(DisplayName = "Orc Faction"),
+    Dwarf      UMETA(DisplayName = "Dwarf Faction"),
+    Elf        UMETA(DisplayName = "Elf Faction"),
+    LizardFolk UMETA(DisplayName = "Lizard Folk Faction"),
+    Undead     UMETA(DisplayName = "Undead Faction"),
+    Gnoll      UMETA(DisplayName = "Gnoll Faction"),
+    Empire     UMETA(DisplayName = "Empire"),
 };
 
 UENUM(BlueprintType)
@@ -51,19 +56,6 @@ enum class EBattleStats : uint8
     Defense      UMETA(DisplayName = "Defense"),
     Speed        UMETA(DisplayName = "Speed"),
     // ...
-};
-
-// Factions available for players to choose at game start
-UENUM(BlueprintType)
-enum class EFaction : uint8
-{
-    Human       UMETA(DisplayName = "Human Faction"),
-    Orc         UMETA(DisplayName = "Orc Faction"),
-    Dwarf       UMETA(DisplayName = "Dwarf Faction"),
-    Elf         UMETA(DisplayName = "Elf Faction"),
-    LizardFolk  UMETA(DisplayName = "Lizard Folk Faction"),
-    Undead      UMETA(DisplayName = "Undead Faction"),
-    Gnoll       UMETA(DisplayName = "Gnoll Faction"),
 };
 
 USTRUCT(BlueprintType)


### PR DESCRIPTION
## Summary
- consolidate EFaction into a single enum
- remove duplicate definition to resolve build error

## Testing
- `g++ -c Source/Skald/Skald_PlayerState.cpp` *(fails: CoreMinimal.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68abd642185083248c7f3dd5a48efbfe