### PR TITLE
Add explicit territory adjacency configuration

### DIFF
--- a/Content/DataTables/TerritoryTable.csv
+++ b/Content/DataTables/TerritoryTable.csv
@@ -1,44 +1,44 @@
-TerritoryID,TerritoryName,bIsCapital,ContinentID,LocationX,LocationY,LocationZ
-0,Howling Veil,True,0,-600.0,-600.0,0.0
-1,Thond,False,0,-400.0,-600.0,0.0
-2,Elmyre,False,0,-200.0,-600.0,0.0
-3,Skarlstorm,False,0,0.0,-600.0,0.0
-4,Direford,False,0,200.0,-600.0,0.0
-5,Grimrest,False,0,400.0,-600.0,0.0
-6,Lakehold,False,0,600.0,-600.0,0.0
-7,Argoth,False,0,-600.0,-400.0,0.0
-8,Chala,False,1,-400.0,-400.0,0.0
-9,Rylan,False,1,-200.0,-400.0,0.0
-10,Uris,False,1,0.0,-400.0,0.0
-11,Achre,True,1,200.0,-400.0,0.0
-12,Erif,False,2,400.0,-400.0,0.0
-13,Nevar,False,1,600.0,-400.0,0.0
-14,Frayton,False,0,-600.0,-200.0,0.0
-15,Past Fields,False,1,-400.0,-200.0,0.0
-16,Spring Isle,False,1,-200.0,-200.0,0.0
-17,Sunder Isle,False,2,0.0,-200.0,0.0
-18,Sugiria,True,2,200.0,-200.0,0.0
-19,Blindshade,False,2,400.0,-200.0,0.0
-20,Whimswallow,False,2,600.0,-200.0,0.0
-21,Forgotten Coast,False,2,-600.0,0.0,0.0
-22,Oria,False,2,-400.0,0.0,0.0
-23,Brell,False,3,-200.0,0.0,0.0
-24,Revel,True,3,0.0,0.0,0.0
-25,Velaria,False,3,200.0,0.0,0.0
-26,Essivar,False,3,400.0,0.0,0.0
-27,Caldemire,False,3,600.0,0.0,0.0
-28,HazelHallow,False,4,-600.0,200.0,0.0
-29,Sirholde,False,4,-400.0,200.0,0.0
-30,Styr,False,4,-200.0,200.0,0.0
-31,Dawnmere,True,4,0.0,200.0,0.0
-32,Killbrooke,False,4,200.0,200.0,0.0
-33,Broken Plains,False,5,400.0,200.0,0.0
-34,Everlands,False,5,600.0,200.0,0.0
-35,Vigilmoore,False,5,-600.0,400.0,0.0
-36,Vulkrum,False,5,-400.0,400.0,0.0
-37,Timber Rock,False,5,-200.0,400.0,0.0
-38,Omenwhick,False,5,0.0,400.0,0.0
-39,Armens Grasp,False,5,200.0,400.0,0.0
-40,Volkridge,True,5,400.0,400.0,0.0
-41,Bakas,False,5,600.0,400.0,0.0
-42,Kesis,False,5,-600.0,600.0,0.0
+TerritoryID,TerritoryName,bIsCapital,ContinentID,LocationX,LocationY,LocationZ,AdjacentTerritoryIDs
+0,Howling Veil,True,0,-600.0,-600.0,0.0,1;7
+1,Thond,False,0,-400.0,-600.0,0.0,0;2;8
+2,Elmyre,False,0,-200.0,-600.0,0.0,1;3;9
+3,Skarlstorm,False,0,0.0,-600.0,0.0,2;4;10
+4,Direford,False,0,200.0,-600.0,0.0,3;5;11
+5,Grimrest,False,0,400.0,-600.0,0.0,4;6;12
+6,Lakehold,False,0,600.0,-600.0,0.0,5;13
+7,Argoth,False,0,-600.0,-400.0,0.0,0;8;14
+8,Chala,False,1,-400.0,-400.0,0.0,1;7;9;15
+9,Rylan,False,1,-200.0,-400.0,0.0,2;8;10;16
+10,Uris,False,1,0.0,-400.0,0.0,3;9;11;17
+11,Achre,True,1,200.0,-400.0,0.0,4;10;12;18
+12,Erif,False,2,400.0,-400.0,0.0,5;11;13;19
+13,Nevar,False,1,600.0,-400.0,0.0,6;12;20
+14,Frayton,False,0,-600.0,-200.0,0.0,7;15;21
+15,Past Fields,False,1,-400.0,-200.0,0.0,8;14;16;22
+16,Spring Isle,False,1,-200.0,-200.0,0.0,9;15;17;23
+17,Sunder Isle,False,2,0.0,-200.0,0.0,10;16;18;24
+18,Sugiria,True,2,200.0,-200.0,0.0,11;17;19;25
+19,Blindshade,False,2,400.0,-200.0,0.0,12;18;20;26
+20,Whimswallow,False,2,600.0,-200.0,0.0,13;19;27
+21,Forgotten Coast,False,2,-600.0,0.0,0.0,14;22;28
+22,Oria,False,2,-400.0,0.0,0.0,15;21;23;29
+23,Brell,False,3,-200.0,0.0,0.0,16;22;24;30
+24,Revel,True,3,0.0,0.0,0.0,17;23;25;31
+25,Velaria,False,3,200.0,0.0,0.0,18;24;26;32
+26,Essivar,False,3,400.0,0.0,0.0,19;25;27;33
+27,Caldemire,False,3,600.0,0.0,0.0,20;26;34
+28,HazelHallow,False,4,-600.0,200.0,0.0,21;29;35
+29,Sirholde,False,4,-400.0,200.0,0.0,22;28;30;36
+30,Styr,False,4,-200.0,200.0,0.0,23;29;31;37
+31,Dawnmere,True,4,0.0,200.0,0.0,24;30;32;38
+32,Killbrooke,False,4,200.0,200.0,0.0,25;31;33;39
+33,Broken Plains,False,5,400.0,200.0,0.0,26;32;34;40
+34,Everlands,False,5,600.0,200.0,0.0,27;33;41
+35,Vigilmoore,False,5,-600.0,400.0,0.0,28;36;42
+36,Vulkrum,False,5,-400.0,400.0,0.0,29;35;37
+37,Timber Rock,False,5,-200.0,400.0,0.0,30;36;38
+38,Omenwhick,False,5,0.0,400.0,0.0,31;37;39
+39,Armens Grasp,False,5,200.0,400.0,0.0,32;38;40
+40,Volkridge,True,5,400.0,400.0,0.0,33;39;41
+41,Bakas,False,5,600.0,400.0,0.0,34;40
+42,Kesis,False,5,-600.0,600.0,0.0,35

