### PR TITLE
Enable reinforcement kickoff with AI auto-deployment and phase skipping

### DIFF
--- a/Source/Skald/Skald_GameMode.cpp
+++ b/Source/Skald/Skald_GameMode.cpp
@@ -260,6 +260,10 @@ void ASkaldGameMode::AdvanceArmyPlacement() {
       continue;
     }
 
+    if (TurnManager) {
+      TurnManager->BroadcastArmyPool(PS);
+    }
+
     // AI players automatically distribute their armies evenly.
     if (PS->bIsAI) {
       TArray<ATerritory *> OwnedTerritories;
@@ -278,14 +282,14 @@ void ASkaldGameMode::AdvanceArmyPlacement() {
         ++SpreadIndex;
       }
       PS->ForceNetUpdate();
+      if (TurnManager) {
+        TurnManager->BroadcastArmyPool(PS);
+      }
       ++PlacementIndex;
       continue;
     }
 
-    // Human player: update HUD and wait for manual deployment.
-    if (USkaldMainHUDWidget *HUD = PC->GetHUDWidget()) {
-      HUD->UpdateDeployableUnits(PS->ArmyPool);
-    }
+    // Human player: wait for manual deployment with current pool visible.
     break;
   }
 }

--- a/Source/Skald/Skald_TurnManager.h
+++ b/Source/Skald/Skald_TurnManager.h
@@ -54,6 +54,10 @@ public:
     UFUNCTION(BlueprintCallable, BlueprintPure, Category="Turn")
     const TArray<ASkaldPlayerController*>& GetControllers() const { return Controllers; }
 
+    /** Retrieve the current phase of play. */
+    UFUNCTION(BlueprintCallable, BlueprintPure, Category="Turn")
+    ETurnPhase GetCurrentPhase() const { return CurrentPhase; }
+
 protected:
     UPROPERTY(BlueprintReadOnly, Category="Turn")
     TArray<ASkaldPlayerController*> Controllers;

--- a/Source/Skald/UI/SkaldMainHUDWidget.cpp
+++ b/Source/Skald/UI/SkaldMainHUDWidget.cpp
@@ -428,14 +428,12 @@ void USkaldMainHUDWidget::SyncPhaseButtons(bool bIsMyTurn) {
 
   if (EndPhaseButton) {
     EndPhaseButton->SetVisibility(ESlateVisibility::Visible);
-    EndPhaseButton->SetIsEnabled(bIsMyTurn &&
-                                 CurrentPhase != ETurnPhase::EndTurn);
+    EndPhaseButton->SetIsEnabled(bIsMyTurn);
   }
 
   if (EndTurnButton) {
     EndTurnButton->SetVisibility(ESlateVisibility::Visible);
-    EndTurnButton->SetIsEnabled(bIsMyTurn &&
-                                CurrentPhase == ETurnPhase::EndTurn);
+    EndTurnButton->SetIsEnabled(bIsMyTurn);
   }
 }
 


### PR DESCRIPTION
## Summary
- Expose current turn phase to game logic
- Broadcast deployable armies during pre-placement and auto-distribute for AI
- AI auto-deploys reinforcements then ends turn
- End phase and end turn controls remain active during player's turn

## Testing
- `pytest` (no tests ran)


------
https://chatgpt.com/codex/tasks/task_e_68ae9021785c832492fa488d6d5af4a9