### PR TITLE
Fix compile errors in HUD visibility handling

### DIFF
--- a/Source/Skald/UI/SkaldMainHUDWidget.cpp
+++ b/Source/Skald/UI/SkaldMainHUDWidget.cpp
@@ -403,27 +403,27 @@ void USkaldMainHUDWidget::SyncPhaseButtons(bool bIsMyTurn) {
   BP_SetPhaseButtons(CurrentPhase, bIsMyTurn);
 
   if (AttackButton) {
-    const ESlateVisibility Visibility =
+    const ESlateVisibility DesiredVisibility =
         (bIsMyTurn && CurrentPhase == ETurnPhase::Attack)
             ? ESlateVisibility::Visible
             : ESlateVisibility::Collapsed;
-    AttackButton->SetVisibility(Visibility);
+    AttackButton->SetVisibility(DesiredVisibility);
   }
 
   if (MoveButton) {
-    const ESlateVisibility Visibility =
+    const ESlateVisibility DesiredVisibility =
         (bIsMyTurn && CurrentPhase == ETurnPhase::Movement)
             ? ESlateVisibility::Visible
             : ESlateVisibility::Collapsed;
-    MoveButton->SetVisibility(Visibility);
+    MoveButton->SetVisibility(DesiredVisibility);
   }
 
   if (DeployButton) {
-    const ESlateVisibility Visibility =
+    const ESlateVisibility DesiredVisibility =
         (bIsMyTurn && CurrentPhase == ETurnPhase::Reinforcement)
             ? ESlateVisibility::Visible
             : ESlateVisibility::Collapsed;
-    DeployButton->SetVisibility(Visibility);
+    DeployButton->SetVisibility(DesiredVisibility);
   }
 
   if (EndPhaseButton) {


### PR DESCRIPTION
## Summary
- rename local variables hiding `UWidget::Visibility`

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ae8d53b68883248ed0f6543d71d272