### PR TITLE
Fix duplicate SelectionPrompt declaration

### DIFF
--- a/Source/Skald/UI/SkaldMainHUDWidget.h
+++ b/Source/Skald/UI/SkaldMainHUDWidget.h
@@ -206,7 +206,6 @@ public:
   UPROPERTY(BlueprintReadOnly, Category = "Skald|Widgets",
             meta = (BindWidgetOptional))
   UTextBlock *EndingTurnText;
-  UWidget *SelectionPrompt;
 
   UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Skald|Widgets")
   TSubclassOf<UConfirmAttackWidget> ConfirmAttackWidgetClass;


### PR DESCRIPTION
## Summary
- remove duplicate SelectionPrompt member to resolve redefinition error

## Testing
- `g++ -c Source/Skald/UI/SkaldMainHUDWidget.cpp -I Source/Skald -I Source -I /usr/include` *(fails: Blueprint/UserWidget.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68ae2a2637688324a0b81059ba75a390