### PR TITLE
Disable controls until player lock in

### DIFF
--- a/Build/validate.sh
+++ b/Build/validate.sh
@@ -12,7 +12,7 @@ fi
 
 echo "Running automation tests..."
 if command -v UnrealEditor &>/dev/null; then
-  UnrealEditor "$UPROJECT" -ExecCmds="Automation RunTests Skald.UI.BindingsRemain+Skald.PlayerController.ValidationFeedback+Skald.TurnManager.PhaseTransitions+Skald.TurnManager.InitiativeSort+Skald.WorldMap.FindPath.Valid+Skald.WorldMap.FindPath.Blocked+Skald.TurnManager.ResourceAccumulation+Skald.GridBattle.ResolveAttackClamp;Quit" -unattended -nop4 || exit 1
+  UnrealEditor "$UPROJECT" -ExecCmds="Automation RunTests Skald.UI.BindingsRemain+Skald.PlayerController.ValidationFeedback+Skald.PlayerController.LockInMovement+Skald.TurnManager.PhaseTransitions+Skald.TurnManager.InitiativeSort+Skald.WorldMap.FindPath.Valid+Skald.WorldMap.FindPath.Blocked+Skald.TurnManager.ResourceAccumulation+Skald.GridBattle.ResolveAttackClamp;Quit" -unattended -nop4 || exit 1
 else
   echo "UnrealEditor not found; cannot run tests." >&2
 fi

--- a/Source/Skald/Skald_PlayerController.cpp
+++ b/Source/Skald/Skald_PlayerController.cpp
@@ -122,6 +122,10 @@ void ASkaldPlayerController::BeginPlay() {
         ChoosePlayerWidget->OnPlayerLockedIn.AddDynamic(
             this, &ASkaldPlayerController::HandlePlayerLockedIn);
         ChoosePlayerWidget->AddToViewport();
+        // While the player is choosing their faction, restrict controls to the UI
+        SetInputMode(FInputModeUIOnly());
+        SetIgnoreMoveInput(true);
+        SetIgnoreLookInput(true);
       }
     }
   }
@@ -870,6 +874,11 @@ void ASkaldPlayerController::HandlePlayerLockedIn() {
         this, &ASkaldPlayerController::HandlePlayerLockedIn);
     ChoosePlayerWidget->RemoveFromParent();
   }
+  // Restore game controls now that the player has locked in
+  SetInputMode(FInputModeGameAndUI());
+  SetIgnoreMoveInput(false);
+  SetIgnoreLookInput(false);
+
   if (MainHudWidget) {
     MainHudWidget->SetVisibility(ESlateVisibility::Visible);
   }

--- a/Source/Skald/Tests/PlayerControllerLockInMovementTest.cpp
+++ b/Source/Skald/Tests/PlayerControllerLockInMovementTest.cpp
@@ -1,0 +1,47 @@
+#include "ChoosePlayerWidget.h"
+#include "Misc/AutomationTest.h"
+#include "Skald_PlayerController.h"
+#include "Tests/AutomationEditorCommon.h"
+#include "UObject/UnrealType.h"
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FSkaldPlayerControllerLockInMovementTest,
+                                 "Skald.PlayerController.LockInMovement",
+                                 EAutomationTestFlags::EditorContext |
+                                     EAutomationTestFlags::EngineFilter)
+
+bool FSkaldPlayerControllerLockInMovementTest::RunTest(const FString &)
+{
+    UWorld *World = FAutomationEditorCommonUtils::CreateNewMap();
+    TestNotNull(TEXT("World created"), World);
+    if (!World)
+    {
+        return false;
+    }
+
+    ASkaldPlayerController *PC = World->SpawnActor<ASkaldPlayerController>();
+    TestNotNull(TEXT("PlayerController"), PC);
+    if (!PC)
+    {
+        return false;
+    }
+
+    UChoosePlayerWidget *Widget = NewObject<UChoosePlayerWidget>(PC);
+    FObjectProperty *ChooseProp = FindFProperty<FObjectProperty>(
+        ASkaldPlayerController::StaticClass(), TEXT("ChoosePlayerWidget"));
+    ChooseProp->SetObjectPropertyValue_InContainer(PC, Widget);
+
+    PC->SetInputMode(FInputModeUIOnly());
+    PC->SetIgnoreMoveInput(true);
+    PC->SetIgnoreLookInput(true);
+
+    TestTrue(TEXT("Movement disabled before lock in"), PC->IsMoveInputIgnored());
+    TestTrue(TEXT("Look disabled before lock in"), PC->IsLookInputIgnored());
+
+    PC->HandlePlayerLockedIn();
+
+    TestFalse(TEXT("Movement enabled after lock in"), PC->IsMoveInputIgnored());
+    TestFalse(TEXT("Look enabled after lock in"), PC->IsLookInputIgnored());
+
+    return true;
+}
+


### PR DESCRIPTION
## Summary
- Restrict input to UI while ChoosePlayerWidget is open, preventing movement and look
- Restore input and HUD visibility when player locks in
- Add automation test ensuring movement remains disabled until lock in

## Testing
- `./Build/validate.sh` *(fails: UnrealBuildTool not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b52812ebf48324ae6b75dae4943290