### PR TITLE
Use TObjectPtr for world map territories

### DIFF
--- a/Source/Skald/WorldMap.cpp
+++ b/Source/Skald/WorldMap.cpp
@@ -6,49 +6,91 @@
 // mirrors the data supplied by design and is used to spawn the territories at
 // runtime.
 const TArray<FTerritorySpawnData> AWorldMap::DefaultTerritories = {
-    FTerritorySpawnData(0, TEXT("Howling Veil"), true, 0, FVector(-600.0f, -600.0f, 0.f)),
-    FTerritorySpawnData(1, TEXT("Thond"), false, 0, FVector(-400.0f, -600.0f, 0.f)),
-    FTerritorySpawnData(2, TEXT("Elmyre"), false, 0, FVector(-200.0f, -600.0f, 0.f)),
-    FTerritorySpawnData(3, TEXT("Skarlstorm"), false, 0, FVector(0.0f, -600.0f, 0.f)),
-    FTerritorySpawnData(4, TEXT("Direford"), false, 0, FVector(200.0f, -600.0f, 0.f)),
-    FTerritorySpawnData(5, TEXT("Grimrest"), false, 0, FVector(400.0f, -600.0f, 0.f)),
-    FTerritorySpawnData(6, TEXT("Lakehold"), false, 0, FVector(600.0f, -600.0f, 0.f)),
-    FTerritorySpawnData(7, TEXT("Argoth"), false, 0, FVector(-600.0f, -400.0f, 0.f)),
-    FTerritorySpawnData(8, TEXT("Chala"), false, 1, FVector(-400.0f, -400.0f, 0.f)),
-    FTerritorySpawnData(9, TEXT("Rylan"), false, 1, FVector(-200.0f, -400.0f, 0.f)),
-    FTerritorySpawnData(10, TEXT("Uris"), false, 1, FVector(0.0f, -400.0f, 0.f)),
-    FTerritorySpawnData(11, TEXT("Achre"), true, 1, FVector(200.0f, -400.0f, 0.f)),
-    FTerritorySpawnData(12, TEXT("Erif"), false, 2, FVector(400.0f, -400.0f, 0.f)),
-    FTerritorySpawnData(13, TEXT("Nevar"), false, 1, FVector(600.0f, -400.0f, 0.f)),
-    FTerritorySpawnData(14, TEXT("Frayton"), false, 0, FVector(-600.0f, -200.0f, 0.f)),
-    FTerritorySpawnData(15, TEXT("Past Fields"), false, 1, FVector(-400.0f, -200.0f, 0.f)),
-    FTerritorySpawnData(16, TEXT("Spring Isle"), false, 1, FVector(-200.0f, -200.0f, 0.f)),
-    FTerritorySpawnData(17, TEXT("Sunder Isle"), false, 2, FVector(0.0f, -200.0f, 0.f)),
-    FTerritorySpawnData(18, TEXT("Sugiria"), true, 2, FVector(200.0f, -200.0f, 0.f)),
-    FTerritorySpawnData(19, TEXT("Blindshade"), false, 2, FVector(400.0f, -200.0f, 0.f)),
-    FTerritorySpawnData(20, TEXT("Whimswallow"), false, 2, FVector(600.0f, -200.0f, 0.f)),
-    FTerritorySpawnData(21, TEXT("Forgotten Coast"), false, 2, FVector(-600.0f, 0.0f, 0.f)),
-    FTerritorySpawnData(22, TEXT("Oria"), false, 2, FVector(-400.0f, 0.0f, 0.f)),
-    FTerritorySpawnData(23, TEXT("Brell"), false, 3, FVector(-200.0f, 0.0f, 0.f)),
+    FTerritorySpawnData(0, TEXT("Howling Veil"), true, 0,
+                        FVector(-600.0f, -600.0f, 0.f)),
+    FTerritorySpawnData(1, TEXT("Thond"), false, 0,
+                        FVector(-400.0f, -600.0f, 0.f)),
+    FTerritorySpawnData(2, TEXT("Elmyre"), false, 0,
+                        FVector(-200.0f, -600.0f, 0.f)),
+    FTerritorySpawnData(3, TEXT("Skarlstorm"), false, 0,
+                        FVector(0.0f, -600.0f, 0.f)),
+    FTerritorySpawnData(4, TEXT("Direford"), false, 0,
+                        FVector(200.0f, -600.0f, 0.f)),
+    FTerritorySpawnData(5, TEXT("Grimrest"), false, 0,
+                        FVector(400.0f, -600.0f, 0.f)),
+    FTerritorySpawnData(6, TEXT("Lakehold"), false, 0,
+                        FVector(600.0f, -600.0f, 0.f)),
+    FTerritorySpawnData(7, TEXT("Argoth"), false, 0,
+                        FVector(-600.0f, -400.0f, 0.f)),
+    FTerritorySpawnData(8, TEXT("Chala"), false, 1,
+                        FVector(-400.0f, -400.0f, 0.f)),
+    FTerritorySpawnData(9, TEXT("Rylan"), false, 1,
+                        FVector(-200.0f, -400.0f, 0.f)),
+    FTerritorySpawnData(10, TEXT("Uris"), false, 1,
+                        FVector(0.0f, -400.0f, 0.f)),
+    FTerritorySpawnData(11, TEXT("Achre"), true, 1,
+                        FVector(200.0f, -400.0f, 0.f)),
+    FTerritorySpawnData(12, TEXT("Erif"), false, 2,
+                        FVector(400.0f, -400.0f, 0.f)),
+    FTerritorySpawnData(13, TEXT("Nevar"), false, 1,
+                        FVector(600.0f, -400.0f, 0.f)),
+    FTerritorySpawnData(14, TEXT("Frayton"), false, 0,
+                        FVector(-600.0f, -200.0f, 0.f)),
+    FTerritorySpawnData(15, TEXT("Past Fields"), false, 1,
+                        FVector(-400.0f, -200.0f, 0.f)),
+    FTerritorySpawnData(16, TEXT("Spring Isle"), false, 1,
+                        FVector(-200.0f, -200.0f, 0.f)),
+    FTerritorySpawnData(17, TEXT("Sunder Isle"), false, 2,
+                        FVector(0.0f, -200.0f, 0.f)),
+    FTerritorySpawnData(18, TEXT("Sugiria"), true, 2,
+                        FVector(200.0f, -200.0f, 0.f)),
+    FTerritorySpawnData(19, TEXT("Blindshade"), false, 2,
+                        FVector(400.0f, -200.0f, 0.f)),
+    FTerritorySpawnData(20, TEXT("Whimswallow"), false, 2,
+                        FVector(600.0f, -200.0f, 0.f)),
+    FTerritorySpawnData(21, TEXT("Forgotten Coast"), false, 2,
+                        FVector(-600.0f, 0.0f, 0.f)),
+    FTerritorySpawnData(22, TEXT("Oria"), false, 2,
+                        FVector(-400.0f, 0.0f, 0.f)),
+    FTerritorySpawnData(23, TEXT("Brell"), false, 3,
+                        FVector(-200.0f, 0.0f, 0.f)),
     FTerritorySpawnData(24, TEXT("Revel"), true, 3, FVector(0.0f, 0.0f, 0.f)),
-    FTerritorySpawnData(25, TEXT("Velaria"), false, 3, FVector(200.0f, 0.0f, 0.f)),
-    FTerritorySpawnData(26, TEXT("Essivar"), false, 3, FVector(400.0f, 0.0f, 0.f)),
-    FTerritorySpawnData(27, TEXT("Caldemire"), false, 3, FVector(600.0f, 0.0f, 0.f)),
-    FTerritorySpawnData(28, TEXT("HazelHallow"), false, 4, FVector(-600.0f, 200.0f, 0.f)),
-    FTerritorySpawnData(29, TEXT("Sirholde"), false, 4, FVector(-400.0f, 200.0f, 0.f)),
-    FTerritorySpawnData(30, TEXT("Styr"), false, 4, FVector(-200.0f, 200.0f, 0.f)),
-    FTerritorySpawnData(31, TEXT("Dawnmere"), true, 4, FVector(0.0f, 200.0f, 0.f)),
-    FTerritorySpawnData(32, TEXT("Killbrooke"), false, 4, FVector(200.0f, 200.0f, 0.f)),
-    FTerritorySpawnData(33, TEXT("Broken Plains"), false, 5, FVector(400.0f, 200.0f, 0.f)),
-    FTerritorySpawnData(34, TEXT("Everlands"), false, 5, FVector(600.0f, 200.0f, 0.f)),
-    FTerritorySpawnData(35, TEXT("Vigilmoore"), false, 5, FVector(-600.0f, 400.0f, 0.f)),
-    FTerritorySpawnData(36, TEXT("Vulkrum"), false, 5, FVector(-400.0f, 400.0f, 0.f)),
-    FTerritorySpawnData(37, TEXT("Timber Rock"), false, 5, FVector(-200.0f, 400.0f, 0.f)),
-    FTerritorySpawnData(38, TEXT("Omenwhick"), false, 5, FVector(0.0f, 400.0f, 0.f)),
-    FTerritorySpawnData(39, TEXT("Armens Grasp"), false, 5, FVector(200.0f, 400.0f, 0.f)),
-    FTerritorySpawnData(40, TEXT("Volkridge"), true, 5, FVector(400.0f, 400.0f, 0.f)),
-    FTerritorySpawnData(41, TEXT("Bakas"), false, 5, FVector(600.0f, 400.0f, 0.f)),
-    FTerritorySpawnData(42, TEXT("Kesis"), false, 5, FVector(-600.0f, 600.0f, 0.f))};
+    FTerritorySpawnData(25, TEXT("Velaria"), false, 3,
+                        FVector(200.0f, 0.0f, 0.f)),
+    FTerritorySpawnData(26, TEXT("Essivar"), false, 3,
+                        FVector(400.0f, 0.0f, 0.f)),
+    FTerritorySpawnData(27, TEXT("Caldemire"), false, 3,
+                        FVector(600.0f, 0.0f, 0.f)),
+    FTerritorySpawnData(28, TEXT("HazelHallow"), false, 4,
+                        FVector(-600.0f, 200.0f, 0.f)),
+    FTerritorySpawnData(29, TEXT("Sirholde"), false, 4,
+                        FVector(-400.0f, 200.0f, 0.f)),
+    FTerritorySpawnData(30, TEXT("Styr"), false, 4,
+                        FVector(-200.0f, 200.0f, 0.f)),
+    FTerritorySpawnData(31, TEXT("Dawnmere"), true, 4,
+                        FVector(0.0f, 200.0f, 0.f)),
+    FTerritorySpawnData(32, TEXT("Killbrooke"), false, 4,
+                        FVector(200.0f, 200.0f, 0.f)),
+    FTerritorySpawnData(33, TEXT("Broken Plains"), false, 5,
+                        FVector(400.0f, 200.0f, 0.f)),
+    FTerritorySpawnData(34, TEXT("Everlands"), false, 5,
+                        FVector(600.0f, 200.0f, 0.f)),
+    FTerritorySpawnData(35, TEXT("Vigilmoore"), false, 5,
+                        FVector(-600.0f, 400.0f, 0.f)),
+    FTerritorySpawnData(36, TEXT("Vulkrum"), false, 5,
+                        FVector(-400.0f, 400.0f, 0.f)),
+    FTerritorySpawnData(37, TEXT("Timber Rock"), false, 5,
+                        FVector(-200.0f, 400.0f, 0.f)),
+    FTerritorySpawnData(38, TEXT("Omenwhick"), false, 5,
+                        FVector(0.0f, 400.0f, 0.f)),
+    FTerritorySpawnData(39, TEXT("Armens Grasp"), false, 5,
+                        FVector(200.0f, 400.0f, 0.f)),
+    FTerritorySpawnData(40, TEXT("Volkridge"), true, 5,
+                        FVector(400.0f, 400.0f, 0.f)),
+    FTerritorySpawnData(41, TEXT("Bakas"), false, 5,
+                        FVector(600.0f, 400.0f, 0.f)),
+    FTerritorySpawnData(42, TEXT("Kesis"), false, 5,
+                        FVector(-600.0f, 600.0f, 0.f))};
 
 AWorldMap::AWorldMap() {
   PrimaryActorTick.bCanEverTick = false;
@@ -86,8 +128,8 @@ void AWorldMap::BeginPlay() {
       if (FVector::Dist2D(Territories[i]->GetActorLocation(),
                           Territories[j]->GetActorLocation()) <=
           AdjacencyDistance) {
-        Territories[i]->AdjacentTerritories.Add(Territories[j]);
-        Territories[j]->AdjacentTerritories.Add(Territories[i]);
+        Territories[i]->AdjacentTerritories.Add(Territories[j].Get());
+        Territories[j]->AdjacentTerritories.Add(Territories[i].Get());
       }
     }
   }
