### PR TITLE
Use FMath::IsNearlyZero for input checks

### DIFF
--- a/Source/Skald/Skald_PlayerCharacter.cpp
+++ b/Source/Skald/Skald_PlayerCharacter.cpp
@@ -78,7 +78,7 @@ void ASkald_PlayerCharacter::SetupPlayerInputComponent(UInputComponent* PlayerIn
 
 void ASkald_PlayerCharacter::MoveForward(float Value)
 {
-        if (Value != 0.0f)
+        if (!FMath::IsNearlyZero(Value))
         {
                 AddMovementInput(GetActorForwardVector(), Value);
         }
@@ -86,7 +86,7 @@ void ASkald_PlayerCharacter::MoveForward(float Value)
 
 void ASkald_PlayerCharacter::MoveRight(float Value)
 {
-        if (Value != 0.0f)
+        if (!FMath::IsNearlyZero(Value))
         {
                 AddMovementInput(GetActorRightVector(), Value);
         }
@@ -94,7 +94,7 @@ void ASkald_PlayerCharacter::MoveRight(float Value)
 
 void ASkald_PlayerCharacter::MoveUp(float Value)
 {
-        if (Value != 0.0f)
+        if (!FMath::IsNearlyZero(Value))
         {
                 // Move strictly along world Z to ensure SpaceBar and LeftControl
                 // translate vertically regardless of character rotation
@@ -104,7 +104,7 @@ void ASkald_PlayerCharacter::MoveUp(float Value)
 
 void ASkald_PlayerCharacter::Turn(float Value)
 {
-        if (Value != 0.0f)
+        if (!FMath::IsNearlyZero(Value))
         {
                 AddControllerYawInput(Value);
         }
@@ -112,7 +112,7 @@ void ASkald_PlayerCharacter::Turn(float Value)
 
 void ASkald_PlayerCharacter::LookUp(float Value)
 {
-        if (Value != 0.0f)
+        if (!FMath::IsNearlyZero(Value))
         {
                 AddControllerPitchInput(Value);
         }


### PR DESCRIPTION
## Summary
- use `FMath::IsNearlyZero` for movement and rotation input checks

## Testing
- `make` *(fails: No targets specified and no makefile found)*
- `clang++ -Wall -c Source/Skald/Skald_PlayerCharacter.cpp` *(fails: 'CoreMinimal.h' file not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b024dbfd2c8324b9127682ae8a6834