### PR TITLE
Highlight selected territories in white

### DIFF
--- a/Source/Skald/Territory.cpp
+++ b/Source/Skald/Territory.cpp
@@ -117,7 +117,7 @@ void ATerritory::GetLifetimeReplicatedProps(
   DOREPLIFETIME(ATerritory, ArmyStrength);
 }
 
-void ATerritory::Select(bool bSelectingForAttack) {
+void ATerritory::Select() {
   if (bIsSelected) {
     return;
   }
@@ -127,10 +127,10 @@ void ATerritory::Select(bool bSelectingForAttack) {
     MeshComponent->SetRenderCustomDepth(true);
   }
   if (DynamicMaterial) {
-    const FLinearColor Gold(1.0f, 0.84f, 0.0f, 1.0f);
-    const FLinearColor White(1.0f, 1.0f, 1.0f, 1.0f);
-    DynamicMaterial->SetVectorParameterValue(
-        FName("Color"), bSelectingForAttack ? White : Gold);
+    // Remember the existing color so it can be restored on deselect
+    DynamicMaterial->GetVectorParameterValue(FName("Color"), DefaultColor);
+    DynamicMaterial->SetVectorParameterValue(FName("Color"),
+                                             FLinearColor::White);
   }
   OnTerritorySelected.Broadcast(this);
 }
@@ -141,6 +141,7 @@ void ATerritory::Deselect() {
     MeshComponent->SetRenderCustomDepth(false);
   }
   if (DynamicMaterial) {
+    // Restore the color that was in use prior to selection
     DynamicMaterial->SetVectorParameterValue(FName("Color"), DefaultColor);
   }
 }

--- a/Source/Skald/Territory.h
+++ b/Source/Skald/Territory.h
@@ -73,7 +73,7 @@ public:
 
     /** Mark this territory as selected. */
     UFUNCTION(BlueprintCallable, Category = "Territory")
-    void Select(bool bSelectingForAttack = false);
+    void Select();
 
     /** Remove selection state from this territory. */
     UFUNCTION(BlueprintCallable, Category = "Territory")

--- a/Source/Skald/UI/SkaldMainHUDWidget.cpp
+++ b/Source/Skald/UI/SkaldMainHUDWidget.cpp
@@ -360,6 +360,7 @@ void USkaldMainHUDWidget::OnTerritoryClickedUI(ATerritory *Territory) {
     if (SelectedSourceID == -1) {
       if (bOwnedByLocal) {
         SelectedSourceID = Territory->TerritoryID;
+        Territory->Select();
 
         if (AWorldMap *WorldMap =
                 Cast<AWorldMap>(UGameplayStatics::GetActorOfClass(
@@ -399,7 +400,7 @@ void USkaldMainHUDWidget::OnTerritoryClickedUI(ATerritory *Territory) {
       }
       if (bOwnedByLocal && Territory->ArmyStrength > 0) {
         SelectedSourceID = Territory->TerritoryID;
-        Territory->Select(true);
+        Territory->Select();
         if (SelectionPrompt) {
           SelectionPrompt->SetText(
               FText::FromString(TEXT("Choose enemy territory.")));


### PR DESCRIPTION
## Summary
- Always highlight selected territories in white and restore their original colors when deselected
- Ensure selecting a source territory highlights it and adjacent enemies uniformly

## Testing
- `./Build/validate.sh` *(UnrealBuildTool not found; skipping compile check. UnrealEditor not found; cannot run tests.)*

------
https://chatgpt.com/codex/tasks/task_e_68ae7d14cb608324835c133f647f2885