### PR TITLE
Fix test include order and add UnrealEd dependency

### DIFF
--- a/Source/Skald/Skald.Build.cs
+++ b/Source/Skald/Skald.Build.cs
@@ -32,6 +32,11 @@ public class Skald : ModuleRules
                         ModuleDirectory
                 });
 
+                if (Target.bBuildEditor)
+                {
+                        PrivateDependencyModuleNames.Add("UnrealEd");
+                }
+
                 // To include OnlineSubsystemSteam, add it to the plugins section in your uproject file with the Enabled attribute set to true
         }
 }

--- a/Source/Skald/Tests/BattleResolutionSyncTest.cpp
+++ b/Source/Skald/Tests/BattleResolutionSyncTest.cpp
@@ -1,11 +1,11 @@
-#include "CoreMinimal.h"
+#include "BattleResolutionSyncTest.h"
+
 #include "Misc/AutomationTest.h"
 #include "Tests/AutomationEditorCommon.h"
 #include "Skald_TurnManager.h"
 #include "Skald_PlayerState.h"
 #include "Territory.h"
 #include "WorldMap.h"
-#include "BattleResolutionSyncTest.h"
 
 IMPLEMENT_SIMPLE_AUTOMATION_TEST(FSkaldBattleResolutionSyncTest, "Skald.Multiplayer.BattleResolutionSync", EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
 bool FSkaldBattleResolutionSyncTest::RunTest(const FString& Parameters) {

--- a/Source/Skald/Tests/PlayerControllerValidationTest.cpp
+++ b/Source/Skald/Tests/PlayerControllerValidationTest.cpp
@@ -1,6 +1,7 @@
+#include "PlayerControllerValidationTest.h"
+
 #include "Misc/AutomationTest.h"
 #include "Tests/AutomationEditorCommon.h"
-#include "PlayerControllerValidationTest.h"
 
 void UTestHUDWidget::ShowErrorMessage(const FString& Message)
 {


### PR DESCRIPTION
## Summary
- Ensure test source files include their own headers first
- Add UnrealEd as an editor-only dependency for automation utilities

## Testing
- `bash Build/validate.sh` *(fails: UnrealBuildTool not found; skipping compile check. UnrealEditor not found; cannot run tests.)*

------
https://chatgpt.com/codex/tasks/task_e_68af30a1d69083248ced4723d12f9778