### PR TITLE
feat(ui): allow optional widget bindings

### DIFF
--- a/Source/Skald/LoadGameWidget.h
+++ b/Source/Skald/LoadGameWidget.h
@@ -17,16 +17,16 @@ class SKALD_API ULoadGameWidget : public UUserWidget
 protected:
     virtual void NativeConstruct() override;
 
-    UPROPERTY(meta=(BindWidget))
+    UPROPERTY(BlueprintReadOnly, meta=(BindWidgetOptional))
     UButton* Slot0Button;
 
-    UPROPERTY(meta=(BindWidget))
+    UPROPERTY(BlueprintReadOnly, meta=(BindWidgetOptional))
     UButton* Slot1Button;
 
-    UPROPERTY(meta=(BindWidget))
+    UPROPERTY(BlueprintReadOnly, meta=(BindWidgetOptional))
     UButton* Slot2Button;
 
-    UPROPERTY(meta=(BindWidget))
+    UPROPERTY(BlueprintReadOnly, meta=(BindWidgetOptional))
     UButton* MainMenuButton;
 
     UFUNCTION(BlueprintCallable)

--- a/Source/Skald/LobbyMenuWidget.h
+++ b/Source/Skald/LobbyMenuWidget.h
@@ -18,19 +18,19 @@ class SKALD_API ULobbyMenuWidget : public UUserWidget
 protected:
     virtual void NativeConstruct() override;
 
-    UPROPERTY(meta=(BindWidget))
+    UPROPERTY(BlueprintReadOnly, meta=(BindWidgetOptional))
     UVerticalBox* Root;
 
-    UPROPERTY(meta=(BindWidget))
+    UPROPERTY(BlueprintReadOnly, meta=(BindWidgetOptional))
     UButton* StartButton;
 
-    UPROPERTY(meta=(BindWidget))
+    UPROPERTY(BlueprintReadOnly, meta=(BindWidgetOptional))
     UButton* LoadButton;
 
-    UPROPERTY(meta=(BindWidget))
+    UPROPERTY(BlueprintReadOnly, meta=(BindWidgetOptional))
     UButton* SettingsButton;
 
-    UPROPERTY(meta=(BindWidget))
+    UPROPERTY(BlueprintReadOnly, meta=(BindWidgetOptional))
     UButton* ExitButton;
 
     UFUNCTION(BlueprintCallable)

--- a/Source/Skald/PlayerSetupWidget.h
+++ b/Source/Skald/PlayerSetupWidget.h
@@ -5,6 +5,9 @@
 #include "SkaldTypes.h"
 #include "PlayerSetupWidget.generated.h"
 
+class UEditableTextBox;
+class UComboBoxString;
+
 /**
  * Widget shown after selecting single or multiplayer that allows the
  * player to choose a display name and faction before entering the game.
@@ -24,6 +27,14 @@ public:
     /** Set the faction chosen from the UI. */
     UFUNCTION(BlueprintCallable)
     void OnFactionSelected(ESkaldFaction NewFaction);
+
+    /** Optional binding to the player's name entry box. */
+    UPROPERTY(BlueprintReadOnly, meta=(BindWidgetOptional))
+    UEditableTextBox* NameEntryBox;
+
+    /** Optional binding to the faction selection combo box. */
+    UPROPERTY(BlueprintReadOnly, meta=(BindWidgetOptional))
+    UComboBoxString* FactionSelectionBox;
 
     /** Display name entered by the player. */
     UPROPERTY(BlueprintReadWrite, EditAnywhere, Category="Setup")

--- a/Source/Skald/SaveGameWidget.h
+++ b/Source/Skald/SaveGameWidget.h
@@ -18,16 +18,16 @@ protected:
     virtual void NativeConstruct() override;
     virtual void NativeDestruct() override;
 
-    UPROPERTY(meta=(BindWidget))
+    UPROPERTY(BlueprintReadOnly, meta=(BindWidgetOptional))
     UButton* Slot0Button;
 
-    UPROPERTY(meta=(BindWidget))
+    UPROPERTY(BlueprintReadOnly, meta=(BindWidgetOptional))
     UButton* Slot1Button;
 
