### PR TITLE
Fix slot name redefinition in save/load widgets

### DIFF
--- a/Source/Skald/LoadGameWidget.cpp
+++ b/Source/Skald/LoadGameWidget.cpp
@@ -3,8 +3,7 @@
 #include "Kismet/GameplayStatics.h"
 #include "GameFramework/SaveGame.h"
 #include "LobbyMenuWidget.h"
-
-static const TCHAR* SlotNames[3] = { TEXT("Slot0"), TEXT("Slot1"), TEXT("Slot2") };
+#include "SlotNameConstants.h"
 
 void ULoadGameWidget::NativeConstruct()
 {

--- a/Source/Skald/SaveGameWidget.cpp
+++ b/Source/Skald/SaveGameWidget.cpp
@@ -3,8 +3,7 @@
 #include "Kismet/GameplayStatics.h"
 #include "GameFramework/SaveGame.h"
 #include "LobbyMenuWidget.h"
-
-static const TCHAR* SlotNames[3] = { TEXT("Slot0"), TEXT("Slot1"), TEXT("Slot2") };
+#include "SlotNameConstants.h"
 
 void USaveGameWidget::NativeConstruct()
 {

--- a/Source/Skald/SlotNameConstants.h
+++ b/Source/Skald/SlotNameConstants.h
@@ -1,0 +1,3 @@
+#pragma once
+
+inline constexpr const TCHAR* SlotNames[3] = { TEXT("Slot0"), TEXT("Slot1"), TEXT("Slot2") };


### PR DESCRIPTION
## Summary
- centralize shared slot name constants in a new header
- include shared constant in save and load widgets to avoid redefinition

## Testing
- `g++ -c Source/Skald/LoadGameWidget.cpp` *(fails: CoreMinimal.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68ad46c0076c83249f0459c7ad1e205e