### PR TITLE
Initialize world early and show territory info

### DIFF
--- a/Source/Skald/Skald_GameMode.h
+++ b/Source/Skald/Skald_GameMode.h
@@ -67,4 +67,7 @@ private:
 
   /** Index of the controller currently placing armies. */
   int32 PlacementIndex = 0;
+
+  /** Attempt to initialise the world and start the game flow. */
+  void TryInitializeWorldAndStart();
 };

--- a/Source/Skald/Territory.h
+++ b/Source/Skald/Territory.h
@@ -10,6 +10,7 @@ class ATerritory;
 class UStaticMeshComponent;
 class UPrimitiveComponent;
 class UMaterialInstanceDynamic;
+class UTextRenderComponent;
 
 DECLARE_DYNAMIC_MULTICAST_DELEGATE_OneParam(FTerritorySelectedSignature, ATerritory*, Territory);
 
@@ -58,7 +59,7 @@ public:
     TArray<ATerritory*> AdjacentTerritories;
 
     /** Number of armies stationed in this territory. */
-    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Territory", Replicated)
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Territory", ReplicatedUsing = OnRep_ArmyStrength)
     int32 ArmyStrength = 0;
 
     /** Called when the territory is selected. */
@@ -100,10 +101,17 @@ public:
     UFUNCTION()
     void OnRep_OwningPlayer();
 
+    UFUNCTION()
+    void OnRep_ArmyStrength();
+
 protected:
     /** Visual representation of the territory. */
     UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "Territory")
     UStaticMeshComponent* MeshComponent = nullptr;
+
+    /** Text label showing name, owner and army count. */
+    UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "Territory")
+    UTextRenderComponent* LabelComponent = nullptr;
 
     /** Dynamic material used for highlighting. */
     UPROPERTY()
@@ -116,4 +124,5 @@ protected:
     bool bIsSelected = false;
 
     void UpdateTerritoryColor();
+    void UpdateLabel();
 };


### PR DESCRIPTION
## Summary
- Initialize the world map as soon as the level loads and when players join so territories are assigned before turns start
- Display dynamic text on each territory with its name, owner and army strength

## Testing
- `bash Build/validate.sh` *(fails: UnrealBuildTool not found; UnrealEditor not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ae70d4dffc8324b69f0dc0e34aa683