### PR TITLE
Add lock-in confirmation to start game flow

### DIFF
--- a/Source/Skald/StartGameWidget.h
+++ b/Source/Skald/StartGameWidget.h
@@ -28,6 +28,10 @@ public:
     UPROPERTY(BlueprintReadOnly, Category="Skald|Widgets", meta = (BindWidgetOptional))
     UComboBoxString* FactionComboBox;
 
+    /** Button to confirm the player's selections before starting. */
+    UPROPERTY(BlueprintReadOnly, Category="Skald|Widgets", meta = (BindWidgetOptional))
+    UButton* LockInButton;
+
     /** Button to start singleplayer. */
     UPROPERTY(BlueprintReadOnly, Category="Skald|Widgets", meta = (BindWidgetOptional))
     UButton* SingleplayerButton;
@@ -54,6 +58,9 @@ protected:
 
     UFUNCTION()
     void OnMainMenu();
+
+    UFUNCTION()
+    void OnLockIn();
 
     UFUNCTION()
     void OnDisplayNameChanged(const FText& Text);


### PR DESCRIPTION
## Summary
- Add lock-in button so players confirm display name and faction before choosing play mode
- Hide display name and faction controls after locking in and reveal single/multiplayer buttons
- Update player and game instance data when locking in and simplify start logic

## Testing
- `make` *(fails: No targets specified and no makefile found)*

------
https://chatgpt.com/codex/tasks/task_e_68ae1db103c08324ac79425cde824729