### PR TITLE
Display existing save names for each slot

### DIFF
--- a/Source/Skald/SaveGameWidget.cpp
+++ b/Source/Skald/SaveGameWidget.cpp
@@ -1,5 +1,6 @@
 #include "SaveGameWidget.h"
 #include "Components/Button.h"
+#include "Components/TextBlock.h"
 #include "Kismet/GameplayStatics.h"
 #include "LobbyMenuWidget.h"
 #include "Skald.h"
@@ -14,13 +15,19 @@ void USaveGameWidget::NativeConstruct() {
     Slot0Button->OnClicked.AddDynamic(this, &USaveGameWidget::OnSaveSlot0);
   }
 
+  UpdateSlotDisplay(0, Slot0Button, Slot0Text);
+
   if (Slot1Button) {
     Slot1Button->OnClicked.AddDynamic(this, &USaveGameWidget::OnSaveSlot1);
   }
 
+  UpdateSlotDisplay(1, Slot1Button, Slot1Text);
+
   if (Slot2Button) {
     Slot2Button->OnClicked.AddDynamic(this, &USaveGameWidget::OnSaveSlot2);
   }
+
+  UpdateSlotDisplay(2, Slot2Button, Slot2Text);
 
   if (MainMenuButton) {
     MainMenuButton->OnClicked.AddDynamic(this, &USaveGameWidget::OnMainMenu);
@@ -77,5 +84,28 @@ void USaveGameWidget::HandleSaveSlot(int32 SlotIndex) {
   } else {
     UE_LOG(LogSkald, Error, TEXT("Failed to save slot %s"),
            SlotNames[SlotIndex]);
+  }
+}
+
+void USaveGameWidget::UpdateSlotDisplay(int32 SlotIndex, UButton *SlotButton,
+                                        UTextBlock *SlotText) {
+  const FString SlotName = SlotNames[SlotIndex];
+  const bool bExists = UGameplayStatics::DoesSaveGameExist(SlotName, 0);
+
+  if (SlotButton) {
+    SlotButton->SetIsEnabled(bExists);
+  }
+
+  if (SlotText) {
+    if (bExists) {
+      if (USkaldSaveGame *Save = Cast<USkaldSaveGame>(
+              UGameplayStatics::LoadGameFromSlot(SlotName, 0))) {
+        const FString DateString = Save->SaveDate.ToString();
+        SlotText->SetText(FText::FromString(
+            FString::Printf(TEXT("%s - %s"), *Save->SaveName, *DateString)));
+      }
+    } else {
+      SlotText->SetText(FText::FromString(SlotName));
+    }
   }
 }

--- a/Source/Skald/SaveGameWidget.h
+++ b/Source/Skald/SaveGameWidget.h
@@ -1,55 +1,73 @@
 #pragma once
 
-#include "CoreMinimal.h"
 #include "Blueprint/UserWidget.h"
+#include "CoreMinimal.h"
 #include "SaveGameWidget.generated.h"
 
 class UButton;
+class UTextBlock;
 class ULobbyMenuWidget;
 /**
  * Simple save game menu listing a few save slots.
  */
 UCLASS(Blueprintable, BlueprintType)
-class SKALD_API USaveGameWidget : public UUserWidget
-{
-    GENERATED_BODY()
+class SKALD_API USaveGameWidget : public UUserWidget {
+  GENERATED_BODY()
 
 public:
-    UPROPERTY(BlueprintReadOnly, Category="Skald|Widgets", meta=(BindWidgetOptional))
-    UButton* Slot0Button;
+  UPROPERTY(BlueprintReadOnly, Category = "Skald|Widgets",
+            meta = (BindWidgetOptional))
+  UButton *Slot0Button;
 
-    UPROPERTY(BlueprintReadOnly, Category="Skald|Widgets", meta=(BindWidgetOptional))
-    UButton* Slot1Button;
+  UPROPERTY(BlueprintReadOnly, Category = "Skald|Widgets",
+            meta = (BindWidgetOptional))
+  UTextBlock *Slot0Text;
 
-    UPROPERTY(BlueprintReadOnly, Category="Skald|Widgets", meta=(BindWidgetOptional))
-    UButton* Slot2Button;
+  UPROPERTY(BlueprintReadOnly, Category = "Skald|Widgets",
+            meta = (BindWidgetOptional))
+  UButton *Slot1Button;
 
-    UPROPERTY(BlueprintReadOnly, Category="Skald|Widgets", meta=(BindWidgetOptional))
-    UButton* MainMenuButton;
+  UPROPERTY(BlueprintReadOnly, Category = "Skald|Widgets",
+            meta = (BindWidgetOptional))
+  UTextBlock *Slot1Text;
 
-    void SetLobbyMenu(ULobbyMenuWidget* InMenu) { LobbyMenu = InMenu; }
+  UPROPERTY(BlueprintReadOnly, Category = "Skald|Widgets",
+            meta = (BindWidgetOptional))
+  UButton *Slot2Button;
+
+  UPROPERTY(BlueprintReadOnly, Category = "Skald|Widgets",
+            meta = (BindWidgetOptional))
+  UTextBlock *Slot2Text;
+
+  UPROPERTY(BlueprintReadOnly, Category = "Skald|Widgets",
+            meta = (BindWidgetOptional))
+  UButton *MainMenuButton;
+
+  void SetLobbyMenu(ULobbyMenuWidget *InMenu) { LobbyMenu = InMenu; }
 
 protected:
-    virtual void NativeConstruct() override;
-    virtual void NativeDestruct() override;
+  virtual void NativeConstruct() override;
+  virtual void NativeDestruct() override;
 
-    UFUNCTION(BlueprintCallable)
-    void OnSaveSlot0();
+  UFUNCTION(BlueprintCallable)
+  void OnSaveSlot0();
 
-    UFUNCTION(BlueprintCallable)
-    void OnSaveSlot1();
+  UFUNCTION(BlueprintCallable)
+  void OnSaveSlot1();
 
-    UFUNCTION(BlueprintCallable)
-    void OnSaveSlot2();
+  UFUNCTION(BlueprintCallable)
+  void OnSaveSlot2();
 
-    UFUNCTION()
-    void OnMainMenu();
+  UFUNCTION()
+  void OnMainMenu();
 
 private:
-    /** Shared implementation for the individual save slot handlers. */
-    void HandleSaveSlot(int32 SlotIndex);
+  /** Shared implementation for the individual save slot handlers. */
+  void HandleSaveSlot(int32 SlotIndex);
 
-    UPROPERTY()
-    TWeakObjectPtr<ULobbyMenuWidget> LobbyMenu;
+  void UpdateSlotDisplay(int32 SlotIndex, UButton *SlotButton,
+                         UTextBlock *SlotText);
+
+  UPROPERTY()
+  TWeakObjectPtr<ULobbyMenuWidget> LobbyMenu;
 };
-


### PR DESCRIPTION
## Summary
- Load existing save game files for each slot and display their names and timestamps
- Replace hardcoded slot strings with constants from SlotNameConstants
- Disable save slot buttons when no save file is present

## Testing
- `g++ -std=c++17 -c Source/Skald/SaveGameWidget.cpp` *(fails: Blueprint/UserWidget.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68aeb938499c832481b73f8cf2c52caa