### PR TITLE
Remove duplicate Resources property from FS_PlayerData

### DIFF
--- a/Source/Skald/SkaldTypes.h
+++ b/Source/Skald/SkaldTypes.h
@@ -158,9 +158,6 @@ struct SKALD_API FS_PlayerData
     ESkaldFaction Faction = ESkaldFaction::Human;
 
     UPROPERTY(BlueprintReadWrite, EditAnywhere)
-    int32 Resources = 0;
-
-    UPROPERTY(BlueprintReadWrite, EditAnywhere)
     TArray<int32> CapitalTerritoryIDs;
 
     UPROPERTY(BlueprintReadWrite, EditAnywhere)


### PR DESCRIPTION
## Summary
- remove redundant `Resources` field from `FS_PlayerData`

## Testing
- `./Build/validate.sh` *(fails: UnrealBuildTool not found; skipping compile check. UnrealEditor not found; cannot run tests.)*

------
https://chatgpt.com/codex/tasks/task_e_68aec6081cd88324927b38332b33b9f4