### PR TITLE
Fix attack unit selection checks

### DIFF
--- a/Source/Skald/Skald_TurnManager.cpp
+++ b/Source/Skald/Skald_TurnManager.cpp
@@ -432,8 +432,11 @@ void ATurnManager::BroadcastArmyPool(ASkaldPlayerState *ForPlayer) {
   }
   for (const TWeakObjectPtr<ASkaldPlayerController> &ControllerPtr : Controllers) {
     if (ASkaldPlayerController *Controller = ControllerPtr.Get()) {
-      if (USkaldMainHUDWidget *HUD = Controller->GetHUDWidget()) {
-        HUD->UpdateDeployableUnits(ForPlayer->ArmyPool);
+      ASkaldPlayerState *PS = Controller->GetPlayerState<ASkaldPlayerState>();
+      if (PS == ForPlayer) {
+        if (USkaldMainHUDWidget *HUD = Controller->GetHUDWidget()) {
+          HUD->UpdateDeployableUnits(ForPlayer->ArmyPool);
+        }
       }
     }
   }

--- a/Source/Skald/UI/SkaldMainHUDWidget.cpp
+++ b/Source/Skald/UI/SkaldMainHUDWidget.cpp
@@ -403,7 +403,7 @@ void USkaldMainHUDWidget::OnTerritoryClickedUI(ATerritory *Territory) {
 
   if (bSelectingForAttack) {
     if (SelectedSourceID == -1) {
-      if (bOwnedByLocal && Territory->ArmyStrength > 0) {
+      if (bOwnedByLocal && Territory->ArmyStrength > 1) {
         SelectedSourceID = Territory->TerritoryID;
         Territory->Select();
         if (SelectionPrompt) {
@@ -417,6 +417,8 @@ void USkaldMainHUDWidget::OnTerritoryClickedUI(ATerritory *Territory) {
             HighlightedTerritories.Add(Adj);
           }
         }
+      } else if (bOwnedByLocal) {
+        ShowErrorMessage(TEXT("Need more than one unit to attack"));
       }
       return;
     }
@@ -439,7 +441,7 @@ void USkaldMainHUDWidget::OnTerritoryClickedUI(ATerritory *Territory) {
                       GetWorld(), AWorldMap::StaticClass()))) {
             if (ATerritory *Source =
                     WorldMap->GetTerritoryById(SelectedSourceID)) {
-              MaxUnits = Source->ArmyStrength;
+              MaxUnits = Source->ArmyStrength - 1;
             }
           }
           ActiveConfirmWidget->Setup(MaxUnits);


### PR DESCRIPTION
## Summary
- prevent selecting territories with a single unit for attacks
- limit attack confirmation to send at most armies minus one
- show deployable units only for the owning player

## Testing
- `clang++ -fsyntax-only -std=c++17 Source/Skald/Skald_TurnManager.cpp` *(fails: 'CoreMinimal.h' file not found)*
- `clang++ -fsyntax-only -std=c++17 Source/Skald/UI/SkaldMainHUDWidget.cpp` *(fails: 'UI/SkaldMainHUDWidget.h' file not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b570762fdc8324ab80b33de0c56710