### PR TITLE
Document Main HUD blueprint player list rebuild

### DIFF
--- a/Content/C++_BPs/README.md
+++ b/Content/C++_BPs/README.md
@@ -3,3 +3,5 @@
 This folder holds Blueprint assets referenced by the C++ code. Some UI widgets are not committed to source control.
 
 * **Skald_SaveGameWidget** – Create a `UserWidget` Blueprint named `Skald_SaveGameWidget` with an editable text box for the slot name and a button that triggers `USkaldSaveGameLibrary::SaveSkaldGame`. See `Skald_SaveGameWidget.json` for a text description of the expected setup.
+
+* **Skald_MainHUDBP** – Blueprint subclass of `USkaldMainHUDWidget` used for the in-game HUD. Implements `BP_RebuildPlayerList` to rebuild the on-screen player list. See `Skald_MainHUDBP.json` for a description of the expected setup.

--- a/Content/C++_BPs/Skald_MainHUDBP.json
+++ b/Content/C++_BPs/Skald_MainHUDBP.json
@@ -1,0 +1,22 @@
+{
+  "Blueprint": "WidgetBlueprint'/Game/C++_BPs/Skald_MainHUDBP'",
+  "ParentClass": "/Script/Skald.SkaldMainHUDWidget",
+  "Purpose": "Main HUD widget used during gameplay",
+  "Widgets": {
+    "PlayerListBox": {
+      "Type": "VerticalBox",
+      "Purpose": "Container for dynamically generated player entries"
+    }
+  },
+  "Events": {
+    "BP_RebuildPlayerList": {
+      "Parameters": "Array of FS_PlayerData",
+      "Steps": [
+        "Clear children of PlayerListBox",
+        "For each player in Players:",
+        "  - Create a TextBlock showing PlayerName and faction",
+        "  - Add the TextBlock to PlayerListBox"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Document MainHUDBP Blueprint so BP_RebuildPlayerList can rebuild player list entries

## Testing
- `g++ -std=c++17 -c Source/Skald/Skald_PlayerController.cpp` *(fails: CoreMinimal.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68ae072c8f4483249684eadc6f656615