### PR TITLE
Display initiative winner on HUD

### DIFF
--- a/Source/Skald/Skald_GameMode.cpp
+++ b/Source/Skald/Skald_GameMode.cpp
@@ -254,6 +254,8 @@ void ASkaldGameMode::InitializeWorld() {
   }
 
   // Calculate starting armies and initiative rolls
+  ASkaldPlayerState *HighestPS = nullptr;
+  int32 HighestRoll = 0;
   for (APlayerState *PSBase : GS->PlayerArray) {
     ASkaldPlayerState *PS = Cast<ASkaldPlayerState>(PSBase);
     if (!PS) {
@@ -269,5 +271,24 @@ void ASkaldGameMode::InitializeWorld() {
 
     PS->ArmyPool = Owned / 3;
     PS->InitiativeRoll = FMath::RandRange(1, 6);
+    if (PS->InitiativeRoll > HighestRoll) {
+      HighestRoll = PS->InitiativeRoll;
+      HighestPS = PS;
+    }
+  }
+
+  if (HighestPS) {
+    const FString Message = FString::Printf(
+        TEXT("%s wins initiative with a roll of %d"),
+        *HighestPS->DisplayName, HighestRoll);
+    for (FConstPlayerControllerIterator It =
+             GetWorld()->GetPlayerControllerIterator();
+         It; ++It) {
+      if (ASkaldPlayerController *PC = Cast<ASkaldPlayerController>(*It)) {
+        if (USkaldMainHUDWidget *HUD = PC->GetHUDWidget()) {
+          HUD->UpdateInitiativeText(Message);
+        }
+      }
+    }
   }
 }

--- a/Source/Skald/UI/SkaldMainHUDWidget.cpp
+++ b/Source/Skald/UI/SkaldMainHUDWidget.cpp
@@ -134,6 +134,13 @@ void USkaldMainHUDWidget::HideEndingTurn() {
   }
 }
 
+void USkaldMainHUDWidget::UpdateInitiativeText(const FString &Message) {
+  if (InitiativeText) {
+    InitiativeText->SetText(FText::FromString(Message));
+    InitiativeText->SetVisibility(ESlateVisibility::Visible);
+  }
+}
+
 void USkaldMainHUDWidget::BeginAttackSelection() {
   bSelectingForAttack = true;
   bSelectingForMove = false;

--- a/Source/Skald/UI/SkaldMainHUDWidget.h
+++ b/Source/Skald/UI/SkaldMainHUDWidget.h
@@ -128,6 +128,10 @@ public:
   UFUNCTION(BlueprintCallable, Category = "Skald|HUD")
   void HideEndingTurn();
 
+  /** Update and display the initiative announcement. */
+  UFUNCTION(BlueprintCallable, Category = "Skald|HUD")
+  void UpdateInitiativeText(const FString &Message);
+
   // BlueprintCallable functions — selection UX helpers
   UFUNCTION(BlueprintCallable, Category = "Skald|Selection")
   void BeginAttackSelection();
@@ -206,6 +210,10 @@ public:
   UPROPERTY(BlueprintReadOnly, Category = "Skald|Widgets",
             meta = (BindWidgetOptional))
   UTextBlock *EndingTurnText;
+
+  UPROPERTY(BlueprintReadOnly, Category = "Skald|Widgets",
+            meta = (BindWidgetOptional))
+  UTextBlock *InitiativeText;
 
   UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Skald|Widgets")
   TSubclassOf<UConfirmAttackWidget> ConfirmAttackWidgetClass;


### PR DESCRIPTION
## Summary
- expose initiative text on the main HUD and add helper to update it
- show initiative winner after world initialization by sending a message to every player's HUD

## Testing
- `clang++ -std=c++17 -I Skald_TurnBasedStrategy_Code/Source -fsyntax-only Skald_TurnBasedStrategy_Code/Source/Skald/Skald_GameMode.cpp` *(fails: 'CoreMinimal.h' file not found)*
- `clang++ -std=c++17 -I Skald_TurnBasedStrategy_Code/Source -fsyntax-only Skald_TurnBasedStrategy_Code/Source/Skald/UI/SkaldMainHUDWidget.cpp` *(fails: 'UI/SkaldMainHUDWidget.h' file not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ae3c905a2c832487d2ef2633dc3029