### PR TITLE
Fix HUD blueprint path for FClassFinder

### DIFF
--- a/Source/Skald/Skald_PlayerController.cpp
+++ b/Source/Skald/Skald_PlayerController.cpp
@@ -30,7 +30,7 @@ ASkaldPlayerController::ASkaldPlayerController() {
 
   // Load a default HUD widget blueprint if available.
   static ConstructorHelpers::FClassFinder<UUserWidget> HUDWidgetFinder(
-      TEXT("/Game/C++_BPs/Skald_MainHUDBP.Skald_MainHUDBP_C"));
+      TEXT("/Game/C++_BPs/Skald_MainHUDBP"));
   if (HUDWidgetFinder.Succeeded()) {
     HUDWidgetClass = HUDWidgetFinder.Class;
   }


### PR DESCRIPTION
## Summary
- fix HUD widget blueprint path to avoid `_C` duplication when using `FClassFinder`

## Testing
- `./Build/validate.sh` *(fails: UnrealBuildTool not found; UnrealEditor not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b51b13bc6883248efc4faa81cb84a0