### PR TITLE
Initialize player state at lock-in

### DIFF
--- a/Source/Skald/Skald_PlayerController.cpp
+++ b/Source/Skald/Skald_PlayerController.cpp
@@ -49,11 +49,6 @@ void ASkaldPlayerController::BeginPlay() {
   } else {
     CachedGameInstance->OnFactionsUpdated.AddDynamic(
         this, &ASkaldPlayerController::HandleFactionsUpdated);
-
-    if (IsLocalController()) {
-      ServerInitPlayerState(CachedGameInstance->DisplayName,
-                            CachedGameInstance->Faction);
-    }
   }
 
   // Create and show the HUD widget if a class has been assigned (expected via

--- a/Source/Skald/StartGameWidget.cpp
+++ b/Source/Skald/StartGameWidget.cpp
@@ -5,6 +5,7 @@
 #include "Components/EditableTextBox.h"
 #include "Engine/Engine.h"
 #include "GameFramework/PlayerController.h"
+#include "Skald_PlayerController.h"
 #include "Kismet/GameplayStatics.h"
 #include "LobbyMenuWidget.h"
 #include "Skald_GameInstance.h"
@@ -204,11 +205,13 @@ void UStartGameWidget::OnLockIn() {
     }
   }
 
-  if (APlayerController *PC = GetOwningPlayer()) {
+  if (ASkaldPlayerController *PC =
+          Cast<ASkaldPlayerController>(GetOwningPlayer())) {
     if (ASkaldPlayerState *PS = PC->GetPlayerState<ASkaldPlayerState>()) {
       PS->DisplayName = Name;
       PS->Faction = Faction;
     }
+    PC->ServerInitPlayerState(Name, Faction);
   }
 
   if (DisplayNameBox) {


### PR DESCRIPTION
## Summary
- Call `ServerInitPlayerState` when the player locks in their name and faction
- Drop redundant `ServerInitPlayerState` call from `ASkaldPlayerController::BeginPlay`

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68afb2bba57483249d6ac61669351522