### PR TITLE
Increase adjacency radius and replicate territory selection

### DIFF
--- a/Source/Skald/Skald_PlayerController.cpp
+++ b/Source/Skald/Skald_PlayerController.cpp
@@ -13,8 +13,8 @@
 #include "Territory.h"
 #include "UI/DeployWidget.h"
 #include "UI/SkaldMainHUDWidget.h"
-#include "WorldMap.h"
 #include "UObject/ConstructorHelpers.h"
+#include "WorldMap.h"
 #include <limits>
 
 constexpr int32 MaxAIIterations = 100;
@@ -441,7 +441,7 @@ bool ASkaldPlayerController::ValidateAttack(int32 FromID, int32 ToID,
     return false;
   }
 
-  if (!Source->IsAdjacentTo(Target)) {
+  if (!WorldMap->AreTerritoriesAdjacent(Source, Target)) {
     if (OutError) {
       *OutError = TEXT("Cannot attack non-adjacent territory");
     }
@@ -674,7 +674,7 @@ void ASkaldPlayerController::ServerDeployUnits_Implementation(int32 TerritoryID,
     return;
   }
 
-  if (Terr->OwningPlayer != PS || PS->ArmyPool < Amount) {
+  if (!WorldMap->IsOwnedBy(Terr, PS) || PS->ArmyPool < Amount) {
     return;
   }
 
@@ -699,24 +699,11 @@ void ASkaldPlayerController::ServerSelectTerritory_Implementation(
   }
 
   ATerritory *Terr = WorldMap->GetTerritoryById(TerritoryID);
-  if (!Terr) {
+  if (!Terr || WorldMap->SelectedTerritory == Terr) {
     return;
   }
 
-  FString OwnerName = Terr->OwningPlayer ? Terr->OwningPlayer->PlayerDisplayName
-                                         : TEXT("Neutral");
-
-  Terr->ForceNetUpdate();
-
-  if (TurnManager) {
-    for (ASkaldPlayerController *Controller : TurnManager->GetControllers()) {
-      if (USkaldMainHUDWidget *HUD =
-              Controller ? Controller->GetHUDWidget() : nullptr) {
-        HUD->UpdateTerritoryInfo(Terr->TerritoryName, OwnerName,
-                                 Terr->ArmyStrength);
-      }
-    }
-  }
+  WorldMap->MulticastSelectTerritory(Terr);
 }
 
 void ASkaldPlayerController::HandleEndAttackRequested(bool bConfirmed) {
@@ -741,8 +728,8 @@ void ASkaldPlayerController::HandleEngineeringRequested(int32 CapitalID,
   }
 }
 
-void ASkaldPlayerController::HandleBuildSiegeRequested(
-    int32 TerritoryID, ESiegeWeapon SiegeType) {
+void ASkaldPlayerController::HandleBuildSiegeRequested(int32 TerritoryID,
+                                                       ESiegeWeapon SiegeType) {
   ServerBuildSiege(TerritoryID, SiegeType);
 }
 

--- a/Source/Skald/WorldMap.cpp
+++ b/Source/Skald/WorldMap.cpp
@@ -6,12 +6,14 @@
 #include "Engine/World.h"
 #include "Skald.h"
 #include "Skald_GameMode.h"
+#include "Skald_PlayerState.h"
+#include "Templates/Function.h"
 #include "Territory.h"
 #include <cfloat>
-#include "Templates/Function.h"
 
 AWorldMap::AWorldMap() {
   PrimaryActorTick.bCanEverTick = false;
+  bReplicates = true;
   SelectedTerritory = nullptr;
   TerritoryClass = ATerritory::StaticClass();
 }
@@ -266,6 +268,10 @@ void AWorldMap::SelectTerritory(ATerritory *Territory) {
 
   SelectedTerritory = Territory;
 
+  if (Territory) {
+    Territory->Select();
+  }
+
   OnTerritorySelected.Broadcast(Territory);
 }
 
@@ -296,7 +302,7 @@ bool AWorldMap::FindPath(ATerritory *From, ATerritory *To,
     }
 
     for (ATerritory *Neighbor : Current->AdjacentTerritories) {
-      if (!Neighbor || Neighbor->OwningPlayer != StartOwner ||
+      if (!Neighbor || !IsOwnedBy(Neighbor, StartOwner) ||
           CameFrom.Contains(Neighbor)) {
         continue;
       }
@@ -323,7 +329,7 @@ bool AWorldMap::MoveBetween(ATerritory *From, ATerritory *To, int32 Troops) {
     return false;
   }
 
-  if (From->OwningPlayer != To->OwningPlayer) {
+  if (!IsOwnedBy(To, From->OwningPlayer)) {
     return false;
   }
 
@@ -353,4 +359,29 @@ bool AWorldMap::MoveBetween(ATerritory *From, ATerritory *To, int32 Troops) {
   }
 
   return true;
+}
+
+bool AWorldMap::AreTerritoriesAdjacent(const ATerritory *A,
+                                       const ATerritory *B) const {
+  if (!A || !B) {
+    return false;
+  }
+  if (A->IsAdjacentTo(B) || B->IsAdjacentTo(A)) {
+    return true;
+  }
+  const float Dist =
+      FVector::Dist(A->GetActorLocation(), B->GetActorLocation());
+  return Dist <= AdjacencyDistance;
+}
+
+bool AWorldMap::IsOwnedBy(const ATerritory *Territory,
+                          const ASkaldPlayerState *Player) const {
+  if (!Territory || !Player || !Territory->OwningPlayer) {
+    return false;
+  }
+  return Territory->OwningPlayer->GetPlayerId() == Player->GetPlayerId();
+}
+
+void AWorldMap::MulticastSelectTerritory_Implementation(ATerritory *Territory) {
+  SelectTerritory(Territory);
 }

--- a/Source/Skald/WorldMap.h
+++ b/Source/Skald/WorldMap.h
@@ -6,6 +6,7 @@
 #include "WorldMap.generated.h"
 
 class ATerritory;
+class ASkaldPlayerState;
 
 // Broadcast when a territory is selected on the world map so that interested
 // systems (e.g. player controllers) can react.
@@ -86,6 +87,10 @@ public:
   UFUNCTION(BlueprintCallable, Category = "WorldMap")
   void SelectTerritory(ATerritory *Territory);
 
+  /** Multicast selection so all clients highlight the same territory. */
+  UFUNCTION(NetMulticast, Reliable)
+  void MulticastSelectTerritory(ATerritory *Territory);
+
   /** Find a path across friendly territories from one territory to another. */
   UFUNCTION(BlueprintCallable, Category = "WorldMap")
   bool FindPath(ATerritory *From, ATerritory *To,
@@ -111,13 +116,23 @@ public:
   UPROPERTY(EditAnywhere, Category = "WorldMap")
   FVector2D SpawnAreaMax = FVector2D(500.f, 500.f);
 
-  /** Maximum distance to consider two territories adjacent. */
-  UPROPERTY(EditAnywhere, Category = "WorldMap")
-  float AdjacencyDistance = 210.f;
+  /** Maximum distance (in Unreal units) to consider two territories adjacent.
+   */
+  UPROPERTY(EditAnywhere, Config, Category = "WorldMap")
+  float AdjacencyDistance = 5000.f;
 
   /** Randomly generated spawn locations keyed by territory ID. */
   UPROPERTY(BlueprintReadOnly, Category = "WorldMap")
   TMap<int32, FVector> SpawnedLocations;
+
+  /** Check whether two territories are adjacent, falling back to distance. */
+  UFUNCTION(BlueprintCallable, Category = "WorldMap")
+  bool AreTerritoriesAdjacent(const ATerritory *A, const ATerritory *B) const;
+
+  /** Determine if a territory is owned by a given player state. */
+  UFUNCTION(BlueprintCallable, Category = "WorldMap")
+  bool IsOwnedBy(const ATerritory *Territory,
+                 const ASkaldPlayerState *Player) const;
 
 protected:
 };


### PR DESCRIPTION
## Summary
- expand world map adjacency range to 50m and expose helpers for adjacency and ownership
- validate attacks by distance and deploy units using player IDs
- replicate territory selection to all clients via multicast

## Testing
- `bash Build/validate.sh` *(fails: UnrealBuildTool not found; UnrealEditor not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b55c2e1fa883249090a60ec049d55f