### PR TITLE
Register initial controllers and default world map class

### DIFF
--- a/Source/Skald/Skald_GameMode.cpp
+++ b/Source/Skald/Skald_GameMode.cpp
@@ -57,6 +57,14 @@ void ASkaldGameMode::BeginPlay() {
     }
   }
 
+  for (FConstPlayerControllerIterator It =
+           GetWorld()->GetPlayerControllerIterator();
+       It; ++It) {
+    if (ASkaldPlayerController *PC = Cast<ASkaldPlayerController>(*It)) {
+      RegisterPlayer(PC);
+    }
+  }
+
   if (USkaldGameInstance *GI = GetGameInstance<USkaldGameInstance>()) {
     if (GI->LoadedSaveGame) {
       ApplyLoadedGame(GI->LoadedSaveGame);
@@ -64,6 +72,9 @@ void ASkaldGameMode::BeginPlay() {
       return;
     }
   }
+
+  PopulateAIPlayers();
+  RefreshHUDs();
 
   TryInitializeWorldAndStart();
 }
@@ -90,7 +101,9 @@ void ASkaldGameMode::RegisterPlayer(ASkaldPlayerController *PC) {
 
   if (ASkaldGameState *GS = GetGameState<ASkaldGameState>()) {
     if (ASkaldPlayerState *PS = PC->GetPlayerState<ASkaldPlayerState>()) {
-      GS->AddPlayerState(PS);
+      if (!GS->PlayerArray.Contains(PS)) {
+        GS->AddPlayerState(PS);
+      }
 
       if (PlayersData.Num() < GS->PlayerArray.Num()) {
         PlayersData.SetNum(GS->PlayerArray.Num());

--- a/Source/Skald/Skald_TurnManager.cpp
+++ b/Source/Skald/Skald_TurnManager.cpp
@@ -43,7 +43,7 @@ void ATurnManager::BeginPlay() {
 }
 
 void ATurnManager::RegisterController(ASkaldPlayerController *Controller) {
-  if (IsValid(Controller)) {
+  if (IsValid(Controller) && !Controllers.Contains(Controller)) {
     Controllers.Add(Controller);
     Controller->SetTurnManager(this);
   }

--- a/Source/Skald/WorldMap.cpp
+++ b/Source/Skald/WorldMap.cpp
@@ -13,6 +13,7 @@
 AWorldMap::AWorldMap() {
   PrimaryActorTick.bCanEverTick = false;
   SelectedTerritory = nullptr;
+  TerritoryClass = ATerritory::StaticClass();
 }
 
 void AWorldMap::BeginPlay() {


### PR DESCRIPTION
## Summary
- Automatically register existing player controllers when the game mode begins so turn logic has valid controllers
- Avoid registering the same controller twice in the turn manager and game mode
- Provide a default territory class for the world map to prevent missing-class errors

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68af9d172a388324bf55a75051b7c852