### PR TITLE
Replicate player details from GameInstance on login

### DIFF
--- a/Source/Skald/Skald_GameMode.cpp
+++ b/Source/Skald/Skald_GameMode.cpp
@@ -67,6 +67,19 @@ void ASkaldGameMode::PostLogin(APlayerController *NewPlayer) {
         if (PlayersData.Num() < GS->PlayerArray.Num()) {
           PlayersData.SetNum(GS->PlayerArray.Num());
         }
+
+        if (USkaldGameInstance* GI = GetGameInstance<USkaldGameInstance>()) {
+          PS->DisplayName = GI->DisplayName;
+          PS->Faction = GI->Faction;
+        }
+
+        const int32 Index = GS->PlayerArray.IndexOfByKey(PS);
+        if (PlayersData.IsValidIndex(Index)) {
+          PlayersData[Index].PlayerID = PS->GetPlayerId();
+          PlayersData[Index].PlayerName = PS->DisplayName;
+          PlayersData[Index].IsAI = PS->bIsAI;
+          PlayersData[Index].Faction = PS->Faction;
+        }
       }
 
       // In singleplayer fill remaining slots with AI opponents

--- a/Source/Skald/Skald_PlayerState.cpp
+++ b/Source/Skald/Skald_PlayerState.cpp
@@ -1,4 +1,5 @@
 #include "Skald_PlayerState.h"
+#include "Net/UnrealNetwork.h"
 
 ASkaldPlayerState::ASkaldPlayerState()
     : bIsAI(false)
@@ -7,5 +8,14 @@ ASkaldPlayerState::ASkaldPlayerState()
     , DisplayName(TEXT("Player"))
     , Faction(ESkaldFaction::None)
 {
+}
+
+void ASkaldPlayerState::GetLifetimeReplicatedProps(
+    TArray<FLifetimeProperty>& OutLifetimeProps) const
+{
+    Super::GetLifetimeReplicatedProps(OutLifetimeProps);
+
+    DOREPLIFETIME(ASkaldPlayerState, DisplayName);
+    DOREPLIFETIME(ASkaldPlayerState, Faction);
 }
 

--- a/Source/Skald/Skald_PlayerState.h
+++ b/Source/Skald/Skald_PlayerState.h
@@ -28,11 +28,13 @@ public:
     int32 InitiativeRoll;
 
     /** Player chosen display name. */
-    UPROPERTY(BlueprintReadWrite, Category="PlayerState")
+    UPROPERTY(BlueprintReadWrite, Replicated, Category="PlayerState")
     FString DisplayName;
 
     /** Selected faction for this player. */
-    UPROPERTY(BlueprintReadWrite, Category="PlayerState")
+    UPROPERTY(BlueprintReadWrite, Replicated, Category="PlayerState")
     ESkaldFaction Faction;
+
+    virtual void GetLifetimeReplicatedProps(TArray<FLifetimeProperty>& OutLifetimeProps) const override;
 };
 


### PR DESCRIPTION
## Summary
- Pull display name and faction from `USkaldGameInstance` for human players during `PostLogin`
- Replicate player `DisplayName` and `Faction` in `ASkaldPlayerState`

## Testing
- `make` *(fails: No targets specified and no makefile found)*

------
https://chatgpt.com/codex/tasks/task_e_68ae3bd6d0a48324b1a4e6adbb51636e