### PR TITLE
Send all but one troop when attacking

### DIFF
--- a/Source/Skald/Skald_PlayerController.cpp
+++ b/Source/Skald/Skald_PlayerController.cpp
@@ -284,9 +284,8 @@ void ASkaldPlayerController::MakeAIDecision() {
       }
     }
 
-    if (BestSource && BestTarget) {
-      const int32 ArmySent = FMath::Clamp(BestSource->ArmyStrength - 1, 1,
-                                          BestSource->ArmyStrength - 1);
+    if (BestSource && BestTarget && BestSource->ArmyStrength > 1) {
+      const int32 ArmySent = BestSource->ArmyStrength - 1;
       HandleAttackRequested(BestSource->TerritoryID, BestTarget->TerritoryID,
                             ArmySent, false);
     }


### PR DESCRIPTION
## Summary
- send all but one troop in AI attacks by removing redundant clamp

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68aec70c8d94832481db047e0e8df542