### PR TITLE
Add capital mesh support to territories

### DIFF
--- a/Source/Skald/Territory.cpp
+++ b/Source/Skald/Territory.cpp
@@ -57,6 +57,19 @@ ATerritory::ATerritory() {
 void ATerritory::BeginPlay() {
   Super::BeginPlay();
 
+  if (!CapitalMesh) {
+    CapitalMesh = NewObject<UStaticMeshComponent>(this, TEXT("CapitalMesh"));
+    if (CapitalMesh) {
+      CapitalMesh->SetupAttachment(RootComponent);
+      if (CapitalMeshAsset) {
+        CapitalMesh->SetStaticMesh(CapitalMeshAsset);
+      }
+      CapitalMesh->SetVisibility(false);
+      CapitalMesh->SetHiddenInGame(true);
+      CapitalMesh->RegisterComponent();
+    }
+  }
+
   if (MeshComponent) {
     MeshComponent->OnBeginCursorOver.AddDynamic(this,
                                                 &ATerritory::HandleMouseEnter);
@@ -80,6 +93,11 @@ void ATerritory::BeginPlay() {
 
   UpdateTerritoryColor();
   UpdateLabel();
+
+  if (CapitalMesh) {
+    CapitalMesh->SetVisibility(bIsCapital);
+    CapitalMesh->SetHiddenInGame(!bIsCapital);
+  }
 
   // Territories are registered with the world map immediately after
   // spawning, so no self-registration is required here.
@@ -170,6 +188,11 @@ void ATerritory::RefreshAppearance() { UpdateTerritoryColor(); UpdateLabel(); }
 void ATerritory::OnRep_OwningPlayer() {
   UpdateTerritoryColor();
   UpdateLabel();
+
+  if (CapitalMesh) {
+    CapitalMesh->SetVisibility(bIsCapital);
+    CapitalMesh->SetHiddenInGame(!bIsCapital);
+  }
 }
 
 void ATerritory::OnRep_ArmyStrength() { UpdateLabel(); }

--- a/Source/Skald/Territory.h
+++ b/Source/Skald/Territory.h
@@ -7,6 +7,7 @@
 
 class ASkaldPlayerState;
 class ATerritory;
+class UStaticMesh;
 class UStaticMeshComponent;
 class UPrimitiveComponent;
 class UMaterialInstanceDynamic;
@@ -49,6 +50,10 @@ public:
     /** Whether this territory is a capital. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Territory", Replicated)
     bool bIsCapital = false;
+
+    /** Mesh asset used to mark this territory as a capital. */
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Territory")
+    UStaticMesh* CapitalMeshAsset = nullptr;
 
     /** Optional identifier describing which continent this territory belongs to. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Territory", Replicated)
@@ -108,6 +113,10 @@ protected:
     /** Visual representation of the territory. */
     UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "Territory")
     UStaticMeshComponent* MeshComponent = nullptr;
+
+    /** Mesh indicating this territory is a capital. */
+    UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "Territory")
+    UStaticMeshComponent* CapitalMesh = nullptr;
 
     /** Text label showing name, owner and army count. */
     UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "Territory")


### PR DESCRIPTION
## Summary
- allow blueprint selection of a capital mesh asset per territory
- spawn and attach a capital mesh component at runtime
- toggle capital mesh visibility based on capital status

## Testing
- `./Build/validate.sh` *(fails: UnrealBuildTool not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ae7c38295483249d559f881a157d8a