### PR TITLE
Fix compile error by avoiding call to protected function

### DIFF
--- a/Source/Skald/Skald_GameMode.cpp
+++ b/Source/Skald/Skald_GameMode.cpp
@@ -230,7 +230,6 @@ void ASkaldGameMode::TryInitializeWorldAndStart() {
       bTurnsStarted = true;
       TurnManager->SortControllersByInitiative();
       TurnManager->StartTurns();
-      TurnManager->BroadcastCurrentPhase();
 
       if (GEngine) {
         GEngine->AddOnScreenDebugMessage(-1, 4.f, FColor::Green,


### PR DESCRIPTION
## Summary
- Avoid calling ATurnManager::BroadcastCurrentPhase from game mode to prevent access violation

## Testing
- `bash Build/validate.sh` *(fails: UnrealBuildTool not found; UnrealEditor not found)*

------
https://chatgpt.com/codex/tasks/task_e_68af95d2cfe48324b2893e6082435ccd