### PR TITLE
Add resolution, quality, and audio options to settings widget

### DIFF
--- a/Source/Skald/SettingsWidget.cpp
+++ b/Source/Skald/SettingsWidget.cpp
@@ -1,8 +1,13 @@
 #include "SettingsWidget.h"
 #include "Components/Button.h"
+#include "Components/ComboBoxString.h"
+#include "Components/Slider.h"
 #include "GameFramework/GameUserSettings.h"
+#include "Kismet/GameplayStatics.h"
 #include "Engine/Engine.h"
 #include "LobbyMenuWidget.h"
+#include "Sound/SoundClass.h"
+#include "Sound/SoundMix.h"
 
 void USettingsWidget::SetLobbyMenu(ULobbyMenuWidget* InMenu)
 {
@@ -21,13 +26,84 @@ void USettingsWidget::NativeConstruct()
     {
         MainMenuButton->OnClicked.AddDynamic(this, &USettingsWidget::OnMainMenu);
     }
+
+    if (DisplaySizeCombo)
+    {
+        DisplaySizeCombo->ClearOptions();
+        ResolutionMap.Empty();
+        ResolutionMap.Add(TEXT("1280x720"), FIntPoint(1280, 720));
+        ResolutionMap.Add(TEXT("1920x1080"), FIntPoint(1920, 1080));
+        ResolutionMap.Add(TEXT("2560x1440"), FIntPoint(2560, 1440));
+        ResolutionMap.Add(TEXT("3840x2160"), FIntPoint(3840, 2160));
+        for (const TPair<FString, FIntPoint>& Pair : ResolutionMap)
+        {
+            DisplaySizeCombo->AddOption(Pair.Key);
+        }
+        DisplaySizeCombo->OnSelectionChanged.AddDynamic(this, &USettingsWidget::HandleResolutionChanged);
+    }
+
+    if (GraphicsQualityCombo)
+    {
+        GraphicsQualityCombo->ClearOptions();
+        QualityMap.Empty();
+        QualityMap.Add(TEXT("Poor"), 0);
+        QualityMap.Add(TEXT("Medium"), 1);
+        QualityMap.Add(TEXT("High"), 2);
+        QualityMap.Add(TEXT("Max"), 3);
+        for (const TPair<FString, int32>& Pair : QualityMap)
+        {
+            GraphicsQualityCombo->AddOption(Pair.Key);
+        }
+        GraphicsQualityCombo->OnSelectionChanged.AddDynamic(this, &USettingsWidget::HandleQualityChanged);
+    }
+
+    if (AudioSlider)
+    {
+        AudioSlider->OnValueChanged.AddDynamic(this, &USettingsWidget::HandleAudioChanged);
+        if (MasterSoundClass)
+        {
+            AudioSlider->SetValue(MasterSoundClass->Properties.Volume);
+            PendingAudioVolume = MasterSoundClass->Properties.Volume;
+        }
+        else
+        {
+            PendingAudioVolume = AudioSlider->GetValue();
+        }
+    }
+
+    if (UGameUserSettings* Settings = GEngine->GetGameUserSettings())
+    {
+        PendingResolution = Settings->GetScreenResolution();
+        const FString CurrentRes = FString::Printf(TEXT("%dx%d"), PendingResolution.X, PendingResolution.Y);
+        if (DisplaySizeCombo)
+        {
+            DisplaySizeCombo->SetSelectedOption(CurrentRes);
+        }
+
+        PendingQuality = Settings->GetOverallScalabilityLevel();
+        if (GraphicsQualityCombo)
+        {
+            if (const FString* Quality = QualityMap.FindKey(PendingQuality))
+            {
+                GraphicsQualityCombo->SetSelectedOption(*Quality);
+            }
+        }
+    }
 }
 
 void USettingsWidget::OnApply()
 {
     if (UGameUserSettings* Settings = GEngine->GetGameUserSettings())
     {
+        Settings->SetScreenResolution(PendingResolution);
+        Settings->SetOverallScalabilityLevel(PendingQuality);
         Settings->ApplySettings(false);
+    }
+
+    if (MasterSoundMix && MasterSoundClass)
+    {
+        UGameplayStatics::SetSoundMixClassOverride(this, MasterSoundMix, MasterSoundClass, PendingAudioVolume, 1.0f, 0.0f, true);
+        UGameplayStatics::PushSoundMixModifier(this, MasterSoundMix);
     }
 }
 
