### PR TITLE
Hook up blueprint HUD, controller, and pawn

### DIFF
--- a/Source/Skald/Skald_GameMode.h
+++ b/Source/Skald/Skald_GameMode.h
@@ -3,6 +3,8 @@
 #include "CoreMinimal.h"
 #include "GameFramework/GameModeBase.h"
 #include "SkaldTypes.h"
+#include "TimerManager.h"
+#include "UObject/SoftObjectPtr.h"
 #include "Skald_GameMode.generated.h"
 
 class ATurnManager;
@@ -10,6 +12,8 @@ class ASkaldGameState;
 class ASkaldPlayerController;
 class ASkaldPlayerState;
 class AWorldMap;
+class APlayerController;
+class APawn;
 
 /**
  * GameMode responsible for managing player login and spawning the turn manager.
@@ -22,6 +26,7 @@ class SKALD_API ASkaldGameMode : public AGameModeBase
 public:
     ASkaldGameMode();
 
+    virtual void InitGame(const FString& MapName, const FString& Options, FString& ErrorMessage) override;
     virtual void BeginPlay() override;
     virtual void PostLogin(APlayerController* NewPlayer) override;
 
@@ -46,5 +51,20 @@ protected:
     /** Allow players to position initial armies based on initiative. */
     UFUNCTION(BlueprintCallable, Category="GameMode")
     void BeginArmyPlacementPhase();
+
+private:
+    /** Timer that triggers auto-start of the turn sequence. */
+    FTimerHandle StartGameTimerHandle;
+
+    /** Tracks whether turns have already begun to avoid duplicates. */
+    bool bTurnsStarted;
+
+    /** Soft reference to the player controller blueprint to allow delayed loading. */
+    UPROPERTY(EditDefaultsOnly, Category="GameMode")
+    TSoftClassPtr<APlayerController> PlayerControllerBPClass;
+
+    /** Soft reference to the player pawn blueprint. */
+    UPROPERTY(EditDefaultsOnly, Category="GameMode")
+    TSoftClassPtr<APawn> PawnBPClass;
 };
 

--- a/Source/Skald/Skald_PlayerController.cpp
+++ b/Source/Skald/Skald_PlayerController.cpp
@@ -1,13 +1,15 @@
 #include "Skald_PlayerController.h"
 #include "Skald_TurnManager.h"
 #include "Skald_PlayerState.h"
