### PR TITLE
Fix player sorting comparator for object pointers

### DIFF
--- a/Source/Skald/Skald_GameMode.cpp
+++ b/Source/Skald/Skald_GameMode.cpp
@@ -308,9 +308,9 @@ void ASkaldGameMode::InitializeWorld() {
     }
   }
 
-  GS->PlayerArray.Sort([](const APlayerState *A, const APlayerState *B) {
-    const ASkaldPlayerState *PSA = Cast<ASkaldPlayerState>(A);
-    const ASkaldPlayerState *PSB = Cast<ASkaldPlayerState>(B);
+  GS->PlayerArray.Sort([](const APlayerState &A, const APlayerState &B) {
+    const ASkaldPlayerState *PSA = Cast<const ASkaldPlayerState>(&A);
+    const ASkaldPlayerState *PSB = Cast<const ASkaldPlayerState>(&B);
     const int32 RollA = PSA ? PSA->InitiativeRoll : 0;
     const int32 RollB = PSB ? PSB->InitiativeRoll : 0;
     return RollA > RollB;


### PR DESCRIPTION
## Summary
- adapt player sorting lambda to use const references for TObjectPtr sorting

## Testing
- `clang-format --dry-run --Werror Source/Skald/Skald_GameMode.cpp` *(fails: Source/Skald/Skald_GameMode.cpp:240:28: code should be clang-formatted)*
- `g++ -fsyntax-only Source/Skald/Skald_GameMode.cpp` *(fails: Source/Skald/Skald_GameMode.cpp:1: CoreMinimal.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68ae4e5852048324a7081eba7f195b99