### PR TITLE
Fix Skald_PlayerState UWorld include

### DIFF
--- a/Source/Skald/Skald_PlayerState.cpp
+++ b/Source/Skald/Skald_PlayerState.cpp
@@ -1,6 +1,7 @@
 #include "Skald_PlayerState.h"
 #include "Net/UnrealNetwork.h"
 #include "Skald_GameState.h"
+#include "Engine/World.h"
 
 ASkaldPlayerState::ASkaldPlayerState()
     : bIsAI(false)
@@ -31,17 +32,23 @@ void ASkaldPlayerState::GetLifetimeReplicatedProps(
 
 void ASkaldPlayerState::OnRep_HasLockedIn()
 {
-    if (ASkaldGameState* GS = GetWorld() ? GetWorld()->GetGameState<ASkaldGameState>() : nullptr)
+    if (UWorld* World = GetWorld())
     {
-        GS->OnPlayersUpdated.Broadcast();
+        if (ASkaldGameState* GS = World->GetGameState<ASkaldGameState>())
+        {
+            GS->OnPlayersUpdated.Broadcast();
+        }
     }
 }
 
 void ASkaldPlayerState::OnRep_IsEliminated()
 {
-    if (ASkaldGameState* GS = GetWorld() ? GetWorld()->GetGameState<ASkaldGameState>() : nullptr)
+    if (UWorld* World = GetWorld())
     {
-        GS->OnPlayersUpdated.Broadcast();
+        if (ASkaldGameState* GS = World->GetGameState<ASkaldGameState>())
+        {
+            GS->OnPlayersUpdated.Broadcast();
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- include Engine/World in player state for GetWorld usage
- streamline replication callbacks to safely access game state

## Testing
- `g++ -std=c++17 -fsyntax-only Source/Skald/Skald_PlayerState.cpp` *(fails: CoreMinimal.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b1746c8a3c832488066eb3f0aa6a61