### PR TITLE
fix: ensure generated header is last include

### DIFF
--- a/Source/Skald/Skald_GameMode.h
+++ b/Source/Skald/Skald_GameMode.h
@@ -2,10 +2,8 @@
 
 #include "CoreMinimal.h"
 #include "GameFramework/GameModeBase.h"
-#include "TimerManager.h"
 #include "SkaldTypes.h"
 #include "Skald_GameMode.generated.h"
-#include "TimerManager.h"
 
 struct FTimerHandle;
 class ATurnManager;


### PR DESCRIPTION
## Summary
- remove redundant TimerManager include from Skald_GameMode header
- keep .generated.h as final include to satisfy UE build order requirement

## Testing
- `g++ -fsyntax-only Source/Skald/Skald_GameMode.cpp` *(fails: CoreMinimal.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68acd46764288324b39b0e9262ab12df