### PR TITLE
Log error when world map assets missing

### DIFF
--- a/Source/Skald/Tests/WorldMapMissingAssetsTest.cpp
+++ b/Source/Skald/Tests/WorldMapMissingAssetsTest.cpp
@@ -1,0 +1,26 @@
+#include "Misc/AutomationTest.h"
+#include "WorldMap.h"
+#include "Tests/AutomationEditorCommon.h"
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FWorldMapMissingAssetsTest, "Skald.WorldMap.MissingAssetsLogged", EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+
+bool FWorldMapMissingAssetsTest::RunTest(const FString& Parameters)
+{
+    UWorld* World = FAutomationEditorCommonUtils::CreateNewMap();
+    TestNotNull(TEXT("World should be created"), World);
+    if (!World)
+    {
+        return false;
+    }
+
+    AWorldMap* Map = World->SpawnActor<AWorldMap>();
+    TestNotNull(TEXT("WorldMap spawned"), Map);
+    if (!Map)
+    {
+        return false;
+    }
+
+    AddExpectedError(TEXT("WorldMap requires valid TerritoryClass and TerritoryTable."), EAutomationExpectedErrorFlags::Contains);
+    Map->BeginPlay();
+    return true;
+}

--- a/Source/Skald/WorldMap.cpp
+++ b/Source/Skald/WorldMap.cpp
@@ -1,6 +1,7 @@
 #include "WorldMap.h"
 #include "Containers/Map.h"
 #include "Containers/Queue.h"
+#include "Engine/Engine.h"
 #include "Engine/World.h"
 #include "Skald_GameMode.h"
 #include "Territory.h"
@@ -14,6 +15,27 @@ void AWorldMap::BeginPlay() {
   Super::BeginPlay();
 
   if (!TerritoryClass || !TerritoryTable) {
+    UE_LOG(LogTemp, Error,
+           TEXT("WorldMap requires valid TerritoryClass and TerritoryTable."));
+
+    if (GEngine) {
+      GEngine->AddOnScreenDebugMessage(
+          -1, 5.f, FColor::Red,
+          TEXT("World map failed to initialize: missing assets."));
+    }
+
+    if (TerritoryClass && !TerritoryTable) {
+      FActorSpawnParameters Params;
+      Params.Owner = this;
+      ATerritory *Placeholder = GetWorld()->SpawnActor<ATerritory>(
+          TerritoryClass, GetActorLocation(), FRotator::ZeroRotator, Params);
+      if (Placeholder) {
+        Placeholder->TerritoryID = -1;
+        Placeholder->TerritoryName = TEXT("Placeholder Territory");
+        RegisterTerritory(Placeholder);
+      }
+    }
+
     return;
   }
 


### PR DESCRIPTION
## Summary
- log missing assets on WorldMap BeginPlay and spawn a placeholder territory
- add automation test checking error log for missing territory assets

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68aecf0b36ec832483a806b675264de8