### PR TITLE
Populate singleplayer slots with AI and show start banner

### DIFF
--- a/Source/Skald/Skald_GameInstance.h
+++ b/Source/Skald/Skald_GameInstance.h
@@ -19,5 +19,9 @@ public:
     /** Selected faction for this player. */
     UPROPERTY(BlueprintReadWrite, Category="Player")
     ESkaldFaction Faction;
+
+    /** Whether the game was started in multiplayer mode. */
+    UPROPERTY(BlueprintReadWrite, Category="Player")
+    bool bIsMultiplayer;
 };
 

--- a/Source/Skald/Skald_GameMode.cpp
+++ b/Source/Skald/Skald_GameMode.cpp
@@ -8,9 +8,11 @@
 #include "Territory.h"
 #include "TimerManager.h"
 #include "WorldMap.h"
+#include "Skald_GameInstance.h"
+#include "UI/SkaldMainHUDWidget.h"
 
 namespace {
-constexpr int32 ExpectedPlayerCount = 2;
+constexpr int32 ExpectedPlayerCount = 4;
 constexpr float StartGameTimeout = 10.f;
 // Instance variables moved into ASkaldGameMode to avoid cross-instance
 // interference; see header for declarations.
@@ -26,9 +28,9 @@ ASkaldGameMode::ASkaldGameMode() {
   WorldMap = nullptr;
   bTurnsStarted = false;
 
-  // Preallocate two slots so blueprint scripts can safely write
+  // Preallocate slots so blueprint scripts can safely write
   // player data to indices without hitting "invalid index" warnings.
-  PlayersData.SetNum(2);
+  PlayersData.SetNum(ExpectedPlayerCount);
 }
 
 void ASkaldGameMode::BeginPlay() {
@@ -51,6 +53,10 @@ void ASkaldGameMode::BeginPlay() {
           bTurnsStarted = true;
           TurnManager->SortControllersByInitiative();
           TurnManager->StartTurns();
+          if (GEngine)
+          {
+            GEngine->AddOnScreenDebugMessage(-1, 4.f, FColor::Green, TEXT("Game started"));
+          }
         }
       }),
       StartGameTimeout, false);
@@ -77,12 +83,102 @@ void ASkaldGameMode::PostLogin(APlayerController *NewPlayer) {
         }
       }
 
+      // In singleplayer fill remaining slots with AI opponents
+      if (USkaldGameInstance* GI = GetGameInstance<USkaldGameInstance>())
+      {
+        if (!GI->bIsMultiplayer)
+        {
+          // Populate AI players up to the expected count
+          while (GS->PlayerArray.Num() < ExpectedPlayerCount)
+          {
+            ASkaldPlayerState* AIState = GetWorld()->SpawnActor<ASkaldPlayerState>(PlayerStateClass);
+            if (!AIState)
+            {
+              break;
+            }
+            AIState->bIsAI = true;
+            AIState->DisplayName = FString::Printf(TEXT("AI_%d"), GS->PlayerArray.Num());
+
+            // Choose a faction not already taken
+            TArray<ESkaldFaction> Taken;
+            for (APlayerState* ExistingPS : GS->PlayerArray)
+            {
+              if (ASkaldPlayerState* EPS = Cast<ASkaldPlayerState>(ExistingPS))
+              {
+                Taken.Add(EPS->Faction);
+              }
+            }
+            TArray<ESkaldFaction> Available;
+            if (UEnum* Enum = StaticEnum<ESkaldFaction>())
+            {
+              for (int32 i = 0; i < Enum->NumEnums(); ++i)
+              {
+                if (Enum->HasMetaData(TEXT("Hidden"), i))
+                {
+                  continue;
+                }
+                ESkaldFaction Fac = static_cast<ESkaldFaction>(Enum->GetValueByIndex(i));
+                if (Fac != ESkaldFaction::None && !Taken.Contains(Fac))
+                {
+                  Available.Add(Fac);
+                }
+              }
+            }
+            if (Available.Num() > 0)
+            {
+              AIState->Faction = Available[FMath::RandRange(0, Available.Num() - 1)];
+            }
+
+            GS->AddPlayerState(AIState);
+
+            if (PlayersData.Num() < GS->PlayerArray.Num())
+            {
+              PlayersData.SetNum(GS->PlayerArray.Num());
+            }
+            const int32 Index = GS->PlayerArray.Num() - 1;
+            PlayersData[Index].PlayerID = AIState->GetPlayerId();
+            PlayersData[Index].PlayerName = AIState->DisplayName;
+            PlayersData[Index].IsAI = true;
+            PlayersData[Index].Faction = AIState->Faction;
+          }
+
+          // Refresh HUDs with the updated player list
+          TArray<FS_PlayerData> AllPlayers;
+          for (APlayerState* PSBase : GS->PlayerArray)
+          {
+            if (ASkaldPlayerState* SPS = Cast<ASkaldPlayerState>(PSBase))
+            {
+              FS_PlayerData Data;
+              Data.PlayerID = SPS->GetPlayerId();
+              Data.PlayerName = SPS->DisplayName;
+              Data.IsAI = SPS->bIsAI;
+              Data.Faction = SPS->Faction;
+              AllPlayers.Add(Data);
+            }
+          }
+          for (FConstPlayerControllerIterator It = GetWorld()->GetPlayerControllerIterator(); It; ++It)
+          {
+            if (ASkaldPlayerController* RefreshPC = Cast<ASkaldPlayerController>(*It))
+            {
+              if (USkaldMainHUDWidget* HUD = RefreshPC->GetHUDWidget())
+              {
+                HUD->RefreshPlayerList(AllPlayers);
+              }
+            }
+          }
+        }
+      }
+
       if (GS->PlayerArray.Num() >= ExpectedPlayerCount && !bTurnsStarted) {
         bTurnsStarted = true;
         GetWorldTimerManager().ClearTimer(StartGameTimerHandle);
         if (TurnManager) {
           TurnManager->SortControllersByInitiative();
           TurnManager->StartTurns();
+          if (GEngine)
+          {
+            GEngine->AddOnScreenDebugMessage(-1, 4.f, FColor::Green, TEXT("Game started"));
+          }
         }
       }
     }

--- a/Source/Skald/Skald_PlayerController.h
+++ b/Source/Skald/Skald_PlayerController.h
@@ -41,6 +41,10 @@ public:
     UFUNCTION(BlueprintCallable, Category="UI")
     void HandleTerritorySelected(ATerritory* Terr);
 
+    /** Accessor for the main HUD widget instance. */
+    UFUNCTION(BlueprintCallable, Category="UI")
+    USkaldMainHUDWidget* GetHUDWidget() const { return MainHudWidget; }
+
 protected:
     /** Whether this controller is controlled by AI. */
     UPROPERTY(BlueprintReadOnly, Category="Turn")

--- a/Source/Skald/StartGameWidget.cpp
+++ b/Source/Skald/StartGameWidget.cpp
@@ -124,6 +124,7 @@ void UStartGameWidget::StartGame(bool bMultiplayer)
         {
             GI->DisplayName = Name;
             GI->Faction = Faction;
+            GI->bIsMultiplayer = bMultiplayer;
         }
 
         if (APlayerController* PC = GetOwningPlayer())


### PR DESCRIPTION
## Summary
- track multiplayer mode in the game instance and lobby start widget
- expand game mode to support four players, auto-fill empty slots with AIs, update HUD, and display a start banner
- expose HUD widget from player controller for game mode updates

## Testing
- `make` *(fails: No targets specified and no makefile found)*

------
https://chatgpt.com/codex/tasks/task_e_68ae0fdfe208832497c6a26108ab95fc