### PR TITLE
Persist territory positions in saves

### DIFF
--- a/Source/Skald/SkaldTypes.h
+++ b/Source/Skald/SkaldTypes.h
@@ -221,6 +221,9 @@ struct SKALD_API FS_Territory
     UPROPERTY(BlueprintReadWrite, EditAnywhere)
     int32 ContinentID = 0;
 
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, SaveGame)
+    FVector Location = FVector::ZeroVector;
+
     UPROPERTY(BlueprintReadWrite, EditAnywhere)
     bool HasTreasure = false;
 

--- a/Source/Skald/Skald_GameMode.cpp
+++ b/Source/Skald/Skald_GameMode.cpp
@@ -324,6 +324,7 @@ void ASkaldGameMode::ApplyLoadedGame(USkaldSaveGame *LoadedGame) {
     Territory->bIsCapital = TerrData.IsCapital;
     Territory->ContinentID = TerrData.ContinentID;
     Territory->BuiltSiegeID = TerrData.BuiltSiegeID;
+    Territory->SetActorLocation(TerrData.Location);
     Territory->RefreshAppearance();
     Territory->ForceNetUpdate();
   }
@@ -677,6 +678,7 @@ void ASkaldGameMode::FillSaveGame(USkaldSaveGame *SaveGameObject) const {
           TerrData.AdjacentIDs.Add(Adj->TerritoryID);
         }
       }
+      TerrData.Location = Territory->GetActorLocation();
       TerrData.BuiltSiegeID = Territory->BuiltSiegeID;
       SaveGameObject->Territories.Add(TerrData);
     }


### PR DESCRIPTION
## Summary
- Track a `FVector` location for each territory
- Save and restore territory positions in `Skald_GameMode`

## Testing
- `Build/validate.sh` *(fails: UnrealBuildTool not found; UnrealEditor not found)*

------
https://chatgpt.com/codex/tasks/task_e_68af8e1aac1483248902403930a5ea70