### PR TITLE
Hook up blueprint HUD, controller, and pawn

### DIFF
--- a/Source/Skald/Skald_GameMode.h
+++ b/Source/Skald/Skald_GameMode.h
@@ -3,6 +3,7 @@
 #include "CoreMinimal.h"
 #include "GameFramework/GameModeBase.h"
 #include "SkaldTypes.h"
+#include "TimerManager.h"
 #include "Skald_GameMode.generated.h"
 
 class ATurnManager;
@@ -46,5 +47,12 @@ protected:
     /** Allow players to position initial armies based on initiative. */
     UFUNCTION(BlueprintCallable, Category="GameMode")
     void BeginArmyPlacementPhase();
+
+private:
+    /** Timer that triggers auto-start of the turn sequence. */
+    FTimerHandle StartGameTimerHandle;
+
+    /** Tracks whether turns have already begun to avoid duplicates. */
+    bool bTurnsStarted;
 };
 

--- a/Source/Skald/Skald_PlayerController.h
+++ b/Source/Skald/Skald_PlayerController.h
@@ -5,7 +5,7 @@
 #include "Skald_PlayerController.generated.h"
 
 class ATurnManager;
-class UUserWidget;
+class USkaldMainHUDWidget;
 
 /**
  * Player controller capable of participating in turn based gameplay.
@@ -43,11 +43,27 @@ protected:
 
     /** Widget class to instantiate for the player's HUD. */
     UPROPERTY(EditDefaultsOnly, Category="UI")
-    TSubclassOf<UUserWidget> HUDWidgetClass;
+    TSubclassOf<USkaldMainHUDWidget> HUDWidgetClass;
 
     /** Reference to the HUD widget instance. */
     UPROPERTY(BlueprintReadOnly, Category="UI", meta=(AllowPrivateAccess="true"))
-    TObjectPtr<UUserWidget> HUDRef;
+    TObjectPtr<USkaldMainHUDWidget> HUDRef;
+
+    /** Handle HUD attack submissions. */
+    UFUNCTION()
+    void HandleAttackRequested(int32 FromID, int32 ToID, int32 ArmySent);
+
+    /** Handle HUD move submissions. */
+    UFUNCTION()
+    void HandleMoveRequested(int32 FromID, int32 ToID, int32 Troops);
+
+    /** Handle HUD end-attack confirmations. */
+    UFUNCTION()
+    void HandleEndAttackRequested(bool bConfirmed);
+
+    /** Handle HUD end-movement confirmations. */
+    UFUNCTION()
+    void HandleEndMovementRequested(bool bConfirmed);
 
     /** Reference to the game's turn manager.
      *  Exposed to Blueprints so BP_Skald_PlayerController can bind to


### PR DESCRIPTION
## Summary
- Load `Skald_PController` and `Skald_PC` blueprint subclasses in game mode
- Auto-create `Skald_MainHudBP` widget from the player controller
- Track game start timer per instance and warn if blueprints are missing
- Bind HUD widget button delegates to player controller handlers

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68abf3f3678083248ad528c7d2ebb4b4