-    UPROPERTY(meta=(BindWidget))
+    UPROPERTY(BlueprintReadOnly, meta=(BindWidgetOptional))
     UButton* Slot2Button;
 
-    UPROPERTY(meta=(BindWidget))
+    UPROPERTY(BlueprintReadOnly, meta=(BindWidgetOptional))
     UButton* MainMenuButton;
 
     UFUNCTION(BlueprintCallable)

--- a/Source/Skald/SettingsWidget.h
+++ b/Source/Skald/SettingsWidget.h
@@ -17,10 +17,10 @@ class SKALD_API USettingsWidget : public UUserWidget
 protected:
     virtual void NativeConstruct() override;
 
-    UPROPERTY(meta = (BindWidget))
+    UPROPERTY(BlueprintReadOnly, meta = (BindWidgetOptional))
     UButton* ApplyButton;
 
-    UPROPERTY(meta = (BindWidget))
+    UPROPERTY(BlueprintReadOnly, meta = (BindWidgetOptional))
     UButton* MainMenuButton;
 
     UFUNCTION(BlueprintCallable)

--- a/Source/Skald/StartGameWidget.h
+++ b/Source/Skald/StartGameWidget.h
@@ -22,11 +22,11 @@ protected:
     virtual void NativeConstruct() override;
 
     /** Entry box for the player's display name. */
-    UPROPERTY(meta = (BindWidget))
+    UPROPERTY(BlueprintReadOnly, meta = (BindWidgetOptional))
     UEditableTextBox* DisplayNameBox;
 
     /** Combo box to choose a faction. */
-    UPROPERTY(meta = (BindWidget))
+    UPROPERTY(BlueprintReadOnly, meta = (BindWidgetOptional))
     UComboBoxString* FactionComboBox;
 
     /** Reference back to the owning lobby menu so it can be restored. */
@@ -34,15 +34,15 @@ protected:
     TWeakObjectPtr<ULobbyMenuWidget> OwningLobbyMenu;
 
     /** Button to start singleplayer. */
-    UPROPERTY(meta = (BindWidget))
+    UPROPERTY(BlueprintReadOnly, meta = (BindWidgetOptional))
     UButton* SingleplayerButton;
 
     /** Button to start multiplayer. */
-    UPROPERTY(meta = (BindWidget))
+    UPROPERTY(BlueprintReadOnly, meta = (BindWidgetOptional))
     UButton* MultiplayerButton;
 
     /** Button to return to the lobby menu. */
-    UPROPERTY(meta = (BindWidgetOptional))
+    UPROPERTY(BlueprintReadOnly, meta = (BindWidgetOptional))
     UButton* MainMenuButton;
 
     UFUNCTION()

--- a/Source/Skald/UI/SkaldMainHUDWidget.h
+++ b/Source/Skald/UI/SkaldMainHUDWidget.h
@@ -139,20 +139,20 @@ public:
     void SyncPhaseButtons(bool bIsMyTurn);
 
 protected:
-    // Bound widget references
-    UPROPERTY(meta=(BindWidget))
+    // Bound widget references - optional so subclasses can customise layouts
+    UPROPERTY(BlueprintReadOnly, meta=(BindWidgetOptional))
     UTextBlock* TurnText;
 
-    UPROPERTY(meta=(BindWidget))
+    UPROPERTY(BlueprintReadOnly, meta=(BindWidgetOptional))
     UTextBlock* PhaseText;
 
-    UPROPERTY(meta=(BindWidget))
+    UPROPERTY(BlueprintReadOnly, meta=(BindWidgetOptional))
     UButton* AttackButton;
 
-    UPROPERTY(meta=(BindWidget))
+    UPROPERTY(BlueprintReadOnly, meta=(BindWidgetOptional))
     UButton* MoveButton;
 
-    UPROPERTY(meta=(BindWidget))
+    UPROPERTY(BlueprintReadOnly, meta=(BindWidgetOptional))
     UButton* EndTurnButton;
 
     // Internal handlers for widget actions


### PR DESCRIPTION
## Summary
- make HUD widget references optional for flexible subclass layouts
- apply same optional binding pattern to menu and setup widgets

## Testing
- `pytest`
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ad4b42a6c48324b01ebc7ed823a1aa