### PR TITLE
Spawn controllers for AI players

### DIFF
--- a/Source/Skald/Skald_GameMode.cpp
+++ b/Source/Skald/Skald_GameMode.cpp
@@ -181,6 +181,25 @@ void ASkaldGameMode::PopulateAIPlayers() {
     PlayersData[Index].IsAI = true;
     PlayersData[Index].Faction = AIState->Faction;
     PlayersData[Index].Resources = AIState->Resources;
+
+    // Spawn a controller and pawn for the AI player and register it with the
+    // turn system so it can participate normally in HUD updates and turn
+    // sequencing.
+    ASkaldPlayerController *AIController =
+        GetWorld()->SpawnActor<ASkaldPlayerController>(PlayerControllerClass);
+    if (AIController) {
+      AIController->PlayerState = AIState;
+      AIController->bIsAI = true;
+
+      if (APawn *AIPawn =
+              GetWorld()->SpawnActor<APawn>(DefaultPawnClass)) {
+        AIController->Possess(AIPawn);
+      }
+
+      if (TurnManager) {
+        TurnManager->RegisterController(AIController);
+      }
+    }
   }
 }
 

--- a/Source/Skald/Tests/PopulateAIPlayersTest.cpp
+++ b/Source/Skald/Tests/PopulateAIPlayersTest.cpp
@@ -1,0 +1,65 @@
+#include "Misc/AutomationTest.h"
+#include "Tests/AutomationEditorCommon.h"
+#include "Skald_GameMode.h"
+#include "Skald_PlayerController.h"
+#include "Skald_PlayerState.h"
+#include "Skald_TurnManager.h"
+#include "Skald_GameInstance.h"
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FSkaldPopulateAIPlayersTest, "Skald.AI.PopulateCreatesControllers", EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+
+bool FSkaldPopulateAIPlayersTest::RunTest(const FString& Parameters)
+{
+    UWorld* World = FAutomationEditorCommonUtils::CreateNewMap();
+    TestNotNull(TEXT("World created"), World);
+    if (!World)
+    {
+        return false;
+    }
+
+    USkaldGameInstance* GI = NewObject<USkaldGameInstance>();
+    World->SetGameInstance(GI);
+
+    ASkaldGameMode* GM = World->SpawnActor<ASkaldGameMode>();
+    TestNotNull(TEXT("GameMode spawned"), GM);
+    if (!GM)
+    {
+        return false;
+    }
+    GM->BeginPlay();
+
+    ASkaldPlayerController* HumanPC = World->SpawnActor<ASkaldPlayerController>();
+    ASkaldPlayerState* HumanPS = World->SpawnActor<ASkaldPlayerState>();
+    HumanPC->PlayerState = HumanPS;
+
+    GM->PostLogin(HumanPC);
+
+    ATurnManager* TM = GM->GetTurnManager();
+    TestNotNull(TEXT("TurnManager valid"), TM);
+    if (!TM)
+    {
+        return false;
+    }
+
+    const TArray<TWeakObjectPtr<ASkaldPlayerController>>& Controllers = TM->GetControllers();
+    TestEqual(TEXT("Total controllers"), Controllers.Num(), 4);
+
+    int32 AICount = 0;
+    for (const TWeakObjectPtr<ASkaldPlayerController>& Ptr : Controllers)
+    {
+        ASkaldPlayerController* PC = Ptr.Get();
+        if (!PC)
+        {
+            continue;
+        }
+        if (PC->bIsAI)
+        {
+            ++AICount;
+            TestNotNull(TEXT("AI pawn"), PC->GetPawn());
+        }
+    }
+    TestEqual(TEXT("AI controller count"), AICount, 3);
+
+    return true;
+}
+


### PR DESCRIPTION
## Summary
- Spawn a controller and pawn for each AI player during game setup
- Register AI controllers with the TurnManager so they join turn order and HUD updates
- Add automation test confirming AI controllers are spawned and possess pawns

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68aed28ebb4083248c93a9d0b1d216ff