### PR TITLE
Replicate player data in game state

### DIFF
--- a/Source/Skald/Skald_GameState.cpp
+++ b/Source/Skald/Skald_GameState.cpp
@@ -1,9 +1,19 @@
 #include "Skald_GameState.h"
 #include "Skald_PlayerState.h"
+#include "Net/UnrealNetwork.h"
 
 ASkaldGameState::ASkaldGameState()
     : CurrentTurnIndex(0)
 {
+}
+
+void ASkaldGameState::GetLifetimeReplicatedProps(
+    TArray<FLifetimeProperty>& OutLifetimeProps) const
+{
+    Super::GetLifetimeReplicatedProps(OutLifetimeProps);
+
+    DOREPLIFETIME(ASkaldGameState, Players);
+    DOREPLIFETIME(ASkaldGameState, CurrentTurnIndex);
 }
 
 void ASkaldGameState::AddPlayerState(APlayerState* PlayerState)

--- a/Source/Skald/Skald_GameState.h
+++ b/Source/Skald/Skald_GameState.h
@@ -20,7 +20,7 @@ public:
     ASkaldGameState();
 
     /** List of players participating in the match. */
-    UPROPERTY(BlueprintReadOnly, Category="GameState")
+    UPROPERTY(BlueprintReadOnly, Replicated, Category="GameState")
     TArray<ASkaldPlayerState*> Players;
 
     /** Broadcast whenever the player list changes. */
@@ -28,8 +28,10 @@ public:
     FSkaldPlayersUpdated OnPlayersUpdated;
 
     /** Index of the player whose turn is active. */
-    UPROPERTY(BlueprintReadOnly, Category="GameState")
+    UPROPERTY(BlueprintReadOnly, Replicated, Category="GameState")
     int32 CurrentTurnIndex;
+
+    virtual void GetLifetimeReplicatedProps(TArray<FLifetimeProperty>& OutLifetimeProps) const override;
 
     virtual void AddPlayerState(APlayerState* PlayerState) override;
 


### PR DESCRIPTION
## Summary
- replicate players array and current turn index across the network
- implement GetLifetimeReplicatedProps for game state

## Testing
- `./Engine/Build/BatchFiles/Build.sh SkaldEditor Linux Development -project="$(pwd)/Skald.uproject"` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68ae9700644083248b4180dfd335edfd