### PR TITLE
Allow DeployWidget to clear itself

### DIFF
--- a/Source/Skald/UI/SkaldMainHUDWidget.h
+++ b/Source/Skald/UI/SkaldMainHUDWidget.h
@@ -51,6 +51,8 @@ UCLASS(Blueprintable, BlueprintType)
 class SKALD_API USkaldMainHUDWidget : public UUserWidget {
   GENERATED_BODY()
 
+  friend class UDeployWidget;
+
 public:
   USkaldMainHUDWidget(const FObjectInitializer& ObjectInitializer);
 


### PR DESCRIPTION
## Summary
- Allow DeployWidget to invoke SkaldMainHUDWidget's cleanup helper by granting it friend access

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b5492c9db483248c18a646f9682479