### PR TITLE
Ensure space/ctrl move character vertically

### DIFF
--- a/Source/Skald/Skald_PlayerCharacter.cpp
+++ b/Source/Skald/Skald_PlayerCharacter.cpp
@@ -94,10 +94,12 @@ void ASkald_PlayerCharacter::MoveRight(float Value)
 
 void ASkald_PlayerCharacter::MoveUp(float Value)
 {
-       if (Value != 0.0f)
-       {
-               AddMovementInput(GetActorUpVector(), Value);
-       }
+        if (Value != 0.0f)
+        {
+                // Move strictly along world Z to ensure SpaceBar and LeftControl
+                // translate vertically regardless of character rotation
+                AddMovementInput(FVector::UpVector, Value);
+        }
 }
 
 void ASkald_PlayerCharacter::Turn(float Value)


### PR DESCRIPTION
## Summary
- Ensure MoveUp input always uses world Z so SpaceBar and LeftControl move vertically

## Testing
- `./Build/validate.sh`

------
https://chatgpt.com/codex/tasks/task_e_68b02314ce448324a32a0822ce05cdce