### PR TITLE
Handle player lock-in in game mode

### DIFF
--- a/Source/Skald/Skald_GameMode.cpp
+++ b/Source/Skald/Skald_GameMode.cpp
@@ -184,6 +184,24 @@ void ASkaldGameMode::PopulateAIPlayers() {
   }
 }
 
+void ASkaldGameMode::HandlePlayerLockedIn(ASkaldPlayerState *PS) {
+  if (!PS) {
+    return;
+  }
+
+  FS_PlayerData *PlayerData =
+      PlayersData.FindByPredicate([PS](const FS_PlayerData &Data) {
+        return Data.PlayerID == PS->GetPlayerId();
+      });
+  if (PlayerData) {
+    PlayerData->PlayerName = PS->DisplayName;
+    PlayerData->Faction = PS->Faction;
+  }
+
+  RefreshHUDs();
+  TryInitializeWorldAndStart();
+}
+
 void ASkaldGameMode::RefreshHUDs() {
   ASkaldGameState *GS = GetGameState<ASkaldGameState>();
   if (!GS) {

--- a/Source/Skald/Skald_GameMode.h
+++ b/Source/Skald/Skald_GameMode.h
@@ -52,6 +52,9 @@ public:
   UFUNCTION(BlueprintCallable, BlueprintPure, Category = "GameMode")
   ATurnManager *GetTurnManager() const { return TurnManager; }
 
+  /** Handle a player confirming their name and faction selection. */
+  void HandlePlayerLockedIn(ASkaldPlayerState *PS);
+
 protected:
   /** Handles turn sequencing for the match. */
   UPROPERTY(BlueprintReadOnly, Category = "GameMode")

--- a/Source/Skald/Skald_PlayerController.cpp
+++ b/Source/Skald/Skald_PlayerController.cpp
@@ -135,6 +135,11 @@ void ASkaldPlayerController::ServerInitPlayerState_Implementation(
   if (ASkaldPlayerState *PS = GetPlayerState<ASkaldPlayerState>()) {
     PS->DisplayName = Name;
     PS->Faction = Faction;
+    PS->bHasLockedIn = true;
+
+    if (ASkaldGameMode *GM = GetWorld()->GetAuthGameMode<ASkaldGameMode>()) {
+      GM->HandlePlayerLockedIn(PS);
+    }
   }
 }
 


### PR DESCRIPTION
## Summary
- mark player as locked in during player state initialization
- update game mode with locked-in players and refresh HUDs
- kick off game start attempts after player lock-in

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68afc643416c83249a94bc3b0dac3ec4