### PR TITLE
Cache world map in turn manager

### DIFF
--- a/Source/Skald/Skald_TurnManager.h
+++ b/Source/Skald/Skald_TurnManager.h
@@ -7,6 +7,7 @@
 
 class ASkaldPlayerController;
 class ASkaldPlayerState;
+class AWorldMap;
 
 // Broadcast whenever the overall world state changes so HUDs can refresh.
 DECLARE_DYNAMIC_MULTICAST_DELEGATE(FSkaldWorldStateChanged);
@@ -100,6 +101,9 @@ protected:
 
     UPROPERTY(BlueprintReadWrite, EditAnywhere, Category="Turn")
     FS_BattlePayload PendingBattle;
+
+    UPROPERTY()
+    AWorldMap* CachedWorldMap;
 
     /** Notify controllers and HUDs of a phase change. */
     void BroadcastCurrentPhase();


### PR DESCRIPTION
## Summary
- cache WorldMap actor once during turn manager BeginPlay
- use cached map instead of repeated GetActorOfClass calls

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b0dcb1df3c832485ee18c6da58a055