### PR TITLE
Improve deployment and attack UI feedback

### DIFF
--- a/Build/validate.sh
+++ b/Build/validate.sh
@@ -12,7 +12,7 @@ fi
 
 echo "Running automation tests..."
 if command -v UnrealEditor &>/dev/null; then
-  UnrealEditor "$UPROJECT" -ExecCmds="Automation RunTests Skald.UI.BindingsRemain+Skald.PlayerController.ValidationFeedback+Skald.PlayerController.LockInMovement+Skald.TurnManager.PhaseTransitions+Skald.TurnManager.InitiativeSort+Skald.WorldMap.FindPath.Valid+Skald.WorldMap.FindPath.Blocked+Skald.TurnManager.ResourceAccumulation+Skald.GridBattle.ResolveAttackClamp+Skald.Multiplayer.DeployReplication;Quit" -unattended -nop4 || exit 1
+  UnrealEditor "$UPROJECT" -ExecCmds="Automation RunTests Skald.UI.BindingsRemain+Skald.PlayerController.ValidationFeedback+Skald.PlayerController.LockInMovement+Skald.TurnManager.PhaseTransitions+Skald.TurnManager.InitiativeSort+Skald.WorldMap.FindPath.Valid+Skald.WorldMap.FindPath.Blocked+Skald.TurnManager.ResourceAccumulation+Skald.GridBattle.ResolveAttackClamp+Skald.Multiplayer.DeployReplication+Skald.TurnManager.ArmyPoolCalculation;Quit" -unattended -nop4 || exit 1
 else
   echo "UnrealEditor not found; cannot run tests." >&2
 fi

--- a/Source/Skald/Tests/ArmyPoolCalculationTest.cpp
+++ b/Source/Skald/Tests/ArmyPoolCalculationTest.cpp
@@ -1,0 +1,69 @@
+
+#include "Misc/AutomationTest.h"
+#include "Tests/AutomationEditorCommon.h"
+#include "Skald_TurnManager.h"
+#include "Skald_PlayerState.h"
+#include "Territory.h"
+#include "WorldMap.h"
+#include "DeployUnitsReplicationTest.h"
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FSkaldArmyPoolCalculationTest, "Skald.TurnManager.ArmyPoolCalculation", EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+bool FSkaldArmyPoolCalculationTest::RunTest(const FString& Parameters) {
+  UWorld* World = FAutomationEditorCommonUtils::CreateNewMap();
+  TestNotNull(TEXT("World created"), World);
+  if (!World) {
+    return false;
+  }
+
+  ATurnManager* TM = World->SpawnActor<ATurnManager>();
+  ADeployTestPlayerController* PC = World->SpawnActor<ADeployTestPlayerController>();
+  ASkaldPlayerState* PS = World->SpawnActor<ASkaldPlayerState>();
+  AWorldMap* Map = World->SpawnActor<AWorldMap>();
+  TestNotNull(TEXT("TurnManager"), TM);
+  TestNotNull(TEXT("PlayerController"), PC);
+  TestNotNull(TEXT("PlayerState"), PS);
+  TestNotNull(TEXT("WorldMap"), Map);
+  if (!TM || !PC || !PS || !Map) {
+    return false;
+  }
+
+  PC->PlayerState = PS;
+  TM->RegisterController(PC);
+  UDeployTestHUDWidget* HUD = NewObject<UDeployTestHUDWidget>(PC);
+  PC->SetHUD(HUD);
+
+  // start with 5 owned territories
+  TArray<ATerritory*> Terrs;
+  for (int32 i = 0; i < 5; ++i) {
+    ATerritory* T = World->SpawnActor<ATerritory>();
+    TestNotNull(TEXT("Territory"), T);
+    if (!T) {
+      return false;
+    }
+    T->OwningPlayer = PS;
+    Terrs.Add(T);
+  }
+  Map->Territories = Terrs;
+
+  TM->StartTurns();
+  TestEqual(TEXT("Army pool after start"), PS->ArmyPool, 2);
+  TestEqual(TEXT("HUD after start"), HUD->LastUnits, 2);
+
+  // add two more territories and advance turn to recalc
+  for (int32 i = 0; i < 2; ++i) {
+    ATerritory* T = World->SpawnActor<ATerritory>();
+    TestNotNull(TEXT("ExtraTerritory"), T);
+    if (!T) {
+      return false;
+    }
+    T->OwningPlayer = PS;
+    Terrs.Add(T);
+  }
+  Map->Territories = Terrs;
+
+  TM->AdvanceTurn();
+  TestEqual(TEXT("Army pool after advance"), PS->ArmyPool, 3);
+  TestEqual(TEXT("HUD after advance"), HUD->LastUnits, 3);
+
+  return true;
+}

