### PR TITLE
Add save game support

### DIFF
--- a/Source/Skald/SaveGameWidget.cpp
+++ b/Source/Skald/SaveGameWidget.cpp
@@ -1,100 +1,81 @@
 #include "SaveGameWidget.h"
-#include "Skald.h"
 #include "Components/Button.h"
 #include "Kismet/GameplayStatics.h"
-#include "GameFramework/SaveGame.h"
 #include "LobbyMenuWidget.h"
+#include "Skald.h"
+#include "SkaldSaveGame.h"
+#include "Skald_GameMode.h"
 #include "SlotNameConstants.h"
 
-void USaveGameWidget::NativeConstruct()
-{
-    Super::NativeConstruct();
+void USaveGameWidget::NativeConstruct() {
+  Super::NativeConstruct();
 
-    if (Slot0Button)
-    {
-        Slot0Button->OnClicked.AddDynamic(this, &USaveGameWidget::OnSaveSlot0);
-    }
+  if (Slot0Button) {
+    Slot0Button->OnClicked.AddDynamic(this, &USaveGameWidget::OnSaveSlot0);
+  }
 
-    if (Slot1Button)
-    {
-        Slot1Button->OnClicked.AddDynamic(this, &USaveGameWidget::OnSaveSlot1);
-    }
+  if (Slot1Button) {
+    Slot1Button->OnClicked.AddDynamic(this, &USaveGameWidget::OnSaveSlot1);
+  }
 
-    if (Slot2Button)
-    {
-        Slot2Button->OnClicked.AddDynamic(this, &USaveGameWidget::OnSaveSlot2);
-    }
+  if (Slot2Button) {
+    Slot2Button->OnClicked.AddDynamic(this, &USaveGameWidget::OnSaveSlot2);
+  }
 
-    if (MainMenuButton)
-    {
-        MainMenuButton->OnClicked.AddDynamic(this, &USaveGameWidget::OnMainMenu);
-    }
+  if (MainMenuButton) {
+    MainMenuButton->OnClicked.AddDynamic(this, &USaveGameWidget::OnMainMenu);
+  }
 }
 
-void USaveGameWidget::NativeDestruct()
-{
-    if (Slot0Button)
-    {
-        Slot0Button->OnClicked.RemoveDynamic(this, &USaveGameWidget::OnSaveSlot0);
-    }
+void USaveGameWidget::NativeDestruct() {
+  if (Slot0Button) {
+    Slot0Button->OnClicked.RemoveDynamic(this, &USaveGameWidget::OnSaveSlot0);
+  }
 
-    if (Slot1Button)
-    {
-        Slot1Button->OnClicked.RemoveDynamic(this, &USaveGameWidget::OnSaveSlot1);
-    }
+  if (Slot1Button) {
+    Slot1Button->OnClicked.RemoveDynamic(this, &USaveGameWidget::OnSaveSlot1);
+  }
 
-    if (Slot2Button)
-    {
-        Slot2Button->OnClicked.RemoveDynamic(this, &USaveGameWidget::OnSaveSlot2);
-    }
+  if (Slot2Button) {
+    Slot2Button->OnClicked.RemoveDynamic(this, &USaveGameWidget::OnSaveSlot2);
+  }
 
-    if (MainMenuButton)
-    {
-        MainMenuButton->OnClicked.RemoveDynamic(this, &USaveGameWidget::OnMainMenu);
-    }
+  if (MainMenuButton) {
+    MainMenuButton->OnClicked.RemoveDynamic(this, &USaveGameWidget::OnMainMenu);
+  }
 
-    Super::NativeDestruct();
+  Super::NativeDestruct();
 }
 
-void USaveGameWidget::OnSaveSlot0()
-{
-    HandleSaveSlot(0);
+void USaveGameWidget::OnSaveSlot0() { HandleSaveSlot(0); }
+
+void USaveGameWidget::OnSaveSlot1() { HandleSaveSlot(1); }
+
+void USaveGameWidget::OnSaveSlot2() { HandleSaveSlot(2); }
+
+void USaveGameWidget::OnMainMenu() {
+  RemoveFromParent();
+  if (LobbyMenu.IsValid()) {
+    LobbyMenu->SetVisibility(ESlateVisibility::Visible);
+  }
 }
 
-void USaveGameWidget::OnSaveSlot1()
-{
-    HandleSaveSlot(1);
-}
-
-void USaveGameWidget::OnSaveSlot2()
-{
-    HandleSaveSlot(2);
-}
-
-void USaveGameWidget::OnMainMenu()
-{
+void USaveGameWidget::HandleSaveSlot(int32 SlotIndex) {
+  USkaldSaveGame *SaveGameObject = Cast<USkaldSaveGame>(
+      UGameplayStatics::CreateSaveGameObject(USkaldSaveGame::StaticClass()));
+  if (ASkaldGameMode *GM =
+          Cast<ASkaldGameMode>(UGameplayStatics::GetGameMode(this))) {
+    GM->FillSaveGame(SaveGameObject);
+  }
+  if (SaveGameObject && UGameplayStatics::SaveGameToSlot(
+                            SaveGameObject, SlotNames[SlotIndex], 0)) {
+    // After saving, transition back to main menu
     RemoveFromParent();
-    if (LobbyMenu.IsValid())
-    {
-        LobbyMenu->SetVisibility(ESlateVisibility::Visible);
+    if (LobbyMenu.IsValid()) {
+      LobbyMenu->SetVisibility(ESlateVisibility::Visible);
     }
+  } else {
+    UE_LOG(LogSkald, Error, TEXT("Failed to save slot %s"),
+           SlotNames[SlotIndex]);
+  }
 }
-
-void USaveGameWidget::HandleSaveSlot(int32 SlotIndex)
-{
-    USaveGame* SaveGameObject = UGameplayStatics::CreateSaveGameObject(USaveGame::StaticClass());
-    if (UGameplayStatics::SaveGameToSlot(SaveGameObject, SlotNames[SlotIndex], 0))
-    {
-        // After saving, transition back to main menu
-        RemoveFromParent();
-        if (LobbyMenu.IsValid())
-        {
-            LobbyMenu->SetVisibility(ESlateVisibility::Visible);
-        }
-    }
-    else
-    {
-        UE_LOG(LogSkald, Error, TEXT("Failed to save slot %s"), SlotNames[SlotIndex]);
-    }
-}
-

--- a/Source/Skald/SkaldSaveGameLibrary.cpp
+++ b/Source/Skald/SkaldSaveGameLibrary.cpp
@@ -1,27 +1,30 @@
 #include "SkaldSaveGameLibrary.h"
-#include "SkaldSaveGame.h"
 #include "Kismet/GameplayStatics.h"
+#include "SkaldSaveGame.h"
 
-bool USkaldSaveGameLibrary::SaveSkaldGame(USkaldSaveGame* SaveGameObject, const FString& SlotName, int32 UserIndex)
-{
-    if (!SaveGameObject)
-    {
-        return false;
+bool USkaldSaveGameLibrary::SaveSkaldGame(USkaldSaveGame *SaveGameObject,
+                                          const FString &SlotName,
+                                          int32 UserIndex) {
+  if (!SaveGameObject) {
+    SaveGameObject = Cast<USkaldSaveGame>(
+        UGameplayStatics::CreateSaveGameObject(USkaldSaveGame::StaticClass()));
+    if (!SaveGameObject) {
+      return false;
     }
+  }
 
-    SaveGameObject->SaveName = SlotName;
-    SaveGameObject->SaveDate = FDateTime::Now();
+  SaveGameObject->SaveName = SlotName;
+  SaveGameObject->SaveDate = FDateTime::Now();
 
-    return UGameplayStatics::SaveGameToSlot(SaveGameObject, SlotName, UserIndex);
+  return UGameplayStatics::SaveGameToSlot(SaveGameObject, SlotName, UserIndex);
 }
 
-USkaldSaveGame* USkaldSaveGameLibrary::LoadSkaldGame(const FString& SlotName, int32 UserIndex)
-{
-    USkaldSaveGame* LoadedGame = Cast<USkaldSaveGame>(UGameplayStatics::LoadGameFromSlot(SlotName, UserIndex));
-    if (LoadedGame)
-    {
-        LoadedGame->SaveName = SlotName;
-    }
-    return LoadedGame;
+USkaldSaveGame *USkaldSaveGameLibrary::LoadSkaldGame(const FString &SlotName,
+                                                     int32 UserIndex) {
+  USkaldSaveGame *LoadedGame = Cast<USkaldSaveGame>(
+      UGameplayStatics::LoadGameFromSlot(SlotName, UserIndex));
+  if (LoadedGame) {
+    LoadedGame->SaveName = SlotName;
+  }
+  return LoadedGame;
 }
-

--- a/Source/Skald/Skald_GameMode.h
+++ b/Source/Skald/Skald_GameMode.h
@@ -12,6 +12,7 @@ class ASkaldPlayerController;
 class ASkaldPlayerState;
 class AWorldMap;
 class APlayerController;
+class USkaldSaveGame;
 
 /**
  * GameMode responsible for managing player login and spawning the turn manager.
@@ -28,6 +29,10 @@ public:
 
   /** Advance army placement to the next controller. */
   void AdvanceArmyPlacement();
+
+  /** Populate a save game object with the current match state. */
+  UFUNCTION(BlueprintCallable, Category = "SaveGame")
+  void FillSaveGame(USkaldSaveGame *SaveGameObject) const;
 
 protected:
   /** Handles turn sequencing for the match. */


### PR DESCRIPTION
## Summary
- use USkaldSaveGame for saving
- add method to Skald_GameMode to populate save data
- ensure SkaldSaveGameLibrary creates custom save objects

## Testing
- `clang-format -i Source/Skald/SaveGameWidget.cpp Source/Skald/Skald_GameMode.h Source/Skald/Skald_GameMode.cpp Source/Skald/SkaldSaveGameLibrary.cpp`
- `clang++ -c Source/Skald/SaveGameWidget.cpp 2>&1 | head -n 20` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aea6757d8c8324acb1d25f02e79570