### PR TITLE
Populate faction options and gate lock-in

### DIFF
--- a/Source/Skald/ChoosePlayerWidget.h
+++ b/Source/Skald/ChoosePlayerWidget.h
@@ -8,6 +8,10 @@
 class UEditableTextBox;
 class UComboBoxString;
 class UButton;
+namespace ESelectInfo
+{
+    enum Type;
+}
 
 DECLARE_DYNAMIC_MULTICAST_DELEGATE(FPlayerLockedIn);
 
@@ -41,5 +45,18 @@ public:
     /** Delegate fired when the player locks in their selection. */
     UPROPERTY(BlueprintAssignable, Category="Skald|Widgets|Events")
     FPlayerLockedIn OnPlayerLockedIn;
+
+protected:
+    /** Text box change handler. */
+    UFUNCTION()
+    void HandleDisplayNameChanged(const FText& Text);
+
+    /** Faction combo selection handler. */
+    UFUNCTION()
+    void HandleFactionSelected(FString SelectedItem, ESelectInfo::Type SelectionType);
+
+    /** Enable lock in button when prerequisites are met. */
+    UFUNCTION()
+    void UpdateLockInEnabled();
 };
 


### PR DESCRIPTION
## Summary
- Populate faction combo with available ESkaldFaction values, skipping None and those already taken
- Enable lock-in only when a name and faction are chosen
- Record selected faction in game instance when locking in

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b01bd3fd6c8324adcac0493fdafe6c