### PR TITLE
Delay controller registration until after world initialization

### DIFF
--- a/Source/Skald/Skald_GameMode.h
+++ b/Source/Skald/Skald_GameMode.h
@@ -87,6 +87,7 @@ protected:
   /** Allow players to position initial armies based on initiative. */
   UFUNCTION(BlueprintCallable, Category = "GameMode")
   void BeginArmyPlacementPhase();
+
 public:
   /** Build siege equipment during the engineering phase. */
   UFUNCTION(BlueprintCallable, Category = "Siege")
@@ -98,6 +99,7 @@ public:
 
   /** Update cached player resource values. */
   void UpdatePlayerResources(ASkaldPlayerState *Player);
+
 private:
   /** Timer that triggers auto-start of the turn sequence. */
   FTimerHandle StartGameTimerHandle;
@@ -107,6 +109,9 @@ private:
 
   /** Whether the world has been initialized and territories assigned. */
   bool bWorldInitialized;
+
+  /** Controllers waiting for world initialization before registration. */
+  TArray<ASkaldPlayerController *> PendingControllers;
 
   /** Index of the controller currently placing armies. */
   int32 PlacementIndex = 0;
@@ -119,7 +124,6 @@ private:
 
   /** Notify HUDs of the current player roster. */
   void RefreshHUDs();
-
 
   /** Attempt to initialise the world and start the game flow. */
   void TryInitializeWorldAndStart();


### PR DESCRIPTION
## Summary
- defer registering player controllers with the turn manager until the world is initialized
- gate world initialization on players locking in and register pending controllers afterward
- let InitializeWorld spawn the world map and use pending controllers during army placement

## Testing
- `Build/validate.sh` *(fails: UnrealBuildTool not found; UnrealEditor not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b01c9dfb34832498b1599dc6b3043b