### PR TITLE
Rename EFaction enum to ESkaldFaction

### DIFF
--- a/Source/Skald/GridBattleManager.h
+++ b/Source/Skald/GridBattleManager.h
@@ -46,7 +46,7 @@ struct FFighter
     FFighterStats Stats;
 
     UPROPERTY(BlueprintReadWrite, EditAnywhere, Category="Fighter")
-    EFaction Faction = EFaction::None;
+    ESkaldFaction Faction = ESkaldFaction::None;
 };
 
 /**

--- a/Source/Skald/PlayerSetupWidget.cpp
+++ b/Source/Skald/PlayerSetupWidget.cpp
@@ -8,12 +8,12 @@ void UPlayerSetupWidget::NativeConstruct()
     Super::NativeConstruct();
     // UI is expected to be created in Blueprint or elsewhere.
     // Defaults
-    SelectedFaction = EFaction::None;
+    SelectedFaction = ESkaldFaction::None;
     DisplayName = TEXT("Player");
     bMultiplayer = false;
 }
 
-void UPlayerSetupWidget::OnFactionSelected(EFaction NewFaction)
+void UPlayerSetupWidget::OnFactionSelected(ESkaldFaction NewFaction)
 {
     SelectedFaction = NewFaction;
 }

--- a/Source/Skald/PlayerSetupWidget.h
+++ b/Source/Skald/PlayerSetupWidget.h
@@ -23,7 +23,7 @@ public:
 
     /** Set the faction chosen from the UI. */
     UFUNCTION(BlueprintCallable)
-    void OnFactionSelected(EFaction NewFaction);
+    void OnFactionSelected(ESkaldFaction NewFaction);
 
     /** Display name entered by the player. */
     UPROPERTY(BlueprintReadWrite, EditAnywhere, Category="Setup")
@@ -31,10 +31,9 @@ public:
 
     /** Currently selected faction. */
     UPROPERTY(BlueprintReadWrite, EditAnywhere, Category="Setup")
-    EFaction SelectedFaction;
+    ESkaldFaction SelectedFaction;
 
     /** Whether the game should start in multiplayer. */
     UPROPERTY(BlueprintReadWrite, EditAnywhere, Category="Setup")
     bool bMultiplayer;
 };
-

--- a/Source/Skald/SkaldTypes.h
+++ b/Source/Skald/SkaldTypes.h
@@ -26,12 +26,17 @@ enum class ETurnPhase : uint8
 
 /** Factions a player or fighter can belong to. */
 UENUM(BlueprintType)
-enum class EFaction : uint8
+enum class ESkaldFaction : uint8
 {
-    None   UMETA(DisplayName = "None"),
-    Empire UMETA(DisplayName = "Empire"),
-    Orcs   UMETA(DisplayName = "Orcs"),
-    Undead UMETA(DisplayName = "Undead"),
+    None       UMETA(DisplayName = "None"),
+    Human      UMETA(DisplayName = "Human Faction"),
+    Orc        UMETA(DisplayName = "Orc Faction"),
+    Dwarf      UMETA(DisplayName = "Dwarf Faction"),
+    Elf        UMETA(DisplayName = "Elf Faction"),
+    LizardFolk UMETA(DisplayName = "Lizard Folk Faction"),
+    Undead     UMETA(DisplayName = "Undead Faction"),
+    Gnoll      UMETA(DisplayName = "Gnoll Faction"),
+    Empire     UMETA(DisplayName = "Empire"),
 };
 
 UENUM(BlueprintType)
@@ -51,19 +56,6 @@ enum class EBattleStats : uint8
     Defense      UMETA(DisplayName = "Defense"),
     Speed        UMETA(DisplayName = "Speed"),
     // ...
-};
-
-// Factions available for players to choose at game start
-UENUM(BlueprintType)
-enum class EFaction : uint8
-{
-    Human       UMETA(DisplayName = "Human Faction"),
-    Orc         UMETA(DisplayName = "Orc Faction"),
-    Dwarf       UMETA(DisplayName = "Dwarf Faction"),
-    Elf         UMETA(DisplayName = "Elf Faction"),
-    LizardFolk  UMETA(DisplayName = "Lizard Folk Faction"),
-    Undead      UMETA(DisplayName = "Undead Faction"),
-    Gnoll       UMETA(DisplayName = "Gnoll Faction"),
 };
 
 USTRUCT(BlueprintType)
@@ -153,7 +145,7 @@ struct SKALD_API FS_PlayerData
     int32 Resources = 0;
 
     UPROPERTY(BlueprintReadWrite, EditAnywhere)
-    EFaction Faction = EFaction::Human;
+    ESkaldFaction Faction = ESkaldFaction::Human;
 
     UPROPERTY(BlueprintReadWrite, EditAnywhere)
     TArray<int32> CapitalTerritoryIDs;
@@ -255,7 +247,7 @@ struct SKALD_API FPlayerSaveStruct
     bool IsAI = false;
 
     UPROPERTY(BlueprintReadWrite, EditAnywhere)
-    EFaction Faction = EFaction::Human;
+    ESkaldFaction Faction = ESkaldFaction::Human;
 
     UPROPERTY(BlueprintReadWrite, EditAnywhere)
     TArray<int32> CapitalTerritoryIDs;

--- a/Source/Skald/Skald_PlayerState.cpp
+++ b/Source/Skald/Skald_PlayerState.cpp
@@ -5,7 +5,7 @@ ASkaldPlayerState::ASkaldPlayerState()
     , ArmyPool(0)
     , InitiativeRoll(0)
     , DisplayName(TEXT("Player"))
-    , Faction(EFaction::None)
+    , Faction(ESkaldFaction::None)
 {
 }
 

--- a/Source/Skald/Skald_PlayerState.h
+++ b/Source/Skald/Skald_PlayerState.h
@@ -33,6 +33,6 @@ public:
 
     /** Selected faction for this player. */
     UPROPERTY(BlueprintReadWrite, Category="PlayerState")
-    EFaction Faction;
+    ESkaldFaction Faction;
 };
 


### PR DESCRIPTION
## Summary
- rename EFaction to ESkaldFaction to avoid Unreal naming conflict
- update player state, save data, widgets, and battle manager to use the new faction enum

## Testing
- `g++ -c Source/Skald/PlayerSetupWidget.cpp` *(fails: CoreMinimal.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68abd642185083248c7f3dd5a48efbfe