### PR TITLE
Fix undefined TerritoryID usage in HUD widget

### DIFF
--- a/Source/Skald/UI/SkaldMainHUDWidget.cpp
+++ b/Source/Skald/UI/SkaldMainHUDWidget.cpp
@@ -219,7 +219,7 @@ void USkaldMainHUDWidget::OnTerritoryClickedUI(ATerritory* Territory) {
   if (bSelectingForAttack) {
     if (SelectedSourceID == -1) {
       if (bOwnedByLocal) {
-        SelectedSourceID = TerritoryID;
+        SelectedSourceID = Territory->TerritoryID;
 
         if (AWorldMap *WorldMap =
                 Cast<AWorldMap>(UGameplayStatics::GetActorOfClass(
@@ -236,7 +236,7 @@ void USkaldMainHUDWidget::OnTerritoryClickedUI(ATerritory* Territory) {
         }
       }
     } else if (SelectedTargetID == -1) {
-      SelectedTargetID = TerritoryID;
+      SelectedTargetID = Territory->TerritoryID;
 
       if (SelectionPrompt) {
         SelectionPrompt->SetVisibility(ESlateVisibility::Collapsed);


### PR DESCRIPTION
## Summary
- fix undefined `TerritoryID` reference in `USkaldMainHUDWidget::OnTerritoryClickedUI`

## Testing
- `clang++ -c Source/Skald/UI/SkaldMainHUDWidget.cpp` *(fails: command not found: clang++)*
- `g++ -c Source/Skald/UI/SkaldMainHUDWidget.cpp` *(fails: UI/SkaldMainHUDWidget.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68ae2bc438688324b03d2fa9170701fa