### PR TITLE
Add vertical movement controls

### DIFF
--- a/Config/DefaultInput.ini
+++ b/Config/DefaultInput.ini
@@ -83,6 +83,8 @@ DoubleClickTime=0.200000
 +AxisMappings=(AxisName="MoveRight",Scale=1.000000,Key=D)
 +AxisMappings=(AxisName="MoveForward",Scale=-1.000000,Key=S)
 +AxisMappings=(AxisName="MoveRight",Scale=-1.000000,Key=A)
++AxisMappings=(AxisName="MoveUp",Scale=1.000000,Key=SpaceBar)
++AxisMappings=(AxisName="MoveUp",Scale=-1.000000,Key=LeftControl)
 +AxisMappings=(AxisName="Turn",Scale=1.000000,Key=MouseX)
 +AxisMappings=(AxisName="LookUp",Scale=-1.000000,Key=MouseY)
 DefaultPlayerInputClass=/Script/EnhancedInput.EnhancedPlayerInput

--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@ from Blueprints and level actors. To hook everything up:
    `Select()` function on territories under the mouse cursor when the
    `Select` action is triggered.
 
-4. **Input** – Add axis mappings for `MoveForward` and `MoveRight` and action
-   mappings for `Select`, `Ability1`, `Ability2`, and `Ability3` in the
+4. **Input** – Add axis mappings for `MoveForward`, `MoveRight`, and `MoveUp` and
+   action mappings for `Select`, `Ability1`, `Ability2`, and `Ability3` in the
    project settings. Also enable *Click Events* and *Mouse Over Events* on the
    player controller so territory meshes can generate the appropriate input
    callbacks.

--- a/Source/Skald/Skald_PlayerCharacter.cpp
+++ b/Source/Skald/Skald_PlayerCharacter.cpp
@@ -66,6 +66,7 @@ void ASkald_PlayerCharacter::SetupPlayerInputComponent(UInputComponent* PlayerIn
 
         PlayerInputComponent->BindAxis("MoveForward", this, &ASkald_PlayerCharacter::MoveForward);
         PlayerInputComponent->BindAxis("MoveRight", this, &ASkald_PlayerCharacter::MoveRight);
+       PlayerInputComponent->BindAxis("MoveUp", this, &ASkald_PlayerCharacter::MoveUp);
         PlayerInputComponent->BindAxis("Turn", this, &ASkald_PlayerCharacter::Turn);
         PlayerInputComponent->BindAxis("LookUp", this, &ASkald_PlayerCharacter::LookUp);
 
@@ -89,6 +90,14 @@ void ASkald_PlayerCharacter::MoveRight(float Value)
         {
                 AddMovementInput(GetActorRightVector(), Value);
         }
+}
+
+void ASkald_PlayerCharacter::MoveUp(float Value)
+{
+       if (Value != 0.0f)
+       {
+               AddMovementInput(GetActorUpVector(), Value);
+       }
 }
 
 void ASkald_PlayerCharacter::Turn(float Value)

--- a/Source/Skald/Skald_PlayerCharacter.h
+++ b/Source/Skald/Skald_PlayerCharacter.h
@@ -59,6 +59,10 @@ public:
         UFUNCTION(BlueprintCallable, Category="Input")
         void MoveRight(float Value);
 
+       /** Handle up/down movement input */
+       UFUNCTION(BlueprintCallable, Category="Input")
+       void MoveUp(float Value);
+
         /** Handle yaw input */
         UFUNCTION(BlueprintCallable, Category="Input")
         void Turn(float Value);


### PR DESCRIPTION
## Summary
- enable vertical character movement through Spacebar and Left Control
- update input settings and documentation for new MoveUp axis

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b004e00cf083248dd1c49062c91872