### PR TITLE
Gate territory spawning to default world map

### DIFF
--- a/Source/Skald/Skald_GameMode.cpp
+++ b/Source/Skald/Skald_GameMode.cpp
@@ -102,12 +102,15 @@ void ASkaldGameMode::InitializeWorld() {
     return;
   }
 
-  // Spawn 43 territories with unique identifiers
-  for (int32 Id = 0; Id < 43; ++Id) {
-    ATerritory *Territory = GetWorld()->SpawnActor<ATerritory>();
-    if (Territory) {
-      Territory->TerritoryID = Id;
-      WorldMap->RegisterTerritory(Territory);
+  // If the world map failed to spawn its default territories, create them
+  // here as a fallback. Normally AWorldMap::BeginPlay() handles this.
+  if (WorldMap->Territories.Num() == 0) {
+    for (int32 Id = 0; Id < 43; ++Id) {
+      ATerritory *Territory = GetWorld()->SpawnActor<ATerritory>();
+      if (Territory) {
+        Territory->TerritoryID = Id;
+        WorldMap->RegisterTerritory(Territory);
+      }
     }
   }
 


### PR DESCRIPTION
## Summary
- avoid duplicate territory spawning by deferring to AWorldMap's defaults
- maintain round-robin territory assignment for existing map entries

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b0d1f816bc8324a9be6d24ebfcfd75