### PR TITLE
Add siege weapon construction and assignment

### DIFF
--- a/Source/Skald/Skald_GameMode.h
+++ b/Source/Skald/Skald_GameMode.h
@@ -62,6 +62,13 @@ protected:
   UPROPERTY(BlueprintReadOnly, Category = "Players")
   TArray<FS_PlayerData> PlayersData;
 
+  /** All siege equipment constructed on the map. */
+  UPROPERTY(BlueprintReadOnly, Category = "Siege")
+  TArray<FS_Siege> SiegePool;
+
+  /** Next unique identifier for siege equipment. */
+  int32 NextSiegeID = 1;
+
   /**
    * Setup initial territories, armies, and initiative.
    * Returns true if the world was successfully initialised with at least one
@@ -73,6 +80,14 @@ protected:
   /** Allow players to position initial armies based on initiative. */
   UFUNCTION(BlueprintCallable, Category = "GameMode")
   void BeginArmyPlacementPhase();
+
+  /** Build siege equipment during the engineering phase. */
+  UFUNCTION(BlueprintCallable, Category = "Siege")
+  int32 BuildSiegeAtTerritory(int32 TerritoryID, E_SiegeWeapons Type);
+
+  /** Consume a built siege from a territory for an attack. */
+  UFUNCTION(BlueprintCallable, Category = "Siege")
+  int32 ConsumeSiege(int32 TerritoryID);
 
 private:
   /** Timer that triggers auto-start of the turn sequence. */

--- a/Source/Skald/Skald_PlayerController.h
+++ b/Source/Skald/Skald_PlayerController.h
@@ -101,7 +101,8 @@ protected:
    *  Blueprint widgets invoke this when an attack is submitted.
    */
   UFUNCTION(BlueprintCallable, Category = "UI")
-  void HandleAttackRequested(int32 FromID, int32 ToID, int32 ArmySent);
+  void HandleAttackRequested(int32 FromID, int32 ToID, int32 ArmySent,
+                             bool bUseSiege);
 
   /** Handle HUD move submissions.
    *  Bound to USkaldMainHUDWidget::OnMoveRequested in the HUD.
@@ -142,7 +143,16 @@ protected:
 
   /** Server-side processing of an attack request. */
   UFUNCTION(Server, Reliable)
-  void ServerHandleAttack(int32 FromID, int32 ToID, int32 ArmySent);
+  void ServerHandleAttack(int32 FromID, int32 ToID, int32 ArmySent,
+                          bool bUseSiege);
+
+  /** Handle HUD siege build requests. */
+  UFUNCTION(BlueprintCallable, Category = "UI")
+  void HandleBuildSiegeRequested(int32 TerritoryID, E_SiegeWeapons SiegeType);
+
+  /** Server-side processing of a siege build request. */
+  UFUNCTION(Server, Reliable)
+  void ServerBuildSiege(int32 TerritoryID, E_SiegeWeapons SiegeType);
 
   /** Server-side processing of a move request. */
   UFUNCTION(Server, Reliable)

