### PR TITLE
Skip eliminated players in turn order

### DIFF
--- a/Source/Skald/Skald_PlayerController.cpp
+++ b/Source/Skald/Skald_PlayerController.cpp
@@ -508,6 +508,7 @@ void ASkaldPlayerController::HandlePlayersUpdated() {
       Data.PlayerName = PS->DisplayName;
       Data.IsAI = PS->bIsAI;
       Data.Faction = PS->Faction;
+      Data.IsEliminated = PS->IsEliminated;
       Players.Add(Data);
     }
   }

--- a/Source/Skald/Skald_PlayerState.cpp
+++ b/Source/Skald/Skald_PlayerState.cpp
@@ -1,5 +1,6 @@
 #include "Skald_PlayerState.h"
 #include "Net/UnrealNetwork.h"
+#include "Skald_GameState.h"
 
 ASkaldPlayerState::ASkaldPlayerState()
     : bIsAI(false)
@@ -7,6 +8,7 @@ ASkaldPlayerState::ASkaldPlayerState()
     , InitiativeRoll(0)
     , DisplayName(TEXT("Player"))
     , Faction(ESkaldFaction::None)
+    , IsEliminated(false)
 {
 }
 
@@ -20,5 +22,14 @@ void ASkaldPlayerState::GetLifetimeReplicatedProps(
     DOREPLIFETIME(ASkaldPlayerState, ArmyPool);
     DOREPLIFETIME(ASkaldPlayerState, bIsAI);
     DOREPLIFETIME(ASkaldPlayerState, InitiativeRoll);
+    DOREPLIFETIME(ASkaldPlayerState, IsEliminated);
+}
+
+void ASkaldPlayerState::OnRep_IsEliminated()
+{
+    if (ASkaldGameState* GS = GetWorld() ? GetWorld()->GetGameState<ASkaldGameState>() : nullptr)
+    {
+        GS->OnPlayersUpdated.Broadcast();
+    }
 }
 

--- a/Source/Skald/Skald_PlayerState.h
+++ b/Source/Skald/Skald_PlayerState.h
@@ -35,6 +35,13 @@ public:
     UPROPERTY(BlueprintReadWrite, Replicated, Category="PlayerState")
     ESkaldFaction Faction;
 
+    /** Whether this player has been eliminated from the match. */
+    UPROPERTY(BlueprintReadWrite, ReplicatedUsing = OnRep_IsEliminated, Category="PlayerState")
+    bool IsEliminated;
+
+    UFUNCTION()
+    void OnRep_IsEliminated();
+
     virtual void GetLifetimeReplicatedProps(TArray<FLifetimeProperty>& OutLifetimeProps) const override;
 };
 

--- a/Source/Skald/Skald_TurnManager.cpp
+++ b/Source/Skald/Skald_TurnManager.cpp
@@ -75,12 +75,29 @@ void ATurnManager::StartTurns() {
 }
 
 void ATurnManager::AdvanceTurn() {
+  ASkaldPlayerController *PreviousController =
+      Controllers.IsValidIndex(CurrentIndex) ? Controllers[CurrentIndex].Get() : nullptr;
+
   Controllers.RemoveAll([](const TWeakObjectPtr<ASkaldPlayerController> &Ptr) {
-    return !Ptr.IsValid();
+    if (!Ptr.IsValid()) {
+      return true;
+    }
+    if (ASkaldPlayerController *PC = Ptr.Get()) {
+      if (ASkaldPlayerState *PS = PC->GetPlayerState<ASkaldPlayerState>()) {
+        return PS->IsEliminated;
+      }
+    }
+    return false;
   });
   if (Controllers.Num() == 0) {
     return;
   }
+
+  int32 FoundIndex = Controllers.IndexOfByPredicate(
+      [PreviousController](const TWeakObjectPtr<ASkaldPlayerController> &Ptr) {
+        return Ptr.Get() == PreviousController;
+      });
+  CurrentIndex = (FoundIndex != INDEX_NONE) ? FoundIndex : Controllers.Num() - 1;
 
   CurrentIndex = (CurrentIndex + 1) % Controllers.Num();
   if (ASkaldPlayerController *CurrentController = Controllers[CurrentIndex].Get()) {

--- a/Source/Skald/UI/SkaldMainHUDWidget.cpp
+++ b/Source/Skald/UI/SkaldMainHUDWidget.cpp
@@ -157,6 +157,9 @@ void USkaldMainHUDWidget::RebuildPlayerList(
   UEnum *FactionEnum = StaticEnum<ESkaldFaction>();
 
   for (const FS_PlayerData &Player : Players) {
+    if (Player.IsEliminated) {
+      continue;
+    }
     UTextBlock *Entry = NewObject<UTextBlock>(PlayerListBox);
     if (!Entry) {
       continue;


### PR DESCRIPTION
## Summary
- track elimination status on player states and notify clients
- skip eliminated players when advancing turns
- refresh HUD lists to hide eliminated players

## Testing
- `./Build/validate.sh` *(UnrealBuildTool not found; UnrealEditor not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aeaa4d4b5c83248568156fd8b7dae6