### PR TITLE
Unify gameplay map travel

### DIFF
--- a/Source/Skald/PlayerSetupWidget.cpp
+++ b/Source/Skald/PlayerSetupWidget.cpp
@@ -1,65 +1,38 @@
 #include "PlayerSetupWidget.h"
+#include "GameFramework/PlayerController.h"
+#include "Kismet/GameplayStatics.h"
 #include "Skald_GameInstance.h"
 #include "Skald_PlayerState.h"
-#include "Kismet/GameplayStatics.h"
-#include "GameFramework/PlayerController.h"
+#include "StartGameWidget.h"
 
-void UPlayerSetupWidget::NativeConstruct()
-{
-    Super::NativeConstruct();
-    // UI is expected to be created in Blueprint or elsewhere.
-    // Defaults
-    SelectedFaction = ESkaldFaction::None;
-    DisplayName = TEXT("Player");
-    bMultiplayer = false;
+void UPlayerSetupWidget::NativeConstruct() {
+  Super::NativeConstruct();
+  // UI is expected to be created in Blueprint or elsewhere.
+  // Defaults
+  SelectedFaction = ESkaldFaction::None;
+  DisplayName = TEXT("Player");
+  bMultiplayer = false;
 }
 
-void UPlayerSetupWidget::OnFactionSelected(ESkaldFaction NewFaction)
-{
-    SelectedFaction = NewFaction;
+void UPlayerSetupWidget::OnFactionSelected(ESkaldFaction NewFaction) {
+  SelectedFaction = NewFaction;
 }
 
-void UPlayerSetupWidget::OnConfirm()
-{
-    if (UWorld* World = GetWorld())
-    {
-        if (USkaldGameInstance* GI = World->GetGameInstance<USkaldGameInstance>())
-        {
-            GI->DisplayName = DisplayName;
-            GI->Faction = SelectedFaction;
-            GI->bIsMultiplayer = bMultiplayer;
-        }
-
-        if (APlayerController* PC = GetOwningPlayer())
-        {
-            if (ASkaldPlayerState* PS = PC->GetPlayerState<ASkaldPlayerState>())
-            {
-                PS->DisplayName = DisplayName;
-                PS->Faction = SelectedFaction;
-            }
-
-            PC->SetInputMode(FInputModeGameOnly());
-            PC->bShowMouseCursor = false;
-            PC->bEnableClickEvents = false;
-            PC->bEnableMouseOverEvents = false;
-
-            // Launch the main gameplay map once setup is confirmed
-            FName LevelName(TEXT("Skald_OverTop"));
-            FString Options;
-            if (bMultiplayer)
-            {
-                Options = TEXT("listen");
-            }
-            if (UWorld* WorldToTravel = GetWorld())
-            {
-                FString URL = LevelName.ToString();
-                if (!Options.IsEmpty())
-                {
-                    URL += TEXT("?") + Options;
-                }
-                WorldToTravel->ServerTravel(URL);
-            }
-        }
+void UPlayerSetupWidget::OnConfirm() {
+  if (UWorld *World = GetWorld()) {
+    if (USkaldGameInstance *GI = World->GetGameInstance<USkaldGameInstance>()) {
+      GI->DisplayName = DisplayName;
+      GI->Faction = SelectedFaction;
+      GI->bIsMultiplayer = bMultiplayer;
     }
-}
 
+    if (APlayerController *PC = GetOwningPlayer()) {
+      if (ASkaldPlayerState *PS = PC->GetPlayerState<ASkaldPlayerState>()) {
+        PS->DisplayName = DisplayName;
+        PS->Faction = SelectedFaction;
+      }
+
+      UStartGameWidget::TravelToGameplayMap(PC, bMultiplayer);
+    }
+  }
+}

--- a/Source/Skald/StartGameWidget.cpp
+++ b/Source/Skald/StartGameWidget.cpp
@@ -1,319 +1,272 @@
 #include "StartGameWidget.h"
 
 #include "Components/Button.h"
-#include "Components/EditableTextBox.h"
 #include "Components/ComboBoxString.h"
+#include "Components/EditableTextBox.h"
+#include "Engine/Engine.h"
+#include "GameFramework/PlayerController.h"
 #include "Kismet/GameplayStatics.h"
+#include "LobbyMenuWidget.h"
 #include "Skald_GameInstance.h"
 #include "Skald_PlayerState.h"
-#include "GameFramework/PlayerController.h"
-#include "LobbyMenuWidget.h"
-#include "Engine/Engine.h"
 
-void UStartGameWidget::SetLobbyMenu(ULobbyMenuWidget* InMenu)
-{
-    OwningLobbyMenu = InMenu;
+void UStartGameWidget::SetLobbyMenu(ULobbyMenuWidget *InMenu) {
+  OwningLobbyMenu = InMenu;
 }
 
-void UStartGameWidget::NativeConstruct()
-{
-    Super::NativeConstruct();
+void UStartGameWidget::NativeConstruct() {
+  Super::NativeConstruct();
 
-    if (DisplayNameBox)
-    {
-        DisplayNameBox->SetText(FText::GetEmpty());
-        DisplayNameBox->OnTextChanged.AddDynamic(this, &UStartGameWidget::OnDisplayNameChanged);
-    }
+  if (DisplayNameBox) {
+    DisplayNameBox->SetText(FText::GetEmpty());
+    DisplayNameBox->OnTextChanged.AddDynamic(
+        this, &UStartGameWidget::OnDisplayNameChanged);
+  }
 
-    if (FactionComboBox)
-    {
-        RefreshFactionOptions();
-        FactionComboBox->OnSelectionChanged.AddDynamic(this, &UStartGameWidget::OnFactionChanged);
-    }
-
-    if (USkaldGameInstance* GI = GetWorld()->GetGameInstance<USkaldGameInstance>())
-    {
-        GI->OnFactionsUpdated.AddDynamic(this, &UStartGameWidget::HandleFactionsUpdated);
-    }
-
-    if (LockInButton)
-    {
-        LockInButton->OnClicked.AddDynamic(this, &UStartGameWidget::OnLockIn);
-        LockInButton->SetIsEnabled(true);
-    }
-
-    if (SingleplayerButton)
-    {
-        SingleplayerButton->OnClicked.AddDynamic(this, &UStartGameWidget::OnSingleplayer);
-        SingleplayerButton->SetIsEnabled(false);
-        SingleplayerButton->SetVisibility(ESlateVisibility::Collapsed);
-    }
-
-    if (MultiplayerButton)
-    {
-        MultiplayerButton->OnClicked.AddDynamic(this, &UStartGameWidget::OnMultiplayer);
-        MultiplayerButton->SetIsEnabled(false);
-        MultiplayerButton->SetVisibility(ESlateVisibility::Collapsed);
-    }
-
-    if (MainMenuButton)
-    {
-        MainMenuButton->OnClicked.AddDynamic(this, &UStartGameWidget::OnMainMenu);
-    }
-
-    ValidateSelections();
-}
-
-void UStartGameWidget::OnSingleplayer()
-{
-    StartGame(false);
-}
-
-void UStartGameWidget::OnMultiplayer()
-{
-    StartGame(true);
-}
-
-void UStartGameWidget::OnMainMenu()
-{
-    RemoveFromParent();
-    if (OwningLobbyMenu.IsValid())
-    {
-        OwningLobbyMenu->SetVisibility(ESlateVisibility::Visible);
-    }
-}
-
-void UStartGameWidget::OnDisplayNameChanged(const FText& /*Text*/)
-{
-    ValidateSelections();
-}
-
-void UStartGameWidget::OnFactionChanged(FString /*SelectedItem*/, ESelectInfo::Type /*SelectionType*/)
-{
-    ValidateSelections();
-}
-
-void UStartGameWidget::ValidateSelections()
-{
-    bool bFactionAvailable = true;
-
-    if (FactionComboBox && FactionComboBox->GetSelectedIndex() != INDEX_NONE)
-    {
-        const FString Selected = FactionComboBox->GetSelectedOption();
-        if (UEnum* Enum = StaticEnum<ESkaldFaction>())
-        {
-            const int32 Value = Enum->GetValueByNameString(Selected);
-            if (Value != INDEX_NONE)
-            {
-                if (USkaldGameInstance* GI = GetWorld()->GetGameInstance<USkaldGameInstance>())
-                {
-                    const ESkaldFaction Faction = static_cast<ESkaldFaction>(Value);
-                    if (GI->TakenFactions.Contains(Faction))
-                    {
-                        bFactionAvailable = false;
-                        if (GEngine)
-                        {
-                            GEngine->AddOnScreenDebugMessage(-1, 4.f, FColor::Yellow, TEXT("Selected faction already taken"));
-                        }
-                    }
-                }
-            }
-        }
-    }
-    else
-    {
-        bFactionAvailable = false;
-    }
-
-    if (LockInButton)
-    {
-        LockInButton->SetIsEnabled(bFactionAvailable);
-    }
-}
-
-void UStartGameWidget::RefreshFactionOptions()
-{
-    if (!FactionComboBox)
-    {
-        return;
-    }
-
-    const FString PreviouslySelected = FactionComboBox->GetSelectedOption();
-    FactionComboBox->ClearOptions();
-
-    if (UEnum* Enum = StaticEnum<ESkaldFaction>())
-    {
-        for (int32 i = 0; i < Enum->NumEnums(); ++i)
-        {
-            if (!Enum->HasMetaData(TEXT("Hidden"), i))
-            {
-                const FString Option = Enum->GetNameStringByIndex(i);
-                if (Option != TEXT("None"))
-                {
-                    FactionComboBox->AddOption(Option);
-                }
-            }
-        }
-
-        if (USkaldGameInstance* GI = GetWorld()->GetGameInstance<USkaldGameInstance>())
-        {
-            for (ESkaldFaction Taken : GI->TakenFactions)
-            {
-                const FString Option = Enum->GetNameStringByValue(static_cast<int64>(Taken));
-                FactionComboBox->RemoveOption(Option);
-            }
-        }
-    }
-
-    const int32 Index = FactionComboBox->FindOptionIndex(PreviouslySelected);
-    if (Index != INDEX_NONE)
-    {
-        FactionComboBox->SetSelectedIndex(Index);
-    }
-    else
-    {
-        if (!PreviouslySelected.IsEmpty() && GEngine)
-        {
-            GEngine->AddOnScreenDebugMessage(-1, 4.f, FColor::Red, TEXT("Selected faction is no longer available"));
-        }
-        FactionComboBox->SetSelectedIndex(INDEX_NONE);
-    }
-
-    ValidateSelections();
-}
-
-void UStartGameWidget::HandleFactionsUpdated()
-{
+  if (FactionComboBox) {
     RefreshFactionOptions();
+    FactionComboBox->OnSelectionChanged.AddDynamic(
+        this, &UStartGameWidget::OnFactionChanged);
+  }
+
+  if (USkaldGameInstance *GI =
+          GetWorld()->GetGameInstance<USkaldGameInstance>()) {
+    GI->OnFactionsUpdated.AddDynamic(this,
+                                     &UStartGameWidget::HandleFactionsUpdated);
+  }
+
+  if (LockInButton) {
+    LockInButton->OnClicked.AddDynamic(this, &UStartGameWidget::OnLockIn);
+    LockInButton->SetIsEnabled(true);
+  }
+
+  if (SingleplayerButton) {
+    SingleplayerButton->OnClicked.AddDynamic(this,
+                                             &UStartGameWidget::OnSingleplayer);
+    SingleplayerButton->SetIsEnabled(false);
+    SingleplayerButton->SetVisibility(ESlateVisibility::Collapsed);
+  }
+
+  if (MultiplayerButton) {
+    MultiplayerButton->OnClicked.AddDynamic(this,
+                                            &UStartGameWidget::OnMultiplayer);
+    MultiplayerButton->SetIsEnabled(false);
+    MultiplayerButton->SetVisibility(ESlateVisibility::Collapsed);
+  }
+
+  if (MainMenuButton) {
+    MainMenuButton->OnClicked.AddDynamic(this, &UStartGameWidget::OnMainMenu);
+  }
+
+  ValidateSelections();
 }
 
-void UStartGameWidget::OnLockIn()
-{
-    FString Name = DisplayNameBox ? DisplayNameBox->GetText().ToString() : FString();
+void UStartGameWidget::OnSingleplayer() { StartGame(false); }
 
-    if (Name.IsEmpty())
-    {
-        if (APlayerController* PC = GetOwningPlayer())
-        {
-            if (APlayerState* PSBase = PC->PlayerState)
-            {
-                Name = FString::Printf(TEXT("Player%d"), PSBase->GetPlayerId());
-            }
-            else
-            {
-                Name = TEXT("Player");
-            }
-        }
-    }
+void UStartGameWidget::OnMultiplayer() { StartGame(true); }
 
-    ESkaldFaction Faction = ESkaldFaction::Human;
-    if (FactionComboBox && FactionComboBox->GetSelectedIndex() != INDEX_NONE)
-    {
-        FString FactionName = FactionComboBox->GetSelectedOption();
-        if (UEnum* Enum = StaticEnum<ESkaldFaction>())
-        {
-            int32 Value = Enum->GetValueByNameString(FactionName);
-            if (Value != INDEX_NONE)
-            {
-                Faction = static_cast<ESkaldFaction>(Value);
-            }
-        }
-    }
-
-    if (UWorld* World = GetWorld())
-    {
-        if (USkaldGameInstance* GI = World->GetGameInstance<USkaldGameInstance>())
-        {
-            if (GI->TakenFactions.Contains(Faction))
-            {
-                if (LockInButton)
-                {
-                    LockInButton->SetIsEnabled(false);
-                }
-                if (GEngine)
-                {
-                    GEngine->AddOnScreenDebugMessage(-1, 4.f, FColor::Red, TEXT("Selected faction is no longer available"));
-                }
-                RefreshFactionOptions();
-                return;
-            }
-
-            GI->DisplayName = Name;
-            GI->Faction = Faction;
-            GI->TakenFactions.AddUnique(Faction);
-            GI->OnFactionsUpdated.Broadcast();
-        }
-    }
-
-    if (APlayerController* PC = GetOwningPlayer())
-    {
-        if (ASkaldPlayerState* PS = PC->GetPlayerState<ASkaldPlayerState>())
-        {
-            PS->DisplayName = Name;
-            PS->Faction = Faction;
-        }
-    }
-
-    if (DisplayNameBox)
-    {
-        DisplayNameBox->SetVisibility(ESlateVisibility::Collapsed);
-    }
-
-    if (FactionComboBox)
-    {
-        FactionComboBox->SetVisibility(ESlateVisibility::Collapsed);
-    }
-
-    if (LockInButton)
-    {
-        LockInButton->SetVisibility(ESlateVisibility::Collapsed);
-    }
-
-    if (SingleplayerButton)
-    {
-        SingleplayerButton->SetIsEnabled(true);
-        SingleplayerButton->SetVisibility(ESlateVisibility::Visible);
-    }
-
-    if (MultiplayerButton)
-    {
-        MultiplayerButton->SetIsEnabled(true);
-        MultiplayerButton->SetVisibility(ESlateVisibility::Visible);
-    }
+void UStartGameWidget::OnMainMenu() {
+  RemoveFromParent();
+  if (OwningLobbyMenu.IsValid()) {
+    OwningLobbyMenu->SetVisibility(ESlateVisibility::Visible);
+  }
 }
 
-void UStartGameWidget::StartGame(bool bMultiplayer)
-{
-    if (UWorld* World = GetWorld())
-    {
-        if (USkaldGameInstance* GI = World->GetGameInstance<USkaldGameInstance>())
-        {
-            GI->bIsMultiplayer = bMultiplayer;
-        }
-
-        if (APlayerController* PC = GetOwningPlayer())
-        {
-            PC->SetInputMode(FInputModeGameOnly());
-            PC->bShowMouseCursor = false;
-            PC->bEnableClickEvents = false;
-            PC->bEnableMouseOverEvents = false;
-
-            FName LevelName(TEXT("/Game/Blueprints/Maps/OverviewMap"));
-            FString Options;
-            if (bMultiplayer)
-            {
-                Options = TEXT("listen");
-            }
-            if (UWorld* WorldToTravel = GetWorld())
-            {
-                FString URL = LevelName.ToString();
-                if (!Options.IsEmpty())
-                {
-                    URL += TEXT("?") + Options;
-                }
-                WorldToTravel->ServerTravel(URL);
-            }
-        }
-    }
+void UStartGameWidget::OnDisplayNameChanged(const FText & /*Text*/) {
+  ValidateSelections();
 }
 
+void UStartGameWidget::OnFactionChanged(FString /*SelectedItem*/,
+                                        ESelectInfo::Type /*SelectionType*/) {
+  ValidateSelections();
+}
+
+void UStartGameWidget::ValidateSelections() {
+  bool bFactionAvailable = true;
+
+  if (FactionComboBox && FactionComboBox->GetSelectedIndex() != INDEX_NONE) {
+    const FString Selected = FactionComboBox->GetSelectedOption();
+    if (UEnum *Enum = StaticEnum<ESkaldFaction>()) {
+      const int32 Value = Enum->GetValueByNameString(Selected);
+      if (Value != INDEX_NONE) {
+        if (USkaldGameInstance *GI =
+                GetWorld()->GetGameInstance<USkaldGameInstance>()) {
+          const ESkaldFaction Faction = static_cast<ESkaldFaction>(Value);
+          if (GI->TakenFactions.Contains(Faction)) {
+            bFactionAvailable = false;
+            if (GEngine) {
+              GEngine->AddOnScreenDebugMessage(
+                  -1, 4.f, FColor::Yellow,
+                  TEXT("Selected faction already taken"));
+            }
+          }
+        }
+      }
+    }
+  } else {
+    bFactionAvailable = false;
+  }
+
+  if (LockInButton) {
+    LockInButton->SetIsEnabled(bFactionAvailable);
+  }
+}
+
+void UStartGameWidget::RefreshFactionOptions() {
+  if (!FactionComboBox) {
+    return;
+  }
+
+  const FString PreviouslySelected = FactionComboBox->GetSelectedOption();
+  FactionComboBox->ClearOptions();
+
+  if (UEnum *Enum = StaticEnum<ESkaldFaction>()) {
+    for (int32 i = 0; i < Enum->NumEnums(); ++i) {
+      if (!Enum->HasMetaData(TEXT("Hidden"), i)) {
+        const FString Option = Enum->GetNameStringByIndex(i);
+        if (Option != TEXT("None")) {
+          FactionComboBox->AddOption(Option);
+        }
+      }
+    }
+
+    if (USkaldGameInstance *GI =
+            GetWorld()->GetGameInstance<USkaldGameInstance>()) {
+      for (ESkaldFaction Taken : GI->TakenFactions) {
+        const FString Option =
+            Enum->GetNameStringByValue(static_cast<int64>(Taken));
+        FactionComboBox->RemoveOption(Option);
+      }
+    }
+  }
+
+  const int32 Index = FactionComboBox->FindOptionIndex(PreviouslySelected);
+  if (Index != INDEX_NONE) {
+    FactionComboBox->SetSelectedIndex(Index);
+  } else {
+    if (!PreviouslySelected.IsEmpty() && GEngine) {
+      GEngine->AddOnScreenDebugMessage(
+          -1, 4.f, FColor::Red,
+          TEXT("Selected faction is no longer available"));
+    }
+    FactionComboBox->SetSelectedIndex(INDEX_NONE);
+  }
+
+  ValidateSelections();
+}
+
+void UStartGameWidget::HandleFactionsUpdated() { RefreshFactionOptions(); }
+
+void UStartGameWidget::OnLockIn() {
+  FString Name =
+      DisplayNameBox ? DisplayNameBox->GetText().ToString() : FString();
+
+  if (Name.IsEmpty()) {
+    if (APlayerController *PC = GetOwningPlayer()) {
+      if (APlayerState *PSBase = PC->PlayerState) {
+        Name = FString::Printf(TEXT("Player%d"), PSBase->GetPlayerId());
+      } else {
+        Name = TEXT("Player");
+      }
+    }
+  }
+
+  ESkaldFaction Faction = ESkaldFaction::Human;
+  if (FactionComboBox && FactionComboBox->GetSelectedIndex() != INDEX_NONE) {
+    FString FactionName = FactionComboBox->GetSelectedOption();
+    if (UEnum *Enum = StaticEnum<ESkaldFaction>()) {
+      int32 Value = Enum->GetValueByNameString(FactionName);
+      if (Value != INDEX_NONE) {
+        Faction = static_cast<ESkaldFaction>(Value);
+      }
+    }
+  }
+
+  if (UWorld *World = GetWorld()) {
+    if (USkaldGameInstance *GI = World->GetGameInstance<USkaldGameInstance>()) {
+      if (GI->TakenFactions.Contains(Faction)) {
+        if (LockInButton) {
+          LockInButton->SetIsEnabled(false);
+        }
+        if (GEngine) {
+          GEngine->AddOnScreenDebugMessage(
+              -1, 4.f, FColor::Red,
+              TEXT("Selected faction is no longer available"));
+        }
+        RefreshFactionOptions();
+        return;
+      }
+
+      GI->DisplayName = Name;
+      GI->Faction = Faction;
+      GI->TakenFactions.AddUnique(Faction);
+      GI->OnFactionsUpdated.Broadcast();
+    }
+  }
+
+  if (APlayerController *PC = GetOwningPlayer()) {
+    if (ASkaldPlayerState *PS = PC->GetPlayerState<ASkaldPlayerState>()) {
+      PS->DisplayName = Name;
+      PS->Faction = Faction;
+    }
+  }
+
+  if (DisplayNameBox) {
+    DisplayNameBox->SetVisibility(ESlateVisibility::Collapsed);
+  }
+
+  if (FactionComboBox) {
+    FactionComboBox->SetVisibility(ESlateVisibility::Collapsed);
+  }
+
+  if (LockInButton) {
+    LockInButton->SetVisibility(ESlateVisibility::Collapsed);
+  }
+
+  if (SingleplayerButton) {
+    SingleplayerButton->SetIsEnabled(true);
+    SingleplayerButton->SetVisibility(ESlateVisibility::Visible);
+  }
+
+  if (MultiplayerButton) {
+    MultiplayerButton->SetIsEnabled(true);
+    MultiplayerButton->SetVisibility(ESlateVisibility::Visible);
+  }
+}
+
+void UStartGameWidget::StartGame(bool bMultiplayer) {
+  if (UWorld *World = GetWorld()) {
+    if (USkaldGameInstance *GI = World->GetGameInstance<USkaldGameInstance>()) {
+      GI->bIsMultiplayer = bMultiplayer;
+    }
+
+    if (APlayerController *PC = GetOwningPlayer()) {
+      TravelToGameplayMap(PC, bMultiplayer);
+    }
+  }
+}
+
+void UStartGameWidget::TravelToGameplayMap(APlayerController *PC,
+                                           bool bMultiplayer) {
+  if (!PC) {
+    return;
+  }
+
+  PC->SetInputMode(FInputModeGameOnly());
+  PC->bShowMouseCursor = false;
+  PC->bEnableClickEvents = false;
+  PC->bEnableMouseOverEvents = false;
+
+  const FName LevelName(TEXT("/Game/Blueprints/Maps/OverviewMap"));
+  FString Options;
+  if (bMultiplayer) {
+    Options = TEXT("listen");
+  }
+  if (UWorld *WorldToTravel = PC->GetWorld()) {
+    FString URL = LevelName.ToString();
+    if (!Options.IsEmpty()) {
+      URL += TEXT("?") + Options;
+    }
+    WorldToTravel->ServerTravel(URL);
+  }
+}

--- a/Source/Skald/StartGameWidget.h
+++ b/Source/Skald/StartGameWidget.h
@@ -1,85 +1,94 @@
 #pragma once
 
-#include "CoreMinimal.h"
 #include "Blueprint/UserWidget.h"
-#include "SkaldTypes.h"
 #include "Components/ComboBoxString.h"
+#include "CoreMinimal.h"
+#include "SkaldTypes.h"
 #include "StartGameWidget.generated.h"
 
 class UEditableTextBox;
 class UComboBoxString;
 class ULobbyMenuWidget;
 class UButton;
+class APlayerController;
 
 /**
  * Menu shown after pressing Start Game, to choose single or multiplayer.
  */
 UCLASS(Blueprintable, BlueprintType)
-class SKALD_API UStartGameWidget : public UUserWidget
-{
-    GENERATED_BODY()
+class SKALD_API UStartGameWidget : public UUserWidget {
+  GENERATED_BODY()
 
 public:
-    /** Entry box for the player's display name. */
-    UPROPERTY(BlueprintReadOnly, Category="Skald|Widgets", meta = (BindWidgetOptional))
-    UEditableTextBox* DisplayNameBox;
+  /** Entry box for the player's display name. */
+  UPROPERTY(BlueprintReadOnly, Category = "Skald|Widgets",
+            meta = (BindWidgetOptional))
+  UEditableTextBox *DisplayNameBox;
 
-    /** Combo box to choose a faction. */
-    UPROPERTY(BlueprintReadOnly, Category="Skald|Widgets", meta = (BindWidgetOptional))
-    UComboBoxString* FactionComboBox;
+  /** Combo box to choose a faction. */
+  UPROPERTY(BlueprintReadOnly, Category = "Skald|Widgets",
+            meta = (BindWidgetOptional))
+  UComboBoxString *FactionComboBox;
 
-    /** Button to confirm the player's selections before starting. */
-    UPROPERTY(BlueprintReadOnly, Category="Skald|Widgets", meta = (BindWidgetOptional))
-    UButton* LockInButton;
+  /** Button to confirm the player's selections before starting. */
+  UPROPERTY(BlueprintReadOnly, Category = "Skald|Widgets",
+            meta = (BindWidgetOptional))
+  UButton *LockInButton;
 
-    /** Button to start singleplayer. */
-    UPROPERTY(BlueprintReadOnly, Category="Skald|Widgets", meta = (BindWidgetOptional))
-    UButton* SingleplayerButton;
+  /** Button to start singleplayer. */
+  UPROPERTY(BlueprintReadOnly, Category = "Skald|Widgets",
+            meta = (BindWidgetOptional))
+  UButton *SingleplayerButton;
 
-    /** Button to start multiplayer. */
-    UPROPERTY(BlueprintReadOnly, Category="Skald|Widgets", meta = (BindWidgetOptional))
-    UButton* MultiplayerButton;
+  /** Button to start multiplayer. */
+  UPROPERTY(BlueprintReadOnly, Category = "Skald|Widgets",
+            meta = (BindWidgetOptional))
+  UButton *MultiplayerButton;
 
-    /** Button to return to the lobby menu. */
-    UPROPERTY(BlueprintReadOnly, Category="Skald|Widgets", meta = (BindWidgetOptional))
-    UButton* MainMenuButton;
+  /** Button to return to the lobby menu. */
+  UPROPERTY(BlueprintReadOnly, Category = "Skald|Widgets",
+            meta = (BindWidgetOptional))
+  UButton *MainMenuButton;
 
-    /** Record the lobby menu that spawned this widget so we can unhide it later. */
-    void SetLobbyMenu(ULobbyMenuWidget* InMenu);
+  /** Record the lobby menu that spawned this widget so we can unhide it later.
+   */
+  void SetLobbyMenu(ULobbyMenuWidget *InMenu);
+
+  /** Shared helper to move the player controller to the gameplay map. */
+  static void TravelToGameplayMap(APlayerController *PC, bool bMultiplayer);
 
 protected:
-    virtual void NativeConstruct() override;
+  virtual void NativeConstruct() override;
 
-    UFUNCTION()
-    void OnSingleplayer();
+  UFUNCTION()
+  void OnSingleplayer();
 
-    UFUNCTION()
-    void OnMultiplayer();
+  UFUNCTION()
+  void OnMultiplayer();
 
-    UFUNCTION()
-    void OnMainMenu();
+  UFUNCTION()
+  void OnMainMenu();
 
-    UFUNCTION()
-    void OnLockIn();
+  UFUNCTION()
+  void OnLockIn();
 
-    UFUNCTION()
-    void OnDisplayNameChanged(const FText& Text);
+  UFUNCTION()
+  void OnDisplayNameChanged(const FText &Text);
 
-    UFUNCTION()
-    void OnFactionChanged(FString SelectedItem, ESelectInfo::Type SelectionType);
+  UFUNCTION()
+  void OnFactionChanged(FString SelectedItem, ESelectInfo::Type SelectionType);
 
-    void StartGame(bool bMultiplayer);
+  void StartGame(bool bMultiplayer);
 
-    void ValidateSelections();
+  void ValidateSelections();
 
-    void RefreshFactionOptions();
+  void RefreshFactionOptions();
 
-    UFUNCTION()
-    void HandleFactionsUpdated();
+  UFUNCTION()
+  void HandleFactionsUpdated();
 
 private:
-    /** Reference back to the owning lobby menu so it can be restored. */
-    UPROPERTY()
-    TWeakObjectPtr<ULobbyMenuWidget> OwningLobbyMenu;
+  /** Reference back to the owning lobby menu so it can be restored. */
+  UPROPERTY()
+  TWeakObjectPtr<ULobbyMenuWidget> OwningLobbyMenu;
 };
-


### PR DESCRIPTION
## Summary
- centralize travel logic and map selection in `TravelToGameplayMap`
- use `TravelToGameplayMap` from start and player setup flows

## Testing
- `bash Build/validate.sh` *(fails: UnrealBuildTool not found; skipping compile check. UnrealEditor not found; cannot run tests.)*

------
https://chatgpt.com/codex/tasks/task_e_68afb0353ea8832481954037fc1364c0