### PR TITLE
Hide settings widget before showing main menu

### DIFF
--- a/Source/Skald/SettingsWidget.cpp
+++ b/Source/Skald/SettingsWidget.cpp
@@ -109,7 +109,10 @@ void USettingsWidget::OnApply()
 
 void USettingsWidget::OnMainMenu()
 {
+    // Hide the settings widget before showing the main menu again
+    SetVisibility(ESlateVisibility::Hidden);
     RemoveFromParent();
+
     if (LobbyMenu.IsValid())
     {
         LobbyMenu->SetVisibility(ESlateVisibility::Visible);


### PR DESCRIPTION
## Summary
- Hide settings widget before revealing lobby menu to ensure clean transition

## Testing
- `g++ -std=c++17 Source/Skald/SettingsWidget.cpp -c` *(fails: CoreMinimal.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b544c0eda883249a5be3490c657300