-#include "Blueprint/UserWidget.h"
+#include "UI/SkaldMainHUDWidget.h"
+#include "UObject/SoftObjectPtr.h"
+#include "UObject/SoftObjectPath.h"
 
 ASkaldPlayerController::ASkaldPlayerController()
 {
     bIsAI = false;
     TurnManager = nullptr;
-    HUDRef = nullptr;
+    MainHudWidget = nullptr;
 
     bShowMouseCursor = true;
     bEnableClickEvents = true;
@@ -18,14 +20,30 @@ void ASkaldPlayerController::BeginPlay()
 {
     Super::BeginPlay();
 
-    // Create and show the HUD widget if a class has been assigned.
-    if (HUDWidgetClass)
+    // Load a default HUD class if one hasn't been specified in the blueprint.
+    if (!MainHudWidgetClass)
     {
-        HUDRef = CreateWidget<UUserWidget>(this, HUDWidgetClass);
-        if (HUDRef)
+        TSoftClassPtr<USkaldMainHUDWidget> HudClassRef(FSoftObjectPath(TEXT("/Game/C++_BPs/Skald_MainHudBP.Skald_MainHudBP_C")));
+        MainHudWidgetClass = HudClassRef.LoadSynchronous();
+    }
+
+    // Create and show the HUD widget if a class has been assigned.
+    if (MainHudWidgetClass)
+    {
+        MainHudWidget = CreateWidget<USkaldMainHUDWidget>(this, MainHudWidgetClass);
+        if (MainHudWidget)
         {
-            HUDRef->AddToViewport();
+            MainHudWidget->AddToViewport();
+
+            MainHudWidget->OnAttackRequested.AddDynamic(this, &ASkaldPlayerController::HandleAttackRequested);
+            MainHudWidget->OnMoveRequested.AddDynamic(this, &ASkaldPlayerController::HandleMoveRequested);
+            MainHudWidget->OnEndAttackRequested.AddDynamic(this, &ASkaldPlayerController::HandleEndAttackRequested);
+            MainHudWidget->OnEndMovementRequested.AddDynamic(this, &ASkaldPlayerController::HandleEndMovementRequested);
         }
+    }
+    else
+    {
+        UE_LOG(LogTemp, Warning, TEXT("MainHudWidgetClass is null; HUD will not be displayed."));
     }
 
     if (ASkaldPlayerState* PS = GetPlayerState<ASkaldPlayerState>())
@@ -71,5 +89,25 @@ void ASkaldPlayerController::MakeAIDecision()
 bool ASkaldPlayerController::IsAIController() const
 {
     return bIsAI;
+}
+
+void ASkaldPlayerController::HandleAttackRequested(int32 FromID, int32 ToID, int32 ArmySent)
+{
+    UE_LOG(LogTemp, Log, TEXT("HUD attack from %d to %d with %d"), FromID, ToID, ArmySent);
+}
+
+void ASkaldPlayerController::HandleMoveRequested(int32 FromID, int32 ToID, int32 Troops)
+{
+    UE_LOG(LogTemp, Log, TEXT("HUD move from %d to %d with %d"), FromID, ToID, Troops);
+}
+
+void ASkaldPlayerController::HandleEndAttackRequested(bool bConfirmed)
+{
+    UE_LOG(LogTemp, Log, TEXT("HUD end attack %s"), bConfirmed ? TEXT("confirmed") : TEXT("cancelled"));
+}
+
+void ASkaldPlayerController::HandleEndMovementRequested(bool bConfirmed)
+{
+    UE_LOG(LogTemp, Log, TEXT("HUD end move %s"), bConfirmed ? TEXT("confirmed") : TEXT("cancelled"));
 }
 

--- a/Source/Skald/Skald_PlayerController.h
+++ b/Source/Skald/Skald_PlayerController.h
@@ -5,7 +5,7 @@
 #include "Skald_PlayerController.generated.h"
 
 class ATurnManager;
-class UUserWidget;
+class USkaldMainHUDWidget;
 
 /**
  * Player controller capable of participating in turn based gameplay.
@@ -41,13 +41,31 @@ protected:
     UPROPERTY(BlueprintReadOnly, Category="Turn")
     bool bIsAI;
 
-    /** Widget class to instantiate for the player's HUD. */
+    /** Widget class to instantiate for the player's HUD.
+     *  Expected to be assigned in the Blueprint subclass to avoid
+     *  hard loading during CDO construction. */
     UPROPERTY(EditDefaultsOnly, Category="UI")
-    TSubclassOf<UUserWidget> HUDWidgetClass;
+    TSubclassOf<USkaldMainHUDWidget> MainHudWidgetClass;
 
     /** Reference to the HUD widget instance. */
-    UPROPERTY(BlueprintReadOnly, Category="UI", meta=(AllowPrivateAccess="true"))
-    TObjectPtr<UUserWidget> HUDRef;
+    UPROPERTY()
+    USkaldMainHUDWidget* MainHudWidget;
+
+    /** Handle HUD attack submissions. */
+    UFUNCTION()
+    void HandleAttackRequested(int32 FromID, int32 ToID, int32 ArmySent);
+
+    /** Handle HUD move submissions. */
+    UFUNCTION()
+    void HandleMoveRequested(int32 FromID, int32 ToID, int32 Troops);
+
+    /** Handle HUD end-attack confirmations. */
+    UFUNCTION()
+    void HandleEndAttackRequested(bool bConfirmed);
+
+    /** Handle HUD end-movement confirmations. */
+    UFUNCTION()
+    void HandleEndMovementRequested(bool bConfirmed);
 
     /** Reference to the game's turn manager.
      *  Exposed to Blueprints so BP_Skald_PlayerController can bind to


### PR DESCRIPTION
## Summary
- Load controller and pawn blueprints via soft references in game mode to avoid blocking editor startup
- Auto-load default HUD widget in player controller when blueprint hasn't specified one

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68abf3f3678083248ad528c7d2ebb4b4