### PR TITLE
Refresh faction selections and warn on conflicts

### DIFF
--- a/Source/Skald/StartGameWidget.h
+++ b/Source/Skald/StartGameWidget.h
@@ -72,6 +72,11 @@ protected:
 
     void ValidateSelections();
 
+    void RefreshFactionOptions();
+
+    UFUNCTION()
+    void HandleFactionsUpdated();
+
 private:
     /** Reference back to the owning lobby menu so it can be restored. */
     UPROPERTY()


### PR DESCRIPTION
## Summary
- Refresh faction combo options when available factions change
- Disable lock-in and warn when a chosen faction becomes unavailable
- Guard lock-in action against newly taken factions

## Testing
- `clang++ -std=c++17 -ISource/Skald -fsyntax-only Source/Skald/StartGameWidget.cpp` *(fails: 'CoreMinimal.h' file not found)*


------
https://chatgpt.com/codex/tasks/task_e_68aeadea158c8324b33280c981eb494b