### PR TITLE
Add debug logging for turn phases and army placement

### DIFF
--- a/Source/Skald/Skald_GameMode.cpp
+++ b/Source/Skald/Skald_GameMode.cpp
@@ -413,6 +413,21 @@ void ASkaldGameMode::BeginArmyPlacementPhase() {
   TurnManager->SortControllersByInitiative();
   TurnManager->StartArmyPlacementPhase();
 
+  const TArray<ASkaldPlayerController *> Controllers =
+      TurnManager->GetControllers();
+  ASkaldPlayerController *ActiveController =
+      Controllers.Num() > 0 ? Controllers[0] : nullptr;
+  const FString PhaseString =
+      UEnum::GetValueAsString(TurnManager->GetCurrentPhase());
+  UE_LOG(LogSkald, Log, TEXT("BeginArmyPlacementPhase: Controller=%s Phase=%s"),
+         *GetNameSafe(ActiveController), *PhaseString);
+  if (GEngine) {
+    GEngine->AddOnScreenDebugMessage(
+        -1, 5.f, FColor::Green,
+        FString::Printf(TEXT("Begin Army Placement: %s - %s"),
+                        *GetNameSafe(ActiveController), *PhaseString));
+  }
+
   // Calculate army pools for each player based on owned territories and
   // update HUDs.
   for (ASkaldPlayerController *PC : TurnManager->GetControllers()) {
@@ -494,6 +509,17 @@ void ASkaldGameMode::AdvanceArmyPlacement() {
     if (PS->ArmyPool <= 0) {
       ++PlacementIndex;
       continue;
+    }
+
+    const FString PhaseString =
+        UEnum::GetValueAsString(TurnManager->GetCurrentPhase());
+    UE_LOG(LogSkald, Log, TEXT("AdvanceArmyPlacement: Controller=%s Phase=%s"),
+           *GetNameSafe(PC), *PhaseString);
+    if (GEngine) {
+      GEngine->AddOnScreenDebugMessage(
+          -1, 5.f, FColor::Green,
+          FString::Printf(TEXT("Army Placement: %s - %s"),
+                          *GetNameSafe(PC), *PhaseString));
     }
 
     TurnManager->BroadcastArmyPool(PS);

--- a/Source/Skald/Skald_TurnManager.cpp
+++ b/Source/Skald/Skald_TurnManager.cpp
@@ -464,6 +464,14 @@ void ATurnManager::BroadcastResources(ASkaldPlayerState *ForPlayer) {
 }
 
 void ATurnManager::BroadcastCurrentPhase() {
+  const FString PhaseString = UEnum::GetValueAsString(CurrentPhase);
+  UE_LOG(LogSkald, Log, TEXT("BroadcastCurrentPhase: %s"), *PhaseString);
+  if (GEngine) {
+    GEngine->AddOnScreenDebugMessage(
+        -1, 5.f, FColor::Green,
+        FString::Printf(TEXT("Current Phase: %s"), *PhaseString));
+  }
+
   for (const TWeakObjectPtr<ASkaldPlayerController> &ControllerPtr : Controllers) {
     if (ASkaldPlayerController *Controller = ControllerPtr.Get()) {
       if (USkaldMainHUDWidget *HUD = Controller->GetHUDWidget()) {


### PR DESCRIPTION
## Summary
- log current turn phase in `ATurnManager::BroadcastCurrentPhase`
- log active controller and phase during army placement

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b01fea4cf48324b7a78a131aa2da7f