### PR TITLE
Trim TerritoryTable to 43 territories

### DIFF
--- a/Content/DataTables/TerritoryTable.csv
+++ b/Content/DataTables/TerritoryTable.csv
@@ -1,88 +1,44 @@
-TerritoryID,TerritoryName,bIsCapital,ContinentID,LocationX,LocationY,LocationZ,AdjacentTerritoryIDs
-0,Howling Veil,True,0,-600.0,-600.0,0.0,1;7
-1,Thond,False,0,-400.0,-600.0,0.0,0;2;8
-2,Elmyre,False,0,-200.0,-600.0,0.0,1;3;9
-3,Skarlstorm,False,0,0.0,-600.0,0.0,2;4;10
-4,Direford,False,0,200.0,-600.0,0.0,3;5;11
-5,Grimrest,False,0,400.0,-600.0,0.0,4;6;12
-6,Lakehold,False,0,600.0,-600.0,0.0,5;13
-7,Argoth,False,0,-600.0,-400.0,0.0,0;8;14
-8,Chala,False,1,-400.0,-400.0,0.0,1;7;9;15
-9,Rylan,False,1,-200.0,-400.0,0.0,2;8;10;16
-10,Uris,False,1,0.0,-400.0,0.0,3;9;11;17
-11,Achre,True,1,200.0,-400.0,0.0,4;10;12;18
-12,Erif,False,2,400.0,-400.0,0.0,5;11;13;19
-13,Nevar,False,1,600.0,-400.0,0.0,6;12;20
-14,Frayton,False,0,-600.0,-200.0,0.0,7;15;21
-15,Past Fields,False,1,-400.0,-200.0,0.0,8;14;16;22
-16,Spring Isle,False,1,-200.0,-200.0,0.0,9;15;17;23
-17,Sunder Isle,False,2,0.0,-200.0,0.0,10;16;18;24
-18,Sugiria,True,2,200.0,-200.0,0.0,11;17;19;25
-19,Blindshade,False,2,400.0,-200.0,0.0,12;18;20;26
-20,Whimswallow,False,2,600.0,-200.0,0.0,13;19;27
-21,Forgotten Coast,False,2,-600.0,0.0,0.0,14;22;28
-22,Oria,False,2,-400.0,0.0,0.0,15;21;23;29
-23,Brell,False,3,-200.0,0.0,0.0,16;22;24;30
-24,Revel,True,3,0.0,0.0,0.0,17;23;25;31
-25,Velaria,False,3,200.0,0.0,0.0,18;24;26;32
-26,Essivar,False,3,400.0,0.0,0.0,19;25;27;33
-27,Caldemire,False,3,600.0,0.0,0.0,20;26;34
-28,HazelHallow,False,4,-600.0,200.0,0.0,21;29;35
-29,Sirholde,False,4,-400.0,200.0,0.0,22;28;30;36
-30,Styr,False,4,-200.0,200.0,0.0,23;29;31;37
-31,Dawnmere,True,4,0.0,200.0,0.0,24;30;32;38
-32,Killbrooke,False,4,200.0,200.0,0.0,25;31;33;39
-33,Broken Plains,False,5,400.0,200.0,0.0,26;32;34;40
-34,Everlands,False,5,600.0,200.0,0.0,27;33;41
-35,Vigilmoore,False,5,-600.0,400.0,0.0,28;36;42
-36,Vulkrum,False,5,-400.0,400.0,0.0,29;35;37
-37,Timber Rock,False,5,-200.0,400.0,0.0,30;36;38
-38,Omenwhick,False,5,0.0,400.0,0.0,31;37;39
-39,Armens Grasp,False,5,200.0,400.0,0.0,32;38;40
-40,Volkridge,True,5,400.0,400.0,0.0,33;39;41
-41,Bakas,False,5,600.0,400.0,0.0,34;40
-42,Kesis,False,5,-600.0,600.0,0.0,35
-Name,TerritoryID,TerritoryName,bIsCapital,ContinentID,Location.X,Location.Y,Location.Z,AdjacentTerritoryIDs
-0,0,Howling Veil,True,0,-600.0,-600.0,0.0,"1;7"
-1,1,Thond,False,0,-400.0,-600.0,0.0,"0;2;8"
-2,2,Elmyre,False,0,-200.0,-600.0,0.0,"1;3;9"
-3,3,Skarlstorm,False,0,0.0,-600.0,0.0,"2;4;10"
-4,4,Direford,False,0,200.0,-600.0,0.0,"3;5;11"
-5,5,Grimrest,False,0,400.0,-600.0,0.0,"4;6;12"
-6,6,Lakehold,False,0,600.0,-600.0,0.0,"5;13"
-7,7,Argoth,False,0,-600.0,-400.0,0.0,"0;8;14"
-8,8,Chala,False,1,-400.0,-400.0,0.0,"1;7;9;15"
-9,9,Rylan,False,1,-200.0,-400.0,0.0,"2;8;10;16"
-10,10,Uris,False,1,0.0,-400.0,0.0,"3;9;11;17"
-11,11,Achre,True,1,200.0,-400.0,0.0,"4;10;12;18"
-12,12,Erif,False,2,400.0,-400.0,0.0,"5;11;13;19"
-13,13,Nevar,False,1,600.0,-400.0,0.0,"6;12;20"
-14,14,Frayton,False,0,-600.0,-200.0,0.0,"7;15;21"
-15,15,Past Fields,False,1,-400.0,-200.0,0.0,"8;14;16;22"
-16,16,Spring Isle,False,1,-200.0,-200.0,0.0,"9;15;17;23"
-17,17,Sunder Isle,False,2,0.0,-200.0,0.0,"10;16;18;24"
-18,18,Sugiria,True,2,200.0,-200.0,0.0,"11;17;19;25"
-19,19,Blindshade,False,2,400.0,-200.0,0.0,"12;18;20;26"
-20,20,Whimswallow,False,2,600.0,-200.0,0.0,"13;19;27"
-21,21,Forgotten Coast,False,2,-600.0,0.0,0.0,"14;22;28"
-22,22,Oria,False,2,-400.0,0.0,0.0,"15;21;23;29"
-23,23,Brell,False,3,-200.0,0.0,0.0,"16;22;24;30"
-24,24,Revel,True,3,0.0,0.0,0.0,"17;23;25;31"
-25,25,Velaria,False,3,200.0,0.0,0.0,"18;24;26;32"
-26,26,Essivar,False,3,400.0,0.0,0.0,"19;25;27;33"
-27,27,Caldemire,False,3,600.0,0.0,0.0,"20;26;34"
-28,28,HazelHallow,False,4,-600.0,200.0,0.0,"21;29;35"
-29,29,Sirholde,False,4,-400.0,200.0,0.0,"22;28;30;36"
-30,30,Styr,False,4,-200.0,200.0,0.0,"23;29;31;37"
-31,31,Dawnmere,True,4,0.0,200.0,0.0,"24;30;32;38"
-32,32,Killbrooke,False,4,200.0,200.0,0.0,"25;31;33;39"
-33,33,Broken Plains,False,5,400.0,200.0,0.0,"26;32;34;40"
-34,34,Everlands,False,5,600.0,200.0,0.0,"27;33;41"
-35,35,Vigilmoore,False,5,-600.0,400.0,0.0,"28;36;42"
-36,36,Vulkrum,False,5,-400.0,400.0,0.0,"29;35;37"
-37,37,Timber Rock,False,5,-200.0,400.0,0.0,"30;36;38"
-38,38,Omenwhick,False,5,0.0,400.0,0.0,"31;37;39"
-39,39,Armens Grasp,False,5,200.0,400.0,0.0,"32;38;40"
-40,40,Volkridge,True,5,400.0,400.0,0.0,"33;39;41"
-41,41,Bakas,False,5,600.0,400.0,0.0,"34;40"
-42,42,Kesis,False,5,-600.0,600.0,0.0,"35"
+Name,TerritoryID,TerritoryName,bIsCapital,ContinentID,Location,AdjacentTerritoryIDs
+T0,0,Howling Veil,True,0,X=-600.0 Y=-600.0 Z=0.0,1;7
+T1,1,Thond,False,0,X=-400.0 Y=-600.0 Z=0.0,0;2;8
+T2,2,Elmyre,False,0,X=-200.0 Y=-600.0 Z=0.0,1;3;9
+T3,3,Skarlstorm,False,0,X=0.0 Y=-600.0 Z=0.0,2;4;10
+T4,4,Direford,False,0,X=200.0 Y=-600.0 Z=0.0,3;5;11
+T5,5,Grimrest,False,0,X=400.0 Y=-600.0 Z=0.0,4;6;12
+T6,6,Lakehold,False,0,X=600.0 Y=-600.0 Z=0.0,5;13
+T7,7,Argoth,False,0,X=-600.0 Y=-400.0 Z=0.0,0;8;14
+T8,8,Chala,False,1,X=-400.0 Y=-400.0 Z=0.0,1;7;9;15
+T9,9,Rylan,False,1,X=-200.0 Y=-400.0 Z=0.0,2;8;10;16
+T10,10,Uris,False,1,X=0.0 Y=-400.0 Z=0.0,3;9;11;17
+T11,11,Achre,True,1,X=200.0 Y=-400.0 Z=0.0,4;10;12;18
+T12,12,Erif,False,2,X=400.0 Y=-400.0 Z=0.0,5;11;13;19
+T13,13,Nevar,False,1,X=600.0 Y=-400.0 Z=0.0,6;12;20
+T14,14,Frayton,False,0,X=-600.0 Y=-200.0 Z=0.0,7;15;21
+T15,15,Past Fields,False,1,X=-400.0 Y=-200.0 Z=0.0,8;14;16;22
+T16,16,Spring Isle,False,1,X=-200.0 Y=-200.0 Z=0.0,9;15;17;23
+T17,17,Sunder Isle,False,2,X=0.0 Y=-200.0 Z=0.0,10;16;18;24
+T18,18,Sugiria,True,2,X=200.0 Y=-200.0 Z=0.0,11;17;19;25
+T19,19,Blindshade,False,2,X=400.0 Y=-200.0 Z=0.0,12;18;20;26
+T20,20,Whimswallow,False,2,X=600.0 Y=-200.0 Z=0.0,13;19;27
+T21,21,Forgotten Coast,False,2,X=-600.0 Y=0.0 Z=0.0,14;22;28
+T22,22,Oria,False,2,X=-400.0 Y=0.0 Z=0.0,15;21;23;29
+T23,23,Brell,False,3,X=-200.0 Y=0.0 Z=0.0,16;22;24;30
+T24,24,Revel,True,3,X=0.0 Y=0.0 Z=0.0,17;23;25;31
+T25,25,Velaria,False,3,X=200.0 Y=0.0 Z=0.0,18;24;26;32
+T26,26,Essivar,False,3,X=400.0 Y=0.0 Z=0.0,19;25;27;33
+T27,27,Caldemire,False,3,X=600.0 Y=0.0 Z=0.0,20;26;34
+T28,28,HazelHallow,False,4,X=-600.0 Y=200.0 Z=0.0,21;29;35
+T29,29,Sirholde,False,4,X=-400.0 Y=200.0 Z=0.0,22;28;30;36
+T30,30,Styr,False,4,X=-200.0 Y=200.0 Z=0.0,23;29;31;37
+T31,31,Dawnmere,True,4,X=0.0 Y=200.0 Z=0.0,24;30;32;38
+T32,32,Killbrooke,False,4,X=200.0 Y=200.0 Z=0.0,25;31;33;39
+T33,33,Broken Plains,False,5,X=400.0 Y=200.0 Z=0.0,26;32;34;40
+T34,34,Everlands,False,5,X=600.0 Y=200.0 Z=0.0,27;33;41
+T35,35,Vigilmoore,False,5,X=-600.0 Y=400.0 Z=0.0,28;36;42
+T36,36,Vulkrum,False,5,X=-400.0 Y=400.0 Z=0.0,29;35;37
+T37,37,Timber Rock,False,5,X=-200.0 Y=400.0 Z=0.0,30;36;38
+T38,38,Omenwhick,False,5,X=0.0 Y=400.0 Z=0.0,31;37;39
+T39,39,Armens Grasp,False,5,X=200.0 Y=400.0 Z=0.0,32;38;40
+T40,40,Volkridge,True,5,X=400.0 Y=400.0 Z=0.0,33;39;41
+T41,41,Bakas,False,5,X=600.0 Y=400.0 Z=0.0,34;40
+T42,42,Kesis,False,5,X=-600.0 Y=600.0 Z=0.0,35


### PR DESCRIPTION
## Summary
- collapse TerritoryTable to a single dataset of 43 territories
- unify schema with "Name,TerritoryID,TerritoryName,bIsCapital,ContinentID,Location,AdjacentTerritoryIDs"

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68af6d48de1c8324a4a980a0fa5a4d6f