### PR TITLE
Refactor UI loading and rename siege enum

### DIFF
--- a/Source/Skald/LobbyMenuWidget.cpp
+++ b/Source/Skald/LobbyMenuWidget.cpp
@@ -5,6 +5,17 @@
 #include "Components/Button.h"
 #include "Kismet/GameplayStatics.h"
 #include "Kismet/KismetSystemLibrary.h"
+#include "UObject/ConstructorHelpers.h"
+
+ULobbyMenuWidget::ULobbyMenuWidget(const FObjectInitializer& ObjectInitializer)
+    : Super(ObjectInitializer) {
+    static ConstructorHelpers::FClassFinder<UStartGameWidget> StartBP(TEXT("/Game/Blueprints/UI/Skald_StartGameWidget"));
+    if (StartBP.Succeeded()) { StartGameWidgetClass = StartBP.Class; }
+    static ConstructorHelpers::FClassFinder<ULoadGameWidget> LoadBP(TEXT("/Game/Blueprints/UI/Skald_LoadGameWidget"));
+    if (LoadBP.Succeeded()) { LoadGameWidgetClass = LoadBP.Class; }
+    static ConstructorHelpers::FClassFinder<USettingsWidget> SettingsBP(TEXT("/Game/Blueprints/UI/Skald_SettingsWidget"));
+    if (SettingsBP.Succeeded()) { SettingsWidgetClass = SettingsBP.Class; }
+}
 
 void ULobbyMenuWidget::NativeConstruct()
 {
@@ -35,7 +46,7 @@ void ULobbyMenuWidget::OnStartGame()
 {
     if (UWorld* World = GetWorld())
     {
-        if (UClass* StartGameWidgetClass = LoadClass<UStartGameWidget>(nullptr, TEXT("/Game/Blueprints/UI/Skald_StartGameWidget.Skald_StartGameWidget_C")))
+        if (StartGameWidgetClass)
         {
             if (UStartGameWidget* Widget = CreateWidget<UStartGameWidget>(World, StartGameWidgetClass))
             {
@@ -53,12 +64,8 @@ void ULobbyMenuWidget::OnLoadGame()
     {
         if (!LoadGameWidgetClass)
         {
-            LoadGameWidgetClass = LoadClass<ULoadGameWidget>(nullptr, TEXT("/Game/Blueprints/UI/Skald_LoadGameWidget.Skald_LoadGameWidget_C"));
-            if (!LoadGameWidgetClass)
-            {
-                UE_LOG(LogTemp, Error, TEXT("Failed to load default LoadGameWidget class."));
-                return;
-            }
+            UE_LOG(LogTemp, Error, TEXT("LoadGameWidgetClass is not set."));
+            return;
         }
 
         if (ULoadGameWidget* Widget = CreateWidget<ULoadGameWidget>(World, LoadGameWidgetClass))
@@ -76,12 +83,8 @@ void ULobbyMenuWidget::OnSettings()
     {
         if (!SettingsWidgetClass)
         {
-            SettingsWidgetClass = LoadClass<USettingsWidget>(nullptr, TEXT("/Game/Blueprints/UI/Skald_SettingsWidget.Skald_SettingsWidget_C"));
-            if (!SettingsWidgetClass)
-            {
-                UE_LOG(LogTemp, Error, TEXT("Failed to load default SettingsWidget class."));
-                return;
-            }
+            UE_LOG(LogTemp, Error, TEXT("SettingsWidgetClass is not set."));
+            return;
         }
 
         if (USettingsWidget* Widget = CreateWidget<USettingsWidget>(World, SettingsWidgetClass))

--- a/Source/Skald/LobbyMenuWidget.h
+++ b/Source/Skald/LobbyMenuWidget.h
@@ -8,6 +8,7 @@ class UButton;
 class UVerticalBox;
 class ULoadGameWidget;
 class USettingsWidget;
+class UStartGameWidget;
 
 /**
  * Main menu widget shown on the lobby map.
@@ -18,6 +19,8 @@ class SKALD_API ULobbyMenuWidget : public UUserWidget
     GENERATED_BODY()
 
 public:
+    ULobbyMenuWidget(const FObjectInitializer& ObjectInitializer);
+
     UPROPERTY(BlueprintReadOnly, Category="Skald|Widgets", meta=(BindWidgetOptional))
     UVerticalBox* Root;
 
@@ -38,6 +41,9 @@ public:
 
     UPROPERTY(EditAnywhere, Category="Lobby")
     TSubclassOf<USettingsWidget> SettingsWidgetClass;
+
+    UPROPERTY(EditAnywhere, Category="Lobby")
+    TSubclassOf<UStartGameWidget> StartGameWidgetClass;
 
 protected:
     virtual void NativeConstruct() override;

--- a/Source/Skald/SkaldTypes.h
+++ b/Source/Skald/SkaldTypes.h
@@ -51,7 +51,7 @@ enum class ESkaldFaction : uint8
 };
 
 UENUM(BlueprintType)
-enum class E_SiegeWeapons : uint8   // (Consider E prefix instead of Enum_ for UE style)
+enum class ESiegeWeapon : uint8
 {
     BatteringRam UMETA(DisplayName = "BatteringRam"),
     Trebuchet    UMETA(DisplayName = "Trebuchet"),
@@ -181,7 +181,7 @@ struct SKALD_API FS_Siege
     int32 SiegeID = 0;
 
     UPROPERTY(BlueprintReadWrite, EditAnywhere)
-    E_SiegeWeapons Type = E_SiegeWeapons::BatteringRam;
+    ESiegeWeapon Type = ESiegeWeapon::BatteringRam;
 
     UPROPERTY(BlueprintReadWrite, EditAnywhere)
     int32 BuiltAtTerritoryID = 0;

--- a/Source/Skald/Skald_GameMode.cpp
+++ b/Source/Skald/Skald_GameMode.cpp
@@ -471,7 +471,7 @@ void ASkaldGameMode::BeginArmyPlacementPhase() {
 }
 
 int32 ASkaldGameMode::BuildSiegeAtTerritory(int32 TerritoryID,
-                                            E_SiegeWeapons Type) {
+                                            ESiegeWeapon Type) {
   if (!WorldMap) {
     return 0;
   }

--- a/Source/Skald/Skald_GameMode.h
+++ b/Source/Skald/Skald_GameMode.h
@@ -91,7 +91,7 @@ protected:
 public:
   /** Build siege equipment during the engineering phase. */
   UFUNCTION(BlueprintCallable, Category = "Siege")
-  int32 BuildSiegeAtTerritory(int32 TerritoryID, E_SiegeWeapons Type);
+  int32 BuildSiegeAtTerritory(int32 TerritoryID, ESiegeWeapon Type);
 
   /** Consume a built siege from a territory for an attack. */
   UFUNCTION(BlueprintCallable, Category = "Siege")

--- a/Source/Skald/Skald_PlayerController.cpp
+++ b/Source/Skald/Skald_PlayerController.cpp
@@ -14,6 +14,7 @@
 #include "UI/DeployWidget.h"
 #include "UI/SkaldMainHUDWidget.h"
 #include "WorldMap.h"
+#include "UObject/ConstructorHelpers.h"
 #include <limits>
 
 constexpr int32 MaxAIIterations = 100;
@@ -31,6 +32,12 @@ ASkaldPlayerController::ASkaldPlayerController() {
   // Default to the native HUD widget class. This avoids loading a
   // blueprint-derived widget that may not exist or may be corrupt.
   HUDWidgetClass = USkaldMainHUDWidget::StaticClass();
+
+  static ConstructorHelpers::FClassFinder<UChoosePlayerWidget> ChooseBP(
+      TEXT("/Game/Blueprints/UI/Skald_ChoosePlayerWidget"));
+  if (ChooseBP.Succeeded()) {
+    ChoosePlayerWidgetClass = ChooseBP.Class;
+  }
 }
 
 void ASkaldPlayerController::BeginPlay() {
@@ -64,15 +71,6 @@ void ASkaldPlayerController::BeginPlay() {
   if (HUDWidgetClass) {
     MainHudWidget = CreateWidget<USkaldMainHUDWidget>(this, HUDWidgetClass);
     if (MainHudWidget) {
-      // Ensure DeployWidgetClass is set so the Deploy UI can be spawned.
-      if (!MainHudWidget->DeployWidgetClass) {
-        if (UClass *DeployClass = LoadClass<UDeployWidget>(
-                nullptr, TEXT("/Game/Blueprints/UI/"
-                              "Skald_DeployWidget.Skald_DeployWidget_C"))) {
-          MainHudWidget->DeployWidgetClass = DeployClass;
-        }
-      }
-
       HUDRef = MainHudWidget;
       MainHudWidget->AddToViewport();
       MainHudWidget->SetVisibility(ESlateVisibility::Hidden);
@@ -120,23 +118,17 @@ void ASkaldPlayerController::BeginPlay() {
            TEXT("HUDWidgetClass is null; HUD will not be displayed."));
   }
 
-  if (!ChoosePlayerWidget) {
-    if (UClass *ChooseWidgetClass = LoadClass<UChoosePlayerWidget>(
-            nullptr,
-            TEXT("/Game/Blueprints/UI/"
-                 "Skald_ChoosePlayerWidget.Skald_ChoosePlayerWidget_C"))) {
-      ChoosePlayerWidget =
-          CreateWidget<UChoosePlayerWidget>(this, ChooseWidgetClass);
-      if (ChoosePlayerWidget) {
-        ChoosePlayerWidget->OnPlayerLockedIn.AddDynamic(
-            this, &ASkaldPlayerController::HandlePlayerLockedIn);
-        ChoosePlayerWidget->AddToViewport();
-        // While the player is choosing their faction, restrict controls to the
-        // UI
-        SetInputMode(FInputModeUIOnly());
-        SetIgnoreMoveInput(true);
-        SetIgnoreLookInput(true);
-      }
+  if (!ChoosePlayerWidget && ChoosePlayerWidgetClass) {
+    ChoosePlayerWidget =
+        CreateWidget<UChoosePlayerWidget>(this, ChoosePlayerWidgetClass);
+    if (ChoosePlayerWidget) {
+      ChoosePlayerWidget->OnPlayerLockedIn.AddDynamic(
+          this, &ASkaldPlayerController::HandlePlayerLockedIn);
+      ChoosePlayerWidget->AddToViewport();
+      // While the player is choosing their faction, restrict controls to the UI
+      SetInputMode(FInputModeUIOnly());
+      SetIgnoreMoveInput(true);
+      SetIgnoreLookInput(true);
     }
   }
 
@@ -658,7 +650,7 @@ void ASkaldPlayerController::ServerHandleMove_Implementation(int32 FromID,
 }
 
 void ASkaldPlayerController::ServerBuildSiege_Implementation(
-    int32 TerritoryID, E_SiegeWeapons SiegeType) {
+    int32 TerritoryID, ESiegeWeapon SiegeType) {
   if (CachedGameMode) {
     CachedGameMode->BuildSiegeAtTerritory(TerritoryID, SiegeType);
   }
@@ -716,7 +708,7 @@ void ASkaldPlayerController::HandleEngineeringRequested(int32 CapitalID,
 }
 
 void ASkaldPlayerController::HandleBuildSiegeRequested(
-    int32 TerritoryID, E_SiegeWeapons SiegeType) {
+    int32 TerritoryID, ESiegeWeapon SiegeType) {
   ServerBuildSiege(TerritoryID, SiegeType);
 }
 

--- a/Source/Skald/Skald_PlayerController.h
+++ b/Source/Skald/Skald_PlayerController.h
@@ -75,6 +75,10 @@ protected:
   UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category = "UI")
   TSubclassOf<UUserWidget> HUDWidgetClass;
 
+  /** Widget class used for the player faction selection screen. */
+  UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category = "UI")
+  TSubclassOf<UChoosePlayerWidget> ChoosePlayerWidgetClass;
+
   /** Reference to the HUD widget instance. */
   UPROPERTY(BlueprintReadOnly, Category = "UI",
             meta = (AllowPrivateAccess = "true"))
@@ -164,11 +168,11 @@ public:
 
   /** Handle HUD siege build requests. */
   UFUNCTION(BlueprintCallable, Category = "UI")
-  void HandleBuildSiegeRequested(int32 TerritoryID, E_SiegeWeapons SiegeType);
+  void HandleBuildSiegeRequested(int32 TerritoryID, ESiegeWeapon SiegeType);
 
   /** Server-side processing of a siege build request. */
   UFUNCTION(Server, Reliable)
-  void ServerBuildSiege(int32 TerritoryID, E_SiegeWeapons SiegeType);
+  void ServerBuildSiege(int32 TerritoryID, ESiegeWeapon SiegeType);
 
   /** Server-side processing of a treasure dig request. */
   UFUNCTION(Server, Reliable)

--- a/Source/Skald/Tests/CapitalAttackRequirementTest.cpp
+++ b/Source/Skald/Tests/CapitalAttackRequirementTest.cpp
@@ -5,9 +5,8 @@ IMPLEMENT_SIMPLE_AUTOMATION_TEST(FSkaldCapitalAttackRequirementTest, "Skald.Atta
 
 bool FSkaldCapitalAttackRequirementTest::RunTest(const FString& Parameters)
 {
-    using namespace SkaldConstants;
     TestTrue(TEXT("Non-capital attack bypasses requirement"), SkaldHelpers::MeetsCapitalAttackRequirement(false, 1));
-    TestFalse(TEXT("Capital attack below requirement is invalid"), SkaldHelpers::MeetsCapitalAttackRequirement(true, CapitalAttackArmyRequirement - 1));
-    TestTrue(TEXT("Capital attack meeting requirement is valid"), SkaldHelpers::MeetsCapitalAttackRequirement(true, CapitalAttackArmyRequirement));
+    TestFalse(TEXT("Capital attack below requirement is invalid"), SkaldHelpers::MeetsCapitalAttackRequirement(true, SkaldConstants::CapitalAttackArmyRequirement - 1));
+    TestTrue(TEXT("Capital attack meeting requirement is valid"), SkaldHelpers::MeetsCapitalAttackRequirement(true, SkaldConstants::CapitalAttackArmyRequirement));
     return true;
 }

--- a/Source/Skald/UI/SkaldMainHUDWidget.cpp
+++ b/Source/Skald/UI/SkaldMainHUDWidget.cpp
@@ -17,6 +17,16 @@
 #include "UI/ConfirmAttackWidget.h"
 #include "UI/DeployWidget.h"
 #include "WorldMap.h"
+#include "UObject/ConstructorHelpers.h"
+
+USkaldMainHUDWidget::USkaldMainHUDWidget(const FObjectInitializer& ObjectInitializer)
+    : Super(ObjectInitializer) {
+  static ConstructorHelpers::FClassFinder<UDeployWidget> DeployBP(
+      TEXT("/Game/Blueprints/UI/Skald_DeployWidget"));
+  if (DeployBP.Succeeded()) {
+    DeployWidgetClass = DeployBP.Class;
+  }
+}
 
 void USkaldMainHUDWidget::NativeConstruct() {
   Super::NativeConstruct();
@@ -452,7 +462,7 @@ void USkaldMainHUDWidget::OnTerritoryClickedUI(ATerritory *Territory) {
 }
 
 void USkaldMainHUDWidget::BuildSiege(int32 TerritoryID,
-                                     E_SiegeWeapons SiegeType) {
+                                     ESiegeWeapon SiegeType) {
   OnBuildSiegeRequested.Broadcast(TerritoryID, SiegeType);
 }
 

--- a/Source/Skald/UI/SkaldMainHUDWidget.h
+++ b/Source/Skald/UI/SkaldMainHUDWidget.h
@@ -21,7 +21,7 @@ DECLARE_DYNAMIC_MULTICAST_DELEGATE_FourParams(FSkaldAttackRequested, int32,
                                               FromID, int32, ToID, int32,
                                               ArmySent, bool, bUseSiege);
 DECLARE_DYNAMIC_MULTICAST_DELEGATE_TwoParams(FSkaldBuildSiegeRequested, int32,
-                                             TerritoryID, E_SiegeWeapons,
+                                             TerritoryID, ESiegeWeapon,
                                              SiegeType);
 DECLARE_DYNAMIC_MULTICAST_DELEGATE_OneParam(FSkaldEndAttackRequested, bool,
                                             bConfirmed);
@@ -52,6 +52,8 @@ class SKALD_API USkaldMainHUDWidget : public UUserWidget {
   GENERATED_BODY()
 
 public:
+  USkaldMainHUDWidget(const FObjectInitializer& ObjectInitializer);
+
   // Identity / state (read by BP)
   UPROPERTY(BlueprintReadWrite, Category = "Skald|State")
   int32 LocalPlayerID = -1;
@@ -199,7 +201,7 @@ public:
   void OnTerritoryClickedUI(ATerritory *Territory);
 
   UFUNCTION(BlueprintCallable, Category = "Skald|Siege")
-  void BuildSiege(int32 TerritoryID, E_SiegeWeapons SiegeType);
+  void BuildSiege(int32 TerritoryID, ESiegeWeapon SiegeType);
 
   UFUNCTION(BlueprintCallable, Category = "Skald|Siege")
   void SetUseSiegeForNextAttack(bool bEnable);

--- a/Source/Skald/WorldMap.cpp
+++ b/Source/Skald/WorldMap.cpp
@@ -7,7 +7,7 @@
 #include "Skald.h"
 #include "Skald_GameMode.h"
 #include "Territory.h"
-#include <float.h>
+#include <cfloat>
 #include "Templates/Function.h"
 
 AWorldMap::AWorldMap() {

--- a/compile_commands.json
+++ b/compile_commands.json
@@ -1,0 +1,182 @@
+[
+  {
+    "directory": "/workspace/Skald_TurnBasedStrategy_Code",
+    "command": "clang++ -std=c++17 -I../Engine/Source -ISource -c Source/Skald/Skald_GameInstance.cpp",
+    "file": "Source/Skald/Skald_GameInstance.cpp"
+  },
+  {
+    "directory": "/workspace/Skald_TurnBasedStrategy_Code",
+    "command": "clang++ -std=c++17 -I../Engine/Source -ISource -c Source/Skald/WorldMap.cpp",
+    "file": "Source/Skald/WorldMap.cpp"
+  },
+  {
+    "directory": "/workspace/Skald_TurnBasedStrategy_Code",
+    "command": "clang++ -std=c++17 -I../Engine/Source -ISource -c Source/Skald/SaveGameWidget.cpp",
+    "file": "Source/Skald/SaveGameWidget.cpp"
+  },
+  {
+    "directory": "/workspace/Skald_TurnBasedStrategy_Code",
+    "command": "clang++ -std=c++17 -I../Engine/Source -ISource -c Source/Skald/SkaldSaveGame.cpp",
+    "file": "Source/Skald/SkaldSaveGame.cpp"
+  },
+  {
+    "directory": "/workspace/Skald_TurnBasedStrategy_Code",
+    "command": "clang++ -std=c++17 -I../Engine/Source -ISource -c Source/Skald/LoadGameWidget.cpp",
+    "file": "Source/Skald/LoadGameWidget.cpp"
+  },
+  {
+    "directory": "/workspace/Skald_TurnBasedStrategy_Code",
+    "command": "clang++ -std=c++17 -I../Engine/Source -ISource -c Source/Skald/ChoosePlayerWidget.cpp",
+    "file": "Source/Skald/ChoosePlayerWidget.cpp"
+  },
+  {
+    "directory": "/workspace/Skald_TurnBasedStrategy_Code",
+    "command": "clang++ -std=c++17 -I../Engine/Source -ISource -c Source/Skald/GridBattleManager.cpp",
+    "file": "Source/Skald/GridBattleManager.cpp"
+  },
+  {
+    "directory": "/workspace/Skald_TurnBasedStrategy_Code",
+    "command": "clang++ -std=c++17 -I../Engine/Source -ISource -c Source/Skald/StartGameWidget.cpp",
+    "file": "Source/Skald/StartGameWidget.cpp"
+  },
+  {
+    "directory": "/workspace/Skald_TurnBasedStrategy_Code",
+    "command": "clang++ -std=c++17 -I../Engine/Source -ISource -c Source/Skald/Skald.cpp",
+    "file": "Source/Skald/Skald.cpp"
+  },
+  {
+    "directory": "/workspace/Skald_TurnBasedStrategy_Code",
+    "command": "clang++ -std=c++17 -I../Engine/Source -ISource -c Source/Skald/Skald_PlayerState.cpp",
+    "file": "Source/Skald/Skald_PlayerState.cpp"
+  },
+  {
+    "directory": "/workspace/Skald_TurnBasedStrategy_Code",
+    "command": "clang++ -std=c++17 -I../Engine/Source -ISource -c Source/Skald/Skald_TurnManager.cpp",
+    "file": "Source/Skald/Skald_TurnManager.cpp"
+  },
+  {
+    "directory": "/workspace/Skald_TurnBasedStrategy_Code",
+    "command": "clang++ -std=c++17 -I../Engine/Source -ISource -c Source/Skald/SkaldSaveGameLibrary.cpp",
+    "file": "Source/Skald/SkaldSaveGameLibrary.cpp"
+  },
+  {
+    "directory": "/workspace/Skald_TurnBasedStrategy_Code",
+    "command": "clang++ -std=c++17 -I../Engine/Source -ISource -c Source/Skald/SettingsWidget.cpp",
+    "file": "Source/Skald/SettingsWidget.cpp"
+  },
+  {
+    "directory": "/workspace/Skald_TurnBasedStrategy_Code",
+    "command": "clang++ -std=c++17 -I../Engine/Source -ISource -c Source/Skald/Territory.cpp",
+    "file": "Source/Skald/Territory.cpp"
+  },
+  {
+    "directory": "/workspace/Skald_TurnBasedStrategy_Code",
+    "command": "clang++ -std=c++17 -I../Engine/Source -ISource -c Source/Skald/Skald_PlayerCharacter.cpp",
+    "file": "Source/Skald/Skald_PlayerCharacter.cpp"
+  },
+  {
+    "directory": "/workspace/Skald_TurnBasedStrategy_Code",
+    "command": "clang++ -std=c++17 -I../Engine/Source -ISource -c Source/Skald/LobbyGameMode.cpp",
+    "file": "Source/Skald/LobbyGameMode.cpp"
+  },
+  {
+    "directory": "/workspace/Skald_TurnBasedStrategy_Code",
+    "command": "clang++ -std=c++17 -I../Engine/Source -ISource -c Source/Skald/Skald_GameMode.cpp",
+    "file": "Source/Skald/Skald_GameMode.cpp"
+  },
+  {
+    "directory": "/workspace/Skald_TurnBasedStrategy_Code",
+    "command": "clang++ -std=c++17 -I../Engine/Source -ISource -c Source/Skald/LobbyMenuWidget.cpp",
+    "file": "Source/Skald/LobbyMenuWidget.cpp"
+  },
+  {
+    "directory": "/workspace/Skald_TurnBasedStrategy_Code",
+    "command": "clang++ -std=c++17 -I../Engine/Source -ISource -c Source/Skald/Skald_PlayerController.cpp",
+    "file": "Source/Skald/Skald_PlayerController.cpp"
+  },
+  {
+    "directory": "/workspace/Skald_TurnBasedStrategy_Code",
+    "command": "clang++ -std=c++17 -I../Engine/Source -ISource -c Source/Skald/Skald_GameState.cpp",
+    "file": "Source/Skald/Skald_GameState.cpp"
+  },
+  {
+    "directory": "/workspace/Skald_TurnBasedStrategy_Code",
+    "command": "clang++ -std=c++17 -I../Engine/Source -ISource -c Source/Skald/Tests/ResolveAttackClampTest.cpp",
+    "file": "Source/Skald/Tests/ResolveAttackClampTest.cpp"
+  },
+  {
+    "directory": "/workspace/Skald_TurnBasedStrategy_Code",
+    "command": "clang++ -std=c++17 -I../Engine/Source -ISource -c Source/Skald/Tests/TerritoryMoveTest.cpp",
+    "file": "Source/Skald/Tests/TerritoryMoveTest.cpp"
+  },
+  {
+    "directory": "/workspace/Skald_TurnBasedStrategy_Code",
+    "command": "clang++ -std=c++17 -I../Engine/Source -ISource -c Source/Skald/Tests/PlayerControllerValidationTest.cpp",
+    "file": "Source/Skald/Tests/PlayerControllerValidationTest.cpp"
+  },
+  {
+    "directory": "/workspace/Skald_TurnBasedStrategy_Code",
+    "command": "clang++ -std=c++17 -I../Engine/Source -ISource -c Source/Skald/Tests/FullTurnFlowTest.cpp",
+    "file": "Source/Skald/Tests/FullTurnFlowTest.cpp"
+  },
+  {
+    "directory": "/workspace/Skald_TurnBasedStrategy_Code",
+    "command": "clang++ -std=c++17 -I../Engine/Source -ISource -c Source/Skald/Tests/BattleResolutionSyncTest.cpp",
+    "file": "Source/Skald/Tests/BattleResolutionSyncTest.cpp"
+  },
+  {
+    "directory": "/workspace/Skald_TurnBasedStrategy_Code",
+    "command": "clang++ -std=c++17 -I../Engine/Source -ISource -c Source/Skald/Tests/TurnManagerTest.cpp",
+    "file": "Source/Skald/Tests/TurnManagerTest.cpp"
+  },
+  {
+    "directory": "/workspace/Skald_TurnBasedStrategy_Code",
+    "command": "clang++ -std=c++17 -I../Engine/Source -ISource -c Source/Skald/Tests/ReinforcementResourceTest.cpp",
+    "file": "Source/Skald/Tests/ReinforcementResourceTest.cpp"
+  },
+  {
+    "directory": "/workspace/Skald_TurnBasedStrategy_Code",
+    "command": "clang++ -std=c++17 -I../Engine/Source -ISource -c Source/Skald/Tests/PlayerControllerLockInMovementTest.cpp",
+    "file": "Source/Skald/Tests/PlayerControllerLockInMovementTest.cpp"
+  },
+  {
+    "directory": "/workspace/Skald_TurnBasedStrategy_Code",
+    "command": "clang++ -std=c++17 -I../Engine/Source -ISource -c Source/Skald/Tests/WorldMapFindPathTest.cpp",
+    "file": "Source/Skald/Tests/WorldMapFindPathTest.cpp"
+  },
+  {
+    "directory": "/workspace/Skald_TurnBasedStrategy_Code",
+    "command": "clang++ -std=c++17 -I../Engine/Source -ISource -c Source/Skald/Tests/SkaldMainHUDWidgetTest.cpp",
+    "file": "Source/Skald/Tests/SkaldMainHUDWidgetTest.cpp"
+  },
+  {
+    "directory": "/workspace/Skald_TurnBasedStrategy_Code",
+    "command": "clang++ -std=c++17 -I../Engine/Source -ISource -c Source/Skald/Tests/AIDecisionFlowTest.cpp",
+    "file": "Source/Skald/Tests/AIDecisionFlowTest.cpp"
+  },
+  {
+    "directory": "/workspace/Skald_TurnBasedStrategy_Code",
+    "command": "clang++ -std=c++17 -I../Engine/Source -ISource -c Source/Skald/Tests/CapitalAttackRequirementTest.cpp",
+    "file": "Source/Skald/Tests/CapitalAttackRequirementTest.cpp"
+  },
+  {
+    "directory": "/workspace/Skald_TurnBasedStrategy_Code",
+    "command": "clang++ -std=c++17 -I../Engine/Source -ISource -c Source/Skald/Tests/WorldMapMissingAssetsTest.cpp",
+    "file": "Source/Skald/Tests/WorldMapMissingAssetsTest.cpp"
+  },
+  {
+    "directory": "/workspace/Skald_TurnBasedStrategy_Code",
+    "command": "clang++ -std=c++17 -I../Engine/Source -ISource -c Source/Skald/UI/DeployWidget.cpp",
+    "file": "Source/Skald/UI/DeployWidget.cpp"
+  },
+  {
+    "directory": "/workspace/Skald_TurnBasedStrategy_Code",
+    "command": "clang++ -std=c++17 -I../Engine/Source -ISource -c Source/Skald/UI/ConfirmAttackWidget.cpp",
+    "file": "Source/Skald/UI/ConfirmAttackWidget.cpp"
+  },
+  {
+    "directory": "/workspace/Skald_TurnBasedStrategy_Code",
+    "command": "clang++ -std=c++17 -I../Engine/Source -ISource -c Source/Skald/UI/SkaldMainHUDWidget.cpp",
+    "file": "Source/Skald/UI/SkaldMainHUDWidget.cpp"
+  }
+]


### PR DESCRIPTION
## Summary
- replace legacy `<float.h>` with `<cfloat>` in WorldMap
- drop `using namespace` from test and fully qualify constants
- rename `E_SiegeWeapons` to `ESiegeWeapon` and update usage
- load UI widgets via `ConstructorHelpers::FClassFinder` instead of `LoadClass`
- add `compile_commands.json` for static analysis tools

## Testing
- `cppcheck --enable=all --inconclusive --std=c++17 Source/Skald 2>/tmp/cppcheck.log && tail -n 20 /tmp/cppcheck.log`
- `clang-tidy Source/Skald/WorldMap.cpp -- 2>/tmp/clangtidy.log && tail -n 20 /tmp/clangtidy.log` *(fails: 'CoreMinimal.h' file not found)*


------
https://chatgpt.com/codex/tasks/task_e_68b52c2386348324a17de33da672e1ef