### PR TITLE
Implement NativeDestruct for HUD widget and cleanup delegates

### DIFF
--- a/Source/Skald/UI/SkaldMainHUDWidget.cpp
+++ b/Source/Skald/UI/SkaldMainHUDWidget.cpp
@@ -70,6 +70,40 @@ void USkaldMainHUDWidget::NativeConstruct() {
   RebuildPlayerList(CachedPlayers);
 }
 
+void USkaldMainHUDWidget::NativeDestruct() {
+  if (GameState) {
+    GameState->OnPlayersUpdated.RemoveDynamic(
+        this, &USkaldMainHUDWidget::HandlePlayersUpdated);
+  }
+
+  if (AttackButton) {
+    AttackButton->OnClicked.RemoveDynamic(
+        this, &USkaldMainHUDWidget::BeginAttackSelection);
+  }
+
+  if (MoveButton) {
+    MoveButton->OnClicked.RemoveDynamic(
+        this, &USkaldMainHUDWidget::BeginMoveSelection);
+  }
+
+  if (EndTurnButton) {
+    EndTurnButton->OnClicked.RemoveDynamic(
+        this, &USkaldMainHUDWidget::HandleEndTurnClicked);
+  }
+
+  if (EndPhaseButton) {
+    EndPhaseButton->OnClicked.RemoveDynamic(
+        this, &USkaldMainHUDWidget::HandleEndPhaseClicked);
+  }
+
+  if (DeployButton) {
+    DeployButton->OnClicked.RemoveDynamic(
+        this, &USkaldMainHUDWidget::HandleDeployClicked);
+  }
+
+  Super::NativeDestruct();
+}
+
 void USkaldMainHUDWidget::HandleEndTurnClicked() {
   ShowEndingTurn();
   if (APlayerController *PC = GetOwningPlayer()) {

--- a/Source/Skald/UI/SkaldMainHUDWidget.h
+++ b/Source/Skald/UI/SkaldMainHUDWidget.h
@@ -311,6 +311,7 @@ protected:
   TArray<ATerritory *> HighlightedTerritories;
 
   virtual void NativeConstruct() override;
+  virtual void NativeDestruct() override;
 
   /** Refresh player list when the game state notifies us of a change. */
   UFUNCTION()


### PR DESCRIPTION
## Summary
- Implement `NativeDestruct` in `SkaldMainHUDWidget`
- Remove dynamic delegates from GameState and HUD buttons

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b0e092e79883249822009bc3590f68