### PR TITLE
Expose gameplay handlers and add territory treasure state

### DIFF
--- a/Source/Skald/Skald_GameMode.h
+++ b/Source/Skald/Skald_GameMode.h
@@ -84,7 +84,7 @@ protected:
   /** Allow players to position initial armies based on initiative. */
   UFUNCTION(BlueprintCallable, Category = "GameMode")
   void BeginArmyPlacementPhase();
-
+public:
   /** Build siege equipment during the engineering phase. */
   UFUNCTION(BlueprintCallable, Category = "Siege")
   int32 BuildSiegeAtTerritory(int32 TerritoryID, E_SiegeWeapons Type);
@@ -93,6 +93,8 @@ protected:
   UFUNCTION(BlueprintCallable, Category = "Siege")
   int32 ConsumeSiege(int32 TerritoryID);
 
+  /** Update cached player resource values. */
+  void UpdatePlayerResources(ASkaldPlayerState *Player);
 private:
   /** Timer that triggers auto-start of the turn sequence. */
   FTimerHandle StartGameTimerHandle;
@@ -115,8 +117,6 @@ private:
   /** Notify HUDs of the current player roster. */
   void RefreshHUDs();
 
-  /** Update cached player resource values. */
-  void UpdatePlayerResources(ASkaldPlayerState *Player);
 
   /** Attempt to initialise the world and start the game flow. */
   void TryInitializeWorldAndStart();

--- a/Source/Skald/Skald_PlayerController.h
+++ b/Source/Skald/Skald_PlayerController.h
@@ -96,6 +96,8 @@ protected:
             meta = (AllowPrivateAccess = "true"))
   USkaldGameInstance *CachedGameInstance;
 
+public:
+
   /** Handle HUD attack submissions.
    *  Bound to USkaldMainHUDWidget::OnAttackRequested in the HUD.
    *  Blueprint widgets invoke this when an attack is submitted.
@@ -193,6 +195,8 @@ protected:
    */
   UPROPERTY(EditInstanceOnly, BlueprintReadOnly, Category = "Turn",
             meta = (ExposeOnSpawn = true))
+
+protected:
   TObjectPtr<ATurnManager> TurnManager;
 
 private:

--- a/Source/Skald/Territory.cpp
+++ b/Source/Skald/Territory.cpp
@@ -117,6 +117,7 @@ void ATerritory::GetLifetimeReplicatedProps(
   DOREPLIFETIME(ATerritory, AdjacentTerritories);
   DOREPLIFETIME(ATerritory, ArmyStrength);
   DOREPLIFETIME(ATerritory, BuiltSiegeID);
+  DOREPLIFETIME(ATerritory, HasTreasure);
 }
 
 void ATerritory::Select() {

--- a/Source/Skald/Territory.h
+++ b/Source/Skald/Territory.h
@@ -70,6 +70,10 @@ public:
     /** ID of siege equipment built in this territory, 0 if none. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Territory", Replicated)
     int32 BuiltSiegeID = 0;
+    /** Whether this territory contains treasure. */
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Territory", Replicated)
+    bool HasTreasure = false;
+
 
     /** Called when the territory is selected. */
     UPROPERTY(BlueprintAssignable, Category = "Territory")

--- a/Source/Skald/Tests/PlayerControllerValidationTest.cpp
+++ b/Source/Skald/Tests/PlayerControllerValidationTest.cpp
@@ -2,6 +2,7 @@
 #include "Tests/AutomationEditorCommon.h"
 #include "Skald_PlayerController.h"
 #include "UI/SkaldMainHUDWidget.h"
+#include "PlayerControllerValidationTest.generated.h"
 
 UCLASS()
 class UTestHUDWidget : public USkaldMainHUDWidget {

--- a/Source/Skald/WorldMap.cpp
+++ b/Source/Skald/WorldMap.cpp
@@ -26,7 +26,7 @@ void AWorldMap::BeginPlay() {
 
     if (TerritoryClass && !TerritoryTable) {
       FActorSpawnParameters Params;
-      Params.Owner = this;
+      Params.StartOwner = this;
       ATerritory *Placeholder = GetWorld()->SpawnActor<ATerritory>(
           TerritoryClass, GetActorLocation(), FRotator::ZeroRotator, Params);
       if (Placeholder) {
@@ -49,7 +49,7 @@ void AWorldMap::BeginPlay() {
     const FVector SpawnLocation = GetActorLocation() + Data->Location;
 
     FActorSpawnParameters Params;
-    Params.Owner = this;
+    Params.StartOwner = this;
     ATerritory *Territory = GetWorld()->SpawnActor<ATerritory>(
         TerritoryClass, SpawnLocation, FRotator::ZeroRotator, Params);
     if (Territory) {
@@ -127,7 +127,7 @@ bool AWorldMap::FindPath(ATerritory *From, ATerritory *To,
     return true;
   }
 
-  ASkaldPlayerState *Owner = From->OwningPlayer;
+  ASkaldPlayerState *StartOwner = From->OwningPlayer;
   TQueue<ATerritory *> Frontier;
   TMap<ATerritory *, ATerritory *> CameFrom;
 
@@ -142,7 +142,7 @@ bool AWorldMap::FindPath(ATerritory *From, ATerritory *To,
     }
 
     for (ATerritory *Neighbor : Current->AdjacentTerritories) {
-      if (!Neighbor || Neighbor->OwningPlayer != Owner ||
+      if (!Neighbor || Neighbor->OwningPlayer != StartOwner ||
           CameFrom.Contains(Neighbor)) {
         continue;
       }


### PR DESCRIPTION
## Summary
- Make siege and resource helpers in `ASkaldGameMode` public
- Expose player controller action and phase handlers
- Track and replicate `HasTreasure` on territories
- Fix tests for world state broadcasts and controller validation
- Avoid owner variable shadowing in world map pathfinding

## Testing
- `./Build.sh` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68aee793e0748324907cfb56bb39cb05