### PR TITLE
Ensure SlotNameConstants includes required UE headers

### DIFF
--- a/Source/Skald/SlotNameConstants.h
+++ b/Source/Skald/SlotNameConstants.h
@@ -1,3 +1,5 @@
 #pragma once
 
+#include "CoreMinimal.h"
+
 inline constexpr const TCHAR* SlotNames[3] = { TEXT("Slot0"), TEXT("Slot1"), TEXT("Slot2") };


### PR DESCRIPTION
## Summary
- include `CoreMinimal.h` in `SlotNameConstants.h` to provide `TCHAR` and `TEXT`

## Testing
- `g++ -fsyntax-only Source/Skald/SlotNameConstants.h` *(fails: CoreMinimal.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b172fe79d083249e0054c8ca60cbf9