### PR TITLE
Ensure load menu leaves only lobby visible

### DIFF
--- a/Source/Skald/LoadGameWidget.cpp
+++ b/Source/Skald/LoadGameWidget.cpp
@@ -7,6 +7,7 @@
 #include "GameFramework/PlayerController.h"
 #include "SkaldSaveGame.h"
 #include "Skald_GameInstance.h"
+#include "Blueprint/WidgetBlueprintLibrary.h"
 
 void ULoadGameWidget::SetLobbyMenu(ULobbyMenuWidget* InMenu)
 {
@@ -59,6 +60,18 @@ void ULoadGameWidget::OnLoadSlot2()
 void ULoadGameWidget::OnMainMenu()
 {
     RemoveFromParent();
+
+    // Ensure no other widgets linger on the viewport and steal input
+    TArray<UUserWidget*> Widgets;
+    UWidgetBlueprintLibrary::GetAllWidgetsOfClass(this, Widgets, UUserWidget::StaticClass(), /*TopLevelOnly*/ true);
+    for (UUserWidget* Widget : Widgets)
+    {
+        if (Widget && Widget != LobbyMenu.Get())
+        {
+            Widget->RemoveFromParent();
+        }
+    }
+
     if (LobbyMenu.IsValid())
     {
         // Re-enable the lobby once the load-game widget closes


### PR DESCRIPTION
## Summary
- Clear remaining UI widgets when exiting the load game screen

## Testing
- `bash Build/validate.sh` (UnrealBuildTool not found; skipping compile check. UnrealEditor not found; cannot run tests.)

------
https://chatgpt.com/codex/tasks/task_e_68b53684ab5483249920885f5c6545c2