### PR TITLE
Add turn manager and pathfinding tests

### DIFF
--- a/Build/validate.sh
+++ b/Build/validate.sh
@@ -12,7 +12,7 @@ fi
 
 echo "Running automation tests..."
 if command -v UnrealEditor &>/dev/null; then
-  UnrealEditor "$UPROJECT" -ExecCmds="Automation RunTests Skald.UI.BindingsRemain+Skald.PlayerController.ValidationFeedback;Quit" -unattended -nop4 || exit 1
+  UnrealEditor "$UPROJECT" -ExecCmds="Automation RunTests Skald.UI.BindingsRemain+Skald.PlayerController.ValidationFeedback+Skald.TurnManager.PhaseTransitions+Skald.TurnManager.InitiativeSort+Skald.WorldMap.FindPath.Valid+Skald.WorldMap.FindPath.Blocked;Quit" -unattended -nop4 || exit 1
 else
   echo "UnrealEditor not found; cannot run tests." >&2
 fi

--- a/Source/Skald/Tests/TurnManagerTest.cpp
+++ b/Source/Skald/Tests/TurnManagerTest.cpp
@@ -1,0 +1,85 @@
+#include "Misc/AutomationTest.h"
+#include "Tests/AutomationEditorCommon.h"
+#include "Skald_TurnManager.h"
+#include "Skald_PlayerController.h"
+#include "Skald_PlayerState.h"
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FSkaldTurnManagerPhaseTest, "Skald.TurnManager.PhaseTransitions", EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+bool FSkaldTurnManagerPhaseTest::RunTest(const FString& Parameters) {
+  UWorld* World = FAutomationEditorCommonUtils::CreateNewMap();
+  TestNotNull(TEXT("World created"), World);
+  if (!World) {
+    return false;
+  }
+
+  ATurnManager* TM = World->SpawnActor<ATurnManager>();
+  ASkaldPlayerController* PC = World->SpawnActor<ASkaldPlayerController>();
+  ASkaldPlayerState* PS = World->SpawnActor<ASkaldPlayerState>();
+  TestNotNull(TEXT("TurnManager"), TM);
+  TestNotNull(TEXT("PlayerController"), PC);
+  TestNotNull(TEXT("PlayerState"), PS);
+  if (!TM || !PC || !PS) {
+    return false;
+  }
+
+  PC->PlayerState = PS;
+  TM->RegisterController(PC);
+  TM->StartTurns();
+
+  TestEqual(TEXT("Initial phase"), TM->GetCurrentPhase(), ETurnPhase::Reinforcement);
+  TM->AdvancePhase();
+  TestEqual(TEXT("After reinforcement"), TM->GetCurrentPhase(), ETurnPhase::Attack);
+  TM->AdvancePhase();
+  TestEqual(TEXT("After attack"), TM->GetCurrentPhase(), ETurnPhase::Engineering);
+  TM->AdvancePhase();
+  TestEqual(TEXT("After engineering"), TM->GetCurrentPhase(), ETurnPhase::Treasure);
+  TM->AdvancePhase();
+  TestEqual(TEXT("After treasure"), TM->GetCurrentPhase(), ETurnPhase::Movement);
+  TM->AdvancePhase();
+  TestEqual(TEXT("After movement"), TM->GetCurrentPhase(), ETurnPhase::EndTurn);
+  TM->AdvancePhase();
+  TestEqual(TEXT("After end turn"), TM->GetCurrentPhase(), ETurnPhase::Revolt);
+  TM->AdvancePhase();
+  TestEqual(TEXT("Stays in revolt"), TM->GetCurrentPhase(), ETurnPhase::Revolt);
+
+  return true;
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FSkaldTurnManagerInitiativeTest, "Skald.TurnManager.InitiativeSort", EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+bool FSkaldTurnManagerInitiativeTest::RunTest(const FString& Parameters) {
+  UWorld* World = FAutomationEditorCommonUtils::CreateNewMap();
+  TestNotNull(TEXT("World created"), World);
+  if (!World) {
+    return false;
+  }
+
+  ATurnManager* TM = World->SpawnActor<ATurnManager>();
+  ASkaldPlayerController* PC1 = World->SpawnActor<ASkaldPlayerController>();
+  ASkaldPlayerController* PC2 = World->SpawnActor<ASkaldPlayerController>();
+  ASkaldPlayerState* PS1 = World->SpawnActor<ASkaldPlayerState>();
+  ASkaldPlayerState* PS2 = World->SpawnActor<ASkaldPlayerState>();
+  TestNotNull(TEXT("TurnManager"), TM);
+  TestNotNull(TEXT("PlayerController1"), PC1);
+  TestNotNull(TEXT("PlayerController2"), PC2);
+  TestNotNull(TEXT("PlayerState1"), PS1);
+  TestNotNull(TEXT("PlayerState2"), PS2);
+  if (!TM || !PC1 || !PC2 || !PS1 || !PS2) {
+    return false;
+  }
+
+  PC1->PlayerState = PS1;
+  PC2->PlayerState = PS2;
+  PS1->InitiativeRoll = 2;
+  PS2->InitiativeRoll = 5;
+
+  TM->RegisterController(PC1);
+  TM->RegisterController(PC2);
+  TM->SortControllersByInitiative();
+
+  const TArray<TWeakObjectPtr<ASkaldPlayerController>>& Controllers = TM->GetControllers();
+  TestEqual(TEXT("Controller count"), Controllers.Num(), 2);
+  TestTrue(TEXT("Highest initiative first"), Controllers[0].Get() == PC2);
+  TestTrue(TEXT("Lowest initiative second"), Controllers[1].Get() == PC1);
+
+  return true;
+}

--- a/Source/Skald/Tests/WorldMapFindPathTest.cpp
+++ b/Source/Skald/Tests/WorldMapFindPathTest.cpp
@@ -1,0 +1,83 @@
+#include "Misc/AutomationTest.h"
+#include "Tests/AutomationEditorCommon.h"
+#include "WorldMap.h"
+#include "Territory.h"
+#include "Skald_PlayerState.h"
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FWorldMapFindPathValidTest, "Skald.WorldMap.FindPath.Valid", EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+bool FWorldMapFindPathValidTest::RunTest(const FString& Parameters) {
+  UWorld* World = FAutomationEditorCommonUtils::CreateNewMap();
+  TestNotNull(TEXT("World created"), World);
+  if (!World) {
+    return false;
+  }
+
+  AWorldMap* Map = World->SpawnActor<AWorldMap>();
+  ASkaldPlayerState* PS = World->SpawnActor<ASkaldPlayerState>();
+  ATerritory* T1 = World->SpawnActor<ATerritory>();
+  ATerritory* T2 = World->SpawnActor<ATerritory>();
+  ATerritory* T3 = World->SpawnActor<ATerritory>();
+  TestNotNull(TEXT("Map"), Map);
+  TestNotNull(TEXT("PlayerState"), PS);
+  TestNotNull(TEXT("Territory1"), T1);
+  TestNotNull(TEXT("Territory2"), T2);
+  TestNotNull(TEXT("Territory3"), T3);
+  if (!Map || !PS || !T1 || !T2 || !T3) {
+    return false;
+  }
+
+  T1->OwningPlayer = PS;
+  T2->OwningPlayer = PS;
+  T3->OwningPlayer = PS;
+  T1->AdjacentTerritories = {T2};
+  T2->AdjacentTerritories = {T1, T3};
+  T3->AdjacentTerritories = {T2};
+
+  TArray<ATerritory*> Path;
+  const bool bFound = Map->FindPath(T1, T3, Path);
+  TestTrue(TEXT("Path found"), bFound);
+  TestEqual(TEXT("Path length"), Path.Num(), 3);
+  TestTrue(TEXT("Starts at source"), Path[0] == T1);
+  TestTrue(TEXT("Ends at destination"), Path[2] == T3);
+
+  return true;
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FWorldMapFindPathBlockedTest, "Skald.WorldMap.FindPath.Blocked", EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+bool FWorldMapFindPathBlockedTest::RunTest(const FString& Parameters) {
+  UWorld* World = FAutomationEditorCommonUtils::CreateNewMap();
+  TestNotNull(TEXT("World created"), World);
+  if (!World) {
+    return false;
+  }
+
+  AWorldMap* Map = World->SpawnActor<AWorldMap>();
+  ASkaldPlayerState* PS1 = World->SpawnActor<ASkaldPlayerState>();
+  ASkaldPlayerState* PS2 = World->SpawnActor<ASkaldPlayerState>();
+  ATerritory* T1 = World->SpawnActor<ATerritory>();
+  ATerritory* T2 = World->SpawnActor<ATerritory>();
+  ATerritory* T3 = World->SpawnActor<ATerritory>();
+  TestNotNull(TEXT("Map"), Map);
+  TestNotNull(TEXT("PlayerState1"), PS1);
+  TestNotNull(TEXT("PlayerState2"), PS2);
+  TestNotNull(TEXT("Territory1"), T1);
+  TestNotNull(TEXT("Territory2"), T2);
+  TestNotNull(TEXT("Territory3"), T3);
+  if (!Map || !PS1 || !PS2 || !T1 || !T2 || !T3) {
+    return false;
+  }
+
+  T1->OwningPlayer = PS1;
+  T2->OwningPlayer = PS2;
+  T3->OwningPlayer = PS1;
+  T1->AdjacentTerritories = {T2};
+  T2->AdjacentTerritories = {T1, T3};
+  T3->AdjacentTerritories = {T2};
+
+  TArray<ATerritory*> Path;
+  const bool bFound = Map->FindPath(T1, T3, Path);
+  TestFalse(TEXT("Path blocked"), bFound);
+  TestEqual(TEXT("No path"), Path.Num(), 0);
+
+  return true;
+}


### PR DESCRIPTION
## Summary
- add automation tests for turn manager phase transitions and initiative sorting
- cover world map pathfinding with valid and blocked path cases
- run new tests via build validation script

## Testing
- `./Build/validate.sh`

------
https://chatgpt.com/codex/tasks/task_e_68aeda28c9c883249d9f9d479beca2a8