### PR TITLE
Add deploy widget for reinforcement allocation

### DIFF
--- a/Source/Skald/Skald_TurnManager.cpp
+++ b/Source/Skald/Skald_TurnManager.cpp
@@ -42,7 +42,7 @@ void ATurnManager::StartTurns() {
         }
       }
       const int32 Reinforcements = FMath::CeilToInt(Owned / 3.0f);
-      PS->ArmyPool += Reinforcements;
+      PS->ArmyPool = Reinforcements;
       PS->ForceNetUpdate();
       BroadcastArmyPool(PS);
     }
@@ -86,7 +86,7 @@ void ATurnManager::AdvanceTurn() {
       }
     }
     const int32 Reinforcements = FMath::CeilToInt(Owned / 3.0f);
-    PS->ArmyPool += Reinforcements;
+    PS->ArmyPool = Reinforcements;
     PS->ForceNetUpdate();
     BroadcastArmyPool(PS);
   }

--- a/Source/Skald/UI/DeployWidget.cpp
+++ b/Source/Skald/UI/DeployWidget.cpp
@@ -1,0 +1,81 @@
+#include "UI/DeployWidget.h"
+#include "Components/Button.h"
+#include "Components/SpinBox.h"
+#include "Skald_GameMode.h"
+#include "Skald_PlayerController.h"
+#include "Skald_PlayerState.h"
+#include "Skald_TurnManager.h"
+#include "Territory.h"
+#include "UI/SkaldMainHUDWidget.h"
+
+void UDeployWidget::NativeConstruct() {
+  Super::NativeConstruct();
+
+  if (AcceptButton) {
+    AcceptButton->OnClicked.AddDynamic(this, &UDeployWidget::HandleAccept);
+  }
+  if (DeclineButton) {
+    DeclineButton->OnClicked.AddDynamic(this, &UDeployWidget::HandleDecline);
+  }
+  if (AmountSelector) {
+    AmountSelector->SetMinValue(1.f);
+    AmountSelector->SetDelta(1.f);
+    AmountSelector->SetValue(1.f);
+  }
+}
+
+void UDeployWidget::Setup(ATerritory *InTerritory, ASkaldPlayerState *InPlayerState,
+                           USkaldMainHUDWidget *InHUD, int32 MaxAmount) {
+  Territory = InTerritory;
+  PlayerState = InPlayerState;
+  OwningHUD = InHUD;
+  if (AmountSelector) {
+    AmountSelector->SetMaxValue(MaxAmount);
+    AmountSelector->SetValue(FMath::Clamp(1, 1, MaxAmount));
+  }
+}
+
+void UDeployWidget::HandleAccept() {
+  if (!Territory || !PlayerState || !OwningHUD.IsValid()) {
+    RemoveFromParent();
+    return;
+  }
+
+  const int32 Selected = AmountSelector
+                              ? FMath::Clamp(FMath::RoundToInt(AmountSelector->GetValue()), 0,
+                                             PlayerState->ArmyPool)
+                              : 0;
+  if (Selected > 0) {
+    Territory->ArmyStrength += Selected;
+    Territory->RefreshAppearance();
+    PlayerState->ArmyPool -= Selected;
+    PlayerState->ForceNetUpdate();
+    OwningHUD->UpdateDeployableUnits(PlayerState->ArmyPool);
+
+    if (PlayerState->ArmyPool <= 0 && OwningHUD->DeployButton) {
+      OwningHUD->DeployButton->SetVisibility(ESlateVisibility::Collapsed);
+      bool bHandled = false;
+      if (ASkaldGameMode *GM =
+              OwningHUD->GetWorld()->GetAuthGameMode<ASkaldGameMode>()) {
+        if (!GM->HasMatchStarted()) {
+          GM->AdvanceArmyPlacement();
+          bHandled = true;
+        }
+      }
+      if (!bHandled) {
+        if (APlayerController *PC = OwningHUD->GetOwningPlayer()) {
+          if (ASkaldPlayerController *SKPC = Cast<ASkaldPlayerController>(PC)) {
+            if (ATurnManager *TM = SKPC->GetTurnManager()) {
+              TM->AdvancePhase();
+            }
+          }
+        }
+      }
+    }
+  }
+
+  RemoveFromParent();
+}
+
+void UDeployWidget::HandleDecline() { RemoveFromParent(); }
+

--- a/Source/Skald/UI/DeployWidget.h
+++ b/Source/Skald/UI/DeployWidget.h
@@ -1,0 +1,52 @@
+#pragma once
+
+#include "Blueprint/UserWidget.h"
+#include "DeployWidget.generated.h"
+
+class UButton;
+class USpinBox;
+class ATerritory;
+class ASkaldPlayerState;
+class USkaldMainHUDWidget;
+
+/**
+ * Simple widget allowing the player to choose how many units to deploy to a
+ * territory.
+ */
+UCLASS()
+class SKALD_API UDeployWidget : public UUserWidget {
+  GENERATED_BODY()
+
+public:
+  virtual void NativeConstruct() override;
+
+  /** Configure the widget for the given territory and player state. */
+  void Setup(ATerritory *InTerritory, ASkaldPlayerState *InPlayerState,
+             USkaldMainHUDWidget *InHUD, int32 MaxAmount);
+
+  UPROPERTY(BlueprintReadOnly, meta = (BindWidget))
+  USpinBox *AmountSelector;
+
+  UPROPERTY(BlueprintReadOnly, meta = (BindWidget))
+  UButton *AcceptButton;
+
+  UPROPERTY(BlueprintReadOnly, meta = (BindWidget))
+  UButton *DeclineButton;
+
+private:
+  UFUNCTION()
+  void HandleAccept();
+
+  UFUNCTION()
+  void HandleDecline();
+
+  UPROPERTY()
+  ATerritory *Territory;
+
+  UPROPERTY()
+  ASkaldPlayerState *PlayerState;
+
+  UPROPERTY()
+  TWeakObjectPtr<USkaldMainHUDWidget> OwningHUD;
+};
+

--- a/Source/Skald/UI/SkaldMainHUDWidget.h
+++ b/Source/Skald/UI/SkaldMainHUDWidget.h
@@ -10,6 +10,7 @@ class UTextBlock;
 class UVerticalBox;
 class ATerritory;
 class UConfirmAttackWidget;
+class UDeployWidget;
 class UWidget;
 class ASkaldGameMode;
 class ASkaldGameState;
@@ -251,6 +252,9 @@ public:
   UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Skald|Widgets")
   TSubclassOf<UConfirmAttackWidget> ConfirmAttackWidgetClass;
 
+  UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Skald|Widgets")
+  TSubclassOf<UDeployWidget> DeployWidgetClass;
+
 protected:
   // Internal handlers for widget actions
   UFUNCTION()
@@ -267,6 +271,9 @@ protected:
 
   UPROPERTY()
   UConfirmAttackWidget *ActiveConfirmWidget = nullptr;
+
+  UPROPERTY()
+  UDeployWidget *ActiveDeployWidget = nullptr;
 
   UPROPERTY()
   TArray<ATerritory *> HighlightedTerritories;


### PR DESCRIPTION
## Summary
- introduce DeployWidget for selecting number of units to deploy
- spawn DeployWidget from HUD's Deploy button and apply chosen reinforcements
- compute reinforcement pool from owned territories at start of turns

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ae83e938948324a0d99b3631327854