--- a/Source/Skald/WorldMap.h
+++ b/Source/Skald/WorldMap.h
@@ -19,13 +19,15 @@ struct FTerritorySpawnData : public FTableRowBase {
 
   FTerritorySpawnData()
       : TerritoryID(0), TerritoryName(TEXT("")), bIsCapital(false),
-        ContinentID(0), Location(FVector::ZeroVector) {}
+        ContinentID(0), Location(FVector::ZeroVector), AdjacentTerritoryIDs() {}
 
   FTerritorySpawnData(int32 InID, const FString &InName, bool bCapital = false,
                       int32 InContinent = 0,
-                      FVector InLocation = FVector::ZeroVector)
+                      FVector InLocation = FVector::ZeroVector,
+                      const TArray<int32> &InAdjacents = {})
       : TerritoryID(InID), TerritoryName(InName), bIsCapital(bCapital),
-        ContinentID(InContinent), Location(InLocation) {}
+        ContinentID(InContinent), Location(InLocation),
+        AdjacentTerritoryIDs(InAdjacents) {}
 
   UPROPERTY(EditAnywhere, BlueprintReadOnly)
   int32 TerritoryID;
@@ -42,6 +44,10 @@ struct FTerritorySpawnData : public FTableRowBase {
   /** Location for spawning this territory relative to the world map actor. */
   UPROPERTY(EditAnywhere, BlueprintReadOnly)
   FVector Location;
+
+  /** IDs of territories adjacent to this one. */
+  UPROPERTY(EditAnywhere, BlueprintReadOnly)
+  TArray<int32> AdjacentTerritoryIDs;
 };
 
 /**


### PR DESCRIPTION
## Summary
- add `AdjacentTerritoryIDs` to `FTerritorySpawnData`
- read adjacency info in `AWorldMap::BeginPlay` to wire up territories
- extend `TerritoryTable.csv` with adjacency lists

## Testing
- `bash Build/validate.sh` *(UnrealBuildTool not found; skipping compile check. UnrealEditor not found; cannot run tests.)*

------
https://chatgpt.com/codex/tasks/task_e_68aec32044248324875f49a6befaa4f0