### PR TITLE
Bind core HUD widgets and handle button actions

### DIFF
--- a/Source/Skald/UI/SkaldMainHUDWidget.cpp
+++ b/Source/Skald/UI/SkaldMainHUDWidget.cpp
@@ -1,11 +1,38 @@
 #include "UI/SkaldMainHUDWidget.h"
+#include "Components/Button.h"
+#include "Components/TextBlock.h"
 
 void USkaldMainHUDWidget::NativeConstruct()
 {
     Super::NativeConstruct();
 
+    if (AttackButton)
+    {
+        AttackButton->OnClicked.AddDynamic(this, &USkaldMainHUDWidget::BeginAttackSelection);
+    }
+    if (MoveButton)
+    {
+        MoveButton->OnClicked.AddDynamic(this, &USkaldMainHUDWidget::BeginMoveSelection);
+    }
+    if (EndTurnButton)
+    {
+        EndTurnButton->OnClicked.AddDynamic(this, &USkaldMainHUDWidget::HandleEndTurnClicked);
+    }
+
     BP_SetPhaseButtons(CurrentPhase, CurrentPlayerID == LocalPlayerID);
     BP_RebuildPlayerList(CachedPlayers);
+}
+
+void USkaldMainHUDWidget::HandleEndTurnClicked()
+{
+    if (CurrentPhase == ETurnPhase::Attack)
+    {
+        OnEndAttackRequested.Broadcast(true);
+    }
+    else if (CurrentPhase == ETurnPhase::Movement)
+    {
+        OnEndMovementRequested.Broadcast(true);
+    }
 }
 
 void USkaldMainHUDWidget::UpdateTurnBanner(int32 InCurrentPlayerID, int32 InTurnNumber)

--- a/Source/Skald/UI/SkaldMainHUDWidget.h
+++ b/Source/Skald/UI/SkaldMainHUDWidget.h
@@ -5,6 +5,8 @@
 #include "SkaldTypes.h"
 #include "SkaldMainHUDWidget.generated.h"
 
+class UButton;
+class UTextBlock;
 
 // Delegates broadcasting user UI actions to game logic
 DECLARE_DYNAMIC_MULTICAST_DELEGATE_ThreeParams(FSkaldAttackRequested, int32, FromID, int32, ToID, int32, ArmySent);
@@ -137,6 +139,26 @@ public:
     void SyncPhaseButtons(bool bIsMyTurn);
 
 protected:
+    // Bound widget references
+    UPROPERTY(meta=(BindWidget))
+    UTextBlock* TurnText;
+
+    UPROPERTY(meta=(BindWidget))
+    UTextBlock* PhaseText;
+
+    UPROPERTY(meta=(BindWidget))
+    UButton* AttackButton;
+
+    UPROPERTY(meta=(BindWidget))
+    UButton* MoveButton;
+
+    UPROPERTY(meta=(BindWidget))
+    UButton* EndTurnButton;
+
+    // Internal handlers for widget actions
+    UFUNCTION()
+    void HandleEndTurnClicked();
+
     virtual void NativeConstruct() override;
 };
 


### PR DESCRIPTION
## Summary
- Expose key HUD text and button widgets for automatic BP binding
- Wire attack, move, and end-turn buttons to native handlers
- Broadcast phase-complete events when end turn is clicked

## Testing
- ⚠️ `g++ -I Source/Skald -c Source/Skald/UI/SkaldMainHUDWidget.cpp` *(missing Unreal headers)*

------
https://chatgpt.com/codex/tasks/task_e_68ad42e8ea7083248c674ee3bc444497