### PR TITLE
Accumulate resources during reinforcement phase

### DIFF
--- a/Build/validate.sh
+++ b/Build/validate.sh
@@ -12,7 +12,7 @@ fi
 
 echo "Running automation tests..."
 if command -v UnrealEditor &>/dev/null; then
-  UnrealEditor "$UPROJECT" -ExecCmds="Automation RunTests Skald.UI.BindingsRemain+Skald.PlayerController.ValidationFeedback+Skald.TurnManager.PhaseTransitions+Skald.TurnManager.InitiativeSort+Skald.WorldMap.FindPath.Valid+Skald.WorldMap.FindPath.Blocked;Quit" -unattended -nop4 || exit 1
+  UnrealEditor "$UPROJECT" -ExecCmds="Automation RunTests Skald.UI.BindingsRemain+Skald.PlayerController.ValidationFeedback+Skald.TurnManager.PhaseTransitions+Skald.TurnManager.InitiativeSort+Skald.WorldMap.FindPath.Valid+Skald.WorldMap.FindPath.Blocked+Skald.TurnManager.ResourceAccumulation;Quit" -unattended -nop4 || exit 1
 else
   echo "UnrealEditor not found; cannot run tests." >&2
 fi

--- a/Source/Skald/Skald_TurnManager.cpp
+++ b/Source/Skald/Skald_TurnManager.cpp
@@ -54,20 +54,23 @@ void ATurnManager::StartTurns() {
           CurrentController->GetPlayerState<ASkaldPlayerState>();
       const FString PlayerName = PS ? PS->DisplayName : TEXT("Unknown");
 
-      // Determine reinforcements based on owned territories.
+      // Determine reinforcements and resources based on owned territories.
       if (PS) {
         int32 Owned = 0;
+        int32 ResourceGain = 0;
         if (AWorldMap *WorldMap =
                 Cast<AWorldMap>(UGameplayStatics::GetActorOfClass(
                     GetWorld(), AWorldMap::StaticClass()))) {
           for (ATerritory *Terr : WorldMap->Territories) {
             if (Terr && Terr->OwningPlayer == PS) {
               ++Owned;
+              ResourceGain += Terr->Resources;
             }
           }
         }
         const int32 Reinforcements = FMath::CeilToInt(Owned / 3.0f);
         PS->ArmyPool = Reinforcements;
+        PS->Resources += ResourceGain;
         PS->ForceNetUpdate();
         BroadcastArmyPool(PS);
         BroadcastResources(PS);
@@ -127,19 +130,22 @@ void ATurnManager::AdvanceTurn() {
         CurrentController->GetPlayerState<ASkaldPlayerState>();
     const FString PlayerName = PS ? PS->DisplayName : TEXT("Unknown");
 
-    // Calculate reinforcements for the new active player.
+    // Calculate reinforcements and resources for the new active player.
     if (PS) {
       int32 Owned = 0;
+      int32 ResourceGain = 0;
       if (AWorldMap *WorldMap = Cast<AWorldMap>(UGameplayStatics::GetActorOfClass(
               GetWorld(), AWorldMap::StaticClass()))) {
         for (ATerritory *Terr : WorldMap->Territories) {
           if (Terr && Terr->OwningPlayer == PS) {
             ++Owned;
+            ResourceGain += Terr->Resources;
           }
         }
       }
       const int32 Reinforcements = FMath::CeilToInt(Owned / 3.0f);
       PS->ArmyPool = Reinforcements;
+      PS->Resources += ResourceGain;
       PS->ForceNetUpdate();
       BroadcastArmyPool(PS);
       BroadcastResources(PS);

--- a/Source/Skald/Tests/ReinforcementResourceTest.cpp
+++ b/Source/Skald/Tests/ReinforcementResourceTest.cpp
@@ -1,0 +1,55 @@
+#include "Misc/AutomationTest.h"
+#include "Tests/AutomationEditorCommon.h"
+#include "Skald_TurnManager.h"
+#include "Skald_PlayerController.h"
+#include "Skald_PlayerState.h"
+#include "Territory.h"
+#include "WorldMap.h"
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FSkaldReinforcementResourceTest, "Skald.TurnManager.ResourceAccumulation", EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+bool FSkaldReinforcementResourceTest::RunTest(const FString& Parameters) {
+  UWorld* World = FAutomationEditorCommonUtils::CreateNewMap();
+  TestNotNull(TEXT("World created"), World);
+  if (!World) {
+    return false;
+  }
+
+  ATurnManager* TM = World->SpawnActor<ATurnManager>();
+  ASkaldPlayerController* PC = World->SpawnActor<ASkaldPlayerController>();
+  ASkaldPlayerState* PS = World->SpawnActor<ASkaldPlayerState>();
+  AWorldMap* Map = World->SpawnActor<AWorldMap>();
+  TestNotNull(TEXT("TurnManager"), TM);
+  TestNotNull(TEXT("PlayerController"), PC);
+  TestNotNull(TEXT("PlayerState"), PS);
+  TestNotNull(TEXT("WorldMap"), Map);
+  if (!TM || !PC || !PS || !Map) {
+    return false;
+  }
+
+  PC->PlayerState = PS;
+  PC->SetTurnManager(TM);
+  TM->RegisterController(PC);
+
+  ATerritory* T1 = World->SpawnActor<ATerritory>();
+  ATerritory* T2 = World->SpawnActor<ATerritory>();
+  TestNotNull(TEXT("Territory1"), T1);
+  TestNotNull(TEXT("Territory2"), T2);
+  if (!T1 || !T2) {
+    return false;
+  }
+
+  T1->OwningPlayer = PS;
+  T1->Resources = 3;
+  T2->OwningPlayer = PS;
+  T2->Resources = 7;
+  Map->Territories = {T1, T2};
+
+  PS->Resources = 0;
+  TM->StartTurns();
+  TestEqual(TEXT("Resources after first reinforcement"), PS->Resources, 10);
+
+  TM->AdvanceTurn();
+  TestEqual(TEXT("Resources after second reinforcement"), PS->Resources, 20);
+
+  return true;
+}


### PR DESCRIPTION
## Summary
- aggregate owned territory resources during reinforcement and update player state
- add automation test ensuring resources grow each turn
- run validation script to invoke new test

## Testing
- `./Build/validate.sh >/tmp/test.log && tail -n 20 /tmp/test.log`

------
https://chatgpt.com/codex/tasks/task_e_68aedad296d88324a20ccb0e6194061d