### PR TITLE
Add player selection widget flow

### DIFF
--- a/Source/Skald/Skald_PlayerController.h
+++ b/Source/Skald/Skald_PlayerController.h
@@ -8,6 +8,7 @@
 class ATurnManager;
 class UUserWidget;
 class USkaldMainHUDWidget;
+class UChoosePlayerWidget;
 class ATerritory;
 class ASkaldGameMode;
 class ASkaldGameState;
@@ -83,6 +84,11 @@ protected:
             meta = (AllowPrivateAccess = "true"))
   TObjectPtr<USkaldMainHUDWidget> MainHudWidget;
 
+  /** Player selection widget instance. */
+  UPROPERTY(BlueprintReadOnly, Category = "UI",
+            meta = (AllowPrivateAccess = "true"))
+  TObjectPtr<UChoosePlayerWidget> ChoosePlayerWidget;
+
   /** Cached references to core game singletons for blueprint access */
   UPROPERTY(BlueprintReadOnly, Category = "Game",
             meta = (AllowPrivateAccess = "true"))
@@ -145,6 +151,10 @@ public:
   /** React to world state changes broadcast by the turn manager. */
   UFUNCTION()
   void HandleWorldStateChanged();
+
+  /** React to the player finishing their pre-game selection. */
+  UFUNCTION()
+  void HandlePlayerLockedIn();
 
   /** Server-side processing of an attack request. */
   UFUNCTION(Server, Reliable)


### PR DESCRIPTION
## Summary
- Hide main HUD at begin play
- Load ChoosePlayerWidget and show it to pick name and faction
- Reveal HUD once player locks in selection

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68afc25982348324b2dbd9b8a87712f7