### PR TITLE
Ensure territory ownership matches player during deployment

### DIFF
--- a/Source/Skald/Skald_GameMode.cpp
+++ b/Source/Skald/Skald_GameMode.cpp
@@ -722,6 +722,7 @@ bool ASkaldGameMode::InitializeWorld() {
       Territory->bIsCapital = false;
       Territory->ArmyStrength = 1;
       Territory->RefreshAppearance();
+      Territory->ForceNetUpdate();
       ++Index;
     }
   }

--- a/Source/Skald/UI/SkaldMainHUDWidget.cpp
+++ b/Source/Skald/UI/SkaldMainHUDWidget.cpp
@@ -397,7 +397,9 @@ void USkaldMainHUDWidget::OnTerritoryClickedUI(ATerritory *Territory) {
     LocalPS = PC->GetPlayerState<ASkaldPlayerState>();
   }
 
-  const bool bOwnedByLocal = LocalPS && Territory->OwningPlayer == LocalPS;
+  const bool bOwnedByLocal = LocalPS && Territory->OwningPlayer &&
+                             Territory->OwningPlayer->GetPlayerId() ==
+                                 LocalPS->GetPlayerId();
 
   if (bSelectingForAttack) {
     if (SelectedSourceID == -1) {
@@ -679,7 +681,8 @@ void USkaldMainHUDWidget::HandleDeployClicked() {
     Territory = WorldMap->GetTerritoryById(SelectedSourceID);
   }
 
-  if (!Territory || Territory->OwningPlayer != PS) {
+  if (!Territory || !Territory->OwningPlayer ||
+      Territory->OwningPlayer->GetPlayerId() != PS->GetPlayerId()) {
     UE_LOG(LogSkald, Warning,
            TEXT("HandleDeployClicked failed: invalid territory %d"),
            SelectedSourceID);


### PR DESCRIPTION
## Summary
- Force replication of territory ownership after initial assignment
- Compare territory ownership using player IDs when selecting territories and deploying

## Testing
- `./Build/validate.sh` *(UnrealBuildTool not found; skipping compile check. UnrealEditor not found; cannot run tests.)*

------
https://chatgpt.com/codex/tasks/task_e_68b5580da8588324be3f57ee207df678