### PR TITLE
Refactor player data assembly in player controller

### DIFF
--- a/Source/Skald/Skald_PlayerController.h
+++ b/Source/Skald/Skald_PlayerController.h
@@ -186,4 +186,7 @@ protected:
   UPROPERTY(EditInstanceOnly, BlueprintReadOnly, Category = "Turn",
             meta = (ExposeOnSpawn = true))
   TObjectPtr<ATurnManager> TurnManager;
+
+private:
+  void BuildPlayerDataArray(TArray<FS_PlayerData> &OutPlayers) const;
 };


### PR DESCRIPTION
## Summary
- centralize player data extraction from CachedGameState into new BuildPlayerDataArray helper
- reuse BuildPlayerDataArray in HandlePlayersUpdated and HandleWorldStateChanged to avoid duplicated loops

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68aec7a3fb188324b4d64611a8e09c0f