### PR TITLE
Enable pathfinding through friendly territories

### DIFF
--- a/Source/Skald/Skald_PlayerController.cpp
+++ b/Source/Skald/Skald_PlayerController.cpp
@@ -413,7 +413,8 @@ void ASkaldPlayerController::HandleMoveRequested(int32 FromID, int32 ToID,
     return;
   }
 
-  if (!Source->IsAdjacentTo(Target)) {
+  TArray<ATerritory *> Path;
+  if (!WorldMap->FindPath(Source, Target, Path)) {
     return;
   }
 
@@ -435,7 +436,7 @@ void ASkaldPlayerController::ServerHandleMove_Implementation(int32 FromID,
 
   ATerritory *Source = WorldMap->GetTerritoryById(FromID);
   ATerritory *Target = WorldMap->GetTerritoryById(ToID);
-  if (!Source || !Target || !Source->IsAdjacentTo(Target)) {
+  if (!Source || !Target) {
     return;
   }
 

--- a/Source/Skald/WorldMap.cpp
+++ b/Source/Skald/WorldMap.cpp
@@ -2,6 +2,8 @@
 #include "Engine/World.h"
 #include "Territory.h"
 #include "Skald_GameMode.h"
+#include "Containers/Queue.h"
+#include "Containers/Map.h"
 
 AWorldMap::AWorldMap() {
   PrimaryActorTick.bCanEverTick = false;
@@ -81,6 +83,55 @@ void AWorldMap::SelectTerritory(ATerritory *Territory) {
   OnTerritorySelected.Broadcast(Territory);
 }
 
+bool AWorldMap::FindPath(ATerritory *From, ATerritory *To,
+                         TArray<ATerritory *> &OutPath) const {
+  OutPath.Reset();
+  if (!From || !To) {
+    return false;
+  }
+
+  if (From == To) {
+    OutPath.Add(From);
+    return true;
+  }
+
+  ASkaldPlayerState *Owner = From->OwningPlayer;
+  TQueue<ATerritory *> Frontier;
+  TMap<ATerritory *, ATerritory *> CameFrom;
+
+  Frontier.Enqueue(From);
+  CameFrom.Add(From, nullptr);
+
+  while (!Frontier.IsEmpty()) {
+    ATerritory *Current = nullptr;
+    Frontier.Dequeue(Current);
+    if (Current == To) {
+      break;
+    }
+
+    for (ATerritory *Neighbor : Current->AdjacentTerritories) {
+      if (!Neighbor || Neighbor->OwningPlayer != Owner ||
+          CameFrom.Contains(Neighbor)) {
+        continue;
+      }
+      Frontier.Enqueue(Neighbor);
+      CameFrom.Add(Neighbor, Current);
+    }
+  }
+
+  if (!CameFrom.Contains(To)) {
+    return false;
+  }
+
+  ATerritory *Step = To;
+  while (Step) {
+    OutPath.Insert(Step, 0);
+    Step = CameFrom[Step];
+  }
+
+  return true;
+}
+
 bool AWorldMap::MoveBetween(ATerritory *From, ATerritory *To, int32 Troops) {
   if (!From || !To) {
     return false;
@@ -90,23 +141,26 @@ bool AWorldMap::MoveBetween(ATerritory *From, ATerritory *To, int32 Troops) {
     return false;
   }
 
-  if (!From->IsAdjacentTo(To)) {
-    return false;
-  }
-
   if (Troops <= 0 || Troops >= From->ArmyStrength) {
     return false;
   }
 
-  if (!From->MoveTo(To, Troops)) {
+  TArray<ATerritory *> Path;
+  if (!FindPath(From, To, Path) || Path.Num() < 2) {
     return false;
   }
 
-  From->RefreshAppearance();
-  To->RefreshAppearance();
-
-  From->ForceNetUpdate();
-  To->ForceNetUpdate();
+  for (int32 i = 0; i < Path.Num() - 1; ++i) {
+    ATerritory *Curr = Path[i];
+    ATerritory *Next = Path[i + 1];
+    if (!Curr->MoveTo(Next, Troops)) {
+      return false;
+    }
+    Curr->RefreshAppearance();
+    Next->RefreshAppearance();
+    Curr->ForceNetUpdate();
+    Next->ForceNetUpdate();
+  }
 
   if (ASkaldGameMode *GM = GetWorld()->GetAuthGameMode<ASkaldGameMode>()) {
     GM->CheckVictoryConditions();

--- a/Source/Skald/WorldMap.h
+++ b/Source/Skald/WorldMap.h
@@ -80,6 +80,11 @@ public:
   UFUNCTION(BlueprintCallable, Category = "WorldMap")
   void SelectTerritory(ATerritory *Territory);
 
+  /** Find a path across friendly territories from one territory to another. */
+  UFUNCTION(BlueprintCallable, Category = "WorldMap")
+  bool FindPath(ATerritory *From, ATerritory *To,
+                TArray<ATerritory *> &OutPath) const;
+
   /** Move units between territories. */
   UFUNCTION(BlueprintCallable, Category = "WorldMap")
   bool MoveBetween(ATerritory *From, ATerritory *To, int32 Troops);


### PR DESCRIPTION
## Summary
- Add BFS-based `FindPath` to locate routes across friendly territories
- Move armies along computed paths during movement phase
- Validate client moves with pathfinding before issuing commands

## Testing
- `./Build/validate.sh` *(fails: UnrealBuildTool not found; UnrealEditor not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aeaee499f08324ab37982f337d83ab