### PR TITLE
Validate and replicate troop movements

### DIFF
--- a/Source/Skald/Skald_PlayerController.h
+++ b/Source/Skald/Skald_PlayerController.h
@@ -131,6 +131,10 @@ protected:
   UFUNCTION(Server, Reliable)
   void ServerHandleAttack(int32 FromID, int32 ToID, int32 ArmySent);
 
+  /** Server-side processing of a move request. */
+  UFUNCTION(Server, Reliable)
+  void ServerHandleMove(int32 FromID, int32 ToID, int32 Troops);
+
   /** Reference to the game's turn manager.
    *  Exposed to Blueprints so BP_Skald_PlayerController can bind to
    *  turn events without keeping an external pointer that might be


### PR DESCRIPTION
## Summary
- Validate move requests for adjacency and available troops
- Add server-side move handling that updates army strengths and HUDs

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ae9ea8b2ec8324b9ba63f33bed3b7d