### PR TITLE
Handle input mode transitions when leaving lobby

### DIFF
--- a/Source/Skald/LoadGameWidget.cpp
+++ b/Source/Skald/LoadGameWidget.cpp
@@ -4,6 +4,7 @@
 #include "GameFramework/SaveGame.h"
 #include "LobbyMenuWidget.h"
 #include "SlotNameConstants.h"
+#include "GameFramework/PlayerController.h"
 
 void ULoadGameWidget::NativeConstruct()
 {
@@ -62,6 +63,14 @@ void ULoadGameWidget::HandleLoadSlot(int32 SlotIndex)
     USaveGame* LoadedGame = UGameplayStatics::LoadGameFromSlot(SlotNames[SlotIndex], 0);
     if (LoadedGame)
     {
+        if (APlayerController* PC = GetOwningPlayer())
+        {
+            PC->SetInputMode(FInputModeGameOnly());
+            PC->bShowMouseCursor = false;
+            PC->bEnableClickEvents = false;
+            PC->bEnableMouseOverEvents = false;
+        }
+
         // After loading, transition to the main gameplay map
         UGameplayStatics::OpenLevel(this, FName("Skald_OverTop"));
     }

--- a/Source/Skald/LobbyGameMode.cpp
+++ b/Source/Skald/LobbyGameMode.cpp
@@ -1,6 +1,7 @@
 #include "LobbyGameMode.h"
 #include "LobbyMenuWidget.h"
 #include "Blueprint/UserWidget.h"
+#include "GameFramework/PlayerController.h"
 
 ALobbyGameMode::ALobbyGameMode()
     : LobbyWidgetClass(ULobbyMenuWidget::StaticClass())
@@ -17,6 +18,14 @@ void ALobbyGameMode::BeginPlay()
         if (Widget)
         {
             Widget->AddToViewport();
+
+            if (APlayerController* PC = GetWorld()->GetFirstPlayerController())
+            {
+                PC->SetInputMode(FInputModeUIOnly());
+                PC->bShowMouseCursor = true;
+                PC->bEnableClickEvents = true;
+                PC->bEnableMouseOverEvents = true;
+            }
         }
     }
 }

--- a/Source/Skald/PlayerSetupWidget.cpp
+++ b/Source/Skald/PlayerSetupWidget.cpp
@@ -28,6 +28,11 @@ void UPlayerSetupWidget::OnConfirm()
             PS->Faction = SelectedFaction;
         }
 
+        PC->SetInputMode(FInputModeGameOnly());
+        PC->bShowMouseCursor = false;
+        PC->bEnableClickEvents = false;
+        PC->bEnableMouseOverEvents = false;
+
         // Launch the main gameplay map once setup is confirmed
         FName LevelName(TEXT("Skald_OverTop"));
         FString Options;

--- a/Source/Skald/StartGameWidget.cpp
+++ b/Source/Skald/StartGameWidget.cpp
@@ -100,6 +100,11 @@ void UStartGameWidget::StartGame(bool bMultiplayer)
                 PS->Faction = Faction;
             }
 
+            PC->SetInputMode(FInputModeGameOnly());
+            PC->bShowMouseCursor = false;
+            PC->bEnableClickEvents = false;
+            PC->bEnableMouseOverEvents = false;
+
             FName LevelName(TEXT("/Game/Blueprints/Maps/OverviewMap"));
             FString Options;
             if (bMultiplayer)


### PR DESCRIPTION
## Summary
- Enable UI-only input mode with visible mouse in lobby
- Restore game-only input mode when launching gameplay or loading saves

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68adfe17a6788324b39a1d766fea52a6