### PR TITLE
Ensure unique faction selection and territory setup

### DIFF
--- a/Source/Skald/Skald_GameInstance.h
+++ b/Source/Skald/Skald_GameInstance.h
@@ -23,5 +23,9 @@ public:
     /** Whether the game was started in multiplayer mode. */
     UPROPERTY(BlueprintReadWrite, Category="Player")
     bool bIsMultiplayer;
+
+    /** Factions that have already been selected by players or AI. */
+    UPROPERTY(BlueprintReadWrite, Category="Player")
+    TArray<ESkaldFaction> TakenFactions;
 };
 

--- a/Source/Skald/Skald_GameMode.h
+++ b/Source/Skald/Skald_GameMode.h
@@ -54,4 +54,7 @@ private:
 
   /** Tracks whether turns have already begun to avoid duplicates. */
   bool bTurnsStarted;
+
+  /** Whether the world has been initialized and territories assigned. */
+  bool bWorldInitialized;
 };

--- a/Source/Skald/Territory.cpp
+++ b/Source/Skald/Territory.cpp
@@ -4,7 +4,27 @@
 #include "Materials/MaterialInstanceDynamic.h"
 #include "Skald_PlayerState.h"
 #include "Skald_PlayerController.h"
+#include "SkaldTypes.h"
 #include "Net/UnrealNetwork.h"
+
+namespace
+{
+FLinearColor GetFactionColor(ESkaldFaction Faction)
+{
+  switch (Faction)
+  {
+  case ESkaldFaction::Human: return FLinearColor::Blue;
+  case ESkaldFaction::Orc: return FLinearColor::Green;
+  case ESkaldFaction::Dwarf: return FLinearColor(0.6f, 0.6f, 0.6f, 1.f);
+  case ESkaldFaction::Elf: return FLinearColor(0.0f, 0.8f, 0.4f, 1.f);
+  case ESkaldFaction::LizardFolk: return FLinearColor(0.0f, 0.6f, 0.3f, 1.f);
+  case ESkaldFaction::Undead: return FLinearColor(0.5f, 0.0f, 0.5f, 1.f);
+  case ESkaldFaction::Gnoll: return FLinearColor(0.8f, 0.4f, 0.0f, 1.f);
+  case ESkaldFaction::Empire: return FLinearColor::Red;
+  default: return FLinearColor::White;
+  }
+}
+}
 
 ATerritory::ATerritory() {
   PrimaryActorTick.bCanEverTick = false;
@@ -133,7 +153,7 @@ void ATerritory::UpdateTerritoryColor() {
   if (DynamicMaterial) {
     FLinearColor NewColor = DefaultColor;
     if (OwningPlayer) {
-      NewColor = FLinearColor::Red;
+      NewColor = GetFactionColor(OwningPlayer->Faction);
     }
     DynamicMaterial->SetVectorParameterValue(FName("Color"), NewColor);
   }


### PR DESCRIPTION
## Summary
- Hide multiplayer and singleplayer buttons until name and faction are set
- Track taken factions and hide them from selection; assign AI unique factions
- Initialize world after players join and color territories based on faction

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ae1489663c8324bd47d7781d3d7222