### PR TITLE
Ensure world initialization waits for players

### DIFF
--- a/Source/Skald/Skald_GameMode.h
+++ b/Source/Skald/Skald_GameMode.h
@@ -43,9 +43,13 @@ protected:
   UPROPERTY(BlueprintReadOnly, Category = "Players")
   TArray<FS_PlayerData> PlayersData;
 
-  /** Setup initial territories, armies, and initiative. */
+  /**
+   * Setup initial territories, armies, and initiative.
+   * Returns true if the world was successfully initialised with at least one
+   * player present.
+   */
   UFUNCTION(BlueprintCallable, Category = "GameMode")
-  void InitializeWorld();
+  bool InitializeWorld();
 
   /** Allow players to position initial armies based on initiative. */
   UFUNCTION(BlueprintCallable, Category = "GameMode")


### PR DESCRIPTION
## Summary
- Delay world setup until at least one player exists
- Retry initialization by returning success from `InitializeWorld`

## Testing
- `g++ -fsyntax-only Source/Skald/Skald_GameMode.cpp` *(fails: CoreMinimal.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68ae51b531408324ae85d0546fdd020c