### PR TITLE
Clean StartGameWidget declarations

### DIFF
--- a/Source/Skald/StartGameWidget.cpp
+++ b/Source/Skald/StartGameWidget.cpp
@@ -1,17 +1,12 @@
 #include "StartGameWidget.h"
+
 #include "Components/Button.h"
-#include "Components/TextBlock.h"
-#include "Components/VerticalBox.h"
-#include "Components/EditableTextBox.h"
-#include "Components/ComboBoxString.h"
-#include "Blueprint/WidgetTree.h"
 #include "Components/EditableTextBox.h"
 #include "Components/ComboBoxString.h"
 #include "Kismet/GameplayStatics.h"
 #include "Skald_GameInstance.h"
 #include "Skald_PlayerState.h"
 #include "GameFramework/PlayerController.h"
-#include "UObject/UnrealType.h"
 #include "LobbyMenuWidget.h"
 
 void UStartGameWidget::NativeConstruct()
@@ -23,77 +18,6 @@ void UStartGameWidget::NativeConstruct()
         DisplayNameBox->SetText(FText::FromString(TEXT("Player")));
     }
 
-        DisplayNameInput = WidgetTree->ConstructWidget<UEditableTextBox>(UEditableTextBox::StaticClass());
-        DisplayNameInput->SetText(FText::FromString(TEXT("Player")));
-        Root->AddChild(DisplayNameInput);
-
-        FactionCombo = WidgetTree->ConstructWidget<UComboBoxString>(UComboBoxString::StaticClass());
-        if (UEnum* Enum = StaticEnum<ESkaldFaction>())
-        {
-            for (int32 i = 0; i < Enum->NumEnums(); ++i)
-            {
-                if (!Enum->HasMetaData(TEXT("Hidden"), i))
-                {
-                    FactionCombo->AddOption(Enum->GetNameStringByIndex(i));
-                }
-            }
-            FactionCombo->SetSelectedIndex(0);
-        }
-        Root->AddChild(FactionCombo);
-
-        DisplayNameInput = WidgetTree->ConstructWidget<UEditableTextBox>(UEditableTextBox::StaticClass());
-        DisplayNameInput->SetText(FText::FromString(TEXT("Player")));
-        Root->AddChild(DisplayNameInput);
-
-        FactionSelector = WidgetTree->ConstructWidget<UComboBoxString>(UComboBoxString::StaticClass());
-        if (UEnum* Enum = StaticEnum<ESkaldFaction>())
-        {
-            for (int32 i = 0; i < Enum->NumEnums(); ++i)
-            {
-                if (!Enum->HasMetaData(TEXT("Hidden"), i))
-                {
-                    FactionSelector->AddOption(Enum->GetNameStringByIndex(i));
-                }
-            }
-            FactionSelector->SetSelectedIndex(0);
-        }
-        Root->AddChild(FactionSelector);
-
-        auto AddButton = [this, Root](const FString& Label, const FName& FuncName)
-        DisplayNameBox = WidgetTree->ConstructWidget<UEditableTextBox>(UEditableTextBox::StaticClass());
-        DisplayNameBox->SetText(FText::FromString(TEXT("Player")));
-        Root->AddChild(DisplayNameBox);
-
-        FactionComboBox = WidgetTree->ConstructWidget<UComboBoxString>(UComboBoxString::StaticClass());
-        if (UEnum* Enum = StaticEnum<ESkaldFaction>())
-        {
-            for (int32 i = 0; i < Enum->NumEnums(); ++i)
-            {
-                if (!Enum->HasMetaData(TEXT("Hidden"), i))
-                {
-                    FactionComboBox->AddOption(Enum->GetNameStringByIndex(i));
-                }
-            }
-            FactionComboBox->SetSelectedIndex(0);
-        }
-        Root->AddChild(FactionComboBox);
-
-        auto AddButton = [this, Root](const FString& Label, const FName& FuncName)
-        {
-            for (int32 i = 0; i < Enum->NumEnums(); ++i)
-            {
-                if (!Enum->HasMetaData(TEXT("Hidden"), i))
-                {
-                    FactionComboBox->AddOption(Enum->GetNameStringByIndex(i));
-                }
-            }
-            FactionComboBox->SetSelectedIndex(0);
-        }
-        Root->AddChild(FactionComboBox);
-        AddButton(TEXT("Singleplayer"), FName("OnSingleplayer"));
-        AddButton(TEXT("Multiplayer"), FName("OnMultiplayer"));
-        AddButton(TEXT("Main Menu"), FName("OnMainMenu"));
-        auto AddButton = [this, Root](const FString& Label, const FName& FuncName)
     if (FactionComboBox)
     {
         FactionComboBox->ClearOptions();
@@ -108,6 +32,21 @@ void UStartGameWidget::NativeConstruct()
             }
             FactionComboBox->SetSelectedIndex(0);
         }
+    }
+
+    if (SingleplayerButton)
+    {
+        SingleplayerButton->OnClicked.AddDynamic(this, &UStartGameWidget::OnSingleplayer);
+    }
+
+    if (MultiplayerButton)
+    {
+        MultiplayerButton->OnClicked.AddDynamic(this, &UStartGameWidget::OnMultiplayer);
+    }
+
+    if (MainMenuButton)
+    {
+        MainMenuButton->OnClicked.AddDynamic(this, &UStartGameWidget::OnMainMenu);
     }
 }
 
