### PR TITLE
Clamp defender health at zero

### DIFF
--- a/Build/validate.sh
+++ b/Build/validate.sh
@@ -12,7 +12,7 @@ fi
 
 echo "Running automation tests..."
 if command -v UnrealEditor &>/dev/null; then
-  UnrealEditor "$UPROJECT" -ExecCmds="Automation RunTests Skald.UI.BindingsRemain+Skald.PlayerController.ValidationFeedback+Skald.TurnManager.PhaseTransitions+Skald.TurnManager.InitiativeSort+Skald.WorldMap.FindPath.Valid+Skald.WorldMap.FindPath.Blocked+Skald.TurnManager.ResourceAccumulation;Quit" -unattended -nop4 || exit 1
+  UnrealEditor "$UPROJECT" -ExecCmds="Automation RunTests Skald.UI.BindingsRemain+Skald.PlayerController.ValidationFeedback+Skald.TurnManager.PhaseTransitions+Skald.TurnManager.InitiativeSort+Skald.WorldMap.FindPath.Valid+Skald.WorldMap.FindPath.Blocked+Skald.TurnManager.ResourceAccumulation+Skald.GridBattle.ResolveAttackClamp;Quit" -unattended -nop4 || exit 1
 else
   echo "UnrealEditor not found; cannot run tests." >&2
 fi

--- a/Source/Skald/GridBattleManager.cpp
+++ b/Source/Skald/GridBattleManager.cpp
@@ -223,12 +223,14 @@ bool UGridBattleManager::ResolveAttack(FFighter& Attacker, FFighter& Defender, i
         {
             int32 Damage = RandomStream.RandRange(1, Attacker.Stats.DamageDie) + 3;
             Defender.Stats.Health -= Damage;
+            Defender.Stats.Health = FMath::Max(Defender.Stats.Health, 0);
             OutDamage += Damage;
         }
         else if (Roll >= RequiredRoll)
         {
             int32 Damage = RandomStream.RandRange(1, Attacker.Stats.DamageDie);
             Defender.Stats.Health -= Damage;
+            Defender.Stats.Health = FMath::Max(Defender.Stats.Health, 0);
             OutDamage += Damage;
         }
     }

--- a/Source/Skald/Tests/ResolveAttackClampTest.cpp
+++ b/Source/Skald/Tests/ResolveAttackClampTest.cpp
@@ -1,0 +1,20 @@
+#include "Misc/AutomationTest.h"
+#include "GridBattleManager.h"
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FSkaldResolveAttackClampTest, "Skald.GridBattle.ResolveAttackClamp", EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+bool FSkaldResolveAttackClampTest::RunTest(const FString& Parameters) {
+  FFighter Attacker;
+  Attacker.Stats.AttackDice = 1;
+  Attacker.Stats.DamageDie = 6;
+
+  FFighter Defender;
+  Defender.Stats.Health = 5;
+
+  FRandomStream RandomStream(3);
+  int32 OutDamage = 0;
+  UGridBattleManager::ResolveAttack(Attacker, Defender, OutDamage, RandomStream);
+
+  TestTrue(TEXT("Damage exceeds health"), OutDamage > 5);
+  TestEqual(TEXT("Defender health clamped"), Defender.Stats.Health, 0);
+  return true;
+}


### PR DESCRIPTION
## Summary
- Prevent negative defender health by clamping to zero in grid battle attack resolution
- Add test verifying ResolveAttack health clamping
- Include new test in validation script

## Testing
- `./Build/validate.sh` *(fails: UnrealBuildTool and UnrealEditor not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b0dbdf079c8324873b637a4b72b29b