### PR TITLE
Fix attack unit selection checks

### DIFF
--- a/Source/Skald/UI/SkaldMainHUDWidget.cpp
+++ b/Source/Skald/UI/SkaldMainHUDWidget.cpp
@@ -403,7 +403,7 @@ void USkaldMainHUDWidget::OnTerritoryClickedUI(ATerritory *Territory) {
 
   if (bSelectingForAttack) {
     if (SelectedSourceID == -1) {
-      if (bOwnedByLocal && Territory->ArmyStrength > 0) {
+      if (bOwnedByLocal && Territory->ArmyStrength > 1) {
         SelectedSourceID = Territory->TerritoryID;
         Territory->Select();
         if (SelectionPrompt) {
@@ -417,6 +417,8 @@ void USkaldMainHUDWidget::OnTerritoryClickedUI(ATerritory *Territory) {
             HighlightedTerritories.Add(Adj);
           }
         }
+      } else if (bOwnedByLocal) {
+        ShowErrorMessage(TEXT("Need more than one unit to attack"));
       }
       return;
     }
@@ -439,7 +441,7 @@ void USkaldMainHUDWidget::OnTerritoryClickedUI(ATerritory *Territory) {
                       GetWorld(), AWorldMap::StaticClass()))) {
             if (ATerritory *Source =
                     WorldMap->GetTerritoryById(SelectedSourceID)) {
-              MaxUnits = Source->ArmyStrength;
+              MaxUnits = Source->ArmyStrength - 1;
             }
           }
           ActiveConfirmWidget->Setup(MaxUnits);


### PR DESCRIPTION
## Summary
- prevent selecting territories with a single unit for attacks
- limit attack confirmation to send at most armies minus one

## Testing
- `clang++ -fsyntax-only Source/Skald/UI/SkaldMainHUDWidget.cpp` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b570762fdc8324ab80b33de0c56710