### PR TITLE
Resolve property name conflicts with blueprints

### DIFF
--- a/Source/Skald/Skald_GameMode.h
+++ b/Source/Skald/Skald_GameMode.h
@@ -67,7 +67,7 @@ protected:
   /** Data describing each player in the match. Pre-sized so blueprints can
    * safely write to indices without hitting invalid array warnings. */
   UPROPERTY(BlueprintReadOnly, Category = "Players")
-  TArray<FS_PlayerData> PlayersData;
+  TArray<FS_PlayerData> PlayerDataArray;
 
   /** All siege equipment constructed on the map. */
   UPROPERTY(BlueprintReadOnly, Category = "Siege")

--- a/Source/Skald/Skald_PlayerController.cpp
+++ b/Source/Skald/Skald_PlayerController.cpp
@@ -75,7 +75,7 @@ void ASkaldPlayerController::BeginPlay() {
           if (ASkaldPlayerState *PS = Cast<ASkaldPlayerState>(PSBase)) {
             FS_PlayerData Data;
             Data.PlayerID = PS->GetPlayerId();
-            Data.PlayerName = PS->DisplayName;
+            Data.PlayerName = PS->PlayerDisplayName;
             Data.IsAI = PS->bIsAI;
             Data.Faction = PS->Faction;
             Players.Add(Data);
@@ -141,7 +141,7 @@ void ASkaldPlayerController::BeginPlay() {
 void ASkaldPlayerController::ServerInitPlayerState_Implementation(
     const FString &Name, ESkaldFaction Faction) {
   if (ASkaldPlayerState *PS = GetPlayerState<ASkaldPlayerState>()) {
-    PS->DisplayName = Name;
+    PS->PlayerDisplayName = Name;
     PS->Faction = Faction;
     PS->bHasLockedIn = true;
 
@@ -520,7 +520,7 @@ void ASkaldPlayerController::ServerHandleAttack_Implementation(int32 FromID,
     for (ASkaldPlayerController* Controller : TurnManager->GetControllers()) {
       if (USkaldMainHUDWidget* HUD = Controller ? Controller->GetHUDWidget() : nullptr) {
         FString OwnerName = Target->OwningPlayer
-                                ? Target->OwningPlayer->DisplayName
+                                ? Target->OwningPlayer->PlayerDisplayName
                                 : TEXT("Neutral");
         HUD->UpdateTerritoryInfo(Target->TerritoryName, OwnerName,
                                  Target->ArmyStrength);
@@ -589,12 +589,12 @@ void ASkaldPlayerController::ServerHandleMove_Implementation(int32 FromID,
     for (ASkaldPlayerController* Controller : TurnManager->GetControllers()) {
       if (USkaldMainHUDWidget* HUD = Controller ? Controller->GetHUDWidget() : nullptr) {
         FString SourceOwner = Source->OwningPlayer
-                                  ? Source->OwningPlayer->DisplayName
+                                  ? Source->OwningPlayer->PlayerDisplayName
                                   : TEXT("Neutral");
         HUD->UpdateTerritoryInfo(Source->TerritoryName, SourceOwner,
                                  Source->ArmyStrength);
         FString TargetOwner = Target->OwningPlayer
-                                  ? Target->OwningPlayer->DisplayName
+                                  ? Target->OwningPlayer->PlayerDisplayName
                                   : TEXT("Neutral");
         HUD->UpdateTerritoryInfo(Target->TerritoryName, TargetOwner,
                                  Target->ArmyStrength);
@@ -624,7 +624,7 @@ void ASkaldPlayerController::ServerSelectTerritory_Implementation(
   }
 
   FString OwnerName =
-      Terr->OwningPlayer ? Terr->OwningPlayer->DisplayName : TEXT("Neutral");
+      Terr->OwningPlayer ? Terr->OwningPlayer->PlayerDisplayName : TEXT("Neutral");
 
   Terr->ForceNetUpdate();
 
@@ -683,8 +683,8 @@ void ASkaldPlayerController::ServerDigTreasure_Implementation(
   }
 
   if (ASkaldPlayerState *PS = GetPlayerState<ASkaldPlayerState>()) {
-    if (Terr->OwningPlayer == PS && Terr->HasTreasure) {
-      Terr->HasTreasure = false;
+    if (Terr->OwningPlayer == PS && Terr->bHasTreasure) {
+      Terr->bHasTreasure = false;
       Terr->RefreshAppearance();
       PS->Resources += 5;
       PS->ForceNetUpdate();
@@ -766,7 +766,7 @@ void ASkaldPlayerController::BuildPlayerDataArray(
     if (ASkaldPlayerState *PS = Cast<ASkaldPlayerState>(PSBase)) {
       FS_PlayerData Data;
       Data.PlayerID = PS->GetPlayerId();
-      Data.PlayerName = PS->DisplayName;
+      Data.PlayerName = PS->PlayerDisplayName;
       Data.IsAI = PS->bIsAI;
       Data.Faction = PS->Faction;
       Data.Resources = PS->Resources;
@@ -812,8 +812,9 @@ void ASkaldPlayerController::HandleWorldStateChanged() {
   if (AWorldMap *WorldMap = Cast<AWorldMap>(UGameplayStatics::GetActorOfClass(
           GetWorld(), AWorldMap::StaticClass()))) {
     if (ATerritory *Terr = WorldMap->SelectedTerritory) {
-      FString OwnerName = Terr->OwningPlayer ? Terr->OwningPlayer->DisplayName
-                                             : TEXT("Neutral");
+      FString OwnerName =
+          Terr->OwningPlayer ? Terr->OwningPlayer->PlayerDisplayName
+                             : TEXT("Neutral");
       MainHudWidget->UpdateTerritoryInfo(Terr->TerritoryName, OwnerName,
                                          Terr->ArmyStrength);
     }

--- a/Source/Skald/Skald_PlayerState.cpp
+++ b/Source/Skald/Skald_PlayerState.cpp
@@ -7,7 +7,7 @@ ASkaldPlayerState::ASkaldPlayerState()
     , ArmyPool(0)
     , InitiativeRoll(0)
     , Resources(0)
-    , DisplayName(TEXT("Player"))
+    , PlayerDisplayName(TEXT("Player"))
     , Faction(ESkaldFaction::None)
     , bHasLockedIn(false)
     , IsEliminated(false)
@@ -19,7 +19,7 @@ void ASkaldPlayerState::GetLifetimeReplicatedProps(
 {
     Super::GetLifetimeReplicatedProps(OutLifetimeProps);
 
-    DOREPLIFETIME(ASkaldPlayerState, DisplayName);
+    DOREPLIFETIME(ASkaldPlayerState, PlayerDisplayName);
     DOREPLIFETIME(ASkaldPlayerState, Faction);
     DOREPLIFETIME(ASkaldPlayerState, ArmyPool);
     DOREPLIFETIME(ASkaldPlayerState, bIsAI);

--- a/Source/Skald/Skald_PlayerState.h
+++ b/Source/Skald/Skald_PlayerState.h
@@ -33,7 +33,7 @@ public:
 
     /** Player chosen display name. */
     UPROPERTY(BlueprintReadWrite, Replicated, Category="PlayerState")
-    FString DisplayName;
+    FString PlayerDisplayName;
 
     /** Selected faction for this player. */
     UPROPERTY(BlueprintReadWrite, Replicated, Category="PlayerState")

--- a/Source/Skald/Skald_TurnManager.cpp
+++ b/Source/Skald/Skald_TurnManager.cpp
@@ -84,7 +84,7 @@ void ATurnManager::StartTurns() {
   ASkaldPlayerState *PS = CurrentController
                               ? CurrentController->GetPlayerState<ASkaldPlayerState>()
                               : nullptr;
-  const FString PlayerName = PS ? PS->DisplayName : TEXT("Unknown");
+  const FString PlayerName = PS ? PS->PlayerDisplayName : TEXT("Unknown");
 
   // Determine reinforcements and resources based on owned territories.
   if (PS) {
@@ -190,7 +190,7 @@ void ATurnManager::AdvanceTurn() {
   if (ASkaldPlayerController *CurrentController = Controllers[CurrentIndex].Get()) {
     ASkaldPlayerState *PS =
         CurrentController->GetPlayerState<ASkaldPlayerState>();
-    const FString PlayerName = PS ? PS->DisplayName : TEXT("Unknown");
+    const FString PlayerName = PS ? PS->PlayerDisplayName : TEXT("Unknown");
 
     // Calculate reinforcements and resources for the new active player.
     if (PS) {

--- a/Source/Skald/Territory.cpp
+++ b/Source/Skald/Territory.cpp
@@ -132,7 +132,7 @@ void ATerritory::GetLifetimeReplicatedProps(
   DOREPLIFETIME(ATerritory, AdjacentTerritories);
   DOREPLIFETIME(ATerritory, ArmyStrength);
   DOREPLIFETIME(ATerritory, BuiltSiegeID);
-  DOREPLIFETIME(ATerritory, HasTreasure);
+  DOREPLIFETIME(ATerritory, bHasTreasure);
 }
 
 void ATerritory::Select() {
@@ -240,7 +240,8 @@ void ATerritory::UpdateLabel() {
     return;
   }
 
-  const FString OwnerName = OwningPlayer ? OwningPlayer->DisplayName : TEXT("Neutral");
+  const FString OwnerName =
+      OwningPlayer ? OwningPlayer->PlayerDisplayName : TEXT("Neutral");
   const FString Text = FString::Printf(TEXT("%s\nOwner: %s\nArmy: %d"),
                                       *TerritoryName, *OwnerName,
                                       ArmyStrength);

--- a/Source/Skald/Territory.h
+++ b/Source/Skald/Territory.h
@@ -72,7 +72,7 @@ public:
     int32 BuiltSiegeID = 0;
     /** Whether this territory contains treasure. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Territory", Replicated)
-    bool HasTreasure = false;
+    bool bHasTreasure = false;
 
 
     /** Called when the territory is selected. */

--- a/Source/Skald/Tests/FullTurnFlowTest.cpp
+++ b/Source/Skald/Tests/FullTurnFlowTest.cpp
@@ -68,7 +68,7 @@ bool FSkaldFullTurnFlowTest::RunTest(const FString &Parameters) {
   T1->TerritoryID = 1;
   T1->bIsCapital = true;
   T1->OwningPlayer = PS;
-  T1->HasTreasure = true;
+  T1->bHasTreasure = true;
   T1->ArmyStrength = 5;
   T2->TerritoryID = 2;
   T2->OwningPlayer = PS;
@@ -95,7 +95,7 @@ bool FSkaldFullTurnFlowTest::RunTest(const FString &Parameters) {
             ETurnPhase::Treasure);
   HUD->OnTerritoryClickedUI(T1);
   TestEqual(TEXT("Resources after treasure"), PS->Resources, 15);
-  TestFalse(TEXT("Treasure cleared"), T1->HasTreasure);
+  TestFalse(TEXT("Treasure cleared"), T1->bHasTreasure);
 
   PC->EndPhase(); // to movement
   TestEqual(TEXT("Movement phase"), TM->GetCurrentPhase(),

--- a/Source/Skald/UI/SkaldMainHUDWidget.cpp
+++ b/Source/Skald/UI/SkaldMainHUDWidget.cpp
@@ -412,7 +412,7 @@ void USkaldMainHUDWidget::OnTerritoryClickedUI(ATerritory *Territory) {
              Territory->bIsCapital) {
     OnEngineeringRequested.Broadcast(Territory->TerritoryID, 0);
   } else if (CurrentPhase == ETurnPhase::Treasure && bOwnedByLocal &&
-             Territory->HasTreasure) {
+             Territory->bHasTreasure) {
     OnDigTreasureRequested.Broadcast(Territory->TerritoryID);
   }
 }
@@ -436,7 +436,7 @@ void USkaldMainHUDWidget::HandlePlayersUpdated() {
     if (ASkaldPlayerState *PS = Cast<ASkaldPlayerState>(PSBase)) {
       FS_PlayerData Data;
       Data.PlayerID = PS->GetPlayerId();
-      Data.PlayerName = PS->DisplayName;
+      Data.PlayerName = PS->PlayerDisplayName;
       Data.IsAI = PS->bIsAI;
       Data.Faction = PS->Faction;
       Players.Add(Data);


### PR DESCRIPTION
## Summary
- Rename player state `DisplayName` to `PlayerDisplayName` and update all references
- Rename territory treasure flag to `bHasTreasure`
- Rename game mode `PlayersData` array to `PlayerDataArray`

## Testing
- `bash Build/validate.sh` *(fails: UnrealBuildTool not found; tests skipped)*

------
https://chatgpt.com/codex/tasks/task_e_68b0a4d32068832499b5d7170fc1bcf3