### PR TITLE
Align world map territories with predefined layout

### DIFF
--- a/Source/Skald/WorldMap.cpp
+++ b/Source/Skald/WorldMap.cpp
@@ -6,49 +6,49 @@
 // mirrors the data supplied by design and is used to spawn the territories at
 // runtime.
 const TArray<FTerritorySpawnData> AWorldMap::DefaultTerritories = {
-    FTerritorySpawnData(0, TEXT("Howling Veil"), true),
-    FTerritorySpawnData(1, TEXT("Thond")),
-    FTerritorySpawnData(2, TEXT("Elmyre")),
-    FTerritorySpawnData(3, TEXT("Skarlstorm")),
-    FTerritorySpawnData(4, TEXT("Direford")),
-    FTerritorySpawnData(5, TEXT("Grimrest")),
-    FTerritorySpawnData(6, TEXT("Lakehold")),
-    FTerritorySpawnData(7, TEXT("Argoth")),
-    FTerritorySpawnData(8, TEXT("Chala"), false, 1),
-    FTerritorySpawnData(9, TEXT("Rylan"), false, 1),
-    FTerritorySpawnData(10, TEXT("Uris"), false, 1),
-    FTerritorySpawnData(11, TEXT("Achre"), true, 1),
-    FTerritorySpawnData(12, TEXT("Erif"), false, 2),
-    FTerritorySpawnData(13, TEXT("Nevar"), false, 1),
-    FTerritorySpawnData(14, TEXT("Frayton")),
-    FTerritorySpawnData(15, TEXT("Past Fields"), false, 1),
-    FTerritorySpawnData(16, TEXT("Spring Isle"), false, 1),
-    FTerritorySpawnData(17, TEXT("Sunder Isle"), false, 2),
-    FTerritorySpawnData(18, TEXT("Sugiria"), true, 2),
-    FTerritorySpawnData(19, TEXT("Blindshade"), false, 2),
-    FTerritorySpawnData(20, TEXT("Whimswallow"), false, 2),
-    FTerritorySpawnData(21, TEXT("Forgotten Coast"), false, 2),
-    FTerritorySpawnData(22, TEXT("Oria"), false, 2),
-    FTerritorySpawnData(23, TEXT("Brell"), false, 3),
-    FTerritorySpawnData(24, TEXT("Revel"), true, 3),
-    FTerritorySpawnData(25, TEXT("Velaria"), false, 3),
-    FTerritorySpawnData(26, TEXT("Essivar"), false, 3),
-    FTerritorySpawnData(27, TEXT("Caldemire"), false, 3),
-    FTerritorySpawnData(28, TEXT("HazelHallow"), false, 4),
-    FTerritorySpawnData(29, TEXT("Sirholde"), false, 4),
-    FTerritorySpawnData(30, TEXT("Styr"), false, 4),
-    FTerritorySpawnData(31, TEXT("Dawnmere"), true, 4),
-    FTerritorySpawnData(32, TEXT("Killbrooke"), false, 4),
-    FTerritorySpawnData(33, TEXT("Broken Plains"), false, 5),
-    FTerritorySpawnData(34, TEXT("Everlands"), false, 5),
-    FTerritorySpawnData(35, TEXT("Vigilmoore"), false, 5),
-    FTerritorySpawnData(36, TEXT("Vulkrum"), false, 5),
-    FTerritorySpawnData(37, TEXT("Timber Rock"), false, 5),
-    FTerritorySpawnData(38, TEXT("Omenwhick"), false, 5),
-    FTerritorySpawnData(39, TEXT("Armens Grasp"), false, 5),
-    FTerritorySpawnData(40, TEXT("Volkridge"), true, 5),
-    FTerritorySpawnData(41, TEXT("Bakas"), false, 5),
-    FTerritorySpawnData(42, TEXT("Kesis"), false, 5)};
+    FTerritorySpawnData(0, TEXT("Howling Veil"), true, 0, FVector(-600.0f, -600.0f, 0.f)),
+    FTerritorySpawnData(1, TEXT("Thond"), false, 0, FVector(-400.0f, -600.0f, 0.f)),
+    FTerritorySpawnData(2, TEXT("Elmyre"), false, 0, FVector(-200.0f, -600.0f, 0.f)),
+    FTerritorySpawnData(3, TEXT("Skarlstorm"), false, 0, FVector(0.0f, -600.0f, 0.f)),
+    FTerritorySpawnData(4, TEXT("Direford"), false, 0, FVector(200.0f, -600.0f, 0.f)),
+    FTerritorySpawnData(5, TEXT("Grimrest"), false, 0, FVector(400.0f, -600.0f, 0.f)),
+    FTerritorySpawnData(6, TEXT("Lakehold"), false, 0, FVector(600.0f, -600.0f, 0.f)),
+    FTerritorySpawnData(7, TEXT("Argoth"), false, 0, FVector(-600.0f, -400.0f, 0.f)),
+    FTerritorySpawnData(8, TEXT("Chala"), false, 1, FVector(-400.0f, -400.0f, 0.f)),
+    FTerritorySpawnData(9, TEXT("Rylan"), false, 1, FVector(-200.0f, -400.0f, 0.f)),
+    FTerritorySpawnData(10, TEXT("Uris"), false, 1, FVector(0.0f, -400.0f, 0.f)),
+    FTerritorySpawnData(11, TEXT("Achre"), true, 1, FVector(200.0f, -400.0f, 0.f)),
+    FTerritorySpawnData(12, TEXT("Erif"), false, 2, FVector(400.0f, -400.0f, 0.f)),
+    FTerritorySpawnData(13, TEXT("Nevar"), false, 1, FVector(600.0f, -400.0f, 0.f)),
+    FTerritorySpawnData(14, TEXT("Frayton"), false, 0, FVector(-600.0f, -200.0f, 0.f)),
+    FTerritorySpawnData(15, TEXT("Past Fields"), false, 1, FVector(-400.0f, -200.0f, 0.f)),
+    FTerritorySpawnData(16, TEXT("Spring Isle"), false, 1, FVector(-200.0f, -200.0f, 0.f)),
+    FTerritorySpawnData(17, TEXT("Sunder Isle"), false, 2, FVector(0.0f, -200.0f, 0.f)),
+    FTerritorySpawnData(18, TEXT("Sugiria"), true, 2, FVector(200.0f, -200.0f, 0.f)),
+    FTerritorySpawnData(19, TEXT("Blindshade"), false, 2, FVector(400.0f, -200.0f, 0.f)),
+    FTerritorySpawnData(20, TEXT("Whimswallow"), false, 2, FVector(600.0f, -200.0f, 0.f)),
+    FTerritorySpawnData(21, TEXT("Forgotten Coast"), false, 2, FVector(-600.0f, 0.0f, 0.f)),
+    FTerritorySpawnData(22, TEXT("Oria"), false, 2, FVector(-400.0f, 0.0f, 0.f)),
+    FTerritorySpawnData(23, TEXT("Brell"), false, 3, FVector(-200.0f, 0.0f, 0.f)),
+    FTerritorySpawnData(24, TEXT("Revel"), true, 3, FVector(0.0f, 0.0f, 0.f)),
+    FTerritorySpawnData(25, TEXT("Velaria"), false, 3, FVector(200.0f, 0.0f, 0.f)),
+    FTerritorySpawnData(26, TEXT("Essivar"), false, 3, FVector(400.0f, 0.0f, 0.f)),
+    FTerritorySpawnData(27, TEXT("Caldemire"), false, 3, FVector(600.0f, 0.0f, 0.f)),
+    FTerritorySpawnData(28, TEXT("HazelHallow"), false, 4, FVector(-600.0f, 200.0f, 0.f)),
+    FTerritorySpawnData(29, TEXT("Sirholde"), false, 4, FVector(-400.0f, 200.0f, 0.f)),
+    FTerritorySpawnData(30, TEXT("Styr"), false, 4, FVector(-200.0f, 200.0f, 0.f)),
+    FTerritorySpawnData(31, TEXT("Dawnmere"), true, 4, FVector(0.0f, 200.0f, 0.f)),
+    FTerritorySpawnData(32, TEXT("Killbrooke"), false, 4, FVector(200.0f, 200.0f, 0.f)),
+    FTerritorySpawnData(33, TEXT("Broken Plains"), false, 5, FVector(400.0f, 200.0f, 0.f)),
+    FTerritorySpawnData(34, TEXT("Everlands"), false, 5, FVector(600.0f, 200.0f, 0.f)),
+    FTerritorySpawnData(35, TEXT("Vigilmoore"), false, 5, FVector(-600.0f, 400.0f, 0.f)),
+    FTerritorySpawnData(36, TEXT("Vulkrum"), false, 5, FVector(-400.0f, 400.0f, 0.f)),
+    FTerritorySpawnData(37, TEXT("Timber Rock"), false, 5, FVector(-200.0f, 400.0f, 0.f)),
+    FTerritorySpawnData(38, TEXT("Omenwhick"), false, 5, FVector(0.0f, 400.0f, 0.f)),
+    FTerritorySpawnData(39, TEXT("Armens Grasp"), false, 5, FVector(200.0f, 400.0f, 0.f)),
+    FTerritorySpawnData(40, TEXT("Volkridge"), true, 5, FVector(400.0f, 400.0f, 0.f)),
+    FTerritorySpawnData(41, TEXT("Bakas"), false, 5, FVector(600.0f, 400.0f, 0.f)),
+    FTerritorySpawnData(42, TEXT("Kesis"), false, 5, FVector(-600.0f, 600.0f, 0.f))};
 
 AWorldMap::AWorldMap() {
   PrimaryActorTick.bCanEverTick = false;
@@ -62,11 +62,9 @@ void AWorldMap::BeginPlay() {
     return;
   }
 
-  // Spawn each predefined territory at a random location inside the spawn area.
+  // Spawn each predefined territory at its designated location.
   for (const FTerritorySpawnData &Data : DefaultTerritories) {
-    const float X = FMath::FRandRange(SpawnAreaMin.X, SpawnAreaMax.X);
-    const float Y = FMath::FRandRange(SpawnAreaMin.Y, SpawnAreaMax.Y);
-    const FVector SpawnLocation = GetActorLocation() + FVector(X, Y, 0.f);
+    const FVector SpawnLocation = GetActorLocation() + Data.Location;
 
     FActorSpawnParameters Params;
     Params.Owner = this;
@@ -78,6 +76,19 @@ void AWorldMap::BeginPlay() {
       Territory->bIsCapital = Data.bIsCapital;
       Territory->ContinentID = Data.ContinentID;
       RegisterTerritory(Territory);
+    }
+  }
+
+  // Establish adjacency based on territory positions so that neighboring
+  // territories share borders.
+  for (int32 i = 0; i < Territories.Num(); ++i) {
+    for (int32 j = i + 1; j < Territories.Num(); ++j) {
+      if (FVector::Dist2D(Territories[i]->GetActorLocation(),
+                          Territories[j]->GetActorLocation()) <=
+          AdjacencyDistance) {
+        Territories[i]->AdjacentTerritories.Add(Territories[j]);
+        Territories[j]->AdjacentTerritories.Add(Territories[i]);
+      }
     }
   }
 }

