### PR TITLE
Connect territory selections to player controllers

### DIFF
--- a/Source/Skald/Skald_PlayerController.cpp
+++ b/Source/Skald/Skald_PlayerController.cpp
@@ -64,6 +64,13 @@ void ASkaldPlayerController::BeginPlay() {
            TEXT("MainHudWidgetClass is null; HUD will not be displayed."));
   }
 
+  if (AWorldMap *WorldMap = Cast<AWorldMap>(
+          UGameplayStatics::GetActorOfClass(GetWorld(),
+                                            AWorldMap::StaticClass()))) {
+    WorldMap->OnTerritorySelected.AddDynamic(
+        this, &ASkaldPlayerController::HandleTerritorySelected);
+  }
+
   if (ASkaldPlayerState *PS = GetPlayerState<ASkaldPlayerState>()) {
     bIsAI = PS->bIsAI;
   }

--- a/Source/Skald/Territory.cpp
+++ b/Source/Skald/Territory.cpp
@@ -107,10 +107,6 @@ void ATerritory::Select(bool bSelectingForAttack) {
         FName("Color"), bSelectingForAttack ? White : Gold);
   }
   OnTerritorySelected.Broadcast(this);
-  if (ASkaldPlayerController *PC = Cast<ASkaldPlayerController>(
-          GetWorld()->GetFirstPlayerController())) {
-    PC->HandleTerritorySelected(this);
-  }
 }
 
 void ATerritory::Deselect() {

--- a/Source/Skald/WorldMap.cpp
+++ b/Source/Skald/WorldMap.cpp
@@ -121,6 +121,8 @@ void AWorldMap::SelectTerritory(ATerritory *Territory) {
   }
 
   SelectedTerritory = Territory;
+
+  OnTerritorySelected.Broadcast(Territory);
 }
 
 bool AWorldMap::MoveBetween(ATerritory *From, ATerritory *To) {

--- a/Source/Skald/WorldMap.h
+++ b/Source/Skald/WorldMap.h
@@ -6,6 +6,11 @@
 
 class ATerritory;
 
+// Broadcast when a territory is selected on the world map so that interested
+// systems (e.g. player controllers) can react.
+DECLARE_DYNAMIC_MULTICAST_DELEGATE_OneParam(FWorldMapTerritorySelected,
+                                            ATerritory *, Territory);
+
 /** Data describing how a territory should be spawned at runtime. */
 USTRUCT(BlueprintType)
 struct FTerritorySpawnData
@@ -68,6 +73,10 @@ public:
     /** Currently selected territory. */
     UPROPERTY(BlueprintReadOnly, Category = "WorldMap")
     ATerritory* SelectedTerritory;
+
+    /** Event fired whenever SelectTerritory chooses a new territory. */
+    UPROPERTY(BlueprintAssignable, Category = "WorldMap")
+    FWorldMapTerritorySelected OnTerritorySelected;
 
     /** Register a territory with the world map. */
     UFUNCTION(BlueprintCallable, Category = "WorldMap")


### PR DESCRIPTION
## Summary
- Add `FWorldMapTerritorySelected` delegate and `OnTerritorySelected` event to `AWorldMap`
- Bind player controllers to world map selection events to update HUD
- Remove hard-coded first-player-controller call from territories

## Testing
- `clang++ -c Source/Skald/WorldMap.cpp` *(fails: 'CoreMinimal.h' file not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ae57ca5cb48324a07ec90f6797d4e2