### PR TITLE
Expose remaining widget bindings for editor recreation

### DIFF
--- a/Source/Skald/ChoosePlayerWidget.h
+++ b/Source/Skald/ChoosePlayerWidget.h
@@ -48,15 +48,15 @@ public:
 
 protected:
     /** Text box change handler. */
-    UFUNCTION()
+    UFUNCTION(BlueprintCallable, Category="Skald|Widgets")
     void HandleDisplayNameChanged(const FText& Text);
 
     /** Faction combo selection handler. */
-    UFUNCTION()
+    UFUNCTION(BlueprintCallable, Category="Skald|Widgets")
     void HandleFactionSelected(FString SelectedItem, ESelectInfo::Type SelectionType);
 
     /** Enable lock in button when prerequisites are met. */
-    UFUNCTION()
+    UFUNCTION(BlueprintCallable, Category="Skald|Widgets")
     void UpdateLockInEnabled();
 };
 

--- a/Source/Skald/LoadGameWidget.cpp
+++ b/Source/Skald/LoadGameWidget.cpp
@@ -8,6 +8,11 @@
 #include "SkaldSaveGame.h"
 #include "Skald_GameInstance.h"
 
+void ULoadGameWidget::SetLobbyMenu(ULobbyMenuWidget* InMenu)
+{
+    LobbyMenu = InMenu;
+}
+
 void ULoadGameWidget::NativeConstruct()
 {
     Super::NativeConstruct();

--- a/Source/Skald/LoadGameWidget.h
+++ b/Source/Skald/LoadGameWidget.h
@@ -27,7 +27,8 @@ public:
     UPROPERTY(BlueprintReadOnly, Category="Skald|Widgets", meta=(BindWidgetOptional))
     UButton* MainMenuButton;
 
-    void SetLobbyMenu(ULobbyMenuWidget* InMenu) { LobbyMenu = InMenu; }
+    UFUNCTION(BlueprintCallable, Category="Skald|Widgets")
+    void SetLobbyMenu(ULobbyMenuWidget* InMenu);
 
 protected:
     virtual void NativeConstruct() override;
@@ -41,7 +42,7 @@ protected:
     UFUNCTION(BlueprintCallable)
     void OnLoadSlot2();
 
-    UFUNCTION()
+    UFUNCTION(BlueprintCallable, Category="Skald|Widgets")
     void OnMainMenu();
 
 private:

--- a/Source/Skald/SaveGameWidget.cpp
+++ b/Source/Skald/SaveGameWidget.cpp
@@ -7,6 +7,11 @@
 #include "Skald_GameMode.h"
 #include "SlotNameConstants.h"
 
+void USaveGameWidget::SetLobbyMenu(ULobbyMenuWidget* InMenu)
+{
+  LobbyMenu = InMenu;
+}
+
 void USaveGameWidget::NativeConstruct() {
   Super::NativeConstruct();
 

--- a/Source/Skald/SaveGameWidget.h
+++ b/Source/Skald/SaveGameWidget.h
@@ -27,7 +27,8 @@ public:
     UPROPERTY(BlueprintReadOnly, Category="Skald|Widgets", meta=(BindWidgetOptional))
     UButton* MainMenuButton;
 
-    void SetLobbyMenu(ULobbyMenuWidget* InMenu) { LobbyMenu = InMenu; }
+    UFUNCTION(BlueprintCallable, Category="Skald|Widgets")
+    void SetLobbyMenu(ULobbyMenuWidget* InMenu);
 
 protected:
     virtual void NativeConstruct() override;
@@ -42,7 +43,7 @@ protected:
     UFUNCTION(BlueprintCallable)
     void OnSaveSlot2();
 
-    UFUNCTION()
+    UFUNCTION(BlueprintCallable, Category="Skald|Widgets")
     void OnMainMenu();
 
 private:

--- a/Source/Skald/SettingsWidget.cpp
+++ b/Source/Skald/SettingsWidget.cpp
@@ -4,6 +4,11 @@
 #include "Engine/Engine.h"
 #include "LobbyMenuWidget.h"
 
+void USettingsWidget::SetLobbyMenu(ULobbyMenuWidget* InMenu)
+{
+    LobbyMenu = InMenu;
+}
+
 void USettingsWidget::NativeConstruct()
 {
     Super::NativeConstruct();

--- a/Source/Skald/SettingsWidget.h
+++ b/Source/Skald/SettingsWidget.h
@@ -21,7 +21,8 @@ public:
     UPROPERTY(BlueprintReadOnly, Category="Skald|Widgets", meta = (BindWidgetOptional))
     UButton* MainMenuButton;
 
-    void SetLobbyMenu(ULobbyMenuWidget* InMenu) { LobbyMenu = InMenu; }
+    UFUNCTION(BlueprintCallable, Category="Skald|Widgets")
+    void SetLobbyMenu(ULobbyMenuWidget* InMenu);
 
 protected:
     virtual void NativeConstruct() override;
@@ -29,7 +30,7 @@ protected:
     UFUNCTION(BlueprintCallable)
     void OnApply();
 
-    UFUNCTION()
+    UFUNCTION(BlueprintCallable, Category="Skald|Widgets")
     void OnMainMenu();
 
 private:

--- a/Source/Skald/StartGameWidget.h
+++ b/Source/Skald/StartGameWidget.h
@@ -31,23 +31,24 @@ public:
             meta = (BindWidgetOptional))
   UButton *MainMenuButton;
 
-  /** Record the lobby menu that spawned this widget so we can unhide it later.
-   */
+  /** Record the lobby menu that spawned this widget so we can unhide it later. */
+  UFUNCTION(BlueprintCallable, Category = "Skald|Widgets")
   void SetLobbyMenu(ULobbyMenuWidget *InMenu);
 
   /** Shared helper to move the player controller to the gameplay map. */
+  UFUNCTION(BlueprintCallable, Category = "Skald|Widgets")
   static void TravelToGameplayMap(APlayerController *PC, bool bMultiplayer);
 
 protected:
   virtual void NativeConstruct() override;
 
-  UFUNCTION()
+  UFUNCTION(BlueprintCallable, Category = "Skald|Widgets")
   void OnSingleplayer();
 
-  UFUNCTION()
+  UFUNCTION(BlueprintCallable, Category = "Skald|Widgets")
   void OnMultiplayer();
 
-  UFUNCTION()
+  UFUNCTION(BlueprintCallable, Category = "Skald|Widgets")
   void OnMainMenu();
 
   void StartGame(bool bMultiplayer);

--- a/Source/Skald/UI/ConfirmAttackWidget.h
+++ b/Source/Skald/UI/ConfirmAttackWidget.h
@@ -19,6 +19,7 @@ public:
   virtual void NativeConstruct() override;
 
   /** Configure selector for maximum army size available. */
+  UFUNCTION(BlueprintCallable, Category = "Skald|Attack")
   void Setup(int32 MaxUnits);
 
   /** Spin box allowing the player to choose army size. */
@@ -36,6 +37,6 @@ public:
   int32 ArmyCount = 1;
 
 private:
-  UFUNCTION()
+  UFUNCTION(BlueprintCallable, Category = "Skald|Attack")
   void HandleValueChanged(float NewValue);
 };

--- a/Source/Skald/UI/DeployWidget.h
+++ b/Source/Skald/UI/DeployWidget.h
@@ -21,6 +21,7 @@ public:
   virtual void NativeConstruct() override;
 
   /** Configure the widget for the given territory and player state. */
+  UFUNCTION(BlueprintCallable, Category = "Skald|Deploy")
   void Setup(ATerritory *InTerritory, ASkaldPlayerState *InPlayerState,
              USkaldMainHUDWidget *InHUD, int32 MaxAmount);
 
@@ -34,10 +35,10 @@ public:
   UButton *DeclineButton;
 
 private:
-  UFUNCTION()
+  UFUNCTION(BlueprintCallable, Category = "Skald|Deploy")
   void HandleAccept();
 
-  UFUNCTION()
+  UFUNCTION(BlueprintCallable, Category = "Skald|Deploy")
   void HandleDecline();
 
   UPROPERTY()


### PR DESCRIPTION
## Summary
- expose menu widgets' SetLobbyMenu and MainMenu handlers to Blueprints
- expose start-game and confirmation widgets for Blueprint configuration
- mark selection change helpers as BlueprintCallable for easy UI rebinding

## Testing
- `./Build/validate.sh` *(fails: UnrealBuildTool not found; skipping compile check)*


------
https://chatgpt.com/codex/tasks/task_e_68b02a4832548324900cbd9f54bd7d23