### PR TITLE
Add server RPCs for player actions and territory sync

### DIFF
--- a/Source/Skald/Skald_PlayerController.cpp
+++ b/Source/Skald/Skald_PlayerController.cpp
@@ -354,6 +354,9 @@ void ASkaldPlayerController::ServerHandleAttack_Implementation(int32 FromID,
   Source->RefreshAppearance();
   Target->RefreshAppearance();
 
+  Source->ForceNetUpdate();
+  Target->ForceNetUpdate();
+
   if (TurnManager) {
     for (const TWeakObjectPtr<ASkaldPlayerController> &ControllerPtr :
          TurnManager->GetControllers()) {
@@ -451,6 +454,38 @@ void ASkaldPlayerController::ServerHandleMove_Implementation(int32 FromID,
   }
 }
 
+void ASkaldPlayerController::ServerSelectTerritory_Implementation(
+    int32 TerritoryID) {
+  AWorldMap *WorldMap = Cast<AWorldMap>(
+      UGameplayStatics::GetActorOfClass(GetWorld(), AWorldMap::StaticClass()));
+  if (!WorldMap) {
+    return;
+  }
+
+  ATerritory *Terr = WorldMap->GetTerritoryById(TerritoryID);
+  if (!Terr) {
+    return;
+  }
+
+  FString OwnerName = Terr->OwningPlayer
+                           ? Terr->OwningPlayer->DisplayName
+                           : TEXT("Neutral");
+
+  Terr->ForceNetUpdate();
+
+  if (TurnManager) {
+    for (const TWeakObjectPtr<ASkaldPlayerController> &ControllerPtr :
+         TurnManager->GetControllers()) {
+      if (ASkaldPlayerController *Controller = ControllerPtr.Get()) {
+        if (USkaldMainHUDWidget *HUD = Controller->GetHUDWidget()) {
+          HUD->UpdateTerritoryInfo(Terr->TerritoryName, OwnerName,
+                                   Terr->ArmyStrength);
+        }
+      }
+    }
+  }
+}
+
 void ASkaldPlayerController::HandleEndAttackRequested(bool bConfirmed) {
   UE_LOG(LogSkald, Log, TEXT("HUD end attack %s"),
          bConfirmed ? TEXT("confirmed") : TEXT("cancelled"));
@@ -462,17 +497,11 @@ void ASkaldPlayerController::HandleEndMovementRequested(bool bConfirmed) {
 }
 
 void ASkaldPlayerController::HandleTerritorySelected(ATerritory *Terr) {
-  if (!MainHudWidget || !Terr) {
+  if (!Terr) {
     return;
   }
 
-  FString OwnerName = TEXT("Neutral");
-  if (Terr->OwningPlayer) {
-    OwnerName = Terr->OwningPlayer->DisplayName;
-  }
-
-  MainHudWidget->UpdateTerritoryInfo(Terr->TerritoryName, OwnerName,
-                                     Terr->ArmyStrength);
+  ServerSelectTerritory(Terr->TerritoryID);
 }
 
 void ASkaldPlayerController::HandlePlayersUpdated() {

--- a/Source/Skald/Skald_PlayerController.h
+++ b/Source/Skald/Skald_PlayerController.h
@@ -135,6 +135,10 @@ protected:
   UFUNCTION(Server, Reliable)
   void ServerHandleMove(int32 FromID, int32 ToID, int32 Troops);
 
+  /** Server-side processing of a territory selection. */
+  UFUNCTION(Server, Reliable)
+  void ServerSelectTerritory(int32 TerritoryID);
+
   /** Reference to the game's turn manager.
    *  Exposed to Blueprints so BP_Skald_PlayerController can bind to
    *  turn events without keeping an external pointer that might be


### PR DESCRIPTION
## Summary
- Add ServerSelectTerritory RPC and hook territory selection through the server
- Ensure attack results replicate to clients with ForceNetUpdate
- Broadcast territory updates from server to update all HUDs

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68aea4f144fc8324a092e5c3e691d5ec