### PR TITLE
Ensure territory color updates during initialization

### DIFF
--- a/Source/Skald/Skald_GameMode.cpp
+++ b/Source/Skald/Skald_GameMode.cpp
@@ -125,6 +125,7 @@ void ASkaldGameMode::InitializeWorld() {
       ASkaldPlayerState *TerritoryOwner =
           Cast<ASkaldPlayerState>(GS->PlayerArray[Index % PlayerCount]);
       Territory->OwningPlayer = TerritoryOwner;
+      Territory->RefreshAppearance();
       Territory->ArmyStrength = 1;
       ++Index;
     }

--- a/Source/Skald/Territory.cpp
+++ b/Source/Skald/Territory.cpp
@@ -120,6 +120,8 @@ void ATerritory::HandleClicked(UPrimitiveComponent *TouchedComponent,
   }
 }
 
+void ATerritory::RefreshAppearance() { UpdateTerritoryColor(); }
+
 void ATerritory::OnRep_OwningPlayer() { UpdateTerritoryColor(); }
 
 void ATerritory::UpdateTerritoryColor() {

--- a/Source/Skald/Territory.h
+++ b/Source/Skald/Territory.h
@@ -93,6 +93,10 @@ public:
     UFUNCTION()
     void HandleClicked(UPrimitiveComponent* TouchedComponent, FKey ButtonPressed);
 
+    /** Refresh the visual appearance of this territory. */
+    UFUNCTION(BlueprintCallable, Category = "Territory")
+    void RefreshAppearance();
+
     UFUNCTION()
     void OnRep_OwningPlayer();
 


### PR DESCRIPTION
## Summary
- Expose territory appearance refresh so other classes can update visual state
- Update world initialization to refresh territory colors after assigning owners

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68adfe5a5a6483248c3e01872eb24872