### PR TITLE
Implement turn handoff and HUD messaging

### DIFF
--- a/Source/Skald/Skald_PlayerController.h
+++ b/Source/Skald/Skald_PlayerController.h
@@ -13,97 +13,99 @@ class ATerritory;
  * Player controller capable of participating in turn based gameplay.
  */
 UCLASS(Blueprintable, BlueprintType)
-class SKALD_API ASkaldPlayerController : public APlayerController
-{
-    GENERATED_BODY()
+class SKALD_API ASkaldPlayerController : public APlayerController {
+  GENERATED_BODY()
 
 public:
-    ASkaldPlayerController();
+  ASkaldPlayerController();
 
-    virtual void BeginPlay() override;
+  virtual void BeginPlay() override;
 
-    UFUNCTION(BlueprintCallable, Category="Turn")
-    void StartTurn();
+  UFUNCTION(BlueprintCallable, Category = "Turn")
+  void StartTurn();
 
-    UFUNCTION(BlueprintCallable, Category="Turn")
-    void EndTurn();
+  UFUNCTION(BlueprintCallable, Category = "Turn")
+  void EndTurn();
 
-    UFUNCTION(BlueprintCallable, Category="Turn")
-    void MakeAIDecision();
+  UFUNCTION(BlueprintCallable, Category = "Turn")
+  void MakeAIDecision();
 
-    UFUNCTION(BlueprintCallable, BlueprintPure, Category="Turn")
-    bool IsAIController() const;
+  UFUNCTION(BlueprintCallable, BlueprintPure, Category = "Turn")
+  bool IsAIController() const;
 
-    /** Set the turn manager responsible for sequencing play. */
-    UFUNCTION(BlueprintCallable, Category="Turn")
-    void SetTurnManager(ATurnManager* Manager);
+  /** Set the turn manager responsible for sequencing play. */
+  UFUNCTION(BlueprintCallable, Category = "Turn")
+  void SetTurnManager(ATurnManager *Manager);
 
-    UFUNCTION(BlueprintCallable, Category="Turn")
-    void ShowTurnAnnouncement(const FString& PlayerName);
+  UFUNCTION(BlueprintCallable, Category = "Turn")
+  void ShowTurnAnnouncement(const FString &PlayerName, bool bIsMyTurn);
 
-    UFUNCTION(BlueprintCallable, Category="UI")
-    void HandleTerritorySelected(ATerritory* Terr);
+  UFUNCTION(BlueprintCallable, Category = "UI")
+  void HandleTerritorySelected(ATerritory *Terr);
 
-    /** Accessor for the main HUD widget instance. */
-    UFUNCTION(BlueprintCallable, Category="UI")
-    USkaldMainHUDWidget* GetHUDWidget() const { return MainHudWidget; }
+  /** Accessor for the main HUD widget instance. */
+  UFUNCTION(BlueprintCallable, Category = "UI")
+  USkaldMainHUDWidget *GetHUDWidget() const { return MainHudWidget; }
 
-    /** Retrieve the turn manager controlling this player. */
-    UFUNCTION(BlueprintCallable, BlueprintPure, Category="Turn")
-    ATurnManager* GetTurnManager() const { return TurnManager; }
+  /** Retrieve the turn manager controlling this player. */
+  UFUNCTION(BlueprintCallable, BlueprintPure, Category = "Turn")
+  ATurnManager *GetTurnManager() const { return TurnManager; }
 
 protected:
-    /** Whether this controller is controlled by AI. */
-    UPROPERTY(BlueprintReadOnly, Category="Turn")
-    bool bIsAI;
+  /** Whether this controller is controlled by AI. */
+  UPROPERTY(BlueprintReadOnly, Category = "Turn")
+  bool bIsAI;
 
-    /** Widget class to instantiate for the player's HUD.
-     *  Expected to be assigned in the Blueprint subclass to avoid
-     *  hard loading during CDO construction. */
-    UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category="UI")
-    TSubclassOf<USkaldMainHUDWidget> MainHudWidgetClass;
+  /** Widget class to instantiate for the player's HUD.
+   *  Expected to be assigned in the Blueprint subclass to avoid
+   *  hard loading during CDO construction. */
+  UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category = "UI")
+  TSubclassOf<USkaldMainHUDWidget> MainHudWidgetClass;
 
