### PR TITLE
Load confirm attack widget blueprint

### DIFF
--- a/Source/Skald/UI/SkaldMainHUDWidget.cpp
+++ b/Source/Skald/UI/SkaldMainHUDWidget.cpp
@@ -26,6 +26,11 @@ USkaldMainHUDWidget::USkaldMainHUDWidget(const FObjectInitializer& ObjectInitial
   if (DeployBP.Succeeded()) {
     DeployWidgetClass = DeployBP.Class;
   }
+  static ConstructorHelpers::FClassFinder<UConfirmAttackWidget> ConfirmBP(
+      TEXT("/Game/Blueprints/UI/Skald_ConfirmAttackWidget"));
+  if (ConfirmBP.Succeeded()) {
+    ConfirmAttackWidgetClass = ConfirmBP.Class;
+  }
 }
 
 void USkaldMainHUDWidget::NativeConstruct() {
@@ -563,6 +568,10 @@ void USkaldMainHUDWidget::HandleAttackApproved() {
     }
     return;
   }
+
+  // Remove the confirmation widget now that the attack is approved
+  ActiveConfirmWidget->RemoveFromParent();
+  ActiveConfirmWidget = nullptr;
 
   SubmitAttack(SourceID, TargetID, ArmyCount, bUseSiegeForNextAttack);
 


### PR DESCRIPTION
## Summary
- locate and assign Skald_ConfirmAttackWidget blueprint in HUD constructor
- clean up active confirm widget after an attack is approved

## Testing
- `clang++ -std=c++17 -I../Engine/Source -ISource -ISource/Skald -fsyntax-only Source/Skald/UI/SkaldMainHUDWidget.cpp` *(fails: 'Blueprint/UserWidget.h' file not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b53957332c8324bb9061f6c42554ed