### PR TITLE
feat: add HUD widget class property

### DIFF
--- a/Source/Skald/Skald_PlayerController.cpp
+++ b/Source/Skald/Skald_PlayerController.cpp
@@ -14,6 +14,7 @@
 #include "UI/SkaldMainHUDWidget.h"
 #include "ChoosePlayerWidget.h"
 #include "WorldMap.h"
+#include "UObject/ConstructorHelpers.h"
 
 ASkaldPlayerController::ASkaldPlayerController() {
   bIsAI = false;
@@ -24,6 +25,13 @@ ASkaldPlayerController::ASkaldPlayerController() {
   bShowMouseCursor = true;
   bEnableClickEvents = true;
   bEnableMouseOverEvents = true;
+
+  // Load a default HUD widget blueprint if available.
+  static ConstructorHelpers::FClassFinder<UUserWidget> HUDWidgetFinder(
+      TEXT("/Game/C++_BPs/Skald_MainHUDBP"));
+  if (HUDWidgetFinder.Succeeded()) {
+    HUDWidgetClass = HUDWidgetFinder.Class;
+  }
 }
 
 void ASkaldPlayerController::BeginPlay() {
@@ -53,9 +61,9 @@ void ASkaldPlayerController::BeginPlay() {
   }
 
   // Create and show the HUD widget if a class has been assigned (expected via
-  // blueprint).
-  if (MainHudWidgetClass) {
-    MainHudWidget = CreateWidget<USkaldMainHUDWidget>(this, MainHudWidgetClass);
+  // blueprint or constructor).
+  if (HUDWidgetClass) {
+    MainHudWidget = CreateWidget<USkaldMainHUDWidget>(this, HUDWidgetClass);
     if (MainHudWidget) {
       HUDRef = MainHudWidget;
       MainHudWidget->AddToViewport();
@@ -102,7 +110,7 @@ void ASkaldPlayerController::BeginPlay() {
     }
   } else {
     UE_LOG(LogSkald, Warning,
-           TEXT("MainHudWidgetClass is null; HUD will not be displayed."));
+           TEXT("HUDWidgetClass is null; HUD will not be displayed."));
   }
 
   if (!ChoosePlayerWidget) {

--- a/Source/Skald/Skald_PlayerController.h
+++ b/Source/Skald/Skald_PlayerController.h
@@ -69,10 +69,9 @@ protected:
   bool bIsAI;
 
   /** Widget class to instantiate for the player's HUD.
-   *  Expected to be assigned in the Blueprint subclass to avoid
-   *  hard loading during CDO construction. */
+   *  Settable via Blueprint or loaded in the constructor. */
   UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category = "UI")
-  TSubclassOf<USkaldMainHUDWidget> MainHudWidgetClass;
+  TSubclassOf<UUserWidget> HUDWidgetClass;
 
   /** Reference to the HUD widget instance. */
   UPROPERTY(BlueprintReadOnly, Category = "UI",


### PR DESCRIPTION
## Summary
- add `HUDWidgetClass` property to player controller for HUD
- load HUD blueprint in constructor and instantiate in `BeginPlay`

## Testing
- `./Build/validate.sh` *(fails: UnrealBuildTool not found; UnrealEditor not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b02d131b98832490167ac5888e7143