### PR TITLE
Fix BattleResolutionSyncTest compile error

### DIFF
--- a/Source/Skald/Tests/BattleResolutionSyncTest.cpp
+++ b/Source/Skald/Tests/BattleResolutionSyncTest.cpp
@@ -5,23 +5,7 @@
 #include "Skald_PlayerState.h"
 #include "Territory.h"
 #include "WorldMap.h"
-
-// Helper object to bind to the turn manager's dynamic multicast delegate
-// which cannot directly accept lambda functions.
-UCLASS()
-class UWorldStateChangedListener : public UObject
-{
-  GENERATED_BODY()
-
-public:
-  bool bBroadcasted = false;
-
-  UFUNCTION()
-  void HandleBroadcast()
-  {
-    bBroadcasted = true;
-  }
-};
+#include "BattleResolutionSyncTest.h"
 
 IMPLEMENT_SIMPLE_AUTOMATION_TEST(FSkaldBattleResolutionSyncTest, "Skald.Multiplayer.BattleResolutionSync", EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
 bool FSkaldBattleResolutionSyncTest::RunTest(const FString& Parameters) {

--- a/Source/Skald/Tests/BattleResolutionSyncTest.h
+++ b/Source/Skald/Tests/BattleResolutionSyncTest.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "BattleResolutionSyncTest.generated.h"
+
+/**
+ * Helper object to listen for world state change broadcasts.
+ */
+UCLASS()
+class UWorldStateChangedListener : public UObject
+{
+    GENERATED_BODY()
+
+public:
+    bool bBroadcasted = false;
+
+    UFUNCTION()
+    void HandleBroadcast()
+    {
+        bBroadcasted = true;
+    }
+};
+


### PR DESCRIPTION
## Summary
- Move UWorldStateChangedListener into a header to be processed by UnrealHeaderTool
- Include the new header in BattleResolutionSyncTest and remove inline class definition

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68af2c8fb95083249a7cdf699bdf3531