### PR TITLE
Fix HUD blueprint reference

### DIFF
--- a/Source/Skald/Skald_PlayerController.cpp
+++ b/Source/Skald/Skald_PlayerController.cpp
@@ -30,7 +30,7 @@ ASkaldPlayerController::ASkaldPlayerController() {
 
   // Load a default HUD widget blueprint if available.
   static ConstructorHelpers::FClassFinder<UUserWidget> HUDWidgetFinder(
-      TEXT("/Game/C++_BPs/Skald_MainHUDBP"));
+      TEXT("/Game/C++_BPs/Skald_MainHUDBP.Skald_MainHUDBP_C"));
   if (HUDWidgetFinder.Succeeded()) {
     HUDWidgetClass = HUDWidgetFinder.Class;
   }


### PR DESCRIPTION
## Summary
- fix `FClassFinder` path to blueprint class `Skald_MainHUDBP_C`

## Testing
- `bash Build/validate.sh` *(fails: UnrealBuildTool not found; UnrealEditor not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b51110d82883249657145be9ecdb28