### PR TITLE
Use data table for world map territories

### DIFF
--- a/Content/DataTables/TerritoryTable.csv
+++ b/Content/DataTables/TerritoryTable.csv
@@ -1,0 +1,44 @@
+TerritoryID,TerritoryName,bIsCapital,ContinentID,LocationX,LocationY,LocationZ
+0,Howling Veil,True,0,-600.0,-600.0,0.0
+1,Thond,False,0,-400.0,-600.0,0.0
+2,Elmyre,False,0,-200.0,-600.0,0.0
+3,Skarlstorm,False,0,0.0,-600.0,0.0
+4,Direford,False,0,200.0,-600.0,0.0
+5,Grimrest,False,0,400.0,-600.0,0.0
+6,Lakehold,False,0,600.0,-600.0,0.0
+7,Argoth,False,0,-600.0,-400.0,0.0
+8,Chala,False,1,-400.0,-400.0,0.0
+9,Rylan,False,1,-200.0,-400.0,0.0
+10,Uris,False,1,0.0,-400.0,0.0
+11,Achre,True,1,200.0,-400.0,0.0
+12,Erif,False,2,400.0,-400.0,0.0
+13,Nevar,False,1,600.0,-400.0,0.0
+14,Frayton,False,0,-600.0,-200.0,0.0
+15,Past Fields,False,1,-400.0,-200.0,0.0
+16,Spring Isle,False,1,-200.0,-200.0,0.0
+17,Sunder Isle,False,2,0.0,-200.0,0.0
+18,Sugiria,True,2,200.0,-200.0,0.0
+19,Blindshade,False,2,400.0,-200.0,0.0
+20,Whimswallow,False,2,600.0,-200.0,0.0
+21,Forgotten Coast,False,2,-600.0,0.0,0.0
+22,Oria,False,2,-400.0,0.0,0.0
+23,Brell,False,3,-200.0,0.0,0.0
+24,Revel,True,3,0.0,0.0,0.0
+25,Velaria,False,3,200.0,0.0,0.0
+26,Essivar,False,3,400.0,0.0,0.0
+27,Caldemire,False,3,600.0,0.0,0.0
+28,HazelHallow,False,4,-600.0,200.0,0.0
+29,Sirholde,False,4,-400.0,200.0,0.0
+30,Styr,False,4,-200.0,200.0,0.0
+31,Dawnmere,True,4,0.0,200.0,0.0
+32,Killbrooke,False,4,200.0,200.0,0.0
+33,Broken Plains,False,5,400.0,200.0,0.0
+34,Everlands,False,5,600.0,200.0,0.0
+35,Vigilmoore,False,5,-600.0,400.0,0.0
+36,Vulkrum,False,5,-400.0,400.0,0.0
+37,Timber Rock,False,5,-200.0,400.0,0.0
+38,Omenwhick,False,5,0.0,400.0,0.0
+39,Armens Grasp,False,5,200.0,400.0,0.0
+40,Volkridge,True,5,400.0,400.0,0.0
+41,Bakas,False,5,600.0,400.0,0.0
+42,Kesis,False,5,-600.0,600.0,0.0

--- a/Source/Skald/WorldMap.cpp
+++ b/Source/Skald/WorldMap.cpp
@@ -2,96 +2,6 @@
 #include "Engine/World.h"
 #include "Territory.h"
 
