### PR TITLE
Fix test compilation errors by updating delegate bindings

### DIFF
--- a/Source/Skald/Tests/PlayerControllerValidationTest.cpp
+++ b/Source/Skald/Tests/PlayerControllerValidationTest.cpp
@@ -1,25 +1,16 @@
 #include "Misc/AutomationTest.h"
 #include "Tests/AutomationEditorCommon.h"
-#include "Skald_PlayerController.h"
-#include "UI/SkaldMainHUDWidget.h"
-#include "PlayerControllerValidationTest.generated.h"
+#include "PlayerControllerValidationTest.h"
 
-UCLASS()
-class UTestHUDWidget : public USkaldMainHUDWidget {
-  GENERATED_BODY()
-public:
-  FString LastError;
-  virtual void ShowErrorMessage(const FString &Message) override {
+void UTestHUDWidget::ShowErrorMessage(const FString& Message)
+{
     LastError = Message;
-  }
-};
+}
 
-UCLASS()
-class ATestPlayerController : public ASkaldPlayerController {
-  GENERATED_BODY()
-public:
-  void SetHUD(USkaldMainHUDWidget *InHUD) { MainHudWidget = InHUD; }
-};
+void ATestPlayerController::SetHUD(USkaldMainHUDWidget* InHUD)
+{
+    MainHudWidget = InHUD;
+}
 
 IMPLEMENT_SIMPLE_AUTOMATION_TEST(FSkaldPlayerControllerValidationFeedbackTest,
                                  "Skald.PlayerController.ValidationFeedback",

--- a/Source/Skald/Tests/PlayerControllerValidationTest.h
+++ b/Source/Skald/Tests/PlayerControllerValidationTest.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Skald_PlayerController.h"
+#include "UI/SkaldMainHUDWidget.h"
+#include "PlayerControllerValidationTest.generated.h"
+
+UCLASS()
+class UTestHUDWidget : public USkaldMainHUDWidget
+{
+    GENERATED_BODY()
+public:
+    FString LastError;
+    virtual void ShowErrorMessage(const FString& Message) override;
+};
+
+UCLASS()
+class ATestPlayerController : public ASkaldPlayerController
+{
+    GENERATED_BODY()
+public:
+    void SetHUD(USkaldMainHUDWidget* InHUD);
+};
+


### PR DESCRIPTION
## Summary
- adapt battle resolution sync test to bind dynamic multicast delegate via an object listener
- split player controller validation helper classes into a header so UHT generates required code

## Testing
- `bash Build/validate.sh` (UnrealBuildTool not found; skipping compile check. UnrealEditor not found; cannot run tests.)

------
https://chatgpt.com/codex/tasks/task_e_68af26604d208324b14223a7073fc156