-    /** Reference to the HUD widget instance. */
-    UPROPERTY(BlueprintReadOnly, Category="UI", meta=(AllowPrivateAccess="true"))
-    TObjectPtr<UUserWidget> HUDRef;
+  /** Reference to the HUD widget instance. */
+  UPROPERTY(BlueprintReadOnly, Category = "UI",
+            meta = (AllowPrivateAccess = "true"))
+  TObjectPtr<UUserWidget> HUDRef;
 
-    /** Typed reference to the main HUD widget. */
-    UPROPERTY(BlueprintReadOnly, Category="UI", meta=(AllowPrivateAccess="true"))
-    USkaldMainHUDWidget* MainHudWidget;
+  /** Typed reference to the main HUD widget. */
+  UPROPERTY(BlueprintReadOnly, Category = "UI",
+            meta = (AllowPrivateAccess = "true"))
+  USkaldMainHUDWidget *MainHudWidget;
 
-    /** Handle HUD attack submissions.
-     *  Bound to USkaldMainHUDWidget::OnAttackRequested in the HUD.
-     *  Blueprint widgets invoke this when an attack is submitted.
-     */
-    UFUNCTION(BlueprintCallable, Category="UI")
-    void HandleAttackRequested(int32 FromID, int32 ToID, int32 ArmySent);
+  /** Handle HUD attack submissions.
+   *  Bound to USkaldMainHUDWidget::OnAttackRequested in the HUD.
+   *  Blueprint widgets invoke this when an attack is submitted.
+   */
+  UFUNCTION(BlueprintCallable, Category = "UI")
+  void HandleAttackRequested(int32 FromID, int32 ToID, int32 ArmySent);
 
-    /** Handle HUD move submissions.
-     *  Bound to USkaldMainHUDWidget::OnMoveRequested in the HUD.
-     *  Called when a move action is confirmed from a widget.
-     */
-    UFUNCTION(BlueprintCallable, Category="UI")
-    void HandleMoveRequested(int32 FromID, int32 ToID, int32 Troops);
+  /** Handle HUD move submissions.
+   *  Bound to USkaldMainHUDWidget::OnMoveRequested in the HUD.
+   *  Called when a move action is confirmed from a widget.
+   */
+  UFUNCTION(BlueprintCallable, Category = "UI")
+  void HandleMoveRequested(int32 FromID, int32 ToID, int32 Troops);
 
-    /** Handle HUD end-attack confirmations.
-     *  Bound to USkaldMainHUDWidget::OnEndAttackRequested.
-     *  Widgets call this after the player finishes attacking.
-     */
-    UFUNCTION(BlueprintCallable, Category="UI")
-    void HandleEndAttackRequested(bool bConfirmed);
+  /** Handle HUD end-attack confirmations.
+   *  Bound to USkaldMainHUDWidget::OnEndAttackRequested.
+   *  Widgets call this after the player finishes attacking.
+   */
+  UFUNCTION(BlueprintCallable, Category = "UI")
+  void HandleEndAttackRequested(bool bConfirmed);
 
-    /** Handle HUD end-movement confirmations.
-     *  Bound to USkaldMainHUDWidget::OnEndMovementRequested.
-     *  Invoked when the HUD signals the end of movement phase.
-     */
-    UFUNCTION(BlueprintCallable, Category="UI")
-    void HandleEndMovementRequested(bool bConfirmed);
+  /** Handle HUD end-movement confirmations.
+   *  Bound to USkaldMainHUDWidget::OnEndMovementRequested.
+   *  Invoked when the HUD signals the end of movement phase.
+   */
+  UFUNCTION(BlueprintCallable, Category = "UI")
+  void HandleEndMovementRequested(bool bConfirmed);
 
