### PR TITLE
Handle placeholder territories for default world map

### DIFF
--- a/Source/Skald/Skald_GameMode.cpp
+++ b/Source/Skald/Skald_GameMode.cpp
@@ -606,8 +606,29 @@ bool ASkaldGameMode::InitializeWorld() {
     return false;
   }
 
-  // If the world map has not spawned territories yet, create basic ones.
-  if (WorldMap->Territories.Num() == 0) {
+  // If the world map has not spawned territories yet or only contains a
+  // placeholder, create basic ones.
+  if (WorldMap->Territories.Num() == 0 ||
+      (WorldMap->Territories.Num() > 0 && WorldMap->Territories[0] &&
+       WorldMap->Territories[0]->TerritoryID == -1)) {
+    ATerritory *Placeholder = nullptr;
+    if (WorldMap->Territories.Num() > 0) {
+      Placeholder = WorldMap->Territories[0];
+      WorldMap->Territories.Empty();
+    } else {
+      TArray<AActor *> Found;
+      UGameplayStatics::GetAllActorsOfClass(GetWorld(), ATerritory::StaticClass(), Found);
+      for (AActor *Actor : Found) {
+        ATerritory *Terr = Cast<ATerritory>(Actor);
+        if (Terr && Terr->TerritoryID == -1) {
+          Placeholder = Terr;
+          break;
+        }
+      }
+    }
+    if (Placeholder) {
+      Placeholder->Destroy();
+    }
     for (int32 Id = 0; Id < 43; ++Id) {
       ATerritory *Territory = GetWorld()->SpawnActor<ATerritory>();
       if (Territory) {

--- a/Source/Skald/WorldMap.cpp
+++ b/Source/Skald/WorldMap.cpp
@@ -48,7 +48,6 @@ void AWorldMap::BeginPlay() {
     if (Placeholder) {
       Placeholder->TerritoryID = -1;
       Placeholder->TerritoryName = TEXT("Placeholder Territory");
-      RegisterTerritory(Placeholder);
     }
 
     return;


### PR DESCRIPTION
## Summary
- Avoid registering placeholder territories when no data table is available
- Detect placeholder territory during world initialization and replace with standard set

## Testing
- `./Build/validate.sh` *(fails: UnrealBuildTool not found; UnrealEditor not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b028a42d308324b95fb61cebc8820b