### PR TITLE
Randomize territory spawns and store locations

### DIFF
--- a/Source/Skald/WorldMap.cpp
+++ b/Source/Skald/WorldMap.cpp
@@ -39,14 +39,18 @@ void AWorldMap::BeginPlay() {
     return;
   }
 
-  // Spawn territories defined in the data table.
+  // Spawn territories defined in the data table at random locations.
   TArray<FTerritorySpawnData *> Rows;
   TerritoryTable->GetAllRows(TEXT("TerritoryTable"), Rows);
   for (const FTerritorySpawnData *Data : Rows) {
     if (!Data) {
       continue;
     }
-    const FVector SpawnLocation = GetActorLocation() + Data->Location;
+
+    const float RandX = FMath::FRandRange(SpawnAreaMin.X, SpawnAreaMax.X);
+    const float RandY = FMath::FRandRange(SpawnAreaMin.Y, SpawnAreaMax.Y);
+    const FVector SpawnLocation =
+        GetActorLocation() + FVector(RandX, RandY, 0.f);
 
     FActorSpawnParameters Params;
     Params.Owner = this;
@@ -58,6 +62,8 @@ void AWorldMap::BeginPlay() {
       Territory->bIsCapital = Data->bIsCapital;
       Territory->ContinentID = Data->ContinentID;
       RegisterTerritory(Territory);
+
+      SpawnedLocations.Add(Data->TerritoryID, SpawnLocation);
     }
   }
 

--- a/Source/Skald/WorldMap.h
+++ b/Source/Skald/WorldMap.h
@@ -115,5 +115,9 @@ public:
   UPROPERTY(EditAnywhere, Category = "WorldMap")
   float AdjacencyDistance = 210.f;
 
+  /** Randomly generated spawn locations keyed by territory ID. */
+  UPROPERTY(BlueprintReadOnly, Category = "WorldMap")
+  TMap<int32, FVector> SpawnedLocations;
+
 protected:
 };


### PR DESCRIPTION
## Summary
- Spawn territories at random positions within the defined area instead of using table locations
- Store spawned territory locations keyed by ID for reuse

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68af8b0d4a088324b4a659053affeaf0