-    /** Reference to the game's turn manager.
-     *  Exposed to Blueprints so BP_Skald_PlayerController can bind to
-     *  turn events without keeping an external pointer that might be
-     *  uninitialised.
-     */
-    UPROPERTY(EditInstanceOnly, BlueprintReadOnly, Category="Turn", meta=(ExposeOnSpawn=true))
-    TObjectPtr<ATurnManager> TurnManager;
+  /** Reference to the game's turn manager.
+   *  Exposed to Blueprints so BP_Skald_PlayerController can bind to
+   *  turn events without keeping an external pointer that might be
+   *  uninitialised.
+   */
+  UPROPERTY(EditInstanceOnly, BlueprintReadOnly, Category = "Turn",
+            meta = (ExposeOnSpawn = true))
+  TObjectPtr<ATurnManager> TurnManager;
 };

--- a/Source/Skald/UI/SkaldMainHUDWidget.cpp
+++ b/Source/Skald/UI/SkaldMainHUDWidget.cpp
@@ -45,6 +45,12 @@ void USkaldMainHUDWidget::HandleEndTurnClicked() {
   } else if (CurrentPhase == ETurnPhase::Movement) {
     OnEndMovementRequested.Broadcast(true);
   }
+
+  if (APlayerController *PC = GetOwningPlayer()) {
+    if (ASkaldPlayerController *SPC = Cast<ASkaldPlayerController>(PC)) {
+      SPC->EndTurn();
+    }
+  }
 }
 
 void USkaldMainHUDWidget::UpdateTurnBanner(int32 InCurrentPlayerID,
@@ -152,6 +158,18 @@ void USkaldMainHUDWidget::ShowEndingTurn() {
 void USkaldMainHUDWidget::HideEndingTurn() {
   if (EndingTurnText) {
     EndingTurnText->SetVisibility(ESlateVisibility::Collapsed);
+  }
+}
+
+void USkaldMainHUDWidget::ShowTurnMessage(bool bIsMyTurn) {
+  if (EndingTurnText) {
+    EndingTurnText->SetText(
+        FText::FromString(bIsMyTurn ? TEXT("Your turn") : TEXT("Enemy turn")));
+    EndingTurnText->SetVisibility(ESlateVisibility::Visible);
+  }
+  if (EndTurnButton) {
+    EndTurnButton->SetVisibility(bIsMyTurn ? ESlateVisibility::Visible
+                                           : ESlateVisibility::Collapsed);
   }
 }
 

--- a/Source/Skald/UI/SkaldMainHUDWidget.h
+++ b/Source/Skald/UI/SkaldMainHUDWidget.h
@@ -2,8 +2,8 @@
 
 #include "Blueprint/UserWidget.h"
 #include "CoreMinimal.h"
-#include "SkaldTypes.h"
 #include "SkaldMainHUDWidget.generated.h"
+#include "SkaldTypes.h"
 
 class UButton;
 class UTextBlock;
@@ -128,6 +128,10 @@ public:
   UFUNCTION(BlueprintCallable, Category = "Skald|HUD")
   void HideEndingTurn();
 
+  /** Show whose turn it is and toggle the End Turn button. */
+  UFUNCTION(BlueprintCallable, Category = "Skald|HUD")
+  void ShowTurnMessage(bool bIsMyTurn);
+
   /** Update and display the initiative announcement. */
   UFUNCTION(BlueprintCallable, Category = "Skald|HUD")
   void UpdateInitiativeText(const FString &Message);
@@ -156,7 +160,7 @@ public:
   void CancelMoveSelection();
 
   UFUNCTION(BlueprintCallable, Category = "Skald|Selection")
-  void OnTerritoryClickedUI(ATerritory* Territory);
+  void OnTerritoryClickedUI(ATerritory *Territory);
 
   // BlueprintImplementableEvent hooks — BP subclass draws UI
   UFUNCTION(BlueprintImplementableEvent, Category = "Skald|HUD")


### PR DESCRIPTION
## Summary
- Advance to the next player's turn when the End Turn button is pressed
- Display "Your turn" or "Enemy turn" in the HUD and toggle the End Turn button accordingly
- Have the turn manager announce the active player to all controllers

## Testing
- `clang++ -std=c++17 -c Source/Skald/Skald_PlayerController.cpp` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ae55160a5c83249eb5b1f82c95bc80