### PR TITLE
Replace weak controller array with Blueprint-friendly pointers

### DIFF
--- a/Source/Skald/Skald_GameMode.cpp
+++ b/Source/Skald/Skald_GameMode.cpp
@@ -362,19 +362,16 @@ void ASkaldGameMode::BeginArmyPlacementPhase() {
   TurnManager->SortControllersByInitiative();
 
   // Calculate army pools for each player based on owned territories.
-  for (const TWeakObjectPtr<ASkaldPlayerController> &ControllerPtr :
-       TurnManager->GetControllers()) {
-    if (ASkaldPlayerController *PC = ControllerPtr.Get()) {
-      if (ASkaldPlayerState *PS = PC->GetPlayerState<ASkaldPlayerState>()) {
-        int32 Owned = 0;
-        for (ATerritory *Territory : WorldMap->Territories) {
-          if (Territory && Territory->OwningPlayer == PS) {
-            ++Owned;
-          }
+  for (ASkaldPlayerController* PC : TurnManager->GetControllers()) {
+    if (ASkaldPlayerState* PS = PC ? PC->GetPlayerState<ASkaldPlayerState>() : nullptr) {
+      int32 Owned = 0;
+      for (ATerritory* Territory : WorldMap->Territories) {
+        if (Territory && Territory->OwningPlayer == PS) {
+          ++Owned;
         }
-        PS->ArmyPool = FMath::CeilToInt(Owned / 3.0f);
-        PS->ForceNetUpdate();
       }
+      PS->ArmyPool = FMath::CeilToInt(Owned / 3.0f);
+      PS->ForceNetUpdate();
     }
   }
 
@@ -424,14 +421,12 @@ void ASkaldGameMode::AdvanceArmyPlacement() {
     return;
   }
 
-  const TArray<TWeakObjectPtr<ASkaldPlayerController>> &Controllers =
-      TurnManager->GetControllers();
+  const TArray<ASkaldPlayerController*> Controllers = TurnManager->GetControllers();
   const int32 NumControllers = Controllers.Num();
 
   while (PlacementIndex < NumControllers) {
-    ASkaldPlayerController *PC = Controllers[PlacementIndex].Get();
-    ASkaldPlayerState *PS =
-        PC ? PC->GetPlayerState<ASkaldPlayerState>() : nullptr;
+    ASkaldPlayerController* PC = Controllers[PlacementIndex];
+    ASkaldPlayerState* PS = PC ? PC->GetPlayerState<ASkaldPlayerState>() : nullptr;
     if (!PC || !PS) {
       ++PlacementIndex;
       continue;

--- a/Source/Skald/Skald_PlayerController.cpp
+++ b/Source/Skald/Skald_PlayerController.cpp
@@ -475,16 +475,13 @@ void ASkaldPlayerController::ServerHandleAttack_Implementation(int32 FromID,
   Target->ForceNetUpdate();
 
   if (TurnManager) {
-    for (const TWeakObjectPtr<ASkaldPlayerController> &ControllerPtr :
-         TurnManager->GetControllers()) {
-      if (ASkaldPlayerController *Controller = ControllerPtr.Get()) {
-        if (USkaldMainHUDWidget *HUD = Controller->GetHUDWidget()) {
-          FString OwnerName = Target->OwningPlayer
-                                  ? Target->OwningPlayer->DisplayName
-                                  : TEXT("Neutral");
-          HUD->UpdateTerritoryInfo(Target->TerritoryName, OwnerName,
-                                   Target->ArmyStrength);
-        }
+    for (ASkaldPlayerController* Controller : TurnManager->GetControllers()) {
+      if (USkaldMainHUDWidget* HUD = Controller ? Controller->GetHUDWidget() : nullptr) {
+        FString OwnerName = Target->OwningPlayer
+                                ? Target->OwningPlayer->DisplayName
+                                : TEXT("Neutral");
+        HUD->UpdateTerritoryInfo(Target->TerritoryName, OwnerName,
+                                 Target->ArmyStrength);
       }
     }
   }
@@ -547,21 +544,18 @@ void ASkaldPlayerController::ServerHandleMove_Implementation(int32 FromID,
   }
 
   if (TurnManager) {
-    for (const TWeakObjectPtr<ASkaldPlayerController> &ControllerPtr :
-         TurnManager->GetControllers()) {
-      if (ASkaldPlayerController *Controller = ControllerPtr.Get()) {
-        if (USkaldMainHUDWidget *HUD = Controller->GetHUDWidget()) {
-          FString SourceOwner = Source->OwningPlayer
-                                    ? Source->OwningPlayer->DisplayName
-                                    : TEXT("Neutral");
-          HUD->UpdateTerritoryInfo(Source->TerritoryName, SourceOwner,
-                                   Source->ArmyStrength);
-          FString TargetOwner = Target->OwningPlayer
-                                    ? Target->OwningPlayer->DisplayName
-                                    : TEXT("Neutral");
-          HUD->UpdateTerritoryInfo(Target->TerritoryName, TargetOwner,
-                                   Target->ArmyStrength);
-        }
+    for (ASkaldPlayerController* Controller : TurnManager->GetControllers()) {
+      if (USkaldMainHUDWidget* HUD = Controller ? Controller->GetHUDWidget() : nullptr) {
+        FString SourceOwner = Source->OwningPlayer
+                                  ? Source->OwningPlayer->DisplayName
+                                  : TEXT("Neutral");
+        HUD->UpdateTerritoryInfo(Source->TerritoryName, SourceOwner,
+                                 Source->ArmyStrength);
+        FString TargetOwner = Target->OwningPlayer
+                                  ? Target->OwningPlayer->DisplayName
+                                  : TEXT("Neutral");
+        HUD->UpdateTerritoryInfo(Target->TerritoryName, TargetOwner,
+                                 Target->ArmyStrength);
       }
     }
   }
@@ -593,13 +587,10 @@ void ASkaldPlayerController::ServerSelectTerritory_Implementation(
   Terr->ForceNetUpdate();
 
   if (TurnManager) {
-    for (const TWeakObjectPtr<ASkaldPlayerController> &ControllerPtr :
-         TurnManager->GetControllers()) {
-      if (ASkaldPlayerController *Controller = ControllerPtr.Get()) {
-        if (USkaldMainHUDWidget *HUD = Controller->GetHUDWidget()) {
-          HUD->UpdateTerritoryInfo(Terr->TerritoryName, OwnerName,
-                                   Terr->ArmyStrength);
-        }
+    for (ASkaldPlayerController* Controller : TurnManager->GetControllers()) {
+      if (USkaldMainHUDWidget* HUD = Controller ? Controller->GetHUDWidget() : nullptr) {
+        HUD->UpdateTerritoryInfo(Terr->TerritoryName, OwnerName,
+                                 Terr->ArmyStrength);
       }
     }
   }

--- a/Source/Skald/Skald_TurnManager.cpp
+++ b/Source/Skald/Skald_TurnManager.cpp
@@ -191,6 +191,16 @@ void ATurnManager::SortControllersByInitiative() {
   });
 }
 
+TArray<ASkaldPlayerController*> ATurnManager::GetControllers() const {
+  TArray<ASkaldPlayerController*> Result;
+  for (const TWeakObjectPtr<ASkaldPlayerController>& Ptr : Controllers) {
+    if (Ptr.IsValid()) {
+      Result.Add(Ptr.Get());
+    }
+  }
+  return Result;
+}
+
 void ATurnManager::TriggerGridBattle(const FS_BattlePayload &Battle) {
   FS_BattlePayload SeededBattle = Battle;
   SeededBattle.RandomSeed = FMath::Rand();

--- a/Source/Skald/Skald_TurnManager.h
+++ b/Source/Skald/Skald_TurnManager.h
@@ -70,7 +70,7 @@ public:
 
     /** Access the controllers array in its current initiative order. */
     UFUNCTION(BlueprintCallable, BlueprintPure, Category="Turn")
-    const TArray<TWeakObjectPtr<ASkaldPlayerController>>& GetControllers() const { return Controllers; }
+    TArray<ASkaldPlayerController*> GetControllers() const;
 
     /** Retrieve the current phase of play. */
     UFUNCTION(BlueprintCallable, BlueprintPure, Category="Turn")
@@ -81,7 +81,7 @@ public:
     FSkaldWorldStateChanged OnWorldStateChanged;
 
 protected:
-    UPROPERTY(BlueprintReadOnly, Category="Turn")
+    UPROPERTY()
     TArray<TWeakObjectPtr<ASkaldPlayerController>> Controllers;
 
     UPROPERTY(BlueprintReadOnly, Category="Turn")

--- a/Source/Skald/Tests/TurnManagerTest.cpp
+++ b/Source/Skald/Tests/TurnManagerTest.cpp
@@ -76,10 +76,10 @@ bool FSkaldTurnManagerInitiativeTest::RunTest(const FString& Parameters) {
   TM->RegisterController(PC2);
   TM->SortControllersByInitiative();
 
-  const TArray<TWeakObjectPtr<ASkaldPlayerController>>& Controllers = TM->GetControllers();
+  const TArray<ASkaldPlayerController*> Controllers = TM->GetControllers();
   TestEqual(TEXT("Controller count"), Controllers.Num(), 2);
-  TestTrue(TEXT("Highest initiative first"), Controllers[0].Get() == PC2);
-  TestTrue(TEXT("Lowest initiative second"), Controllers[1].Get() == PC1);
+  TestTrue(TEXT("Highest initiative first"), Controllers[0] == PC2);
+  TestTrue(TEXT("Lowest initiative second"), Controllers[1] == PC1);
 
   return true;
 }


### PR DESCRIPTION
## Summary
- Return array of controller pointers in `ATurnManager::GetControllers` and remove Blueprint exposure on internal weak pointer list
- Update game mode, player controller logic, and tests to iterate using direct controller pointers

## Testing
- `bash Build/validate.sh` *(fails: UnrealBuildTool not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aee024fb1c8324acd6ddc44b35e649