@@ -102,13 +144,11 @@ void AWorldMap::RegisterTerritory(ATerritory *Territory) {
 }
 
 ATerritory *AWorldMap::GetTerritoryById(int32 TerritoryId) const {
-  if (ATerritory * const* Found = Territories.FindByPredicate(
-          [TerritoryId](ATerritory *Territory) {
-            return Territory && Territory->TerritoryID == TerritoryId;
-          })) {
-    return *Found;
-  }
-  return nullptr;
+  const TObjectPtr<ATerritory> *Found = Territories.FindByPredicate(
+      [TerritoryId](const TObjectPtr<ATerritory> &Territory) {
+        return Territory && Territory->TerritoryID == TerritoryId;
+      });
+  return Found ? *Found : nullptr;
 }
 
 void AWorldMap::SelectTerritory(ATerritory *Territory) {

--- a/Source/Skald/WorldMap.h
+++ b/Source/Skald/WorldMap.h
@@ -13,105 +13,93 @@ DECLARE_DYNAMIC_MULTICAST_DELEGATE_OneParam(FWorldMapTerritorySelected,
 
 /** Data describing how a territory should be spawned at runtime. */
 USTRUCT(BlueprintType)
-struct FTerritorySpawnData
-{
-    GENERATED_BODY();
+struct FTerritorySpawnData {
+  GENERATED_BODY();
 
-    FTerritorySpawnData()
-        : TerritoryID(0)
-        , TerritoryName(TEXT(""))
-        , bIsCapital(false)
-        , ContinentID(0)
-        , Location(FVector::ZeroVector)
-    {
-    }
+  FTerritorySpawnData()
+      : TerritoryID(0), TerritoryName(TEXT("")), bIsCapital(false),
+        ContinentID(0), Location(FVector::ZeroVector) {}
 
-    FTerritorySpawnData(int32 InID, const FString& InName, bool bCapital = false,
-                        int32 InContinent = 0, FVector InLocation = FVector::ZeroVector)
-        : TerritoryID(InID)
-        , TerritoryName(InName)
-        , bIsCapital(bCapital)
-        , ContinentID(InContinent)
-        , Location(InLocation)
-    {
-    }
+  FTerritorySpawnData(int32 InID, const FString &InName, bool bCapital = false,
+                      int32 InContinent = 0,
+                      FVector InLocation = FVector::ZeroVector)
+      : TerritoryID(InID), TerritoryName(InName), bIsCapital(bCapital),
+        ContinentID(InContinent), Location(InLocation) {}
 
-    UPROPERTY(EditAnywhere, BlueprintReadOnly)
-    int32 TerritoryID;
+  UPROPERTY(EditAnywhere, BlueprintReadOnly)
+  int32 TerritoryID;
 
-    UPROPERTY(EditAnywhere, BlueprintReadOnly)
-    FString TerritoryName;
+  UPROPERTY(EditAnywhere, BlueprintReadOnly)
+  FString TerritoryName;
 
-    UPROPERTY(EditAnywhere, BlueprintReadOnly)
-    bool bIsCapital;
+  UPROPERTY(EditAnywhere, BlueprintReadOnly)
+  bool bIsCapital;
 
-    UPROPERTY(EditAnywhere, BlueprintReadOnly)
-    int32 ContinentID;
+  UPROPERTY(EditAnywhere, BlueprintReadOnly)
+  int32 ContinentID;
 
-    /** Location for spawning this territory relative to the world map actor. */
-    UPROPERTY(EditAnywhere, BlueprintReadOnly)
-    FVector Location;
+  /** Location for spawning this territory relative to the world map actor. */
+  UPROPERTY(EditAnywhere, BlueprintReadOnly)
+  FVector Location;
 };
 
 /**
  * Actor owning and managing all territories in the map.
  */
 UCLASS(Blueprintable, BlueprintType)
-class SKALD_API AWorldMap : public AActor
-{
-    GENERATED_BODY()
+class SKALD_API AWorldMap : public AActor {
+  GENERATED_BODY()
 
 public:
-    AWorldMap();
+  AWorldMap();
 
-    virtual void BeginPlay() override;
+  virtual void BeginPlay() override;
 
-    /** All territories contained in this world map. */
-    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "WorldMap")
-    TArray<ATerritory*> Territories;
+  /** All territories contained in this world map. */
+  UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "WorldMap")
+  TArray<TObjectPtr<ATerritory>> Territories;
 
-    /** Currently selected territory. */
-    UPROPERTY(BlueprintReadOnly, Category = "WorldMap")
-    ATerritory* SelectedTerritory;
+  /** Currently selected territory. */
+  UPROPERTY(BlueprintReadOnly, Category = "WorldMap")
+  ATerritory *SelectedTerritory;
 
-    /** Event fired whenever SelectTerritory chooses a new territory. */
-    UPROPERTY(BlueprintAssignable, Category = "WorldMap")
-    FWorldMapTerritorySelected OnTerritorySelected;
+  /** Event fired whenever SelectTerritory chooses a new territory. */
+  UPROPERTY(BlueprintAssignable, Category = "WorldMap")
+  FWorldMapTerritorySelected OnTerritorySelected;
 
-    /** Register a territory with the world map. */
-    UFUNCTION(BlueprintCallable, Category = "WorldMap")
-    void RegisterTerritory(ATerritory* Territory);
+  /** Register a territory with the world map. */
+  UFUNCTION(BlueprintCallable, Category = "WorldMap")
+  void RegisterTerritory(ATerritory *Territory);
 
-    /** Get a territory by its identifier. */
-    UFUNCTION(BlueprintCallable, Category = "WorldMap")
-    ATerritory* GetTerritoryById(int32 TerritoryId) const;
+  /** Get a territory by its identifier. */
+  UFUNCTION(BlueprintCallable, Category = "WorldMap")
+  ATerritory *GetTerritoryById(int32 TerritoryId) const;
 
-    /** Handle territory selection. */
-    UFUNCTION(BlueprintCallable, Category = "WorldMap")
-    void SelectTerritory(ATerritory* Territory);
+  /** Handle territory selection. */
+  UFUNCTION(BlueprintCallable, Category = "WorldMap")
+  void SelectTerritory(ATerritory *Territory);
 
-    /** Move units between territories. */
-    UFUNCTION(BlueprintCallable, Category = "WorldMap")
-    bool MoveBetween(ATerritory* From, ATerritory* To);
+  /** Move units between territories. */
+  UFUNCTION(BlueprintCallable, Category = "WorldMap")
+  bool MoveBetween(ATerritory *From, ATerritory *To);
 
-    /** Actor class used when spawning territory instances. */
-    UPROPERTY(EditAnywhere, Category = "WorldMap")
-    TSubclassOf<ATerritory> TerritoryClass;
+  /** Actor class used when spawning territory instances. */
+  UPROPERTY(EditAnywhere, Category = "WorldMap")
+  TSubclassOf<ATerritory> TerritoryClass;
 
-    /** Minimum XY (in local space) for random spawn positions. */
-    UPROPERTY(EditAnywhere, Category = "WorldMap")
-    FVector2D SpawnAreaMin = FVector2D(-500.f, -500.f);
+  /** Minimum XY (in local space) for random spawn positions. */
+  UPROPERTY(EditAnywhere, Category = "WorldMap")
+  FVector2D SpawnAreaMin = FVector2D(-500.f, -500.f);
 
-    /** Maximum XY (in local space) for random spawn positions. */
-    UPROPERTY(EditAnywhere, Category = "WorldMap")
-    FVector2D SpawnAreaMax = FVector2D(500.f, 500.f);
+  /** Maximum XY (in local space) for random spawn positions. */
+  UPROPERTY(EditAnywhere, Category = "WorldMap")
+  FVector2D SpawnAreaMax = FVector2D(500.f, 500.f);
 
-    /** Maximum distance to consider two territories adjacent. */
-    UPROPERTY(EditAnywhere, Category = "WorldMap")
-    float AdjacencyDistance = 210.f;
+  /** Maximum distance to consider two territories adjacent. */
+  UPROPERTY(EditAnywhere, Category = "WorldMap")
+  float AdjacencyDistance = 210.f;
 
 protected:
-    /** Predefined territory table used for spawning at begin play. */
-    static const TArray<FTerritorySpawnData> DefaultTerritories;
+  /** Predefined territory table used for spawning at begin play. */
+  static const TArray<FTerritorySpawnData> DefaultTerritories;
 };
-


### PR DESCRIPTION
## Summary
- store world map territories as `TObjectPtr` instead of raw pointers
- adjust adjacency setup and lookup to handle `TObjectPtr`

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ae98e6d44c8324be23449e24c8ac94