### PR TITLE
feat: build player list in C++

### DIFF
--- a/Source/Skald/UI/SkaldMainHUDWidget.cpp
+++ b/Source/Skald/UI/SkaldMainHUDWidget.cpp
@@ -1,164 +1,172 @@
 #include "UI/SkaldMainHUDWidget.h"
 #include "Components/Button.h"
 #include "Components/TextBlock.h"
+#include "Components/VerticalBox.h"
 
-void USkaldMainHUDWidget::NativeConstruct()
-{
-    Super::NativeConstruct();
+void USkaldMainHUDWidget::NativeConstruct() {
+  Super::NativeConstruct();
 
-    if (AttackButton)
-    {
-        AttackButton->OnClicked.AddDynamic(this, &USkaldMainHUDWidget::BeginAttackSelection);
+  if (AttackButton) {
+    AttackButton->OnClicked.AddDynamic(
+        this, &USkaldMainHUDWidget::BeginAttackSelection);
+  }
+  if (MoveButton) {
+    MoveButton->OnClicked.AddDynamic(this,
+                                     &USkaldMainHUDWidget::BeginMoveSelection);
+  }
+  if (EndTurnButton) {
+    EndTurnButton->OnClicked.AddDynamic(
+        this, &USkaldMainHUDWidget::HandleEndTurnClicked);
+  }
+
+  BP_SetPhaseButtons(CurrentPhase, CurrentPlayerID == LocalPlayerID);
+  RebuildPlayerList(CachedPlayers);
+}
+
+void USkaldMainHUDWidget::HandleEndTurnClicked() {
+  if (CurrentPhase == ETurnPhase::Attack) {
+    OnEndAttackRequested.Broadcast(true);
+  } else if (CurrentPhase == ETurnPhase::Movement) {
+    OnEndMovementRequested.Broadcast(true);
+  }
+}
+
+void USkaldMainHUDWidget::UpdateTurnBanner(int32 InCurrentPlayerID,
+                                           int32 InTurnNumber) {
+  CurrentPlayerID = InCurrentPlayerID;
+  TurnNumber = InTurnNumber;
+
+  BP_SetTurnText(TurnNumber, CurrentPlayerID);
+  BP_SetPhaseButtons(CurrentPhase, CurrentPlayerID == LocalPlayerID);
+}
+
+void USkaldMainHUDWidget::UpdatePhaseBanner(ETurnPhase InPhase) {
+  CurrentPhase = InPhase;
+
+  BP_SetPhaseText(CurrentPhase);
+  BP_SetPhaseButtons(CurrentPhase, CurrentPlayerID == LocalPlayerID);
+}
+
+void USkaldMainHUDWidget::UpdateTerritoryInfo(const FString &TerritoryName,
+                                              const FString &OwnerName,
+                                              int32 ArmyCount) {
+  BP_SetTerritoryPanel(TerritoryName, OwnerName, ArmyCount);
+}
+
+void USkaldMainHUDWidget::RefreshPlayerList(
+    const TArray<FS_PlayerData> &Players) {
+  CachedPlayers = Players;
+  RebuildPlayerList(CachedPlayers);
+}
+
+void USkaldMainHUDWidget::RefreshFromState(
+    int32 InCurrentPlayerID, int32 InTurnNumber, ETurnPhase InPhase,
+    const TArray<FS_PlayerData> &Players) {
+  CurrentPlayerID = InCurrentPlayerID;
+  TurnNumber = InTurnNumber;
+  CurrentPhase = InPhase;
+  CachedPlayers = Players;
+
+  BP_SetTurnText(TurnNumber, CurrentPlayerID);
+  BP_SetPhaseText(CurrentPhase);
+  RebuildPlayerList(CachedPlayers);
+  BP_SetPhaseButtons(CurrentPhase, CurrentPlayerID == LocalPlayerID);
+}
+
+void USkaldMainHUDWidget::RebuildPlayerList(
+    const TArray<FS_PlayerData> &Players) {
+  if (!PlayerListBox) {
+    return;
+  }
+
+  PlayerListBox->ClearChildren();
+
+  UEnum *FactionEnum = StaticEnum<ESkaldFaction>();
+
+  for (const FS_PlayerData &Player : Players) {
+    UTextBlock *Entry = NewObject<UTextBlock>(PlayerListBox);
+    if (!Entry) {
+      continue;
     }
-    if (MoveButton)
-    {
-        MoveButton->OnClicked.AddDynamic(this, &USkaldMainHUDWidget::BeginMoveSelection);
+
+    FString FactionName = FactionEnum
+                              ? FactionEnum
+                                    ->GetDisplayNameTextByValue(
+                                        static_cast<int64>(Player.Faction))
+                                    .ToString()
+                              : TEXT("Unknown");
+    FString Line =
+        FString::Printf(TEXT("%s (%s)%s"), *Player.PlayerName, *FactionName,
+                        Player.IsAI ? TEXT(" [AI]") : TEXT(""));
+    Entry->SetText(FText::FromString(Line));
+    PlayerListBox->AddChildToVerticalBox(Entry);
+  }
+}
+
+void USkaldMainHUDWidget::BeginAttackSelection() {
+  bSelectingForAttack = true;
+  bSelectingForMove = false;
+  SelectedSourceID = -1;
+  SelectedTargetID = -1;
+}
+
+void USkaldMainHUDWidget::SubmitAttack(int32 FromID, int32 ToID,
+                                       int32 ArmySent) {
+  OnAttackRequested.Broadcast(FromID, ToID, ArmySent);
+  bSelectingForAttack = false;
+  SelectedSourceID = -1;
+  SelectedTargetID = -1;
+}
+
+void USkaldMainHUDWidget::CancelAttackSelection() {
+  bSelectingForAttack = false;
+  SelectedSourceID = -1;
+  SelectedTargetID = -1;
+}
+
+void USkaldMainHUDWidget::BeginMoveSelection() {
+  bSelectingForMove = true;
+  bSelectingForAttack = false;
+  SelectedSourceID = -1;
+  SelectedTargetID = -1;
+}
+
+void USkaldMainHUDWidget::SubmitMove(int32 FromID, int32 ToID, int32 Troops) {
+  OnMoveRequested.Broadcast(FromID, ToID, Troops);
+  bSelectingForMove = false;
+  SelectedSourceID = -1;
+  SelectedTargetID = -1;
+}
+
+void USkaldMainHUDWidget::CancelMoveSelection() {
+  bSelectingForMove = false;
+  SelectedSourceID = -1;
+  SelectedTargetID = -1;
+}
+
+void USkaldMainHUDWidget::OnTerritoryClickedUI(int32 TerritoryID,
+                                               bool bOwnedByLocal) {
+  if (bSelectingForAttack) {
+    if (SelectedSourceID == -1) {
+      if (bOwnedByLocal) {
+        SelectedSourceID = TerritoryID;
+      }
+    } else if (SelectedTargetID == -1) {
+      SelectedTargetID = TerritoryID;
     }
-    if (EndTurnButton)
-    {
-        EndTurnButton->OnClicked.AddDynamic(this, &USkaldMainHUDWidget::HandleEndTurnClicked);
+  } else if (bSelectingForMove) {
+    if (SelectedSourceID == -1) {
+      if (bOwnedByLocal) {
+        SelectedSourceID = TerritoryID;
+      }
+    } else if (SelectedTargetID == -1) {
+      if (bOwnedByLocal) {
+        SelectedTargetID = TerritoryID;
+      }
     }
-
-    BP_SetPhaseButtons(CurrentPhase, CurrentPlayerID == LocalPlayerID);
-    BP_RebuildPlayerList(CachedPlayers);
+  }
 }
 
-void USkaldMainHUDWidget::HandleEndTurnClicked()
-{
-    if (CurrentPhase == ETurnPhase::Attack)
-    {
-        OnEndAttackRequested.Broadcast(true);
-    }
-    else if (CurrentPhase == ETurnPhase::Movement)
-    {
-        OnEndMovementRequested.Broadcast(true);
-    }
+void USkaldMainHUDWidget::SyncPhaseButtons(bool bIsMyTurn) {
+  BP_SetPhaseButtons(CurrentPhase, bIsMyTurn);
 }
-
-void USkaldMainHUDWidget::UpdateTurnBanner(int32 InCurrentPlayerID, int32 InTurnNumber)
-{
-    CurrentPlayerID = InCurrentPlayerID;
-    TurnNumber = InTurnNumber;
-
-    BP_SetTurnText(TurnNumber, CurrentPlayerID);
-    BP_SetPhaseButtons(CurrentPhase, CurrentPlayerID == LocalPlayerID);
-}
-
-void USkaldMainHUDWidget::UpdatePhaseBanner(ETurnPhase InPhase)
-{
-    CurrentPhase = InPhase;
-
-    BP_SetPhaseText(CurrentPhase);
-    BP_SetPhaseButtons(CurrentPhase, CurrentPlayerID == LocalPlayerID);
-}
-
-void USkaldMainHUDWidget::UpdateTerritoryInfo(const FString& TerritoryName, const FString& OwnerName, int32 ArmyCount)
-{
-    BP_SetTerritoryPanel(TerritoryName, OwnerName, ArmyCount);
-}
-
-void USkaldMainHUDWidget::RefreshPlayerList(const TArray<FS_PlayerData>& Players)
-{
-    CachedPlayers = Players;
-    BP_RebuildPlayerList(CachedPlayers);
-}
-
-void USkaldMainHUDWidget::RefreshFromState(int32 InCurrentPlayerID, int32 InTurnNumber, ETurnPhase InPhase, const TArray<FS_PlayerData>& Players)
-{
-    CurrentPlayerID = InCurrentPlayerID;
-    TurnNumber = InTurnNumber;
-    CurrentPhase = InPhase;
-    CachedPlayers = Players;
-
-    BP_SetTurnText(TurnNumber, CurrentPlayerID);
-    BP_SetPhaseText(CurrentPhase);
-    BP_RebuildPlayerList(CachedPlayers);
-    BP_SetPhaseButtons(CurrentPhase, CurrentPlayerID == LocalPlayerID);
-}
-
-void USkaldMainHUDWidget::BeginAttackSelection()
-{
-    bSelectingForAttack = true;
-    bSelectingForMove = false;
-    SelectedSourceID = -1;
-    SelectedTargetID = -1;
-}
-
-void USkaldMainHUDWidget::SubmitAttack(int32 FromID, int32 ToID, int32 ArmySent)
-{
-    OnAttackRequested.Broadcast(FromID, ToID, ArmySent);
-    bSelectingForAttack = false;
-    SelectedSourceID = -1;
-    SelectedTargetID = -1;
-}
-
-void USkaldMainHUDWidget::CancelAttackSelection()
-{
-    bSelectingForAttack = false;
-    SelectedSourceID = -1;
-    SelectedTargetID = -1;
-}
-
-void USkaldMainHUDWidget::BeginMoveSelection()
-{
-    bSelectingForMove = true;
-    bSelectingForAttack = false;
-    SelectedSourceID = -1;
-    SelectedTargetID = -1;
-}
-
-void USkaldMainHUDWidget::SubmitMove(int32 FromID, int32 ToID, int32 Troops)
-{
-    OnMoveRequested.Broadcast(FromID, ToID, Troops);
-    bSelectingForMove = false;
-    SelectedSourceID = -1;
-    SelectedTargetID = -1;
-}
-
-void USkaldMainHUDWidget::CancelMoveSelection()
-{
-    bSelectingForMove = false;
-    SelectedSourceID = -1;
-    SelectedTargetID = -1;
-}
-
-void USkaldMainHUDWidget::OnTerritoryClickedUI(int32 TerritoryID, bool bOwnedByLocal)
-{
-    if (bSelectingForAttack)
-    {
-        if (SelectedSourceID == -1)
-        {
-            if (bOwnedByLocal)
-            {
-                SelectedSourceID = TerritoryID;
-            }
-        }
-        else if (SelectedTargetID == -1)
-        {
-            SelectedTargetID = TerritoryID;
-        }
-    }
-    else if (bSelectingForMove)
-    {
-        if (SelectedSourceID == -1)
-        {
-            if (bOwnedByLocal)
-            {
-                SelectedSourceID = TerritoryID;
-            }
-        }
-        else if (SelectedTargetID == -1)
-        {
-            if (bOwnedByLocal)
-            {
-                SelectedTargetID = TerritoryID;
-            }
-        }
-    }
-}
-
-void USkaldMainHUDWidget::SyncPhaseButtons(bool bIsMyTurn)
-{
-    BP_SetPhaseButtons(CurrentPhase, bIsMyTurn);
-}
-

--- a/Source/Skald/UI/SkaldMainHUDWidget.h
+++ b/Source/Skald/UI/SkaldMainHUDWidget.h
@@ -1,165 +1,191 @@
 #pragma once
 
-#include "CoreMinimal.h"
 #include "Blueprint/UserWidget.h"
-#include "SkaldTypes.h"
+#include "CoreMinimal.h"
 #include "SkaldMainHUDWidget.generated.h"
+#include "SkaldTypes.h"
 
 class UButton;
 class UTextBlock;
+class UVerticalBox;
 
 // Delegates broadcasting user UI actions to game logic
-DECLARE_DYNAMIC_MULTICAST_DELEGATE_ThreeParams(FSkaldAttackRequested, int32, FromID, int32, ToID, int32, ArmySent);
-DECLARE_DYNAMIC_MULTICAST_DELEGATE_OneParam(FSkaldEndAttackRequested, bool, bConfirmed);
-DECLARE_DYNAMIC_MULTICAST_DELEGATE_TwoParams(FSkaldEngineeringRequested, int32, CapitalID, uint8, UpgradeType);
-DECLARE_DYNAMIC_MULTICAST_DELEGATE_OneParam(FSkaldDigTreasureRequested, int32, TerritoryID);
-DECLARE_DYNAMIC_MULTICAST_DELEGATE_ThreeParams(FSkaldMoveRequested, int32, FromID, int32, ToID, int32, Troops);
-DECLARE_DYNAMIC_MULTICAST_DELEGATE_OneParam(FSkaldEndMovementRequested, bool, bConfirmed);
+DECLARE_DYNAMIC_MULTICAST_DELEGATE_ThreeParams(FSkaldAttackRequested, int32,
+                                               FromID, int32, ToID, int32,
+                                               ArmySent);
+DECLARE_DYNAMIC_MULTICAST_DELEGATE_OneParam(FSkaldEndAttackRequested, bool,
+                                            bConfirmed);
+DECLARE_DYNAMIC_MULTICAST_DELEGATE_TwoParams(FSkaldEngineeringRequested, int32,
+                                             CapitalID, uint8, UpgradeType);
+DECLARE_DYNAMIC_MULTICAST_DELEGATE_OneParam(FSkaldDigTreasureRequested, int32,
+                                            TerritoryID);
+DECLARE_DYNAMIC_MULTICAST_DELEGATE_ThreeParams(FSkaldMoveRequested, int32,
+                                               FromID, int32, ToID, int32,
+                                               Troops);
+DECLARE_DYNAMIC_MULTICAST_DELEGATE_OneParam(FSkaldEndMovementRequested, bool,
+                                            bConfirmed);
 
 /**
  * Base HUD widget that exposes state and events for the game logic.
  *
- * Blueprint subclasses are expected to create the visual elements. Typical wiring:
- *  - Buttons in the BP call the BlueprintCallable functions such as SubmitAttack or SubmitMove.
- *    (e.g. AttackButton->OnClicked -> SubmitAttack(SourceID, TargetID, ArmySent))
- *  - PlayerController binds to the multicast delegates to forward actions to server RPCs:
- *      HUDWidget->OnAttackRequested.AddDynamic(this, &ASKald_PlayerController::Server_RequestAttack);
+ * Blueprint subclasses are expected to create the visual elements. Typical
+ * wiring:
+ *  - Buttons in the BP call the BlueprintCallable functions such as
+ * SubmitAttack or SubmitMove. (e.g. AttackButton->OnClicked ->
+ * SubmitAttack(SourceID, TargetID, ArmySent))
+ *  - PlayerController binds to the multicast delegates to forward actions to
+ * server RPCs: HUDWidget->OnAttackRequested.AddDynamic(this,
+ * &ASKald_PlayerController::Server_RequestAttack);
  */
 UCLASS(Blueprintable, BlueprintType)
-class SKALD_API USkaldMainHUDWidget : public UUserWidget
-{
-    GENERATED_BODY()
+class SKALD_API USkaldMainHUDWidget : public UUserWidget {
+  GENERATED_BODY()
 
 public:
-    // Identity / state (read by BP)
-    UPROPERTY(BlueprintReadWrite, Category="Skald|State")
-    int32 LocalPlayerID = -1;
+  // Identity / state (read by BP)
+  UPROPERTY(BlueprintReadWrite, Category = "Skald|State")
+  int32 LocalPlayerID = -1;
 
-    UPROPERTY(BlueprintReadWrite, Category="Skald|State")
-    int32 CurrentPlayerID = -1;
+  UPROPERTY(BlueprintReadWrite, Category = "Skald|State")
+  int32 CurrentPlayerID = -1;
 
-    UPROPERTY(BlueprintReadWrite, Category="Skald|State")
-    int32 TurnNumber = 1;
+  UPROPERTY(BlueprintReadWrite, Category = "Skald|State")
+  int32 TurnNumber = 1;
 
-    UPROPERTY(BlueprintReadWrite, Category="Skald|State")
-    ETurnPhase CurrentPhase = ETurnPhase::Reinforcement;
+  UPROPERTY(BlueprintReadWrite, Category = "Skald|State")
+  ETurnPhase CurrentPhase = ETurnPhase::Reinforcement;
 
-    // Selection helpers used by Attack/Move flows
-    UPROPERTY(BlueprintReadWrite, Category="Skald|Selection")
-    int32 SelectedSourceID = -1;
+  // Selection helpers used by Attack/Move flows
+  UPROPERTY(BlueprintReadWrite, Category = "Skald|Selection")
+  int32 SelectedSourceID = -1;
 
-    UPROPERTY(BlueprintReadWrite, Category="Skald|Selection")
-    int32 SelectedTargetID = -1;
+  UPROPERTY(BlueprintReadWrite, Category = "Skald|Selection")
+  int32 SelectedTargetID = -1;
 
-    UPROPERTY(BlueprintReadWrite, Category="Skald|Selection")
-    bool bSelectingForAttack = false;
+  UPROPERTY(BlueprintReadWrite, Category = "Skald|Selection")
+  bool bSelectingForAttack = false;
 
-    UPROPERTY(BlueprintReadWrite, Category="Skald|Selection")
-    bool bSelectingForMove = false;
+  UPROPERTY(BlueprintReadWrite, Category = "Skald|Selection")
+  bool bSelectingForMove = false;
 
-    // Cached list of players for UI list building
-    UPROPERTY(BlueprintReadWrite, Category="Skald|Data")
-    TArray<FS_PlayerData> CachedPlayers;
+  // Cached list of players for UI list building
+  UPROPERTY(BlueprintReadWrite, Category = "Skald|Data")
+  TArray<FS_PlayerData> CachedPlayers;
 
-    // Delegates (BlueprintAssignable) — UI → game actions
-    UPROPERTY(BlueprintAssignable, Category="Skald|Events")
-    FSkaldAttackRequested OnAttackRequested;
+  // Delegates (BlueprintAssignable) — UI → game actions
+  UPROPERTY(BlueprintAssignable, Category = "Skald|Events")
+  FSkaldAttackRequested OnAttackRequested;
 
-    UPROPERTY(BlueprintAssignable, Category="Skald|Events")
-    FSkaldEndAttackRequested OnEndAttackRequested;
+  UPROPERTY(BlueprintAssignable, Category = "Skald|Events")
+  FSkaldEndAttackRequested OnEndAttackRequested;
 
-    UPROPERTY(BlueprintAssignable, Category="Skald|Events")
-    FSkaldEngineeringRequested OnEngineeringRequested;
+  UPROPERTY(BlueprintAssignable, Category = "Skald|Events")
+  FSkaldEngineeringRequested OnEngineeringRequested;
 
-    UPROPERTY(BlueprintAssignable, Category="Skald|Events")
-    FSkaldDigTreasureRequested OnDigTreasureRequested;
+  UPROPERTY(BlueprintAssignable, Category = "Skald|Events")
+  FSkaldDigTreasureRequested OnDigTreasureRequested;
 
-    UPROPERTY(BlueprintAssignable, Category="Skald|Events")
-    FSkaldMoveRequested OnMoveRequested;
+  UPROPERTY(BlueprintAssignable, Category = "Skald|Events")
+  FSkaldMoveRequested OnMoveRequested;
 
-    UPROPERTY(BlueprintAssignable, Category="Skald|Events")
-    FSkaldEndMovementRequested OnEndMovementRequested;
+  UPROPERTY(BlueprintAssignable, Category = "Skald|Events")
+  FSkaldEndMovementRequested OnEndMovementRequested;
 
-    // BlueprintCallable functions — game → HUD (push updates)
-    UFUNCTION(BlueprintCallable, Category="Skald|HUD")
-    void UpdateTurnBanner(int32 InCurrentPlayerID, int32 InTurnNumber);
+  // BlueprintCallable functions — game → HUD (push updates)
+  UFUNCTION(BlueprintCallable, Category = "Skald|HUD")
+  void UpdateTurnBanner(int32 InCurrentPlayerID, int32 InTurnNumber);
 
-    UFUNCTION(BlueprintCallable, Category="Skald|HUD")
-    void UpdatePhaseBanner(ETurnPhase InPhase);
+  UFUNCTION(BlueprintCallable, Category = "Skald|HUD")
+  void UpdatePhaseBanner(ETurnPhase InPhase);
 
-    UFUNCTION(BlueprintCallable, Category="Skald|HUD")
-    void UpdateTerritoryInfo(const FString& TerritoryName, const FString& OwnerName, int32 ArmyCount);
+  UFUNCTION(BlueprintCallable, Category = "Skald|HUD")
+  void UpdateTerritoryInfo(const FString &TerritoryName,
+                           const FString &OwnerName, int32 ArmyCount);
 
-    UFUNCTION(BlueprintCallable, Category="Skald|HUD")
-    void RefreshPlayerList(const TArray<FS_PlayerData>& Players);
+  UFUNCTION(BlueprintCallable, Category = "Skald|HUD")
+  void RefreshPlayerList(const TArray<FS_PlayerData> &Players);
 
-    UFUNCTION(BlueprintCallable, Category="Skald|HUD")
-    void RefreshFromState(int32 InCurrentPlayerID, int32 InTurnNumber, ETurnPhase InPhase, const TArray<FS_PlayerData>& Players);
+  UFUNCTION(BlueprintCallable, Category = "Skald|HUD")
+  void RefreshFromState(int32 InCurrentPlayerID, int32 InTurnNumber,
+                        ETurnPhase InPhase,
+                        const TArray<FS_PlayerData> &Players);
 
-    // BlueprintCallable functions — selection UX helpers
-    UFUNCTION(BlueprintCallable, Category="Skald|Selection")
-    void BeginAttackSelection();
+  /** Rebuilds the cached player list into PlayerListBox. */
+  UFUNCTION(BlueprintCallable, Category = "Skald|HUD")
+  void RebuildPlayerList(const TArray<FS_PlayerData> &Players);
 
-    UFUNCTION(BlueprintCallable, Category="Skald|Selection")
-    void SubmitAttack(int32 FromID, int32 ToID, int32 ArmySent);
+  // BlueprintCallable functions — selection UX helpers
+  UFUNCTION(BlueprintCallable, Category = "Skald|Selection")
+  void BeginAttackSelection();
 
-    UFUNCTION(BlueprintCallable, Category="Skald|Selection")
-    void CancelAttackSelection();
+  UFUNCTION(BlueprintCallable, Category = "Skald|Selection")
+  void SubmitAttack(int32 FromID, int32 ToID, int32 ArmySent);
 
-    UFUNCTION(BlueprintCallable, Category="Skald|Selection")
-    void BeginMoveSelection();
+  UFUNCTION(BlueprintCallable, Category = "Skald|Selection")
+  void CancelAttackSelection();
 
-    UFUNCTION(BlueprintCallable, Category="Skald|Selection")
-    void SubmitMove(int32 FromID, int32 ToID, int32 Troops);
+  UFUNCTION(BlueprintCallable, Category = "Skald|Selection")
+  void BeginMoveSelection();
 
-    UFUNCTION(BlueprintCallable, Category="Skald|Selection")
-    void CancelMoveSelection();
+  UFUNCTION(BlueprintCallable, Category = "Skald|Selection")
+  void SubmitMove(int32 FromID, int32 ToID, int32 Troops);
 
-    UFUNCTION(BlueprintCallable, Category="Skald|Selection")
-    void OnTerritoryClickedUI(int32 TerritoryID, bool bOwnedByLocal);
+  UFUNCTION(BlueprintCallable, Category = "Skald|Selection")
+  void CancelMoveSelection();
 
-    // BlueprintImplementableEvent hooks — BP subclass draws UI
-    UFUNCTION(BlueprintImplementableEvent, Category="Skald|HUD")
-    void BP_SetTurnText(int32 InTurnNumber, int32 InCurrentPlayerID);
+  UFUNCTION(BlueprintCallable, Category = "Skald|Selection")
+  void OnTerritoryClickedUI(int32 TerritoryID, bool bOwnedByLocal);
 
-    UFUNCTION(BlueprintImplementableEvent, Category="Skald|HUD")
-    void BP_SetPhaseText(ETurnPhase InPhase);
+  // BlueprintImplementableEvent hooks — BP subclass draws UI
+  UFUNCTION(BlueprintImplementableEvent, Category = "Skald|HUD")
+  void BP_SetTurnText(int32 InTurnNumber, int32 InCurrentPlayerID);
 
-    UFUNCTION(BlueprintImplementableEvent, Category="Skald|HUD")
-    void BP_SetTerritoryPanel(const FString& TerritoryName, const FString& OwnerName, int32 ArmyCount);
+  UFUNCTION(BlueprintImplementableEvent, Category = "Skald|HUD")
+  void BP_SetPhaseText(ETurnPhase InPhase);
 
-    UFUNCTION(BlueprintImplementableEvent, Category="Skald|HUD")
-    void BP_RebuildPlayerList(const TArray<FS_PlayerData>& Players);
+  UFUNCTION(BlueprintImplementableEvent, Category = "Skald|HUD")
+  void BP_SetTerritoryPanel(const FString &TerritoryName,
+                            const FString &OwnerName, int32 ArmyCount);
 
-    UFUNCTION(BlueprintImplementableEvent, Category="Skald|HUD")
-    void BP_SetPhaseButtons(ETurnPhase InPhase, bool bIsMyTurn);
+  UFUNCTION(BlueprintImplementableEvent, Category = "Skald|HUD")
+  void BP_SetPhaseButtons(ETurnPhase InPhase, bool bIsMyTurn);
 
-    // Helper so PlayerController can refresh button enable state after it knows turn ownership
-    UFUNCTION(BlueprintCallable, Category="Skald|HUD")
-    void SyncPhaseButtons(bool bIsMyTurn);
+  // Helper so PlayerController can refresh button enable state after it knows
+  // turn ownership
+  UFUNCTION(BlueprintCallable, Category = "Skald|HUD")
+  void SyncPhaseButtons(bool bIsMyTurn);
 
 public:
-    // Bound widget references - optional so subclasses can customise layouts
-    UPROPERTY(BlueprintReadOnly, Category="Skald|Widgets", meta=(BindWidgetOptional))
-    UTextBlock* TurnText;
+  // Bound widget references - optional so subclasses can customise layouts
+  UPROPERTY(BlueprintReadOnly, Category = "Skald|Widgets",
+            meta = (BindWidgetOptional))
+  UTextBlock *TurnText;
 
-    UPROPERTY(BlueprintReadOnly, Category="Skald|Widgets", meta=(BindWidgetOptional))
-    UTextBlock* PhaseText;
+  UPROPERTY(BlueprintReadOnly, Category = "Skald|Widgets",
+            meta = (BindWidgetOptional))
+  UTextBlock *PhaseText;
 
-    UPROPERTY(BlueprintReadOnly, Category="Skald|Widgets", meta=(BindWidgetOptional))
-    UButton* AttackButton;
+  UPROPERTY(BlueprintReadOnly, Category = "Skald|Widgets",
+            meta = (BindWidgetOptional))
+  UButton *AttackButton;
 
-    UPROPERTY(BlueprintReadOnly, Category="Skald|Widgets", meta=(BindWidgetOptional))
-    UButton* MoveButton;
+  UPROPERTY(BlueprintReadOnly, Category = "Skald|Widgets",
+            meta = (BindWidgetOptional))
+  UButton *MoveButton;
 
-    UPROPERTY(BlueprintReadOnly, Category="Skald|Widgets", meta=(BindWidgetOptional))
-    UButton* EndTurnButton;
+  UPROPERTY(BlueprintReadOnly, Category = "Skald|Widgets",
+            meta = (BindWidgetOptional))
+  UButton *EndTurnButton;
+
+  // Container where RebuildPlayerList will spawn entries
+  UPROPERTY(BlueprintReadOnly, Category = "Skald|Widgets",
+            meta = (BindWidgetOptional))
+  UVerticalBox *PlayerListBox;
 
 protected:
-    // Internal handlers for widget actions
-    UFUNCTION()
-    void HandleEndTurnClicked();
+  // Internal handlers for widget actions
+  UFUNCTION()
+  void HandleEndTurnClicked();
 
-    virtual void NativeConstruct() override;
+  virtual void NativeConstruct() override;
 };
-


### PR DESCRIPTION
## Summary
- Build and display the Main HUD player list directly in C++
- Cache player data and populate a bound vertical box with text entries

## Testing
- `g++ -std=c++17 -ISource/Skald -c Source/Skald/UI/SkaldMainHUDWidget.cpp` *(fails: Blueprint/UserWidget.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68ae06a9bb248324a76f8d6c1775852b