### PR TITLE
feat: broadcast turn announcements

### DIFF
--- a/Source/Skald/Skald_PlayerController.cpp
+++ b/Source/Skald/Skald_PlayerController.cpp
@@ -5,6 +5,7 @@
 #include "UI/SkaldMainHUDWidget.h"
 #include "Skald_GameState.h"
 #include "Territory.h"
+#include "Engine/Engine.h"
 
 ASkaldPlayerController::ASkaldPlayerController() {
   bIsAI = false;
@@ -68,6 +69,15 @@ void ASkaldPlayerController::BeginPlay() {
 
 void ASkaldPlayerController::SetTurnManager(ATurnManager *Manager) {
   TurnManager = Manager;
+}
+
+void ASkaldPlayerController::ShowTurnAnnouncement(const FString& PlayerName) {
+  if (MainHudWidget) {
+    MainHudWidget->ShowTurnAnnouncement(PlayerName);
+  } else if (GEngine) {
+    const FString Message = FString::Printf(TEXT("%s's Turn"), *PlayerName);
+    GEngine->AddOnScreenDebugMessage(-1, 4.f, FColor::Yellow, Message);
+  }
 }
 
 void ASkaldPlayerController::StartTurn() {

--- a/Source/Skald/Skald_PlayerController.h
+++ b/Source/Skald/Skald_PlayerController.h
@@ -38,6 +38,9 @@ public:
     UFUNCTION(BlueprintCallable, Category="Turn")
     void SetTurnManager(ATurnManager* Manager);
 
+    UFUNCTION(BlueprintCallable, Category="Turn")
+    void ShowTurnAnnouncement(const FString& PlayerName);
+
     UFUNCTION(BlueprintCallable, Category="UI")
     void HandleTerritorySelected(ATerritory* Terr);
 

--- a/Source/Skald/Skald_TurnManager.cpp
+++ b/Source/Skald/Skald_TurnManager.cpp
@@ -21,7 +21,18 @@ void ATurnManager::StartTurns() {
   SortControllersByInitiative();
   CurrentIndex = 0;
   if (Controllers.IsValidIndex(CurrentIndex)) {
-    Controllers[CurrentIndex]->StartTurn();
+    ASkaldPlayerController *CurrentController = Controllers[CurrentIndex];
+    ASkaldPlayerState *PS =
+        CurrentController->GetPlayerState<ASkaldPlayerState>();
+    const FString PlayerName = PS ? PS->DisplayName : TEXT("Unknown");
+
+    for (ASkaldPlayerController *Controller : Controllers) {
+      if (Controller) {
+        Controller->ShowTurnAnnouncement(PlayerName);
+      }
+    }
+
+    CurrentController->StartTurn();
   }
 }
 
@@ -31,7 +42,18 @@ void ATurnManager::AdvanceTurn() {
   }
 
   CurrentIndex = (CurrentIndex + 1) % Controllers.Num();
-  Controllers[CurrentIndex]->StartTurn();
+  ASkaldPlayerController *CurrentController = Controllers[CurrentIndex];
+  ASkaldPlayerState *PS =
+      CurrentController->GetPlayerState<ASkaldPlayerState>();
+  const FString PlayerName = PS ? PS->DisplayName : TEXT("Unknown");
+
+  for (ASkaldPlayerController *Controller : Controllers) {
+    if (Controller) {
+      Controller->ShowTurnAnnouncement(PlayerName);
+    }
+  }
+
+  CurrentController->StartTurn();
 }
 
 void ATurnManager::SortControllersByInitiative() {

--- a/Source/Skald/UI/SkaldMainHUDWidget.cpp
+++ b/Source/Skald/UI/SkaldMainHUDWidget.cpp
@@ -2,6 +2,7 @@
 #include "Components/Button.h"
 #include "Components/TextBlock.h"
 #include "Components/VerticalBox.h"
+#include "Engine/Engine.h"
 
 void USkaldMainHUDWidget::NativeConstruct() {
   Super::NativeConstruct();
@@ -71,6 +72,15 @@ void USkaldMainHUDWidget::RefreshFromState(
   BP_SetPhaseText(CurrentPhase);
   RebuildPlayerList(CachedPlayers);
   BP_SetPhaseButtons(CurrentPhase, CurrentPlayerID == LocalPlayerID);
+}
+
+void USkaldMainHUDWidget::ShowTurnAnnouncement(const FString &PlayerName) {
+  BP_ShowTurnAnnouncement(PlayerName);
+  if (GEngine) {
+    const FString Message =
+        FString::Printf(TEXT("%s's Turn"), *PlayerName);
+    GEngine->AddOnScreenDebugMessage(-1, 4.f, FColor::Yellow, Message);
+  }
 }
 
 void USkaldMainHUDWidget::RebuildPlayerList(

--- a/Source/Skald/UI/SkaldMainHUDWidget.h
+++ b/Source/Skald/UI/SkaldMainHUDWidget.h
@@ -110,6 +110,9 @@ public:
                         ETurnPhase InPhase,
                         const TArray<FS_PlayerData> &Players);
 
+  UFUNCTION(BlueprintCallable, Category = "Skald|HUD")
+  void ShowTurnAnnouncement(const FString &PlayerName);
+
   /** Rebuilds the cached player list into PlayerListBox. */
   UFUNCTION(BlueprintCallable, Category = "Skald|HUD")
   void RebuildPlayerList(const TArray<FS_PlayerData> &Players);
@@ -149,6 +152,9 @@ public:
 
   UFUNCTION(BlueprintImplementableEvent, Category = "Skald|HUD")
   void BP_SetPhaseButtons(ETurnPhase InPhase, bool bIsMyTurn);
+
+  UFUNCTION(BlueprintImplementableEvent, Category = "Skald|HUD")
+  void BP_ShowTurnAnnouncement(const FString &PlayerName);
 
   // Helper so PlayerController can refresh button enable state after it knows
   // turn ownership


### PR DESCRIPTION
## Summary
- Announce the active player at the start of each turn
- Forward announcements through player controllers to HUD widgets
- HUD widgets display the turn banner or fallback to on-screen debug

## Testing
- `make` *(fails: No targets specified and no makefile found)*

------
https://chatgpt.com/codex/tasks/task_e_68ae260d9c288324a8cc3155e231929e