### PR TITLE
Expose attack and deploy widgets to UMG

### DIFF
--- a/Source/Skald/UI/ConfirmAttackWidget.h
+++ b/Source/Skald/UI/ConfirmAttackWidget.h
@@ -10,8 +10,8 @@ class USpinBox;
 /**
  * Simple confirmation widget with Approve/Cancel buttons for attack
  * selection.
- */
-UCLASS()
+*/
+UCLASS(BlueprintType, Blueprintable)
 class SKALD_API UConfirmAttackWidget : public UUserWidget {
   GENERATED_BODY()
 

--- a/Source/Skald/UI/DeployWidget.h
+++ b/Source/Skald/UI/DeployWidget.h
@@ -12,8 +12,8 @@ class USkaldMainHUDWidget;
 /**
  * Simple widget allowing the player to choose how many units to deploy to a
  * territory.
- */
-UCLASS()
+*/
+UCLASS(BlueprintType, Blueprintable)
 class SKALD_API UDeployWidget : public UUserWidget {
   GENERATED_BODY()
 


### PR DESCRIPTION
## Summary
- Mark DeployWidget and ConfirmAttackWidget as blueprintable types so they can be subclassed in UMG

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ae7b66c0c08324aaaa6b7f2141fbfc