### PR TITLE
Fix TurnManager property declaration

### DIFF
--- a/Source/Skald/Skald_PlayerController.h
+++ b/Source/Skald/Skald_PlayerController.h
@@ -97,7 +97,6 @@ protected:
   USkaldGameInstance *CachedGameInstance;
 
 public:
-
   /** Handle HUD attack submissions.
    *  Bound to USkaldMainHUDWidget::OnAttackRequested in the HUD.
    *  Blueprint widgets invoke this when an attack is submitted.
@@ -193,10 +192,9 @@ public:
    *  turn events without keeping an external pointer that might be
    *  uninitialised.
    */
+protected:
   UPROPERTY(EditInstanceOnly, BlueprintReadOnly, Category = "Turn",
             meta = (ExposeOnSpawn = true))
-
-protected:
   TObjectPtr<ATurnManager> TurnManager;
 
 private:


### PR DESCRIPTION
## Summary
- fix TurnManager UPROPERTY spec placement in player controller

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68af1fb22f7083249cd1bdf35b332368