### PR TITLE
Validate territory movement and add tests

### DIFF
--- a/Source/Skald/Territory.cpp
+++ b/Source/Skald/Territory.cpp
@@ -157,6 +157,11 @@ bool ATerritory::MoveTo(ATerritory *TargetTerritory, int32 Troops) {
     return false;
   }
 
+  if (!IsAdjacentTo(TargetTerritory) ||
+      TargetTerritory->OwningPlayer != OwningPlayer) {
+    return false;
+  }
+
   ArmyStrength -= Troops;
   TargetTerritory->ArmyStrength += Troops;
 

--- a/Source/Skald/Tests/TerritoryMoveTest.cpp
+++ b/Source/Skald/Tests/TerritoryMoveTest.cpp
@@ -1,0 +1,88 @@
+#include "Misc/AutomationTest.h"
+#include "Tests/AutomationEditorCommon.h"
+#include "Territory.h"
+#include "Skald_PlayerState.h"
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FSkaldTerritoryMoveValidTest, "Skald.Territory.Move.Valid", EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FSkaldTerritoryMoveInvalidTest, "Skald.Territory.Move.Invalid", EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+
+bool FSkaldTerritoryMoveValidTest::RunTest(const FString& Parameters)
+{
+    UWorld* World = FAutomationEditorCommonUtils::CreateNewMap();
+    TestNotNull(TEXT("World created"), World);
+    if (!World)
+    {
+        return false;
+    }
+
+    ASkaldPlayerState* Player = World->SpawnActor<ASkaldPlayerState>();
+    ATerritory* A = World->SpawnActor<ATerritory>();
+    ATerritory* B = World->SpawnActor<ATerritory>();
+    TestNotNull(TEXT("Player"), Player);
+    TestNotNull(TEXT("Territory A"), A);
+    TestNotNull(TEXT("Territory B"), B);
+    if (!Player || !A || !B)
+    {
+        return false;
+    }
+
+    A->OwningPlayer = Player;
+    B->OwningPlayer = Player;
+    A->AdjacentTerritories = {B};
+    B->AdjacentTerritories = {A};
+    A->ArmyStrength = 10;
+    B->ArmyStrength = 0;
+
+    bool bMoved = A->MoveTo(B, 5);
+    TestTrue(TEXT("Move succeeds"), bMoved);
+    TestEqual(TEXT("Origin army reduced"), A->ArmyStrength, 5);
+    TestEqual(TEXT("Target army increased"), B->ArmyStrength, 5);
+
+    return true;
+}
+
+bool FSkaldTerritoryMoveInvalidTest::RunTest(const FString& Parameters)
+{
+    UWorld* World = FAutomationEditorCommonUtils::CreateNewMap();
+    TestNotNull(TEXT("World created"), World);
+    if (!World)
+    {
+        return false;
+    }
+
+    ASkaldPlayerState* Player1 = World->SpawnActor<ASkaldPlayerState>();
+    ASkaldPlayerState* Player2 = World->SpawnActor<ASkaldPlayerState>();
+    ATerritory* A = World->SpawnActor<ATerritory>();
+    ATerritory* B = World->SpawnActor<ATerritory>();
+    TestNotNull(TEXT("Player1"), Player1);
+    TestNotNull(TEXT("Player2"), Player2);
+    TestNotNull(TEXT("Territory A"), A);
+    TestNotNull(TEXT("Territory B"), B);
+    if (!Player1 || !Player2 || !A || !B)
+    {
+        return false;
+    }
+
+    // Non-adjacent move should fail
+    A->OwningPlayer = Player1;
+    B->OwningPlayer = Player1;
+    A->AdjacentTerritories = {};
+    B->AdjacentTerritories = {};
+    A->ArmyStrength = 10;
+    B->ArmyStrength = 0;
+    bool bMoved = A->MoveTo(B, 5);
+    TestFalse(TEXT("Non-adjacent move fails"), bMoved);
+    TestEqual(TEXT("Origin army unchanged"), A->ArmyStrength, 10);
+    TestEqual(TEXT("Target army unchanged"), B->ArmyStrength, 0);
+
+    // Adjacent but different owner should fail
+    A->AdjacentTerritories = {B};
+    B->AdjacentTerritories = {A};
+    B->OwningPlayer = Player2;
+    bMoved = A->MoveTo(B, 5);
+    TestFalse(TEXT("Move to enemy territory fails"), bMoved);
+    TestEqual(TEXT("Origin army unchanged"), A->ArmyStrength, 10);
+    TestEqual(TEXT("Target army unchanged"), B->ArmyStrength, 0);
+
+    return true;
+}


### PR DESCRIPTION
## Summary
- ensure territories only move troops to adjacent territories owned by the same player
- add tests for valid and invalid territory moves

## Testing
- `UnrealEditor-Cmd Skald.uproject -ExecCmds="Automation RunTests Skald.Territory.Move.*; Quit" -unattended` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aed4d199c483248bd329994ee63f6e