### PR TITLE
Expose WorldMap property to Skald player blueprint

### DIFF
--- a/Source/Skald/Skald_PlayerCharacter.h
+++ b/Source/Skald/Skald_PlayerCharacter.h
@@ -24,7 +24,7 @@ protected:
         virtual void BeginPlay() override;
 
         /** Reference to the world map actor for selection and movement */
-        UPROPERTY()
+        UPROPERTY(EditInstanceOnly, BlueprintReadOnly, Category="Selection", meta=(ExposeOnSpawn=true))
         AWorldMap* WorldMap;
 
         /** Currently selected territory, if any */


### PR DESCRIPTION
## Summary
- Allow player character's WorldMap reference to be set and read in Blueprints

## Testing
- `./Engine/Build/BatchFiles/Linux/Build.sh SkaldEditor Linux Development` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68add31ee8c88324956500fcf74d2b57