--- a/Source/Skald/UI/DeployWidget.cpp
+++ b/Source/Skald/UI/DeployWidget.cpp
@@ -79,7 +79,15 @@ void UDeployWidget::HandleAccept() {
   }
 
   RemoveFromParent();
+  if (OwningHUD.IsValid()) {
+    OwningHUD->ClearDeployWidget();
+  }
 }
 
-void UDeployWidget::HandleDecline() { RemoveFromParent(); }
+void UDeployWidget::HandleDecline() {
+  RemoveFromParent();
+  if (OwningHUD.IsValid()) {
+    OwningHUD->ClearDeployWidget();
+  }
+}
 

--- a/Source/Skald/UI/SkaldMainHUDWidget.cpp
+++ b/Source/Skald/UI/SkaldMainHUDWidget.cpp
@@ -25,11 +25,17 @@ USkaldMainHUDWidget::USkaldMainHUDWidget(const FObjectInitializer& ObjectInitial
       TEXT("/Game/Blueprints/UI/Skald_DeployWidget"));
   if (DeployBP.Succeeded()) {
     DeployWidgetClass = DeployBP.Class;
+  } else {
+    UE_LOG(LogSkald, Error,
+           TEXT("SkaldMainHUDWidget: failed to find deploy widget class"));
   }
   static ConstructorHelpers::FClassFinder<UConfirmAttackWidget> ConfirmBP(
       TEXT("/Game/Blueprints/UI/Skald_ConfirmAttackWidget"));
   if (ConfirmBP.Succeeded()) {
     ConfirmAttackWidgetClass = ConfirmBP.Class;
+  } else {
+    UE_LOG(LogSkald, Error,
+           TEXT("SkaldMainHUDWidget: failed to find confirm attack widget class"));
   }
 }
 
