### PR TITLE
Validate selections before enabling start buttons

### DIFF
--- a/Source/Skald/StartGameWidget.cpp
+++ b/Source/Skald/StartGameWidget.cpp
@@ -16,6 +16,7 @@ void UStartGameWidget::NativeConstruct()
     if (DisplayNameBox)
     {
         DisplayNameBox->SetText(FText::FromString(TEXT("Player")));
+        DisplayNameBox->OnTextChanged.AddDynamic(this, &UStartGameWidget::OnDisplayNameChanged);
     }
 
     if (FactionComboBox)
@@ -32,22 +33,27 @@ void UStartGameWidget::NativeConstruct()
             }
             FactionComboBox->SetSelectedIndex(0);
         }
+        FactionComboBox->OnSelectionChanged.AddDynamic(this, &UStartGameWidget::OnFactionChanged);
     }
 
     if (SingleplayerButton)
     {
         SingleplayerButton->OnClicked.AddDynamic(this, &UStartGameWidget::OnSingleplayer);
+        SingleplayerButton->SetIsEnabled(false);
     }
 
     if (MultiplayerButton)
     {
         MultiplayerButton->OnClicked.AddDynamic(this, &UStartGameWidget::OnMultiplayer);
+        MultiplayerButton->SetIsEnabled(false);
     }
 
     if (MainMenuButton)
     {
         MainMenuButton->OnClicked.AddDynamic(this, &UStartGameWidget::OnMainMenu);
     }
+
+    ValidateSelections();
 }
 
 void UStartGameWidget::OnSingleplayer()
@@ -66,6 +72,34 @@ void UStartGameWidget::OnMainMenu()
     if (OwningLobbyMenu.IsValid())
     {
         OwningLobbyMenu->SetVisibility(ESlateVisibility::Visible);
+    }
+}
+
+void UStartGameWidget::OnDisplayNameChanged(const FText& /*Text*/)
+{
+    ValidateSelections();
+}
+
+void UStartGameWidget::OnFactionChanged(FString /*SelectedItem*/, ESelectInfo::Type /*SelectionType*/)
+{
+    ValidateSelections();
+}
+
+void UStartGameWidget::ValidateSelections()
+{
+    const bool bHasName = DisplayNameBox && !DisplayNameBox->GetText().IsEmpty();
+    const bool bHasFaction = FactionComboBox && FactionComboBox->GetSelectedIndex() != INDEX_NONE;
+
+    const bool bEnable = bHasName && bHasFaction;
+
+    if (SingleplayerButton)
+    {
+        SingleplayerButton->SetIsEnabled(bEnable);
+    }
+
+    if (MultiplayerButton)
+    {
+        MultiplayerButton->SetIsEnabled(bEnable);
     }
 }
 

--- a/Source/Skald/StartGameWidget.h
+++ b/Source/Skald/StartGameWidget.h
@@ -3,6 +3,7 @@
 #include "CoreMinimal.h"
 #include "Blueprint/UserWidget.h"
 #include "SkaldTypes.h"
+#include "Components/ComboBoxString.h"
 #include "StartGameWidget.generated.h"
 
 class UEditableTextBox;
@@ -54,7 +55,15 @@ protected:
     UFUNCTION()
     void OnMainMenu();
 
+    UFUNCTION()
+    void OnDisplayNameChanged(const FText& Text);
+
+    UFUNCTION()
+    void OnFactionChanged(FString SelectedItem, ESelectInfo::Type SelectionType);
+
     void StartGame(bool bMultiplayer);
+
+    void ValidateSelections();
 
 private:
     /** Reference back to the owning lobby menu so it can be restored. */


### PR DESCRIPTION
## Summary
- Disable singleplayer and multiplayer buttons on construct
- Add name and faction change handlers to toggle availability
- Enable start buttons only when a name and faction are selected

## Testing
- `npm test` *(fails: package.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_68adfe5275b4832480159b45757d6fc1