### PR TITLE
Use OpenLevel for map travel

### DIFF
--- a/Source/Skald/LoadGameWidget.cpp
+++ b/Source/Skald/LoadGameWidget.cpp
@@ -79,10 +79,8 @@ void ULoadGameWidget::HandleLoadSlot(int32 SlotIndex)
         }
 
         // After loading, transition to the main gameplay map
-        if (UWorld* WorldToTravel = GetWorld())
-        {
-            WorldToTravel->ServerTravel(TEXT("Skald_OverTop"));
-        }
+        const FName LevelName(TEXT("/Game/Blueprints/Maps/Skald_OverTop"));
+        UGameplayStatics::OpenLevel(this, LevelName);
     }
     else
     {

--- a/Source/Skald/StartGameWidget.cpp
+++ b/Source/Skald/StartGameWidget.cpp
@@ -2,6 +2,7 @@
 
 #include "Components/Button.h"
 #include "GameFramework/PlayerController.h"
+#include "Kismet/GameplayStatics.h"
 #include "LobbyMenuWidget.h"
 #include "Skald_GameInstance.h"
 #include "Skald_PlayerController.h"
@@ -62,19 +63,9 @@ void UStartGameWidget::TravelToGameplayMap(APlayerController *PC,
   }
 
   const FName LevelName(TEXT("/Game/Blueprints/Maps/OverviewMap"));
-  FString URL = LevelName.ToString();
-
-  if (UWorld *WorldToTravel = PC->GetWorld()) {
-    if (PC->HasAuthority()) {
-      if (bMultiplayer) {
-        URL += TEXT("?listen");
-      }
-      WorldToTravel->ServerTravel(URL);
-    } else if (PC->IsLocalController()) {
-      PC->ClientTravel(URL, ETravelType::TRAVEL_Absolute);
-    } else {
-      UE_LOG(LogTemp, Error,
-             TEXT("TravelToGameplayMap: invalid context for travel"));
-    }
+  FString Options;
+  if (bMultiplayer) {
+    Options = TEXT("listen");
   }
+  UGameplayStatics::OpenLevel(PC, LevelName, true, Options);
 }


### PR DESCRIPTION
## Summary
- Recreate player controllers on level changes by using `UGameplayStatics::OpenLevel` when starting or loading games
- Include GameplayStatics to support the new travel method

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68afce98d51883248567bd7520a62a34