### PR TITLE
Use weak pointers for turn manager controllers

### DIFF
--- a/Source/Skald/Skald_TurnManager.h
+++ b/Source/Skald/Skald_TurnManager.h
@@ -52,7 +52,7 @@ public:
 
     /** Access the controllers array in its current initiative order. */
     UFUNCTION(BlueprintCallable, BlueprintPure, Category="Turn")
-    const TArray<ASkaldPlayerController*>& GetControllers() const { return Controllers; }
+    const TArray<TWeakObjectPtr<ASkaldPlayerController>>& GetControllers() const { return Controllers; }
 
     /** Retrieve the current phase of play. */
     UFUNCTION(BlueprintCallable, BlueprintPure, Category="Turn")
@@ -60,7 +60,7 @@ public:
 
 protected:
     UPROPERTY(BlueprintReadOnly, Category="Turn")
-    TArray<ASkaldPlayerController*> Controllers;
+    TArray<TWeakObjectPtr<ASkaldPlayerController>> Controllers;
 
     UPROPERTY(BlueprintReadOnly, Category="Turn")
     int32 CurrentIndex;


### PR DESCRIPTION
## Summary
- Store player controllers as `TWeakObjectPtr` in turn manager
- Validate controller references before use and remove invalid entries
- Adjust game mode to handle weak controller pointers

## Testing
- `./Build/validate.sh` *(fails: UnrealBuildTool not found; UnrealEditor not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ae9aedfcc883248d11343dcdbb7b51