-// Table describing each territory that should exist in the world. This
-// mirrors the data supplied by design and is used to spawn the territories at
-// runtime.
-const TArray<FTerritorySpawnData> AWorldMap::DefaultTerritories = {
-    FTerritorySpawnData(0, TEXT("Howling Veil"), true, 0,
-                        FVector(-600.0f, -600.0f, 0.f)),
-    FTerritorySpawnData(1, TEXT("Thond"), false, 0,
-                        FVector(-400.0f, -600.0f, 0.f)),
-    FTerritorySpawnData(2, TEXT("Elmyre"), false, 0,
-                        FVector(-200.0f, -600.0f, 0.f)),
-    FTerritorySpawnData(3, TEXT("Skarlstorm"), false, 0,
-                        FVector(0.0f, -600.0f, 0.f)),
-    FTerritorySpawnData(4, TEXT("Direford"), false, 0,
-                        FVector(200.0f, -600.0f, 0.f)),
-    FTerritorySpawnData(5, TEXT("Grimrest"), false, 0,
-                        FVector(400.0f, -600.0f, 0.f)),
-    FTerritorySpawnData(6, TEXT("Lakehold"), false, 0,
-                        FVector(600.0f, -600.0f, 0.f)),
-    FTerritorySpawnData(7, TEXT("Argoth"), false, 0,
-                        FVector(-600.0f, -400.0f, 0.f)),
-    FTerritorySpawnData(8, TEXT("Chala"), false, 1,
-                        FVector(-400.0f, -400.0f, 0.f)),
-    FTerritorySpawnData(9, TEXT("Rylan"), false, 1,
-                        FVector(-200.0f, -400.0f, 0.f)),
-    FTerritorySpawnData(10, TEXT("Uris"), false, 1,
-                        FVector(0.0f, -400.0f, 0.f)),
-    FTerritorySpawnData(11, TEXT("Achre"), true, 1,
-                        FVector(200.0f, -400.0f, 0.f)),
-    FTerritorySpawnData(12, TEXT("Erif"), false, 2,
-                        FVector(400.0f, -400.0f, 0.f)),
-    FTerritorySpawnData(13, TEXT("Nevar"), false, 1,
-                        FVector(600.0f, -400.0f, 0.f)),
-    FTerritorySpawnData(14, TEXT("Frayton"), false, 0,
-                        FVector(-600.0f, -200.0f, 0.f)),
-    FTerritorySpawnData(15, TEXT("Past Fields"), false, 1,
-                        FVector(-400.0f, -200.0f, 0.f)),
-    FTerritorySpawnData(16, TEXT("Spring Isle"), false, 1,
-                        FVector(-200.0f, -200.0f, 0.f)),
-    FTerritorySpawnData(17, TEXT("Sunder Isle"), false, 2,
-                        FVector(0.0f, -200.0f, 0.f)),
-    FTerritorySpawnData(18, TEXT("Sugiria"), true, 2,
-                        FVector(200.0f, -200.0f, 0.f)),
-    FTerritorySpawnData(19, TEXT("Blindshade"), false, 2,
-                        FVector(400.0f, -200.0f, 0.f)),
-    FTerritorySpawnData(20, TEXT("Whimswallow"), false, 2,
-                        FVector(600.0f, -200.0f, 0.f)),
-    FTerritorySpawnData(21, TEXT("Forgotten Coast"), false, 2,
-                        FVector(-600.0f, 0.0f, 0.f)),
-    FTerritorySpawnData(22, TEXT("Oria"), false, 2,
-                        FVector(-400.0f, 0.0f, 0.f)),
-    FTerritorySpawnData(23, TEXT("Brell"), false, 3,
-                        FVector(-200.0f, 0.0f, 0.f)),
-    FTerritorySpawnData(24, TEXT("Revel"), true, 3, FVector(0.0f, 0.0f, 0.f)),
-    FTerritorySpawnData(25, TEXT("Velaria"), false, 3,
-                        FVector(200.0f, 0.0f, 0.f)),
-    FTerritorySpawnData(26, TEXT("Essivar"), false, 3,
-                        FVector(400.0f, 0.0f, 0.f)),
-    FTerritorySpawnData(27, TEXT("Caldemire"), false, 3,
-                        FVector(600.0f, 0.0f, 0.f)),
-    FTerritorySpawnData(28, TEXT("HazelHallow"), false, 4,
-                        FVector(-600.0f, 200.0f, 0.f)),
-    FTerritorySpawnData(29, TEXT("Sirholde"), false, 4,
-                        FVector(-400.0f, 200.0f, 0.f)),
-    FTerritorySpawnData(30, TEXT("Styr"), false, 4,
-                        FVector(-200.0f, 200.0f, 0.f)),
-    FTerritorySpawnData(31, TEXT("Dawnmere"), true, 4,
-                        FVector(0.0f, 200.0f, 0.f)),
-    FTerritorySpawnData(32, TEXT("Killbrooke"), false, 4,
-                        FVector(200.0f, 200.0f, 0.f)),
-    FTerritorySpawnData(33, TEXT("Broken Plains"), false, 5,
-                        FVector(400.0f, 200.0f, 0.f)),
-    FTerritorySpawnData(34, TEXT("Everlands"), false, 5,
-                        FVector(600.0f, 200.0f, 0.f)),
-    FTerritorySpawnData(35, TEXT("Vigilmoore"), false, 5,
-                        FVector(-600.0f, 400.0f, 0.f)),
-    FTerritorySpawnData(36, TEXT("Vulkrum"), false, 5,
-                        FVector(-400.0f, 400.0f, 0.f)),
-    FTerritorySpawnData(37, TEXT("Timber Rock"), false, 5,
-                        FVector(-200.0f, 400.0f, 0.f)),
-    FTerritorySpawnData(38, TEXT("Omenwhick"), false, 5,
-                        FVector(0.0f, 400.0f, 0.f)),
-    FTerritorySpawnData(39, TEXT("Armens Grasp"), false, 5,
-                        FVector(200.0f, 400.0f, 0.f)),
-    FTerritorySpawnData(40, TEXT("Volkridge"), true, 5,
-                        FVector(400.0f, 400.0f, 0.f)),
-    FTerritorySpawnData(41, TEXT("Bakas"), false, 5,
-                        FVector(600.0f, 400.0f, 0.f)),
-    FTerritorySpawnData(42, TEXT("Kesis"), false, 5,
-                        FVector(-600.0f, 600.0f, 0.f))};
-
 AWorldMap::AWorldMap() {
   PrimaryActorTick.bCanEverTick = false;
   SelectedTerritory = nullptr;
@@ -100,23 +10,28 @@ AWorldMap::AWorldMap() {
 void AWorldMap::BeginPlay() {
   Super::BeginPlay();
 
-  if (!TerritoryClass) {
+  if (!TerritoryClass || !TerritoryTable) {
     return;
   }
 
-  // Spawn each predefined territory at its designated location.
-  for (const FTerritorySpawnData &Data : DefaultTerritories) {
-    const FVector SpawnLocation = GetActorLocation() + Data.Location;
+  // Spawn territories defined in the data table.
+  TArray<FTerritorySpawnData *> Rows;
+  TerritoryTable->GetAllRows(TEXT("TerritoryTable"), Rows);
+  for (const FTerritorySpawnData *Data : Rows) {
+    if (!Data) {
+      continue;
+    }
+    const FVector SpawnLocation = GetActorLocation() + Data->Location;
 
     FActorSpawnParameters Params;
     Params.Owner = this;
     ATerritory *Territory = GetWorld()->SpawnActor<ATerritory>(
         TerritoryClass, SpawnLocation, FRotator::ZeroRotator, Params);
     if (Territory) {
-      Territory->TerritoryID = Data.TerritoryID;
-      Territory->TerritoryName = Data.TerritoryName;
-      Territory->bIsCapital = Data.bIsCapital;
-      Territory->ContinentID = Data.ContinentID;
+      Territory->TerritoryID = Data->TerritoryID;
+      Territory->TerritoryName = Data->TerritoryName;
+      Territory->bIsCapital = Data->bIsCapital;
+      Territory->ContinentID = Data->ContinentID;
       RegisterTerritory(Territory);
     }
   }

--- a/Source/Skald/WorldMap.h
+++ b/Source/Skald/WorldMap.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "CoreMinimal.h"
+#include "Engine/DataTable.h"
 #include "GameFramework/Actor.h"
 #include "WorldMap.generated.h"
 
@@ -13,7 +14,7 @@ DECLARE_DYNAMIC_MULTICAST_DELEGATE_OneParam(FWorldMapTerritorySelected,
 
 /** Data describing how a territory should be spawned at runtime. */
 USTRUCT(BlueprintType)
-struct FTerritorySpawnData {
+struct FTerritorySpawnData : public FTableRowBase {
   GENERATED_BODY();
 
   FTerritorySpawnData()
@@ -87,6 +88,10 @@ public:
   UPROPERTY(EditAnywhere, Category = "WorldMap")
   TSubclassOf<ATerritory> TerritoryClass;
 
+  /** Data table defining territories to spawn. */
+  UPROPERTY(EditAnywhere, Category = "WorldMap")
+  UDataTable *TerritoryTable;
+
   /** Minimum XY (in local space) for random spawn positions. */
   UPROPERTY(EditAnywhere, Category = "WorldMap")
   FVector2D SpawnAreaMin = FVector2D(-500.f, -500.f);
@@ -100,6 +105,4 @@ public:
   float AdjacencyDistance = 210.f;
 
 protected:
-  /** Predefined territory table used for spawning at begin play. */
-  static const TArray<FTerritorySpawnData> DefaultTerritories;
 };


### PR DESCRIPTION
## Summary
- Allow WorldMap to use DataTable-driven territory spawn
- Remove hard-coded DefaultTerritories array
- Provide TerritoryTable.csv for FTerritorySpawnData

## Testing
- `clang-format -i Source/Skald/WorldMap.h Source/Skald/WorldMap.cpp`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ae99bf0e0c8324b5aef22b14634ef3