### PR TITLE
Implement reinforcement phase with attack transition

### DIFF
--- a/Source/Skald/Skald_PlayerController.h
+++ b/Source/Skald/Skald_PlayerController.h
@@ -48,6 +48,10 @@ public:
     UFUNCTION(BlueprintCallable, Category="UI")
     USkaldMainHUDWidget* GetHUDWidget() const { return MainHudWidget; }
 
+    /** Retrieve the turn manager controlling this player. */
+    UFUNCTION(BlueprintCallable, BlueprintPure, Category="Turn")
+    ATurnManager* GetTurnManager() const { return TurnManager; }
+
 protected:
     /** Whether this controller is controlled by AI. */
     UPROPERTY(BlueprintReadOnly, Category="Turn")

--- a/Source/Skald/Skald_TurnManager.h
+++ b/Source/Skald/Skald_TurnManager.h
@@ -6,6 +6,7 @@
 #include "Skald_TurnManager.generated.h"
 
 class ASkaldPlayerController;
+class ASkaldPlayerState;
 
 /**
  * Handles turn sequencing for all registered player controllers.
@@ -28,6 +29,15 @@ public:
 
     UFUNCTION(BlueprintCallable, Category="Turn")
     void AdvanceTurn();
+
+    /** Called when all reinforcements have been deployed to transition
+     *  the active player into the attack phase. */
+    UFUNCTION(BlueprintCallable, Category="Turn")
+    void BeginAttackPhase();
+
+    /** Update all players' HUDs with the specified player's army pool. */
+    UFUNCTION(BlueprintCallable, Category="Turn")
+    void BroadcastArmyPool(class ASkaldPlayerState* ForPlayer);
 
     UFUNCTION(BlueprintCallable, Category="Turn")
     void SortControllersByInitiative();


### PR DESCRIPTION
## Summary
- Recalculate and allocate per-turn reinforcements, broadcasting army pool to all clients
- Provide BeginAttackPhase for switching to attack once reinforcements are spent
- Allow HUD deploy button to drive reinforcement allocation and phase transition

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ae419711188324afbae88cb730b3c0