### PR TITLE
Prevent duplicate button bindings on repeated widget creation

### DIFF
--- a/Source/Skald/LoadGameWidget.cpp
+++ b/Source/Skald/LoadGameWidget.cpp
@@ -36,6 +36,31 @@ void ULoadGameWidget::NativeConstruct()
     }
 }
 
+void ULoadGameWidget::NativeDestruct()
+{
+    if (Slot0Button)
+    {
+        Slot0Button->OnClicked.RemoveDynamic(this, &ULoadGameWidget::OnLoadSlot0);
+    }
+
+    if (Slot1Button)
+    {
+        Slot1Button->OnClicked.RemoveDynamic(this, &ULoadGameWidget::OnLoadSlot1);
+    }
+
+    if (Slot2Button)
+    {
+        Slot2Button->OnClicked.RemoveDynamic(this, &ULoadGameWidget::OnLoadSlot2);
+    }
+
+    if (MainMenuButton)
+    {
+        MainMenuButton->OnClicked.RemoveDynamic(this, &ULoadGameWidget::OnMainMenu);
+    }
+
+    Super::NativeDestruct();
+}
+
 void ULoadGameWidget::OnLoadSlot0()
 {
     HandleLoadSlot(0);

--- a/Source/Skald/LoadGameWidget.h
+++ b/Source/Skald/LoadGameWidget.h
@@ -31,6 +31,7 @@ public:
 
 protected:
     virtual void NativeConstruct() override;
+    virtual void NativeDestruct() override;
 
     UFUNCTION(BlueprintCallable)
     void OnLoadSlot0();

--- a/Source/Skald/StartGameWidget.cpp
+++ b/Source/Skald/StartGameWidget.cpp
@@ -50,6 +50,26 @@ void UStartGameWidget::NativeConstruct()
     }
 }
 
+void UStartGameWidget::NativeDestruct()
+{
+    if (SingleplayerButton)
+    {
+        SingleplayerButton->OnClicked.RemoveDynamic(this, &UStartGameWidget::OnSingleplayer);
+    }
+
+    if (MultiplayerButton)
+    {
+        MultiplayerButton->OnClicked.RemoveDynamic(this, &UStartGameWidget::OnMultiplayer);
+    }
+
+    if (MainMenuButton)
+    {
+        MainMenuButton->OnClicked.RemoveDynamic(this, &UStartGameWidget::OnMainMenu);
+    }
+
+    Super::NativeDestruct();
+}
+
 void UStartGameWidget::OnSingleplayer()
 {
     StartGame(false);

--- a/Source/Skald/StartGameWidget.h
+++ b/Source/Skald/StartGameWidget.h
@@ -44,6 +44,7 @@ public:
 
 protected:
     virtual void NativeConstruct() override;
+    virtual void NativeDestruct() override;
 
     UFUNCTION()
     void OnSingleplayer();


### PR DESCRIPTION
## Summary
- Add `NativeDestruct` overrides to StartGameWidget and LoadGameWidget to remove button bindings
- Ensure `Super::NativeDestruct` is called and old bindings are cleaned up

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b0d997d4548324881517986a753989