### PR TITLE
Fix missing UWorld definition in AI decision test

### DIFF
--- a/Source/Skald/Tests/AIDecisionFlowTest.cpp
+++ b/Source/Skald/Tests/AIDecisionFlowTest.cpp
@@ -1,5 +1,6 @@
 #include "Misc/AutomationTest.h"
 #include "Tests/AutomationEditorCommon.h"
+#include "Engine/World.h"
 #include "Skald_PlayerController.h"
 #include "Skald_PlayerState.h"
 #include "Skald_TurnManager.h"


### PR DESCRIPTION
## Summary
- include UWorld header in AI decision flow test to resolve undefined type errors

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b16acd114883249c915f6e44169856