### PR TITLE
Add server-side attack handling with validation

### DIFF
--- a/Source/Skald/Skald_PlayerController.h
+++ b/Source/Skald/Skald_PlayerController.h
@@ -127,6 +127,10 @@ protected:
   UFUNCTION()
   void HandleFactionsUpdated();
 
+  /** Server-side processing of an attack request. */
+  UFUNCTION(Server, Reliable)
+  void ServerHandleAttack(int32 FromID, int32 ToID, int32 ArmySent);
+
   /** Reference to the game's turn manager.
    *  Exposed to Blueprints so BP_Skald_PlayerController can bind to
    *  turn events without keeping an external pointer that might be


### PR DESCRIPTION
## Summary
- Validate attack adjacency and army strength from HUD requests
- Add `ServerHandleAttack` RPC that triggers grid battles or resolves dice combat
- Apply casualties, update territory ownership, and refresh all HUDs

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ae9d7158f48324baf9ac70c5d13e26