### PR TITLE
Avoid direct blueprint subclass references in C++

### DIFF
--- a/Source/Skald/Skald_GameMode.cpp
+++ b/Source/Skald/Skald_GameMode.cpp
@@ -1,231 +1,150 @@
 #include "Skald_GameMode.h"
+#include "Engine/World.h"
 #include "Skald_GameState.h"
+#include "Skald_PlayerCharacter.h"
 #include "Skald_PlayerController.h"
 #include "Skald_PlayerState.h"
 #include "Skald_TurnManager.h"
-#include "WorldMap.h"
 #include "Territory.h"
-#include "Engine/World.h"
 #include "TimerManager.h"
-#include "UObject/SoftObjectPath.h"
-#include "UObject/ConstructorHelpers.h"
+#include "WorldMap.h"
 
-namespace
-{
-    constexpr int32 ExpectedPlayerCount = 2;
-    constexpr float StartGameTimeout = 10.f;
-    // Instance variables moved into ASkaldGameMode to avoid cross-instance
-    // interference; see header for declarations.
+namespace {
+constexpr int32 ExpectedPlayerCount = 2;
+constexpr float StartGameTimeout = 10.f;
+// Instance variables moved into ASkaldGameMode to avoid cross-instance
+// interference; see header for declarations.
+} // namespace
+
+ASkaldGameMode::ASkaldGameMode() {
+  GameStateClass = ASkaldGameState::StaticClass();
+  PlayerStateClass = ASkaldPlayerState::StaticClass();
+  PlayerControllerClass = ASkaldPlayerController::StaticClass();
+  DefaultPawnClass = ASkald_PlayerCharacter::StaticClass();
+
+  TurnManager = nullptr;
+  WorldMap = nullptr;
+  bTurnsStarted = false;
+
+  // Preallocate two slots so blueprint scripts can safely write
+  // player data to indices without hitting "invalid index" warnings.
+  PlayersData.SetNum(2);
 }
 
-ASkaldGameMode::ASkaldGameMode()
-{
-    GameStateClass = ASkaldGameState::StaticClass();
-    PlayerStateClass = ASkaldPlayerState::StaticClass();
+void ASkaldGameMode::BeginPlay() {
+  Super::BeginPlay();
 
-    // Record soft references to blueprint subclasses for deferred loading.
-    PlayerControllerBPClass = TSoftClassPtr<APlayerController>(FSoftObjectPath(TEXT("/Game/C++_BPs/Skald_PController.Skald_PController_C")));
-    PawnBPClass = TSoftClassPtr<APawn>(FSoftObjectPath(TEXT("/Game/C++_BPs/Skald_PC.Skald_PC_C")));
-    // Use blueprint subclasses for the controller and pawn if they exist.
-    static ConstructorHelpers::FClassFinder<APlayerController> BPController(
-        TEXT("/Game/C++_BPs/Skald_PController"));
-    if (BPController.Succeeded())
-    {
-        PlayerControllerClass = BPController.Class;
-    }
-    else
-    {
-        UE_LOG(LogTemp, Warning, TEXT("Skald_PController blueprint not found. Falling back to C++ class."));
-        PlayerControllerClass = ASkaldPlayerController::StaticClass();
-    }
+  if (!TurnManager) {
+    TurnManager = GetWorld()->SpawnActor<ATurnManager>();
+  }
 
-    static ConstructorHelpers::FClassFinder<APawn> BPPawn(
-        TEXT("/Game/C++_BPs/Skald_PC"));
-    if (BPPawn.Succeeded())
-    {
-        DefaultPawnClass = BPPawn.Class;
-    }
-    else
-    {
-        UE_LOG(LogTemp, Warning, TEXT("Skald_PC blueprint not found. Using default pawn."));
-    }
+  if (!WorldMap) {
+    WorldMap = GetWorld()->SpawnActor<AWorldMap>();
+  }
 
-    TurnManager = nullptr;
-    WorldMap = nullptr;
-    bTurnsStarted = false;
+  InitializeWorld();
+  BeginArmyPlacementPhase();
 
-    // Preallocate two slots so blueprint scripts can safely write
-    // player data to indices without hitting "invalid index" warnings.
-    PlayersData.SetNum(2);
-}
-
-void ASkaldGameMode::InitGame(const FString& MapName, const FString& Options, FString& ErrorMessage)
-{
-    Super::InitGame(MapName, Options, ErrorMessage);
-
-    if (UClass* PCClass = PlayerControllerBPClass.LoadSynchronous())
-    {
-        PlayerControllerClass = PCClass;
-    }
-    else
-    {
-        UE_LOG(LogTemp, Warning, TEXT("Skald_PController blueprint not found. Falling back to C++ class."));
-        PlayerControllerClass = ASkaldPlayerController::StaticClass();
-    }
-
-    if (UClass* PawnClass = PawnBPClass.LoadSynchronous())
-    {
-        DefaultPawnClass = PawnClass;
-    }
-    else
-    {
-        UE_LOG(LogTemp, Warning, TEXT("Skald_PC blueprint not found. Using default pawn."));
-    }
-}
-
-void ASkaldGameMode::BeginPlay()
-{
-    Super::BeginPlay();
-
-    if (!TurnManager)
-    {
-        TurnManager = GetWorld()->SpawnActor<ATurnManager>();
-    }
-
-    if (!WorldMap)
-    {
-        WorldMap = GetWorld()->SpawnActor<AWorldMap>();
-    }
-
-    InitializeWorld();
-    BeginArmyPlacementPhase();
-
-    GetWorldTimerManager().SetTimer(
-        StartGameTimerHandle,
-        FTimerDelegate::CreateLambda([this]()
-        {
-            if (!bTurnsStarted && TurnManager)
-            {
-                bTurnsStarted = true;
-                TurnManager->SortControllersByInitiative();
-                TurnManager->StartTurns();
-            }
-        }),
-        StartGameTimeout,
-        false);
-}
-
-void ASkaldGameMode::PostLogin(APlayerController* NewPlayer)
-{
-    Super::PostLogin(NewPlayer);
-
-    ASkaldPlayerController* PC = Cast<ASkaldPlayerController>(NewPlayer);
-    if (PC)
-    {
-        if (TurnManager)
-        {
-            TurnManager->RegisterController(PC);
+  GetWorldTimerManager().SetTimer(
+      StartGameTimerHandle, FTimerDelegate::CreateLambda([this]() {
+        if (!bTurnsStarted && TurnManager) {
+          bTurnsStarted = true;
+          TurnManager->SortControllersByInitiative();
+          TurnManager->StartTurns();
         }
-
-        if (ASkaldGameState* GS = GetGameState<ASkaldGameState>())
-        {
-            if (ASkaldPlayerState* PS = PC->GetPlayerState<ASkaldPlayerState>())
-            {
-                GS->AddPlayerState(PS);
-
-                // Ensure PlayersData can hold at least as many entries as there
-                // are connected players. Never shrink to avoid index issues in
-                // existing blueprint logic.
-                if (PlayersData.Num() < GS->PlayerArray.Num())
-                {
-                    PlayersData.SetNum(GS->PlayerArray.Num());
-                }
-            }
-
-            if (GS->PlayerArray.Num() >= ExpectedPlayerCount && !bTurnsStarted)
-            {
-                bTurnsStarted = true;
-                GetWorldTimerManager().ClearTimer(StartGameTimerHandle);
-                if (TurnManager)
-                {
-                    TurnManager->SortControllersByInitiative();
-                    TurnManager->StartTurns();
-                }
-            }
-        }
-    }
+      }),
+      StartGameTimeout, false);
 }
 
-void ASkaldGameMode::BeginArmyPlacementPhase()
-{
-    if (TurnManager)
-    {
-        // Initiative order determines who places armies first. The actual
-        // placement UI is expected to be handled in blueprints.
-        TurnManager->SortControllersByInitiative();
+void ASkaldGameMode::PostLogin(APlayerController *NewPlayer) {
+  Super::PostLogin(NewPlayer);
+
+  ASkaldPlayerController *PC = Cast<ASkaldPlayerController>(NewPlayer);
+  if (PC) {
+    if (TurnManager) {
+      TurnManager->RegisterController(PC);
     }
+
+    if (ASkaldGameState *GS = GetGameState<ASkaldGameState>()) {
+      if (ASkaldPlayerState *PS = PC->GetPlayerState<ASkaldPlayerState>()) {
+        GS->AddPlayerState(PS);
+
+        // Ensure PlayersData can hold at least as many entries as there
+        // are connected players. Never shrink to avoid index issues in
+        // existing blueprint logic.
+        if (PlayersData.Num() < GS->PlayerArray.Num()) {
+          PlayersData.SetNum(GS->PlayerArray.Num());
+        }
+      }
+
+      if (GS->PlayerArray.Num() >= ExpectedPlayerCount && !bTurnsStarted) {
+        bTurnsStarted = true;
+        GetWorldTimerManager().ClearTimer(StartGameTimerHandle);
+        if (TurnManager) {
+          TurnManager->SortControllersByInitiative();
+          TurnManager->StartTurns();
+        }
+      }
+    }
+  }
 }
 
-void ASkaldGameMode::InitializeWorld()
-{
-    if (!WorldMap)
-    {
-        return;
-    }
-
-    // Spawn 43 territories with unique identifiers
-    for (int32 Id = 0; Id < 43; ++Id)
-    {
-        ATerritory* Territory = GetWorld()->SpawnActor<ATerritory>();
-        if (Territory)
-        {
-            Territory->TerritoryID = Id;
-            WorldMap->RegisterTerritory(Territory);
-        }
-    }
-
-    ASkaldGameState* GS = GetGameState<ASkaldGameState>();
-    if (!GS)
-    {
-        return;
-    }
-
-    // Assign territories round-robin to players
-    const int32 PlayerCount = GS->PlayerArray.Num();
-    int32 Index = 0;
-    for (ATerritory* Territory : WorldMap->Territories)
-    {
-        if (Territory && PlayerCount > 0)
-        {
-            // Rename local variable to avoid hiding AActor::Owner
-            ASkaldPlayerState* TerritoryOwner = Cast<ASkaldPlayerState>(GS->PlayerArray[Index % PlayerCount]);
-            Territory->OwningPlayer = TerritoryOwner;
-            Territory->ArmyStrength = 1;
-            ++Index;
-        }
-    }
-
-    // Calculate starting armies and initiative rolls
-    for (APlayerState* PSBase : GS->PlayerArray)
-    {
-        ASkaldPlayerState* PS = Cast<ASkaldPlayerState>(PSBase);
-        if (!PS)
-        {
-            continue;
-        }
-
-        int32 Owned = 0;
-        for (ATerritory* Territory : WorldMap->Territories)
-        {
-            if (Territory && Territory->OwningPlayer == PS)
-            {
-                ++Owned;
-            }
-        }
-
-        PS->ArmyPool = Owned / 3;
-        PS->InitiativeRoll = FMath::RandRange(1, 6);
-    }
-
+void ASkaldGameMode::BeginArmyPlacementPhase() {
+  if (TurnManager) {
+    // Initiative order determines who places armies first. The actual
+    // placement UI is expected to be handled in blueprints.
+    TurnManager->SortControllersByInitiative();
+  }
 }
 
+void ASkaldGameMode::InitializeWorld() {
+  if (!WorldMap) {
+    return;
+  }
+
+  // Spawn 43 territories with unique identifiers
+  for (int32 Id = 0; Id < 43; ++Id) {
+    ATerritory *Territory = GetWorld()->SpawnActor<ATerritory>();
+    if (Territory) {
+      Territory->TerritoryID = Id;
+      WorldMap->RegisterTerritory(Territory);
+    }
+  }
+
+  ASkaldGameState *GS = GetGameState<ASkaldGameState>();
+  if (!GS) {
+    return;
+  }
+
+  // Assign territories round-robin to players
+  const int32 PlayerCount = GS->PlayerArray.Num();
+  int32 Index = 0;
+  for (ATerritory *Territory : WorldMap->Territories) {
+    if (Territory && PlayerCount > 0) {
+      // Rename local variable to avoid hiding AActor::Owner
+      ASkaldPlayerState *TerritoryOwner =
+          Cast<ASkaldPlayerState>(GS->PlayerArray[Index % PlayerCount]);
+      Territory->OwningPlayer = TerritoryOwner;
+      Territory->ArmyStrength = 1;
+      ++Index;
+    }
+  }
+
+  // Calculate starting armies and initiative rolls
+  for (APlayerState *PSBase : GS->PlayerArray) {
+    ASkaldPlayerState *PS = Cast<ASkaldPlayerState>(PSBase);
+    if (!PS) {
+      continue;
+    }
+
+    int32 Owned = 0;
+    for (ATerritory *Territory : WorldMap->Territories) {
+      if (Territory && Territory->OwningPlayer == PS) {
+        ++Owned;
+      }
+    }
+
+    PS->ArmyPool = Owned / 3;
+    PS->InitiativeRoll = FMath::RandRange(1, 6);
+  }
+}

--- a/Source/Skald/Skald_GameMode.h
+++ b/Source/Skald/Skald_GameMode.h
@@ -3,9 +3,8 @@
 #include "CoreMinimal.h"
 #include "GameFramework/GameModeBase.h"
 #include "SkaldTypes.h"
-#include "TimerManager.h"
-#include "UObject/SoftObjectPtr.h"
 #include "Skald_GameMode.generated.h"
+#include "TimerManager.h"
 
 class ATurnManager;
 class ASkaldGameState;
@@ -13,58 +12,46 @@ class ASkaldPlayerController;
 class ASkaldPlayerState;
 class AWorldMap;
 class APlayerController;
-class APawn;
 
 /**
  * GameMode responsible for managing player login and spawning the turn manager.
  */
 UCLASS(Blueprintable, BlueprintType)
-class SKALD_API ASkaldGameMode : public AGameModeBase
-{
-    GENERATED_BODY()
+class SKALD_API ASkaldGameMode : public AGameModeBase {
+  GENERATED_BODY()
 
 public:
-    ASkaldGameMode();
+  ASkaldGameMode();
 
-    virtual void InitGame(const FString& MapName, const FString& Options, FString& ErrorMessage) override;
-    virtual void BeginPlay() override;
-    virtual void PostLogin(APlayerController* NewPlayer) override;
+  virtual void BeginPlay() override;
+  virtual void PostLogin(APlayerController *NewPlayer) override;
 
 protected:
-    /** Handles turn sequencing for the match. */
-    UPROPERTY(BlueprintReadOnly, Category="GameMode")
-    ATurnManager* TurnManager;
+  /** Handles turn sequencing for the match. */
+  UPROPERTY(BlueprintReadOnly, Category = "GameMode")
+  ATurnManager *TurnManager;
 
-    /** Holds all territory actors for the current map. */
-    UPROPERTY(BlueprintReadOnly, Category="GameMode")
-    AWorldMap* WorldMap;
+  /** Holds all territory actors for the current map. */
+  UPROPERTY(BlueprintReadOnly, Category = "GameMode")
+  AWorldMap *WorldMap;
 
-    /** Data describing each player in the match. Pre-sized so blueprints can
-     * safely write to indices without hitting invalid array warnings. */
-    UPROPERTY(BlueprintReadOnly, Category="Players")
-    TArray<FS_PlayerData> PlayersData;
+  /** Data describing each player in the match. Pre-sized so blueprints can
+   * safely write to indices without hitting invalid array warnings. */
+  UPROPERTY(BlueprintReadOnly, Category = "Players")
+  TArray<FS_PlayerData> PlayersData;
 
-    /** Setup initial territories, armies, and initiative. */
-    UFUNCTION(BlueprintCallable, Category="GameMode")
-    void InitializeWorld();
+  /** Setup initial territories, armies, and initiative. */
+  UFUNCTION(BlueprintCallable, Category = "GameMode")
+  void InitializeWorld();
 
-    /** Allow players to position initial armies based on initiative. */
-    UFUNCTION(BlueprintCallable, Category="GameMode")
-    void BeginArmyPlacementPhase();
+  /** Allow players to position initial armies based on initiative. */
+  UFUNCTION(BlueprintCallable, Category = "GameMode")
+  void BeginArmyPlacementPhase();
 
 private:
-    /** Timer that triggers auto-start of the turn sequence. */
-    FTimerHandle StartGameTimerHandle;
+  /** Timer that triggers auto-start of the turn sequence. */
+  FTimerHandle StartGameTimerHandle;
 
-    /** Tracks whether turns have already begun to avoid duplicates. */
-    bool bTurnsStarted;
-
-    /** Soft reference to the player controller blueprint to allow delayed loading. */
-    UPROPERTY(EditDefaultsOnly, Category="GameMode")
-    TSoftClassPtr<APlayerController> PlayerControllerBPClass;
-
-    /** Soft reference to the player pawn blueprint. */
-    UPROPERTY(EditDefaultsOnly, Category="GameMode")
-    TSoftClassPtr<APawn> PawnBPClass;
+  /** Tracks whether turns have already begun to avoid duplicates. */
+  bool bTurnsStarted;
 };
-

--- a/Source/Skald/Skald_PlayerController.cpp
+++ b/Source/Skald/Skald_PlayerController.cpp
@@ -1,124 +1,96 @@
 #include "Skald_PlayerController.h"
-#include "Skald_TurnManager.h"
-#include "Skald_PlayerState.h"
-#include "UI/SkaldMainHUDWidget.h"
-#include "UObject/SoftObjectPtr.h"
-#include "UObject/SoftObjectPath.h"
 #include "Blueprint/UserWidget.h"
+#include "Skald_PlayerState.h"
+#include "Skald_TurnManager.h"
 #include "UI/SkaldMainHUDWidget.h"
 
-ASkaldPlayerController::ASkaldPlayerController()
-{
-    bIsAI = false;
-    TurnManager = nullptr;
-    HUDRef = nullptr;
-    MainHudWidget = nullptr;
+ASkaldPlayerController::ASkaldPlayerController() {
+  bIsAI = false;
+  TurnManager = nullptr;
+  HUDRef = nullptr;
+  MainHudWidget = nullptr;
 
-    bShowMouseCursor = true;
-    bEnableClickEvents = true;
-    bEnableMouseOverEvents = true;
+  bShowMouseCursor = true;
+  bEnableClickEvents = true;
+  bEnableMouseOverEvents = true;
 }
 
-void ASkaldPlayerController::BeginPlay()
-{
-    Super::BeginPlay();
+void ASkaldPlayerController::BeginPlay() {
+  Super::BeginPlay();
 
-    // Load a default HUD class if one hasn't been specified in the blueprint.
-    if (!MainHudWidgetClass)
-    {
-        TSoftClassPtr<USkaldMainHUDWidget> HudClassRef(FSoftObjectPath(TEXT("/Game/C++_BPs/Skald_MainHudBP.Skald_MainHudBP_C")));
-        MainHudWidgetClass = HudClassRef.LoadSynchronous();
+  // Create and show the HUD widget if a class has been assigned (expected via
+  // blueprint).
+  if (MainHudWidgetClass) {
+    MainHudWidget = CreateWidget<USkaldMainHUDWidget>(this, MainHudWidgetClass);
+    if (MainHudWidget) {
+      HUDRef = MainHudWidget;
+      MainHudWidget->AddToViewport();
+
+      MainHudWidget->OnAttackRequested.AddDynamic(
+          this, &ASkaldPlayerController::HandleAttackRequested);
+      MainHudWidget->OnMoveRequested.AddDynamic(
+          this, &ASkaldPlayerController::HandleMoveRequested);
+      MainHudWidget->OnEndAttackRequested.AddDynamic(
+          this, &ASkaldPlayerController::HandleEndAttackRequested);
+      MainHudWidget->OnEndMovementRequested.AddDynamic(
+          this, &ASkaldPlayerController::HandleEndMovementRequested);
     }
+  } else {
+    UE_LOG(LogTemp, Warning,
+           TEXT("MainHudWidgetClass is null; HUD will not be displayed."));
+  }
 
-    // Create and show the HUD widget if a class has been assigned.
-    if (MainHudWidgetClass)
-    {
-        MainHudWidget = CreateWidget<USkaldMainHUDWidget>(this, MainHudWidgetClass);
-        if (MainHudWidget)
-        {
-    if (HUDWidgetClass)
-    if (MainHudWidgetClass)
-    {
-        HUDRef = CreateWidget<UUserWidget>(this, HUDWidgetClass);
-        if (HUDRef)
-        MainHudWidget = CreateWidget<USkaldMainHUDWidget>(this, MainHudWidgetClass);
-        if (MainHudWidget)
-        {
-            HUDRef->AddToViewport();
-            MainHudWidget->AddToViewport();
-
-            MainHudWidget->OnAttackRequested.AddDynamic(this, &ASkaldPlayerController::HandleAttackRequested);
-            MainHudWidget->OnMoveRequested.AddDynamic(this, &ASkaldPlayerController::HandleMoveRequested);
-            MainHudWidget->OnEndAttackRequested.AddDynamic(this, &ASkaldPlayerController::HandleEndAttackRequested);
-            MainHudWidget->OnEndMovementRequested.AddDynamic(this, &ASkaldPlayerController::HandleEndMovementRequested);
-        }
-    }
-    else
-    {
-        UE_LOG(LogTemp, Warning, TEXT("MainHudWidgetClass is null; HUD will not be displayed."));
-    }
-
-    if (ASkaldPlayerState* PS = GetPlayerState<ASkaldPlayerState>())
-    {
-        bIsAI = PS->bIsAI;
-    }
+  if (ASkaldPlayerState *PS = GetPlayerState<ASkaldPlayerState>()) {
+    bIsAI = PS->bIsAI;
+  }
 }
 
-void ASkaldPlayerController::SetTurnManager(ATurnManager* Manager)
-{
-    TurnManager = Manager;
+void ASkaldPlayerController::SetTurnManager(ATurnManager *Manager) {
+  TurnManager = Manager;
 }
 
-void ASkaldPlayerController::StartTurn()
-{
-    if (bIsAI)
-    {
-        MakeAIDecision();
-        EndTurn();
-    }
-    else
-    {
-        FInputModeGameAndUI InputMode;
-        SetInputMode(InputMode);
-    }
+void ASkaldPlayerController::StartTurn() {
+  if (bIsAI) {
+    MakeAIDecision();
+    EndTurn();
+  } else {
+    FInputModeGameAndUI InputMode;
+    SetInputMode(InputMode);
+  }
 }
 
-void ASkaldPlayerController::EndTurn()
-{
-    SetInputMode(FInputModeGameOnly());
+void ASkaldPlayerController::EndTurn() {
+  SetInputMode(FInputModeGameOnly());
 
-    if (TurnManager)
-    {
-        TurnManager->AdvanceTurn();
-    }
+  if (TurnManager) {
+    TurnManager->AdvanceTurn();
+  }
 }
 
-void ASkaldPlayerController::MakeAIDecision()
-{
-    UE_LOG(LogTemp, Log, TEXT("AI %s making decision"), *GetName());
+void ASkaldPlayerController::MakeAIDecision() {
+  UE_LOG(LogTemp, Log, TEXT("AI %s making decision"), *GetName());
 }
 
-bool ASkaldPlayerController::IsAIController() const
-{
-    return bIsAI;
+bool ASkaldPlayerController::IsAIController() const { return bIsAI; }
+
+void ASkaldPlayerController::HandleAttackRequested(int32 FromID, int32 ToID,
+                                                   int32 ArmySent) {
+  UE_LOG(LogTemp, Log, TEXT("HUD attack from %d to %d with %d"), FromID, ToID,
+         ArmySent);
 }
 
-void ASkaldPlayerController::HandleAttackRequested(int32 FromID, int32 ToID, int32 ArmySent)
-{
-    UE_LOG(LogTemp, Log, TEXT("HUD attack from %d to %d with %d"), FromID, ToID, ArmySent);
+void ASkaldPlayerController::HandleMoveRequested(int32 FromID, int32 ToID,
+                                                 int32 Troops) {
+  UE_LOG(LogTemp, Log, TEXT("HUD move from %d to %d with %d"), FromID, ToID,
+         Troops);
 }
 
-void ASkaldPlayerController::HandleMoveRequested(int32 FromID, int32 ToID, int32 Troops)
-{
-    UE_LOG(LogTemp, Log, TEXT("HUD move from %d to %d with %d"), FromID, ToID, Troops);
+void ASkaldPlayerController::HandleEndAttackRequested(bool bConfirmed) {
+  UE_LOG(LogTemp, Log, TEXT("HUD end attack %s"),
+         bConfirmed ? TEXT("confirmed") : TEXT("cancelled"));
 }
 
-void ASkaldPlayerController::HandleEndAttackRequested(bool bConfirmed)
-{
-    UE_LOG(LogTemp, Log, TEXT("HUD end attack %s"), bConfirmed ? TEXT("confirmed") : TEXT("cancelled"));
-}
-
-void ASkaldPlayerController::HandleEndMovementRequested(bool bConfirmed)
-{
-    UE_LOG(LogTemp, Log, TEXT("HUD end move %s"), bConfirmed ? TEXT("confirmed") : TEXT("cancelled"));
+void ASkaldPlayerController::HandleEndMovementRequested(bool bConfirmed) {
+  UE_LOG(LogTemp, Log, TEXT("HUD end move %s"),
+         bConfirmed ? TEXT("confirmed") : TEXT("cancelled"));
 }

--- a/Source/Skald/Skald_PlayerController.h
+++ b/Source/Skald/Skald_PlayerController.h
@@ -42,7 +42,6 @@ protected:
     UPROPERTY(BlueprintReadOnly, Category="Turn")
     bool bIsAI;
 
-    /** Widget class to instantiate for the player's HUD. */
     /** Widget class to instantiate for the player's HUD.
      *  Expected to be assigned in the Blueprint subclass to avoid
      *  hard loading during CDO construction. */
@@ -50,12 +49,10 @@ protected:
     TSubclassOf<USkaldMainHUDWidget> MainHudWidgetClass;
 
     /** Reference to the HUD widget instance. */
-    TSubclassOf<UUserWidget> HUDWidgetClass;
-    TSubclassOf<USkaldMainHUDWidget> MainHudWidgetClass;
-
-    /** Reference to the HUD widget instance. */
     UPROPERTY(BlueprintReadOnly, Category="UI", meta=(AllowPrivateAccess="true"))
     TObjectPtr<UUserWidget> HUDRef;
+
+    /** Typed reference to the main HUD widget. */
     UPROPERTY()
     USkaldMainHUDWidget* MainHudWidget;
 


### PR DESCRIPTION
## Summary
- Remove hardcoded Blueprint class paths; rely on configurable `MainHudWidgetClass`
- Use native player controller and pawn classes in `ASkaldGameMode`
- Drop soft class properties and Blueprint lookups for controller and pawn

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ac2964018c832486b88523e86baddc