@@ -160,6 +166,12 @@ void USkaldMainHUDWidget::UpdatePhaseBanner(ETurnPhase InPhase) {
   CurrentPhase = InPhase;
 
   BP_SetPhaseText(CurrentPhase);
+  if (CurrentPhase != ETurnPhase::Attack) {
+    CancelAttackSelection();
+  }
+  if (CurrentPhase != ETurnPhase::Reinforcement && CurrentPhase != ETurnPhase::ArmyPlacement) {
+    ClearDeployWidget();
+  }
   if (!FindFunction(TEXT("BP_SetPhaseButtons"))) {
     UE_LOG(LogSkald, Warning, TEXT("SyncPhaseButtons not bound for HUD %s"),
            *GetName());
@@ -408,7 +420,9 @@ void USkaldMainHUDWidget::OnTerritoryClickedUI(ATerritory *Territory) {
     }
 
     // Source selected: only allow choosing highlighted enemy territories
-    if (HighlightedTerritories.Contains(Territory)) {
+    const bool bIsHighlighted = HighlightedTerritories.ContainsByPredicate(
+        [Territory](ATerritory* T) { return T && T->TerritoryID == Territory->TerritoryID; });
+    if (bIsHighlighted) {
       SelectedTargetID = Territory->TerritoryID;
       if (SelectionPrompt) {
         SelectionPrompt->SetVisibility(ESlateVisibility::Collapsed);
@@ -436,8 +450,21 @@ void USkaldMainHUDWidget::OnTerritoryClickedUI(ATerritory *Territory) {
             ActiveConfirmWidget->CancelButton->OnClicked.AddDynamic(
                 this, &USkaldMainHUDWidget::CancelAttackSelection);
           }
+        } else {
+          UE_LOG(LogSkald, Warning,
+                 TEXT("OnTerritoryClickedUI: failed to create confirm widget"));
+          ShowErrorMessage(TEXT("Could not open confirm attack UI"));
         }
+      } else {
+        UE_LOG(LogSkald, Warning,
+               TEXT("OnTerritoryClickedUI: ConfirmAttackWidgetClass null"));
+        ShowErrorMessage(TEXT("Confirm attack widget missing"));
       }
+    } else {
+      UE_LOG(LogSkald, Warning,
+             TEXT("OnTerritoryClickedUI: territory %d not highlighted for attack"),
+             Territory->TerritoryID);
+      ShowErrorMessage(TEXT("Target not attackable"));
     }
     return;
   } else if (bSelectingForMove) {
@@ -614,12 +641,35 @@ void USkaldMainHUDWidget::HandleAttackApproved() {
 void USkaldMainHUDWidget::HandleDeployClicked() {
   APlayerController *PC = GetOwningPlayer();
   if (!PC) {
+    UE_LOG(LogSkald, Warning,
+           TEXT("HandleDeployClicked failed: no owning PlayerController"));
+    ShowErrorMessage(TEXT("No player controller"));
     return;
   }
 
   ASkaldPlayerState *PS = PC->GetPlayerState<ASkaldPlayerState>();
-  if (!PS || PS->ArmyPool <= 0 || SelectedSourceID == -1 ||
-      !DeployWidgetClass) {
+  if (!PS) {
+    UE_LOG(LogSkald, Warning,
+           TEXT("HandleDeployClicked failed: missing PlayerState"));
+    ShowErrorMessage(TEXT("Missing player state"));
+    return;
+  }
+  if (PS->ArmyPool <= 0) {
+    UE_LOG(LogSkald, Warning,
+           TEXT("HandleDeployClicked failed: ArmyPool empty"));
+    ShowErrorMessage(TEXT("No troops to deploy"));
+    return;
+  }
+  if (SelectedSourceID == -1) {
+    UE_LOG(LogSkald, Warning,
+           TEXT("HandleDeployClicked failed: no territory selected"));
+    ShowErrorMessage(TEXT("No territory selected"));
+    return;
+  }
+  if (!DeployWidgetClass) {
+    UE_LOG(LogSkald, Warning,
+           TEXT("HandleDeployClicked failed: DeployWidgetClass null"));
+    ShowErrorMessage(TEXT("Deploy widget unavailable"));
     return;
   }
 
@@ -630,6 +680,10 @@ void USkaldMainHUDWidget::HandleDeployClicked() {
   }
 
   if (!Territory || Territory->OwningPlayer != PS) {
+    UE_LOG(LogSkald, Warning,
+           TEXT("HandleDeployClicked failed: invalid territory %d"),
+           SelectedSourceID);
+    ShowErrorMessage(TEXT("Invalid territory selected"));
     return;
   }
 
@@ -638,5 +692,17 @@ void USkaldMainHUDWidget::HandleDeployClicked() {
   if (ActiveDeployWidget) {
     ActiveDeployWidget->Setup(Territory, PS, this, PS->ArmyPool);
     ActiveDeployWidget->AddToViewport();
+  } else {
+    UE_LOG(LogSkald, Warning,
+           TEXT("HandleDeployClicked failed: could not create widget"));
+    ShowErrorMessage(TEXT("Could not open deploy UI"));
   }
 }
+
+void USkaldMainHUDWidget::ClearDeployWidget() {
+  if (ActiveDeployWidget) {
+    ActiveDeployWidget->RemoveFromParent();
+    ActiveDeployWidget = nullptr;
+  }
+}
+

--- a/Source/Skald/UI/SkaldMainHUDWidget.h
+++ b/Source/Skald/UI/SkaldMainHUDWidget.h
@@ -303,6 +303,8 @@ protected:
   UFUNCTION()
   void HandleAttackApproved();
 
+  void ClearDeployWidget();
+
   UPROPERTY()
   UConfirmAttackWidget *ActiveConfirmWidget = nullptr;
 


### PR DESCRIPTION
## Summary
- add explicit logging and user feedback for deployment and attack confirmation UI failures
- clear UI widgets on phase changes and ensure deploy widgets cleaned up
- add automation test for army pool calculation and HUD updates

## Testing
- `PATH=/usr/bin:/bin /bin/bash Build/validate.sh` *(fails: UnrealBuildTool not found; UnrealEditor not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b541502b288324b4afa66fab309924