### PR TITLE
Enable deploy widget on territory selection

### DIFF
--- a/Source/Skald/Skald_PlayerController.cpp
+++ b/Source/Skald/Skald_PlayerController.cpp
@@ -12,6 +12,7 @@
 #include "Skald_TurnManager.h"
 #include "Territory.h"
 #include "UI/SkaldMainHUDWidget.h"
+#include "UI/DeployWidget.h"
 #include "WorldMap.h"
 #include <limits>
 
@@ -63,6 +64,15 @@ void ASkaldPlayerController::BeginPlay() {
   if (HUDWidgetClass) {
     MainHudWidget = CreateWidget<USkaldMainHUDWidget>(this, HUDWidgetClass);
     if (MainHudWidget) {
+      // Ensure DeployWidgetClass is set so the Deploy UI can be spawned.
+      if (!MainHudWidget->DeployWidgetClass) {
+        if (UClass *DeployClass = LoadClass<UDeployWidget>(
+                nullptr,
+                TEXT("/Game/Blueprints/UI/Skald_DeployWidget.Skald_DeployWidget_C"))) {
+          MainHudWidget->DeployWidgetClass = DeployClass;
+        }
+      }
+
       HUDRef = MainHudWidget;
       MainHudWidget->AddToViewport();
       MainHudWidget->SetVisibility(ESlateVisibility::Hidden);
@@ -770,6 +780,10 @@ void ASkaldPlayerController::HandleTerritorySelected(ATerritory *Terr) {
   }
 
   ServerSelectTerritory(Terr->TerritoryID);
+
+  if (MainHudWidget) {
+    MainHudWidget->OnTerritoryClickedUI(Terr);
+  }
 }
 
 void ASkaldPlayerController::NotifyActionError_Implementation(


### PR DESCRIPTION
## Summary
- ensure SkaldMainHUDWidget defaults DeployWidgetClass to Skald_DeployWidget
- notify HUD when territory is clicked to expose deploy controls

## Testing
- `./Build/validate.sh` *(fails: UnrealBuildTool not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b5283a9f008324842b2a075f5879f5