### PR TITLE
Add NativeDestruct to SaveGameWidget to clean up delegates

### DIFF
--- a/Source/Skald/SaveGameWidget.cpp
+++ b/Source/Skald/SaveGameWidget.cpp
@@ -1,0 +1,100 @@
+#include "SaveGameWidget.h"
+#include "Components/Button.h"
+#include "Kismet/GameplayStatics.h"
+#include "GameFramework/SaveGame.h"
+#include "LobbyMenuWidget.h"
+
+static const TCHAR* SlotNames[3] = { TEXT("Slot0"), TEXT("Slot1"), TEXT("Slot2") };
+
+void USaveGameWidget::NativeConstruct()
+{
+    Super::NativeConstruct();
+
+    if (Slot0Button)
+    {
+        Slot0Button->OnClicked.AddDynamic(this, &USaveGameWidget::OnSaveSlot0);
+    }
+
+    if (Slot1Button)
+    {
+        Slot1Button->OnClicked.AddDynamic(this, &USaveGameWidget::OnSaveSlot1);
+    }
+
+    if (Slot2Button)
+    {
+        Slot2Button->OnClicked.AddDynamic(this, &USaveGameWidget::OnSaveSlot2);
+    }
+
+    if (MainMenuButton)
+    {
+        MainMenuButton->OnClicked.AddDynamic(this, &USaveGameWidget::OnMainMenu);
+    }
+}
+
+void USaveGameWidget::NativeDestruct()
+{
+    if (Slot0Button)
+    {
+        Slot0Button->OnClicked.RemoveDynamic(this, &USaveGameWidget::OnSaveSlot0);
+    }
+
+    if (Slot1Button)
+    {
+        Slot1Button->OnClicked.RemoveDynamic(this, &USaveGameWidget::OnSaveSlot1);
+    }
+
+    if (Slot2Button)
+    {
+        Slot2Button->OnClicked.RemoveDynamic(this, &USaveGameWidget::OnSaveSlot2);
+    }
+
+    if (MainMenuButton)
+    {
+        MainMenuButton->OnClicked.RemoveDynamic(this, &USaveGameWidget::OnMainMenu);
+    }
+
+    Super::NativeDestruct();
+}
+
+void USaveGameWidget::OnSaveSlot0()
+{
+    HandleSaveSlot(0);
+}
+
+void USaveGameWidget::OnSaveSlot1()
+{
+    HandleSaveSlot(1);
+}
+
+void USaveGameWidget::OnSaveSlot2()
+{
+    HandleSaveSlot(2);
+}
+
+void USaveGameWidget::OnMainMenu()
+{
+    RemoveFromParent();
+    if (LobbyMenu.IsValid())
+    {
+        LobbyMenu->SetVisibility(ESlateVisibility::Visible);
+    }
+}
+
+void USaveGameWidget::HandleSaveSlot(int32 SlotIndex)
+{
+    USaveGame* SaveGameObject = UGameplayStatics::CreateSaveGameObject(USaveGame::StaticClass());
+    if (UGameplayStatics::SaveGameToSlot(SaveGameObject, SlotNames[SlotIndex], 0))
+    {
+        // After saving, transition back to main menu
+        RemoveFromParent();
+        if (LobbyMenu.IsValid())
+        {
+            LobbyMenu->SetVisibility(ESlateVisibility::Visible);
+        }
+    }
+    else
+    {
+        UE_LOG(LogTemp, Error, TEXT("Failed to save slot %s"), SlotNames[SlotIndex]);
+    }
+}
+

--- a/Source/Skald/SaveGameWidget.h
+++ b/Source/Skald/SaveGameWidget.h
@@ -1,0 +1,55 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Blueprint/UserWidget.h"
+#include "SaveGameWidget.generated.h"
+
+class UButton;
+class ULobbyMenuWidget;
+/**
+ * Simple save game menu listing a few save slots.
+ */
+UCLASS(Blueprintable, BlueprintType)
+class SKALD_API USaveGameWidget : public UUserWidget
+{
+    GENERATED_BODY()
+
+protected:
+    virtual void NativeConstruct() override;
+    virtual void NativeDestruct() override;
+
+    UPROPERTY(meta=(BindWidget))
+    UButton* Slot0Button;
+
+    UPROPERTY(meta=(BindWidget))
+    UButton* Slot1Button;
+
+    UPROPERTY(meta=(BindWidget))
+    UButton* Slot2Button;
+
+    UPROPERTY(meta=(BindWidget))
+    UButton* MainMenuButton;
+
+    UFUNCTION(BlueprintCallable)
+    void OnSaveSlot0();
+
+    UFUNCTION(BlueprintCallable)
+    void OnSaveSlot1();
+
+    UFUNCTION(BlueprintCallable)
+    void OnSaveSlot2();
+
+    UFUNCTION()
+    void OnMainMenu();
+
+private:
+    /** Shared implementation for the individual save slot handlers. */
+    void HandleSaveSlot(int32 SlotIndex);
+
+    UPROPERTY()
+    TWeakObjectPtr<ULobbyMenuWidget> LobbyMenu;
+
+public:
+    void SetLobbyMenu(ULobbyMenuWidget* InMenu) { LobbyMenu = InMenu; }
+};
+


### PR DESCRIPTION
## Summary
- Add SaveGameWidget for saving game slots
- Declare and implement NativeDestruct to remove button delegates safely

## Testing
- `clang++ -fsyntax-only Source/Skald/SaveGameWidget.cpp` *(fails: 'CoreMinimal.h' file not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ad4493351083248d669ddc0cfa09ad