### PR TITLE
Allow LobbyMenu to spawn customizable Load and Settings widgets

### DIFF
--- a/Source/Skald/LobbyMenuWidget.cpp
+++ b/Source/Skald/LobbyMenuWidget.cpp
@@ -51,12 +51,14 @@ void ULobbyMenuWidget::OnLoadGame()
 {
     if (UWorld* World = GetWorld())
     {
-        ULoadGameWidget* Widget = CreateWidget<ULoadGameWidget>(World, ULoadGameWidget::StaticClass());
-        if (Widget)
+        if (LoadGameWidgetClass)
         {
-            Widget->SetLobbyMenu(this);
-            Widget->AddToViewport();
-            SetVisibility(ESlateVisibility::Hidden);
+            if (ULoadGameWidget* Widget = CreateWidget<ULoadGameWidget>(World, LoadGameWidgetClass))
+            {
+                Widget->SetLobbyMenu(this);
+                Widget->AddToViewport();
+                SetVisibility(ESlateVisibility::Hidden);
+            }
         }
     }
 }
@@ -65,12 +67,14 @@ void ULobbyMenuWidget::OnSettings()
 {
     if (UWorld* World = GetWorld())
     {
-        USettingsWidget* Widget = CreateWidget<USettingsWidget>(World, USettingsWidget::StaticClass());
-        if (Widget)
+        if (SettingsWidgetClass)
         {
-            Widget->SetLobbyMenu(this);
-            Widget->AddToViewport();
-            SetVisibility(ESlateVisibility::Hidden);
+            if (USettingsWidget* Widget = CreateWidget<USettingsWidget>(World, SettingsWidgetClass))
+            {
+                Widget->SetLobbyMenu(this);
+                Widget->AddToViewport();
+                SetVisibility(ESlateVisibility::Hidden);
+            }
         }
     }
 }

--- a/Source/Skald/LobbyMenuWidget.h
+++ b/Source/Skald/LobbyMenuWidget.h
@@ -6,6 +6,8 @@
 
 class UButton;
 class UVerticalBox;
+class ULoadGameWidget;
+class USettingsWidget;
 
 /**
  * Main menu widget shown on the lobby map.
@@ -30,6 +32,12 @@ public:
 
     UPROPERTY(BlueprintReadOnly, Category="Skald|Widgets", meta=(BindWidgetOptional))
     UButton* ExitButton;
+
+    UPROPERTY(EditAnywhere, Category="Lobby")
+    TSubclassOf<ULoadGameWidget> LoadGameWidgetClass;
+
+    UPROPERTY(EditAnywhere, Category="Lobby")
+    TSubclassOf<USettingsWidget> SettingsWidgetClass;
 
 protected:
     virtual void NativeConstruct() override;


### PR DESCRIPTION
## Summary
- Expose configurable widget classes for the lobby's Load and Settings dialogs
- Instantiate Load and Settings widgets using the configured classes

## Testing
- `UnrealEditor Skald.uproject -run=Automation -nullRHI -nop4 -unattended -testexit="Automation Test Queue Empty" -log -stdout` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68adfe3c8bfc8324a54c2e569d15c820