### PR TITLE
Handle troop transfers between territories

### DIFF
--- a/Source/Skald/Skald_PlayerController.cpp
+++ b/Source/Skald/Skald_PlayerController.cpp
@@ -417,18 +417,9 @@ void ASkaldPlayerController::ServerHandleMove_Implementation(int32 FromID,
     return;
   }
 
-  if (!WorldMap->MoveBetween(Source, Target)) {
+  if (!WorldMap->MoveBetween(Source, Target, Troops)) {
     return;
   }
-
-  Source->ArmyStrength -= Troops;
-  Target->ArmyStrength += Troops;
-
-  Source->RefreshAppearance();
-  Target->RefreshAppearance();
-
-  Source->ForceNetUpdate();
-  Target->ForceNetUpdate();
 
   if (TurnManager) {
     for (const TWeakObjectPtr<ASkaldPlayerController> &ControllerPtr :

--- a/Source/Skald/Territory.cpp
+++ b/Source/Skald/Territory.cpp
@@ -151,16 +151,17 @@ bool ATerritory::IsAdjacentTo(const ATerritory *Other) const {
   return AdjacentTerritories.Contains(Other);
 }
 
-bool ATerritory::MoveTo(ATerritory *TargetTerritory) {
-  if (!TargetTerritory || !IsAdjacentTo(TargetTerritory)) {
+bool ATerritory::MoveTo(ATerritory *TargetTerritory, int32 Troops) {
+  if (!TargetTerritory || Troops <= 0 || Troops >= ArmyStrength) {
     return false;
   }
 
-  // Movement logic would be handled here. For now we simply select the target.
-  // Movement logic would be handled here. For now we simply deselect this
-  // territory and select the target.
+  ArmyStrength -= Troops;
+  TargetTerritory->ArmyStrength += Troops;
+
   Deselect();
   TargetTerritory->Select();
+
   return true;
 }
 

--- a/Source/Skald/Territory.h
+++ b/Source/Skald/Territory.h
@@ -85,7 +85,7 @@ public:
 
     /** Attempt to move units to the target territory. */
     UFUNCTION(BlueprintCallable, Category = "Territory")
-    bool MoveTo(ATerritory* TargetTerritory);
+    bool MoveTo(ATerritory* TargetTerritory, int32 Troops);
 
     /** React to mouse entering the territory. */
     UFUNCTION()

--- a/Source/Skald/WorldMap.cpp
+++ b/Source/Skald/WorldMap.cpp
@@ -80,10 +80,32 @@ void AWorldMap::SelectTerritory(ATerritory *Territory) {
   OnTerritorySelected.Broadcast(Territory);
 }
 
-bool AWorldMap::MoveBetween(ATerritory *From, ATerritory *To) {
+bool AWorldMap::MoveBetween(ATerritory *From, ATerritory *To, int32 Troops) {
   if (!From || !To) {
     return false;
   }
 
-  return From->MoveTo(To);
+  if (From->OwningPlayer != To->OwningPlayer) {
+    return false;
+  }
+
+  if (!From->IsAdjacentTo(To)) {
+    return false;
+  }
+
+  if (Troops <= 0 || Troops >= From->ArmyStrength) {
+    return false;
+  }
+
+  if (!From->MoveTo(To, Troops)) {
+    return false;
+  }
+
+  From->RefreshAppearance();
+  To->RefreshAppearance();
+
+  From->ForceNetUpdate();
+  To->ForceNetUpdate();
+
+  return true;
 }

--- a/Source/Skald/WorldMap.h
+++ b/Source/Skald/WorldMap.h
@@ -82,7 +82,7 @@ public:
 
   /** Move units between territories. */
   UFUNCTION(BlueprintCallable, Category = "WorldMap")
-  bool MoveBetween(ATerritory *From, ATerritory *To);
+  bool MoveBetween(ATerritory *From, ATerritory *To, int32 Troops);
 
   /** Actor class used when spawning territory instances. */
   UPROPERTY(EditAnywhere, Category = "WorldMap")


### PR DESCRIPTION
## Summary
- allow territories to move a specified number of troops to adjacent territories
- validate adjacency and ownership when moving troops on the world map
- update player controller to use the new troop-move API

## Testing
- `make test` (fails: No rule to make target 'test')

------
https://chatgpt.com/codex/tasks/task_e_68aea22841e48324b6ec9f1a523c5f1d