@@ -37,6 +113,31 @@ void USettingsWidget::OnMainMenu()
     if (LobbyMenu.IsValid())
     {
         LobbyMenu->SetVisibility(ESlateVisibility::Visible);
+    }
+}
+
+void USettingsWidget::HandleResolutionChanged(FString SelectedItem, ESelectInfo::Type /*SelectionType*/)
+{
+    if (const FIntPoint* Res = ResolutionMap.Find(SelectedItem))
+    {
+        PendingResolution = *Res;
+    }
+}
+
+void USettingsWidget::HandleQualityChanged(FString SelectedItem, ESelectInfo::Type /*SelectionType*/)
+{
+    if (const int32* Quality = QualityMap.Find(SelectedItem))
+    {
+        PendingQuality = *Quality;
+    }
+}
+
+void USettingsWidget::HandleAudioChanged(float Value)
+{
+    PendingAudioVolume = Value;
+    if (MasterSoundClass)
+    {
+        MasterSoundClass->Properties.Volume = Value;
     }
 }
 

--- a/Source/Skald/SettingsWidget.h
+++ b/Source/Skald/SettingsWidget.h
@@ -6,6 +6,14 @@
 
 class ULobbyMenuWidget;
 class UButton;
+class UComboBoxString;
+class USlider;
+class USoundClass;
+class USoundMix;
+namespace ESelectInfo
+{
+    enum Type;
+}
 /**
  * Basic settings menu allowing to apply current user settings.
  */
@@ -21,6 +29,21 @@ public:
     UPROPERTY(BlueprintReadOnly, Category="Skald|Widgets", meta = (BindWidgetOptional))
     UButton* MainMenuButton;
 
+    UPROPERTY(BlueprintReadOnly, Category="Skald|Widgets", meta = (BindWidgetOptional))
+    UComboBoxString* DisplaySizeCombo;
+
+    UPROPERTY(BlueprintReadOnly, Category="Skald|Widgets", meta = (BindWidgetOptional))
+    UComboBoxString* GraphicsQualityCombo;
+
+    UPROPERTY(BlueprintReadOnly, Category="Skald|Widgets", meta = (BindWidgetOptional))
+    USlider* AudioSlider;
+
+    UPROPERTY(EditAnywhere, Category="Skald|Audio")
+    USoundMix* MasterSoundMix;
+
+    UPROPERTY(EditAnywhere, Category="Skald|Audio")
+    USoundClass* MasterSoundClass;
+
     UFUNCTION(BlueprintCallable, Category="Skald|Widgets")
     void SetLobbyMenu(ULobbyMenuWidget* InMenu);
 
@@ -33,8 +56,24 @@ protected:
     UFUNCTION(BlueprintCallable, Category="Skald|Widgets")
     void OnMainMenu();
 
+    UFUNCTION(BlueprintCallable, Category="Skald|Widgets")
+    void HandleResolutionChanged(FString SelectedItem, ESelectInfo::Type SelectionType);
+
+    UFUNCTION(BlueprintCallable, Category="Skald|Widgets")
+    void HandleQualityChanged(FString SelectedItem, ESelectInfo::Type SelectionType);
+
+    UFUNCTION(BlueprintCallable, Category="Skald|Widgets")
+    void HandleAudioChanged(float Value);
+
 private:
     UPROPERTY()
     TWeakObjectPtr<ULobbyMenuWidget> LobbyMenu;
+
+    TMap<FString, FIntPoint> ResolutionMap;
+    TMap<FString, int32> QualityMap;
+
+    FIntPoint PendingResolution;
+    int32 PendingQuality;
+    float PendingAudioVolume;
 };
 


### PR DESCRIPTION
## Summary
- Add display size and graphics quality combo boxes plus audio volume slider to the settings widget
- Populate new controls and bind events to store pending values and adjust master sound class volume
- Apply chosen resolution, scalability level, and audio volume when saving settings

## Testing
- `clang-format -n Source/Skald/SettingsWidget.h Source/Skald/SettingsWidget.cpp` *(fails: code should be clang-formatted)*
- `clang++ -c Source/Skald/SettingsWidget.cpp -std=c++20` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68b537340e188324a975e7bcf7cdbaa0