### PR TITLE
Add turn phase controls and improve world map setup

### DIFF
--- a/Source/Skald/Skald_GameMode.cpp
+++ b/Source/Skald/Skald_GameMode.cpp
@@ -1,6 +1,7 @@
 #include "Skald_GameMode.h"
 #include "Algo/RandomShuffle.h"
 #include "Engine/World.h"
+#include "Kismet/GameplayStatics.h"
 #include "Skald_GameInstance.h"
 #include "Skald_GameState.h"
 #include "Skald_PlayerCharacter.h"
@@ -43,7 +44,11 @@ void ASkaldGameMode::BeginPlay() {
   }
 
   if (!WorldMap) {
-    WorldMap = GetWorld()->SpawnActor<AWorldMap>();
+    WorldMap = Cast<AWorldMap>(UGameplayStatics::GetActorOfClass(
+        GetWorld(), AWorldMap::StaticClass()));
+    if (!WorldMap) {
+      WorldMap = GetWorld()->SpawnActor<AWorldMap>();
+    }
   }
 
   // Initialization of the world occurs after players join in PostLogin.

--- a/Source/Skald/Skald_PlayerController.cpp
+++ b/Source/Skald/Skald_PlayerController.cpp
@@ -109,6 +109,12 @@ void ASkaldPlayerController::EndTurn() {
   }
 }
 
+void ASkaldPlayerController::EndPhase() {
+  if (TurnManager) {
+    TurnManager->AdvancePhase();
+  }
+}
+
 void ASkaldPlayerController::MakeAIDecision() {
   UE_LOG(LogTemp, Log, TEXT("AI %s making decision"), *GetName());
 }

--- a/Source/Skald/Skald_PlayerController.h
+++ b/Source/Skald/Skald_PlayerController.h
@@ -28,6 +28,9 @@ public:
   void EndTurn();
 
   UFUNCTION(BlueprintCallable, Category = "Turn")
+  void EndPhase();
+
+  UFUNCTION(BlueprintCallable, Category = "Turn")
   void MakeAIDecision();
 
   UFUNCTION(BlueprintCallable, BlueprintPure, Category = "Turn")

--- a/Source/Skald/Skald_TurnManager.cpp
+++ b/Source/Skald/Skald_TurnManager.cpp
@@ -53,6 +53,7 @@ void ATurnManager::StartTurns() {
         const bool bIsActive = Controller == CurrentController;
         Controller->ShowTurnAnnouncement(PlayerName, bIsActive);
         if (USkaldMainHUDWidget *HUD = Controller->GetHUDWidget()) {
+          HUD->UpdateTurnBanner(PS ? PS->GetPlayerId() : -1, 1);
           HUD->UpdatePhaseBanner(CurrentPhase);
         }
       }
@@ -96,6 +97,7 @@ void ATurnManager::AdvanceTurn() {
       const bool bIsActive = Controller == CurrentController;
       Controller->ShowTurnAnnouncement(PlayerName, bIsActive);
       if (USkaldMainHUDWidget *HUD = Controller->GetHUDWidget()) {
+        HUD->UpdateTurnBanner(PS ? PS->GetPlayerId() : -1, 1);
         HUD->UpdatePhaseBanner(CurrentPhase);
       }
     }
@@ -129,6 +131,29 @@ void ATurnManager::BeginAttackPhase() {
     if (Controller) {
       if (USkaldMainHUDWidget *HUD = Controller->GetHUDWidget()) {
         HUD->UpdatePhaseBanner(ETurnPhase::Attack);
+      }
+    }
+  }
+}
+
+void ATurnManager::AdvancePhase() {
+  if (CurrentPhase == ETurnPhase::Reinforcement) {
+    BeginAttackPhase();
+    return;
+  }
+
+  if (CurrentPhase == ETurnPhase::Attack) {
+    CurrentPhase = ETurnPhase::Movement;
+  } else if (CurrentPhase == ETurnPhase::Movement) {
+    CurrentPhase = ETurnPhase::EndTurn;
+  } else {
+    return;
+  }
+
+  for (ASkaldPlayerController *Controller : Controllers) {
+    if (Controller) {
+      if (USkaldMainHUDWidget *HUD = Controller->GetHUDWidget()) {
+        HUD->UpdatePhaseBanner(CurrentPhase);
       }
     }
   }

--- a/Source/Skald/Skald_TurnManager.h
+++ b/Source/Skald/Skald_TurnManager.h
@@ -35,6 +35,10 @@ public:
     UFUNCTION(BlueprintCallable, Category="Turn")
     void BeginAttackPhase();
 
+    /** Move to the next phase in the turn sequence. */
+    UFUNCTION(BlueprintCallable, Category="Turn")
+    void AdvancePhase();
+
     /** Update all players' HUDs with the specified player's army pool. */
     UFUNCTION(BlueprintCallable, Category="Turn")
     void BroadcastArmyPool(class ASkaldPlayerState* ForPlayer);

--- a/Source/Skald/UI/SkaldMainHUDWidget.h
+++ b/Source/Skald/UI/SkaldMainHUDWidget.h
@@ -212,6 +212,10 @@ public:
 
   UPROPERTY(BlueprintReadOnly, Category = "Skald|Widgets",
             meta = (BindWidgetOptional))
+  UButton *EndPhaseButton;
+
+  UPROPERTY(BlueprintReadOnly, Category = "Skald|Widgets",
+            meta = (BindWidgetOptional))
   UButton *DeployButton;
 
   // Container where RebuildPlayerList will spawn entries
@@ -238,6 +242,9 @@ protected:
   // Internal handlers for widget actions
   UFUNCTION()
   void HandleEndTurnClicked();
+
+  UFUNCTION()
+  void HandleEndPhaseClicked();
 
   UFUNCTION()
   void HandleDeployClicked();


### PR DESCRIPTION
## Summary
- reuse existing WorldMap actor instead of spawning new one
- add turn phase progression with end phase UI controls
- separate end turn from phase advancement

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ae5b1678908324a3bebcc029aa127a