### PR TITLE
feat: multicast battle resolution sync

### DIFF
--- a/Source/Skald/Skald_TurnManager.h
+++ b/Source/Skald/Skald_TurnManager.h
@@ -61,6 +61,13 @@ public:
     UFUNCTION(BlueprintCallable, Category="Battle")
     void ResolveGridBattleResult();
 
+    /** Multicast the results of a resolved battle to all clients. */
+    UFUNCTION(NetMulticast, Reliable)
+    void ClientBattleResolved(int32 WinningPlayerID, int32 AttackerCasualties,
+                              int32 DefenderCasualties, int32 FromTerritoryID,
+                              int32 TargetTerritoryID, int32 NewOwnerPlayerID,
+                              int32 SourceArmy, int32 TargetArmy);
+
     /** Access the controllers array in its current initiative order. */
     UFUNCTION(BlueprintCallable, BlueprintPure, Category="Turn")
     const TArray<TWeakObjectPtr<ASkaldPlayerController>>& GetControllers() const { return Controllers; }

--- a/Source/Skald/Tests/BattleResolutionSyncTest.cpp
+++ b/Source/Skald/Tests/BattleResolutionSyncTest.cpp
@@ -1,0 +1,58 @@
+#include "Misc/AutomationTest.h"
+#include "Tests/AutomationEditorCommon.h"
+#include "Skald_TurnManager.h"
+#include "Skald_PlayerState.h"
+#include "Territory.h"
+#include "WorldMap.h"
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FSkaldBattleResolutionSyncTest, "Skald.Multiplayer.BattleResolutionSync", EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+bool FSkaldBattleResolutionSyncTest::RunTest(const FString& Parameters) {
+  UWorld* World = FAutomationEditorCommonUtils::CreateNewMap();
+  TestNotNull(TEXT("World created"), World);
+  if (!World) {
+    return false;
+  }
+
+  ATurnManager* TM = World->SpawnActor<ATurnManager>();
+  AWorldMap* WM = World->SpawnActor<AWorldMap>();
+  ATerritory* Source = World->SpawnActor<ATerritory>();
+  ATerritory* Target = World->SpawnActor<ATerritory>();
+  ASkaldPlayerState* PS1 = World->SpawnActor<ASkaldPlayerState>();
+  ASkaldPlayerState* PS2 = World->SpawnActor<ASkaldPlayerState>();
+
+  TestNotNull(TEXT("TurnManager"), TM);
+  TestNotNull(TEXT("WorldMap"), WM);
+  TestNotNull(TEXT("Source"), Source);
+  TestNotNull(TEXT("Target"), Target);
+  TestNotNull(TEXT("Player1"), PS1);
+  TestNotNull(TEXT("Player2"), PS2);
+  if (!TM || !WM || !Source || !Target || !PS1 || !PS2) {
+    return false;
+  }
+
+  PS1->SetPlayerId(1);
+  PS2->SetPlayerId(2);
+
+  Source->TerritoryID = 1;
+  Source->ArmyStrength = 10;
+  Source->OwningPlayer = PS1;
+
+  Target->TerritoryID = 2;
+  Target->ArmyStrength = 5;
+  Target->OwningPlayer = PS2;
+
+  WM->Territories.Add(Source);
+  WM->Territories.Add(Target);
+
+  bool bBroadcasted = false;
+  TM->OnWorldStateChanged.AddLambda([&bBroadcasted]() { bBroadcasted = true; });
+
+  TM->ClientBattleResolved(1, 3, 5, 1, 2, 1, 5, 2);
+
+  TestTrue(TEXT("Broadcast fired"), bBroadcasted);
+  TestEqual(TEXT("Source army"), Source->ArmyStrength, 5);
+  TestEqual(TEXT("Target army"), Target->ArmyStrength, 2);
+  TestTrue(TEXT("Target owner"), Target->OwningPlayer == PS1);
+
+  return true;
+}


### PR DESCRIPTION
## Summary
- add `ClientBattleResolved` multicast RPC to relay battle results to clients
- update world state and HUDs when battles resolve
- cover battle resolution sync with new multiplayer test

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68aedbdbdd508324b0198cc35e2199c2