### PR TITLE
Add configurable territory visuals and capital mesh defaults

### DIFF
--- a/Source/Skald/Territory.h
+++ b/Source/Skald/Territory.h
@@ -11,6 +11,7 @@ class UStaticMesh;
 class UStaticMeshComponent;
 class UPrimitiveComponent;
 class UMaterialInstanceDynamic;
+class UMaterialInterface;
 class UTextRenderComponent;
 
 DECLARE_DYNAMIC_MULTICAST_DELEGATE_OneParam(FTerritorySelectedSignature, ATerritory*, Territory);
@@ -51,8 +52,16 @@ public:
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Territory", Replicated)
     bool bIsCapital = false;
 
+    /** Base mesh asset used for the territory. */
+    UPROPERTY(EditDefaultsOnly, BlueprintReadWrite, Category = "Territory")
+    UStaticMesh* TerritoryMeshAsset = nullptr;
+
+    /** Material applied to the territory mesh. */
+    UPROPERTY(EditDefaultsOnly, BlueprintReadWrite, Category = "Territory")
+    UMaterialInterface* TerritoryMaterial = nullptr;
+
     /** Mesh asset used to mark this territory as a capital. */
-    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Territory")
+    UPROPERTY(EditDefaultsOnly, BlueprintReadWrite, Category = "Territory")
     UStaticMesh* CapitalMeshAsset = nullptr;
 
     /** Optional identifier describing which continent this territory belongs to. */


### PR DESCRIPTION
## Summary
- allow blueprints to override territory mesh and material assets
- load default plane, neutral material, and capital cone assets in the territory constructor
- ensure mesh and material assignments honor editable properties at runtime

## Testing
- `pytest` *(fails: command not found)*
- `pip install pytest` *(fails: externally-managed-environment)*

------
https://chatgpt.com/codex/tasks/task_e_68af8eecb9b88324a99d041767e35b6a