### PR TITLE
Use Skald save objects and restore data when loading

### DIFF
--- a/Source/Skald/LoadGameWidget.cpp
+++ b/Source/Skald/LoadGameWidget.cpp
@@ -4,6 +4,9 @@
 #include "GameFramework/SaveGame.h"
 #include "LobbyMenuWidget.h"
 #include "SlotNameConstants.h"
+#include "SkaldSaveGame.h"
+#include "SkaldSaveGameLibrary.h"
+#include "Skald_GameInstance.h"
 
 void ULoadGameWidget::NativeConstruct()
 {
@@ -59,10 +62,18 @@ void ULoadGameWidget::OnMainMenu()
 
 void ULoadGameWidget::HandleLoadSlot(int32 SlotIndex)
 {
-    USaveGame* LoadedGame = UGameplayStatics::LoadGameFromSlot(SlotNames[SlotIndex], 0);
+    USkaldSaveGame* LoadedGame = USkaldSaveGameLibrary::LoadSkaldGame(SlotNames[SlotIndex], 0);
     if (LoadedGame)
     {
-        // After loading, transition to the main gameplay map
+        if (USkaldGameInstance* GI = GetWorld()->GetGameInstance<USkaldGameInstance>())
+        {
+            if (LoadedGame->Players.Num() > 0)
+            {
+                GI->DisplayName = LoadedGame->Players[0].PlayerName;
+                GI->Faction = LoadedGame->Players[0].Faction;
+            }
+        }
+
         UGameplayStatics::OpenLevel(this, FName("Skald_OverTop"));
     }
     else


### PR DESCRIPTION
## Summary
- Replace generic save creation with `USkaldSaveGame` and save via `USkaldSaveGameLibrary`
- Gather player and territory state before saving
- Load save games as `USkaldSaveGame` and apply stored player data to the game instance

## Testing
- `make` *(fails: No targets specified and no makefile found)*

------
https://chatgpt.com/codex/tasks/task_e_68b0d331740883248b3ca092b97166ce