### PR TITLE
Refresh HUD after faction updates

### DIFF
--- a/Source/Skald/Skald_PlayerController.cpp
+++ b/Source/Skald/Skald_PlayerController.cpp
@@ -661,7 +661,17 @@ void ASkaldPlayerController::HandlePlayersUpdated() {
 }
 
 void ASkaldPlayerController::HandleFactionsUpdated() {
-  UE_LOG(LogSkald, Log, TEXT("GameInstance factions updated."));
+  if (!MainHudWidget || !CachedGameState) {
+    return;
+  }
+
+  TArray<FS_PlayerData> Players;
+  BuildPlayerDataArray(Players);
+  MainHudWidget->RefreshPlayerList(Players);
+
+  if (ASkaldPlayerState *LocalPS = GetPlayerState<ASkaldPlayerState>()) {
+    MainHudWidget->UpdateResources(LocalPS->Resources);
+  }
 }
 
 void ASkaldPlayerController::HandleWorldStateChanged() {


### PR DESCRIPTION
## Summary
- Rebuild player data when factions update and refresh HUD

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68aec8d666ac8324843790a410954b23