### PR TITLE
Update HUD with game state and territory selection info

### DIFF
--- a/Source/Skald/Skald_PlayerController.h
+++ b/Source/Skald/Skald_PlayerController.h
@@ -7,6 +7,7 @@
 class ATurnManager;
 class UUserWidget;
 class USkaldMainHUDWidget;
+class ATerritory;
 
 /**
  * Player controller capable of participating in turn based gameplay.
@@ -36,6 +37,9 @@ public:
     /** Set the turn manager responsible for sequencing play. */
     UFUNCTION(BlueprintCallable, Category="Turn")
     void SetTurnManager(ATurnManager* Manager);
+
+    UFUNCTION(BlueprintCallable, Category="UI")
+    void HandleTerritorySelected(ATerritory* Terr);
 
 protected:
     /** Whether this controller is controlled by AI. */

--- a/Source/Skald/Territory.cpp
+++ b/Source/Skald/Territory.cpp
@@ -3,6 +3,7 @@
 #include "Components/StaticMeshComponent.h"
 #include "Materials/MaterialInstanceDynamic.h"
 #include "Skald_PlayerState.h"
+#include "Skald_PlayerController.h"
 #include "Net/UnrealNetwork.h"
 
 ATerritory::ATerritory() {
@@ -72,6 +73,10 @@ void ATerritory::Select() {
                                              FLinearColor::Yellow);
   }
   OnTerritorySelected.Broadcast(this);
+  if (ASkaldPlayerController* PC =
+          Cast<ASkaldPlayerController>(GetWorld()->GetFirstPlayerController())) {
+    PC->HandleTerritorySelected(this);
+  }
 }
 
 void ATerritory::Deselect() {


### PR DESCRIPTION
## Summary
- Initialize main HUD with player data from game state on startup
- Expose player controller method for territory selection updates
- Notify controller when a territory is selected to refresh HUD info

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68adfe5761cc8324b08fed29e2f396ba