### PR TITLE
Add lock-in replication to player state

### DIFF
--- a/Source/Skald/Skald_PlayerState.cpp
+++ b/Source/Skald/Skald_PlayerState.cpp
@@ -9,6 +9,7 @@ ASkaldPlayerState::ASkaldPlayerState()
     , Resources(0)
     , DisplayName(TEXT("Player"))
     , Faction(ESkaldFaction::None)
+    , bHasLockedIn(false)
     , IsEliminated(false)
 {
 }
@@ -24,7 +25,16 @@ void ASkaldPlayerState::GetLifetimeReplicatedProps(
     DOREPLIFETIME(ASkaldPlayerState, bIsAI);
     DOREPLIFETIME(ASkaldPlayerState, InitiativeRoll);
     DOREPLIFETIME(ASkaldPlayerState, Resources);
+    DOREPLIFETIME(ASkaldPlayerState, bHasLockedIn);
     DOREPLIFETIME(ASkaldPlayerState, IsEliminated);
+}
+
+void ASkaldPlayerState::OnRep_HasLockedIn()
+{
+    if (ASkaldGameState* GS = GetWorld() ? GetWorld()->GetGameState<ASkaldGameState>() : nullptr)
+    {
+        GS->OnPlayersUpdated.Broadcast();
+    }
 }
 
 void ASkaldPlayerState::OnRep_IsEliminated()

--- a/Source/Skald/Skald_PlayerState.h
+++ b/Source/Skald/Skald_PlayerState.h
@@ -39,9 +39,16 @@ public:
     UPROPERTY(BlueprintReadWrite, Replicated, Category="PlayerState")
     ESkaldFaction Faction;
 
+    /** Whether the player has locked in their actions for the current turn. */
+    UPROPERTY(BlueprintReadWrite, ReplicatedUsing = OnRep_HasLockedIn, Category="PlayerState")
+    bool bHasLockedIn;
+
     /** Whether this player has been eliminated from the match. */
     UPROPERTY(BlueprintReadWrite, ReplicatedUsing = OnRep_IsEliminated, Category="PlayerState")
     bool IsEliminated;
+
+    UFUNCTION()
+    void OnRep_HasLockedIn();
 
     UFUNCTION()
     void OnRep_IsEliminated();


### PR DESCRIPTION
## Summary
- track whether a player has locked in their turn actions
- notify HUDs when lock-in status changes

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68afc58756408324a55c160bdd57d98d