### PR TITLE
Refine AI turn loop termination

### DIFF
--- a/Source/Skald/Tests/AIDecisionFlowTest.cpp
+++ b/Source/Skald/Tests/AIDecisionFlowTest.cpp
@@ -75,6 +75,7 @@ bool FSkaldAIDecisionFlowTest::RunTest(const FString& Parameters)
     TestEqual(TEXT("Resources spent"), PS1->Resources, 0);
     TestEqual(TEXT("Attack captured territory"), TB->OwningPlayer, PS1);
     TestTrue(TEXT("Movement reinforced"), TA->ArmyStrength > 1);
+    TestEqual(TEXT("Turn advanced"), TM->GetCurrentPhase(), ETurnPhase::Reinforcement);
 
     return true;
 }


### PR DESCRIPTION
## Summary
- Replace endless AI decision loop with phase-aware termination capped at `MaxAIIterations`
- Log phase progress and iteration counts, breaking on stagnant phases
- Verify AI turns advance the phase in automation tests

## Testing
- `./Build/validate.sh` *(UnrealBuildTool not found; skipping compile check. UnrealEditor not found; cannot run tests.)*


------
https://chatgpt.com/codex/tasks/task_e_68b0f47deb708324a388d241f0381406