--- a/Source/Skald/Territory.cpp
+++ b/Source/Skald/Territory.cpp
@@ -116,6 +116,7 @@ void ATerritory::GetLifetimeReplicatedProps(
   DOREPLIFETIME(ATerritory, ContinentID);
   DOREPLIFETIME(ATerritory, AdjacentTerritories);
   DOREPLIFETIME(ATerritory, ArmyStrength);
+  DOREPLIFETIME(ATerritory, BuiltSiegeID);
 }
 
 void ATerritory::Select() {

--- a/Source/Skald/Territory.h
+++ b/Source/Skald/Territory.h
@@ -67,6 +67,10 @@ public:
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Territory", ReplicatedUsing = OnRep_ArmyStrength)
     int32 ArmyStrength = 0;
 
+    /** ID of siege equipment built in this territory, 0 if none. */
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Territory", Replicated)
+    int32 BuiltSiegeID = 0;
+
     /** Called when the territory is selected. */
     UPROPERTY(BlueprintAssignable, Category = "Territory")
     FTerritorySelectedSignature OnTerritorySelected;

--- a/Source/Skald/UI/SkaldMainHUDWidget.h
+++ b/Source/Skald/UI/SkaldMainHUDWidget.h
@@ -17,9 +17,12 @@ class ASkaldGameState;
 class USkaldGameInstance;
 
 // Delegates broadcasting user UI actions to game logic
-DECLARE_DYNAMIC_MULTICAST_DELEGATE_ThreeParams(FSkaldAttackRequested, int32,
-                                               FromID, int32, ToID, int32,
-                                               ArmySent);
+DECLARE_DYNAMIC_MULTICAST_DELEGATE_FourParams(FSkaldAttackRequested, int32,
+                                              FromID, int32, ToID, int32,
+                                              ArmySent, bool, bUseSiege);
+DECLARE_DYNAMIC_MULTICAST_DELEGATE_TwoParams(FSkaldBuildSiegeRequested, int32,
+                                             TerritoryID, E_SiegeWeapons,
+                                             SiegeType);
 DECLARE_DYNAMIC_MULTICAST_DELEGATE_OneParam(FSkaldEndAttackRequested, bool,
                                             bConfirmed);
 DECLARE_DYNAMIC_MULTICAST_DELEGATE_TwoParams(FSkaldEngineeringRequested, int32,
@@ -75,6 +78,9 @@ public:
   UPROPERTY(BlueprintReadWrite, Category = "Skald|Selection")
   bool bSelectingForMove = false;
 
+  UPROPERTY(BlueprintReadWrite, Category = "Skald|Siege")
+  bool bUseSiegeForNextAttack = false;
+
   // Cached list of players for UI list building
   UPROPERTY(BlueprintReadWrite, Category = "Skald|Data")
   TArray<FS_PlayerData> CachedPlayers;
@@ -98,6 +104,9 @@ public:
 
   UPROPERTY(BlueprintAssignable, Category = "Skald|Events")
   FSkaldEngineeringRequested OnEngineeringRequested;
+
+  UPROPERTY(BlueprintAssignable, Category = "Skald|Events")
+  FSkaldBuildSiegeRequested OnBuildSiegeRequested;
 
   UPROPERTY(BlueprintAssignable, Category = "Skald|Events")
   FSkaldDigTreasureRequested OnDigTreasureRequested;
@@ -163,7 +172,8 @@ public:
   void BeginAttackSelection();
 
   UFUNCTION(BlueprintCallable, Category = "Skald|Selection")
-  void SubmitAttack(int32 FromID, int32 ToID, int32 ArmySent);
+  void SubmitAttack(int32 FromID, int32 ToID, int32 ArmySent,
+                    bool bUseSiege);
 
   UFUNCTION(BlueprintCallable, Category = "Skald|Selection")
   void CancelAttackSelection();
@@ -179,6 +189,12 @@ public:
 
   UFUNCTION(BlueprintCallable, Category = "Skald|Selection")
   void OnTerritoryClickedUI(ATerritory *Territory);
+
+  UFUNCTION(BlueprintCallable, Category = "Skald|Siege")
+  void BuildSiege(int32 TerritoryID, E_SiegeWeapons SiegeType);
+
+  UFUNCTION(BlueprintCallable, Category = "Skald|Siege")
+  void SetUseSiegeForNextAttack(bool bEnable);
 
   // BlueprintImplementableEvent hooks — BP subclass draws UI
   UFUNCTION(BlueprintImplementableEvent, Category = "Skald|HUD")


### PR DESCRIPTION
## Summary
- allow territories to build siege weapons and track them in the game mode
- consume and attach built siege equipment to attacking armies
- expose UI hooks to build and assign siege gear during attacks

## Testing
- `./Build/validate.sh` *(fails: UnrealBuildTool not found; skipping compile check. UnrealEditor not found; cannot run tests.)*

------
https://chatgpt.com/codex/tasks/task_e_68aeb250a5348324a042d09583c60381