--- a/Source/Skald/WorldMap.h
+++ b/Source/Skald/WorldMap.h
@@ -17,14 +17,17 @@ struct FTerritorySpawnData
         , TerritoryName(TEXT(""))
         , bIsCapital(false)
         , ContinentID(0)
+        , Location(FVector::ZeroVector)
     {
     }
 
-    FTerritorySpawnData(int32 InID, const FString& InName, bool bCapital = false, int32 InContinent = 0)
+    FTerritorySpawnData(int32 InID, const FString& InName, bool bCapital = false,
+                        int32 InContinent = 0, FVector InLocation = FVector::ZeroVector)
         : TerritoryID(InID)
         , TerritoryName(InName)
         , bIsCapital(bCapital)
         , ContinentID(InContinent)
+        , Location(InLocation)
     {
     }
 
@@ -39,6 +42,10 @@ struct FTerritorySpawnData
 
     UPROPERTY(EditAnywhere, BlueprintReadOnly)
     int32 ContinentID;
+
+    /** Location for spawning this territory relative to the world map actor. */
+    UPROPERTY(EditAnywhere, BlueprintReadOnly)
+    FVector Location;
 };
 
 /**
@@ -89,6 +96,10 @@ public:
     /** Maximum XY (in local space) for random spawn positions. */
     UPROPERTY(EditAnywhere, Category = "WorldMap")
     FVector2D SpawnAreaMax = FVector2D(500.f, 500.f);
+
+    /** Maximum distance to consider two territories adjacent. */
+    UPROPERTY(EditAnywhere, Category = "WorldMap")
+    float AdjacencyDistance = 210.f;
 
 protected:
     /** Predefined territory table used for spawning at begin play. */


### PR DESCRIPTION
## Summary
- Extend `FTerritorySpawnData` with explicit spawn locations and an adjacency distance setting
- Spawn territories at predefined coordinates and build adjacency lists based on proximity

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ae262820848324a9ff476733046214