@@ -127,31 +66,11 @@ void UStartGameWidget::OnMainMenu()
     if (OwningLobbyMenu.IsValid())
     {
         OwningLobbyMenu->SetVisibility(ESlateVisibility::Visible);
-    if (LobbyMenu.IsValid())
-    {
-        LobbyMenu->SetVisibility(ESlateVisibility::Visible);
-    {
-        LobbyMenu->SetVisibility(ESlateVisibility::Visible);
-void UStartGameWidget::StartGame(bool bMultiplayer)
-{
-    FString Name = DisplayNameBox ? DisplayNameBox->GetText().ToString() : TEXT("Player");
-    FString FactionName = FactionComboBox ? FactionComboBox->GetSelectedOption() : TEXT("None");
-
-    ESkaldFaction Faction = ESkaldFaction::None;
-    if (UEnum* Enum = StaticEnum<ESkaldFaction>())
-    {
-        int32 Value = Enum->GetValueByNameString(FactionName);
-        if (Value != INDEX_NONE)
-        {
-            Faction = static_cast<ESkaldFaction>(Value);
-        }
     }
+}
 
 void UStartGameWidget::StartGame(bool bMultiplayer)
 {
-    FString Name = DisplayNameInput ? DisplayNameInput->GetText().ToString() : TEXT("Player");
-    FString FactionName = FactionSelector ? FactionSelector->GetSelectedOption() : TEXT("None");
-    FString FactionName = FactionCombo ? FactionCombo->GetSelectedOption() : TEXT("None");
     FString Name = DisplayNameBox ? DisplayNameBox->GetText().ToString() : TEXT("Player");
     FString FactionName = FactionComboBox ? FactionComboBox->GetSelectedOption() : TEXT("None");
 
@@ -175,20 +94,12 @@ void UStartGameWidget::StartGame(bool bMultiplayer)
 
         if (APlayerController* PC = GetOwningPlayer())
         {
-        {
-            GI->DisplayName = Name;
-            GI->Faction = Faction;
-        }
-
-        if (APlayerController* PC = GetOwningPlayer())
-        {
             if (ASkaldPlayerState* PS = PC->GetPlayerState<ASkaldPlayerState>())
             {
                 PS->DisplayName = Name;
                 PS->Faction = Faction;
             }
 
-            // Load the correct gameplay map
             FName LevelName(TEXT("/Game/Blueprints/Maps/OverviewMap"));
             FString Options;
             if (bMultiplayer)

--- a/Source/Skald/StartGameWidget.h
+++ b/Source/Skald/StartGameWidget.h
@@ -22,42 +22,28 @@ protected:
     virtual void NativeConstruct() override;
 
     /** Entry box for the player's display name. */
-    UPROPERTY()
-    UEditableTextBox* DisplayNameInput;
+    UPROPERTY(meta = (BindWidget))
+    UEditableTextBox* DisplayNameBox;
 
     /** Combo box to choose a faction. */
-    UPROPERTY()
-    UComboBoxString* FactionSelector;
+    UPROPERTY(meta = (BindWidget))
+    UComboBoxString* FactionComboBox;
 
     /** Reference back to the owning lobby menu so it can be restored. */
     UPROPERTY()
     TWeakObjectPtr<ULobbyMenuWidget> OwningLobbyMenu;
-    UComboBoxString* FactionCombo;
-
-    UPROPERTY()
-    TWeakObjectPtr<ULobbyMenuWidget> LobbyMenu;
-    UEditableTextBox* DisplayNameBox;
-
-    /** Combo box to choose a faction. */
-    UPROPERTY()
-    UComboBoxString* FactionComboBox;
-
-    UPROPERTY()
-    TWeakObjectPtr<ULobbyMenuWidget> LobbyMenu;
-    UPROPERTY(meta=(BindWidget))
-    UEditableTextBox* DisplayNameBox;
-
-    /** Combo box to choose a faction. */
-    UPROPERTY(meta=(BindWidget))
-    UComboBoxString* FactionComboBox;
 
     /** Button to start singleplayer. */
-    UPROPERTY(meta=(BindWidget))
+    UPROPERTY(meta = (BindWidget))
     UButton* SingleplayerButton;
 
     /** Button to start multiplayer. */
-    UPROPERTY(meta=(BindWidget))
+    UPROPERTY(meta = (BindWidget))
     UButton* MultiplayerButton;
+
+    /** Button to return to the lobby menu. */
+    UPROPERTY(meta = (BindWidgetOptional))
+    UButton* MainMenuButton;
 
     UFUNCTION()
     void OnSingleplayer();
@@ -73,7 +59,5 @@ protected:
 public:
     /** Record the lobby menu that spawned this widget so we can unhide it later. */
     void SetLobbyMenu(ULobbyMenuWidget* InMenu) { OwningLobbyMenu = InMenu; }
-    void SetLobbyMenu(ULobbyMenuWidget* InMenu) { LobbyMenu = InMenu; }
-    void StartGame(bool bMultiplayer);
 };
 


### PR DESCRIPTION
## Summary
- Remove duplicate variable declarations from `UStartGameWidget`
- Simplify widget construction and event binding

## Testing
- `g++ -fsyntax-only Source/Skald/StartGameWidget.cpp` *(fails: CoreMinimal.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68ad3adff2f4832496be58407693de8f