### PR TITLE
Refactor SettingsWidget to use blueprint-bound buttons

### DIFF
--- a/Source/Skald/SettingsWidget.cpp
+++ b/Source/Skald/SettingsWidget.cpp
@@ -1,8 +1,5 @@
 #include "SettingsWidget.h"
 #include "Components/Button.h"
-#include "Components/TextBlock.h"
-#include "Components/VerticalBox.h"
-#include "Blueprint/WidgetTree.h"
 #include "GameFramework/GameUserSettings.h"
 #include "Engine/Engine.h"
 #include "LobbyMenuWidget.h"
@@ -11,24 +8,13 @@ void USettingsWidget::NativeConstruct()
 {
     Super::NativeConstruct();
 
-    if (WidgetTree)
+    if (ApplyButton)
     {
-        UVerticalBox* Root = WidgetTree->ConstructWidget<UVerticalBox>(UVerticalBox::StaticClass());
-        WidgetTree->RootWidget = Root;
-
-        UButton* ApplyButton = WidgetTree->ConstructWidget<UButton>(UButton::StaticClass());
-        UTextBlock* Text = WidgetTree->ConstructWidget<UTextBlock>(UTextBlock::StaticClass());
-        Text->SetText(FText::FromString(TEXT("Apply Settings")));
-        ApplyButton->AddChild(Text);
         ApplyButton->OnClicked.AddDynamic(this, &USettingsWidget::OnApply);
-        Root->AddChild(ApplyButton);
-
-        UButton* MainMenuButton = WidgetTree->ConstructWidget<UButton>(UButton::StaticClass());
-        UTextBlock* MainText = WidgetTree->ConstructWidget<UTextBlock>(UTextBlock::StaticClass());
-        MainText->SetText(FText::FromString(TEXT("Main Menu")));
-        MainMenuButton->AddChild(MainText);
+    }
+    if (MainMenuButton)
+    {
         MainMenuButton->OnClicked.AddDynamic(this, &USettingsWidget::OnMainMenu);
-        Root->AddChild(MainMenuButton);
     }
 }
 

--- a/Source/Skald/SettingsWidget.h
+++ b/Source/Skald/SettingsWidget.h
@@ -5,6 +5,7 @@
 #include "SettingsWidget.generated.h"
 
 class ULobbyMenuWidget;
+class UButton;
 /**
  * Basic settings menu allowing to apply current user settings.
  */
@@ -15,6 +16,12 @@ class SKALD_API USettingsWidget : public UUserWidget
 
 protected:
     virtual void NativeConstruct() override;
+
+    UPROPERTY(meta = (BindWidget))
+    UButton* ApplyButton;
+
+    UPROPERTY(meta = (BindWidget))
+    UButton* MainMenuButton;
 
     UFUNCTION(BlueprintCallable)
     void OnApply();


### PR DESCRIPTION
## Summary
- Remove manual widget tree construction from SettingsWidget
- Bind Apply and Main Menu buttons via UMG blueprint variables
- Ensure only explicit widget bindings by keeping bAuthorizeAutomaticWidgetVariableCreation=False

## Testing
- `npm test` *(fails: ENOENT no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ad42e6bc4c83249b61646852410777