### PR TITLE
Fix test helper compile error and actor spawn parameters

### DIFF
--- a/Source/Skald/Tests/BattleResolutionSyncTest.cpp
+++ b/Source/Skald/Tests/BattleResolutionSyncTest.cpp
@@ -1,3 +1,4 @@
+#include "CoreMinimal.h"
 #include "Misc/AutomationTest.h"
 #include "Tests/AutomationEditorCommon.h"
 #include "Skald_TurnManager.h"

--- a/Source/Skald/WorldMap.cpp
+++ b/Source/Skald/WorldMap.cpp
@@ -26,7 +26,7 @@ void AWorldMap::BeginPlay() {
 
     if (TerritoryClass && !TerritoryTable) {
       FActorSpawnParameters Params;
-      Params.StartOwner = this;
+      Params.Owner = this;
       ATerritory *Placeholder = GetWorld()->SpawnActor<ATerritory>(
           TerritoryClass, GetActorLocation(), FRotator::ZeroRotator, Params);
       if (Placeholder) {
@@ -49,7 +49,7 @@ void AWorldMap::BeginPlay() {
     const FVector SpawnLocation = GetActorLocation() + Data->Location;
 
     FActorSpawnParameters Params;
-    Params.StartOwner = this;
+    Params.Owner = this;
     ATerritory *Territory = GetWorld()->SpawnActor<ATerritory>(
         TerritoryClass, SpawnLocation, FRotator::ZeroRotator, Params);
     if (Territory) {


### PR DESCRIPTION
## Summary
- include `CoreMinimal.h` in BattleResolutionSyncTest to enable `UCLASS`
- set actor spawn `Owner` instead of removed `StartOwner` in `WorldMap`

## Testing
- `./Build/validate.sh` *(fails: UnrealBuildTool not found; UnrealEditor not found)*

------
https://chatgpt.com/codex/tasks/task_e_68af299e4a70832487436b836f192832