### PR TITLE
Add null checks and attempt to reacquire TurnManager

### DIFF
--- a/Source/Skald/Skald_GameMode.h
+++ b/Source/Skald/Skald_GameMode.h
@@ -48,6 +48,10 @@ public:
   UPROPERTY(BlueprintAssignable, Category = "GameMode")
   FSkaldGameOver OnGameOver;
 
+  /** Retrieve the active turn manager controlling turn order. */
+  UFUNCTION(BlueprintCallable, BlueprintPure, Category = "GameMode")
+  ATurnManager *GetTurnManager() const { return TurnManager; }
+
 protected:
   /** Handles turn sequencing for the match. */
   UPROPERTY(BlueprintReadOnly, Category = "GameMode")

--- a/Source/Skald/Skald_PlayerController.cpp
+++ b/Source/Skald/Skald_PlayerController.cpp
@@ -162,15 +162,49 @@ void ASkaldPlayerController::StartTurn() {
 void ASkaldPlayerController::EndTurn() {
   SetInputMode(FInputModeGameOnly());
 
-  if (TurnManager) {
-    TurnManager->AdvanceTurn();
+  if (!TurnManager) {
+    UE_LOG(LogSkald, Warning,
+           TEXT("EndTurn called without a TurnManager. Attempting to reacquire."));
+
+    if (!CachedGameMode) {
+      CachedGameMode = GetWorld()->GetAuthGameMode<ASkaldGameMode>();
+    }
+
+    if (CachedGameMode) {
+      SetTurnManager(CachedGameMode->GetTurnManager());
+    }
+
+    if (!TurnManager) {
+      UE_LOG(LogSkald, Warning,
+             TEXT("TurnManager still missing; aborting EndTurn."));
+      return;
+    }
   }
+
+  TurnManager->AdvanceTurn();
 }
 
 void ASkaldPlayerController::EndPhase() {
-  if (TurnManager) {
-    TurnManager->AdvancePhase();
+  if (!TurnManager) {
+    UE_LOG(LogSkald, Warning,
+           TEXT("EndPhase called without a TurnManager. Attempting to reacquire."));
+
+    if (!CachedGameMode) {
+      CachedGameMode = GetWorld()->GetAuthGameMode<ASkaldGameMode>();
+    }
+
+    if (CachedGameMode) {
+      SetTurnManager(CachedGameMode->GetTurnManager());
+    }
+
+    if (!TurnManager) {
+      UE_LOG(LogSkald, Warning,
+             TEXT("TurnManager still missing; aborting EndPhase."));
+      return;
+    }
   }
+
+  TurnManager->AdvancePhase();
 }
 
 void ASkaldPlayerController::MakeAIDecision() {


### PR DESCRIPTION
## Summary
- add GameMode accessor for active TurnManager
- safeguard EndTurn/EndPhase by reacquiring TurnManager from GameMode and logging warnings

## Testing
- `g++ -std=c++20 -Isomeinclude -fsyntax-only Source/Skald/Skald_PlayerController.cpp` *(fails: CoreMinimal.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68aec3270c38832481880a375b82b0d5