### PR TITLE
Refactor player onboarding helpers

### DIFF
--- a/Source/Skald/Skald_GameMode.h
+++ b/Source/Skald/Skald_GameMode.h
@@ -68,6 +68,15 @@ private:
   /** Index of the controller currently placing armies. */
   int32 PlacementIndex = 0;
 
+  /** Register a newly connected player and update player data. */
+  void RegisterPlayer(ASkaldPlayerController *PC);
+
+  /** Populate remaining slots with AI players in singleplayer. */
+  void PopulateAIPlayers();
+
+  /** Notify HUDs of the current player roster. */
+  void RefreshHUDs();
+
   /** Attempt to initialise the world and start the game flow. */
   void TryInitializeWorldAndStart();
 };


### PR DESCRIPTION
## Summary
- add helper methods RegisterPlayer, PopulateAIPlayers, and RefreshHUDs to SkaldGameMode
- refactor PostLogin to use new helpers for cleaner flow

## Testing
- `npm test` *(fails: Could not read package.json)*
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ae962f6f648324a99a76e322651620