### PR TITLE
Refactor attack validation

### DIFF
--- a/Source/Skald/Skald_PlayerController.h
+++ b/Source/Skald/Skald_PlayerController.h
@@ -208,5 +208,10 @@ protected:
 
 private:
   void BuildPlayerDataArray(TArray<FS_PlayerData> &OutPlayers) const;
+
+  bool ValidateAttack(int32 FromID, int32 ToID, int32 ArmySent, bool bUseSiege,
+                      FString *OutError);
+
+  UFUNCTION(Client, Reliable)
   void NotifyActionError(const FString &Message);
 };


### PR DESCRIPTION
## Summary
- centralize attack validation in `ValidateAttack`
- funnel validation through helper in attack handling functions
- convert `NotifyActionError` to client RPC so server can report errors

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open 'package.json')*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b0e1a14c7483249369de61a5e520c3