### PR TITLE
docs: document missing Save Game widget blueprint

### DIFF
--- a/Content/C++_BPs/README.md
+++ b/Content/C++_BPs/README.md
@@ -1,0 +1,5 @@
+# C++ Blueprint Assets
+
+This folder holds Blueprint assets referenced by the C++ code. Some UI widgets are not committed to source control.
+
+* **Skald_SaveGameWidget** – Create a `UserWidget` Blueprint named `Skald_SaveGameWidget` with an editable text box for the slot name and a button that triggers `USkaldSaveGameLibrary::SaveSkaldGame`. See `Skald_SaveGameWidget.json` for a text description of the expected setup.

--- a/Content/C++_BPs/Skald_SaveGameWidget.json
+++ b/Content/C++_BPs/Skald_SaveGameWidget.json
@@ -1,0 +1,15 @@
+{
+  "Blueprint": "WidgetBlueprint'/Game/C++_BPs/Skald_SaveGameWidget'",
+  "ParentClass": "/Script/UMG.UserWidget",
+  "Purpose": "UI for saving the current game state",
+  "Properties": {
+    "SaveNameField": {
+      "Type": "EditableTextBox",
+      "Purpose": "Enter the name for the save slot"
+    },
+    "SaveButton": {
+      "Type": "Button",
+      "OnClicked": "Calls USkaldSaveGameLibrary::SaveSkaldGame with text from SaveNameField"
+    }
+  }
+}

--- a/README.md
+++ b/README.md
@@ -30,3 +30,7 @@ from Blueprints and level actors. To hook everything up:
 
 With this setup the C++ logic handles selection, deselection, and movement
 between adjacent territories without requiring additional Blueprint wiring.
+
+## Save Game UI
+
+The Save Game menu widget (`Skald_SaveGameWidget`) is not included in the repository. Create a UMG Widget Blueprint with this name under `Content/C++_BPs` and implement a text box for the save slot name and a button that calls `USkaldSaveGameLibrary::SaveSkaldGame`. A JSON description of the expected structure is provided in `Content/C++_BPs/Skald_SaveGameWidget.json`.


### PR DESCRIPTION
## Summary
- Note that the `Skald_SaveGameWidget` asset isn't stored in the repo and explain how to recreate it
- Add text-based description of the `Skald_SaveGameWidget` UMG blueprint
- Document blueprint expectations for `C++_BPs`

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ad448f38f483248a311e1fbb82f876