### PR TITLE
Replicate player setup selections

### DIFF
--- a/Source/Skald/PlayerSetupWidget.cpp
+++ b/Source/Skald/PlayerSetupWidget.cpp
@@ -1,4 +1,5 @@
 #include "PlayerSetupWidget.h"
+#include "Skald_GameInstance.h"
 #include "Skald_PlayerState.h"
 #include "Kismet/GameplayStatics.h"
 #include "GameFramework/PlayerController.h"
@@ -20,27 +21,37 @@ void UPlayerSetupWidget::OnFactionSelected(ESkaldFaction NewFaction)
 
 void UPlayerSetupWidget::OnConfirm()
 {
-    if (APlayerController* PC = GetOwningPlayer())
+    if (UWorld* World = GetWorld())
     {
-        if (ASkaldPlayerState* PS = PC->GetPlayerState<ASkaldPlayerState>())
+        if (USkaldGameInstance* GI = World->GetGameInstance<USkaldGameInstance>())
         {
-            PS->DisplayName = DisplayName;
-            PS->Faction = SelectedFaction;
+            GI->DisplayName = DisplayName;
+            GI->Faction = SelectedFaction;
+            GI->bIsMultiplayer = bMultiplayer;
         }
 
-        PC->SetInputMode(FInputModeGameOnly());
-        PC->bShowMouseCursor = false;
-        PC->bEnableClickEvents = false;
-        PC->bEnableMouseOverEvents = false;
-
-        // Launch the main gameplay map once setup is confirmed
-        FName LevelName(TEXT("Skald_OverTop"));
-        FString Options;
-        if (bMultiplayer)
+        if (APlayerController* PC = GetOwningPlayer())
         {
-            Options = TEXT("listen");
+            if (ASkaldPlayerState* PS = PC->GetPlayerState<ASkaldPlayerState>())
+            {
+                PS->DisplayName = DisplayName;
+                PS->Faction = SelectedFaction;
+            }
+
+            PC->SetInputMode(FInputModeGameOnly());
+            PC->bShowMouseCursor = false;
+            PC->bEnableClickEvents = false;
+            PC->bEnableMouseOverEvents = false;
+
+            // Launch the main gameplay map once setup is confirmed
+            FName LevelName(TEXT("Skald_OverTop"));
+            FString Options;
+            if (bMultiplayer)
+            {
+                Options = TEXT("listen");
+            }
+            UGameplayStatics::OpenLevel(this, LevelName, true, Options);
         }
-        UGameplayStatics::OpenLevel(this, LevelName, true, Options);
     }
 }
 

--- a/Source/Skald/Skald_PlayerController.cpp
+++ b/Source/Skald/Skald_PlayerController.cpp
@@ -48,6 +48,11 @@ void ASkaldPlayerController::BeginPlay() {
   } else {
     CachedGameInstance->OnFactionsUpdated.AddDynamic(
         this, &ASkaldPlayerController::HandleFactionsUpdated);
+
+    if (IsLocalController()) {
+      ServerInitPlayerState(CachedGameInstance->DisplayName,
+                           CachedGameInstance->Faction);
+    }
   }
 
   // Create and show the HUD widget if a class has been assigned (expected via
@@ -100,6 +105,14 @@ void ASkaldPlayerController::BeginPlay() {
 
   if (ASkaldPlayerState *PS = GetPlayerState<ASkaldPlayerState>()) {
     bIsAI = PS->bIsAI;
+  }
+}
+
+void ASkaldPlayerController::ServerInitPlayerState_Implementation(
+    const FString &Name, ESkaldFaction Faction) {
+  if (ASkaldPlayerState *PS = GetPlayerState<ASkaldPlayerState>()) {
+    PS->DisplayName = Name;
+    PS->Faction = Faction;
   }
 }
 

--- a/Source/Skald/Skald_PlayerController.h
+++ b/Source/Skald/Skald_PlayerController.h
@@ -2,6 +2,7 @@
 
 #include "CoreMinimal.h"
 #include "GameFramework/PlayerController.h"
+#include "SkaldTypes.h"
 #include "Skald_PlayerController.generated.h"
 
 class ATurnManager;
@@ -56,6 +57,10 @@ public:
   /** Retrieve the turn manager controlling this player. */
   UFUNCTION(BlueprintCallable, BlueprintPure, Category = "Turn")
   ATurnManager *GetTurnManager() const { return TurnManager; }
+
+  /** Send the local player's initial data to the server for replication. */
+  UFUNCTION(Server, Reliable)
+  void ServerInitPlayerState(const FString &Name, ESkaldFaction Faction);
 
 protected:
   /** Whether this controller is controlled by AI. */


### PR DESCRIPTION
## Summary
- Persist setup selections in game instance
- Send local player data to server to initialise player state

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68aead01e07c8324b3850e97f5ad2275