### PR TITLE
Provide fallback territory assets and redirect legacy player data struct

### DIFF
--- a/Config/DefaultEngine.ini
+++ b/Config/DefaultEngine.ini
@@ -259,3 +259,8 @@ ConnectionType=USBOnly
 bUseManualIPAddress=False
 ManualIPAddress=
 
+[CoreRedirects]
+; Redirect old blueprint struct used for player data to the new C++ struct
+; to prevent load errors when legacy assets are opened.
+StructRedirects=(OldName="/Game/Blueprints/Structs/PlayerSaveStruct.PlayerSaveStruct",NewName="/Script/Skald.S_PlayerData")
+

--- a/Source/Skald/Territory.cpp
+++ b/Source/Skald/Territory.cpp
@@ -8,6 +8,7 @@
 #include "SkaldTypes.h"
 #include "Skald_PlayerController.h"
 #include "Skald_PlayerState.h"
+#include "UObject/ConstructorHelpers.h"
 
 namespace {
 FLinearColor GetFactionColor(ESkaldFaction Faction) {
@@ -39,6 +40,20 @@ ATerritory::ATerritory() {
   bReplicates = true;
   MeshComponent = CreateDefaultSubobject<UStaticMeshComponent>(TEXT("Mesh"));
   RootComponent = MeshComponent;
+
+  // Provide basic visuals so the world map can function even if assets
+  // are missing in the editor. This avoids runtime errors about missing
+  // meshes or materials when spawning territories.
+  static ConstructorHelpers::FObjectFinder<UStaticMesh> DefaultMesh(
+      TEXT("/Engine/BasicShapes/Sphere.Sphere"));
+  if (DefaultMesh.Succeeded()) {
+    MeshComponent->SetStaticMesh(DefaultMesh.Object);
+  }
+  static ConstructorHelpers::FObjectFinder<UMaterialInterface> DefaultMat(
+      TEXT("/Engine/BasicShapes/BasicShapeMaterial.BasicShapeMaterial"));
+  if (DefaultMat.Succeeded()) {
+    MeshComponent->SetMaterial(0, DefaultMat.Object);
+  }
 
   LabelComponent = CreateDefaultSubobject<UTextRenderComponent>(TEXT("Label"));
   LabelComponent->SetupAttachment(RootComponent);


### PR DESCRIPTION
## Summary
- Ensure Territory actors spawn with basic mesh and material to avoid missing asset errors
- Redirect old PlayerSaveStruct blueprint references to new S_PlayerData struct

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68af9775ad948324b58281ed46d7ef2f