### PR TITLE
Load and apply saved game state

### DIFF
--- a/Source/Skald/LoadGameWidget.cpp
+++ b/Source/Skald/LoadGameWidget.cpp
@@ -2,10 +2,11 @@
 #include "Skald.h"
 #include "Components/Button.h"
 #include "Kismet/GameplayStatics.h"
-#include "GameFramework/SaveGame.h"
 #include "LobbyMenuWidget.h"
 #include "SlotNameConstants.h"
 #include "GameFramework/PlayerController.h"
+#include "SkaldSaveGame.h"
+#include "Skald_GameInstance.h"
 
 void ULoadGameWidget::NativeConstruct()
 {
@@ -61,9 +62,14 @@ void ULoadGameWidget::OnMainMenu()
 
 void ULoadGameWidget::HandleLoadSlot(int32 SlotIndex)
 {
-    USaveGame* LoadedGame = UGameplayStatics::LoadGameFromSlot(SlotNames[SlotIndex], 0);
+    USkaldSaveGame* LoadedGame = Cast<USkaldSaveGame>(UGameplayStatics::LoadGameFromSlot(SlotNames[SlotIndex], 0));
     if (LoadedGame)
     {
+        if (USkaldGameInstance* GI = GetGameInstance<USkaldGameInstance>())
+        {
+            GI->LoadedSaveGame = LoadedGame;
+        }
+
         if (APlayerController* PC = GetOwningPlayer())
         {
             PC->SetInputMode(FInputModeGameOnly());

--- a/Source/Skald/Skald_GameInstance.h
+++ b/Source/Skald/Skald_GameInstance.h
@@ -6,6 +6,7 @@
 #include "Skald_GameInstance.generated.h"
 
 class UGridBattleManager;
+class USkaldSaveGame;
 
 DECLARE_DYNAMIC_MULTICAST_DELEGATE(FSkaldFactionsUpdated);
 /** Game instance storing player selections from the lobby. */
@@ -42,5 +43,9 @@ public:
     /** Runtime manager used to execute grid based battles. */
     UPROPERTY(BlueprintReadWrite, Category="Battle")
     class UGridBattleManager* GridBattleManager = nullptr;
+
+    /** Save game loaded when transitioning from the main menu. */
+    UPROPERTY(BlueprintReadWrite, Category="SaveGame")
+    USkaldSaveGame* LoadedSaveGame = nullptr;
 };
 

--- a/Source/Skald/Skald_GameMode.h
+++ b/Source/Skald/Skald_GameMode.h
@@ -34,6 +34,9 @@ public:
   UFUNCTION(BlueprintCallable, Category = "SaveGame")
   void FillSaveGame(USkaldSaveGame *SaveGameObject) const;
 
+  /** Restore match state from a previously loaded save game. */
+  void ApplyLoadedGame(USkaldSaveGame *LoadedGame);
+
 protected:
   /** Handles turn sequencing for the match. */
   UPROPERTY(BlueprintReadOnly, Category = "GameMode")


### PR DESCRIPTION
## Summary
- Load `USkaldSaveGame` when selecting a save slot and store it in the game instance
- Add game instance field for passing loaded saves between levels
- Restore players, territories, turn index, and camera settings from the saved game

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68aea776e948832482d71901aa7916b7