### PR TITLE
Refactor army pool to deployable units

### DIFF
--- a/Build/validate.sh
+++ b/Build/validate.sh
@@ -12,7 +12,7 @@ fi
 
 echo "Running automation tests..."
 if command -v UnrealEditor &>/dev/null; then
-  UnrealEditor "$UPROJECT" -ExecCmds="Automation RunTests Skald.UI.BindingsRemain+Skald.PlayerController.ValidationFeedback+Skald.PlayerController.LockInMovement+Skald.TurnManager.PhaseTransitions+Skald.TurnManager.InitiativeSort+Skald.WorldMap.FindPath.Valid+Skald.WorldMap.FindPath.Blocked+Skald.TurnManager.ResourceAccumulation+Skald.GridBattle.ResolveAttackClamp+Skald.Multiplayer.DeployReplication+Skald.TurnManager.ArmyPoolCalculation;Quit" -unattended -nop4 || exit 1
+  UnrealEditor "$UPROJECT" -ExecCmds="Automation RunTests Skald.UI.BindingsRemain+Skald.PlayerController.ValidationFeedback+Skald.PlayerController.LockInMovement+Skald.TurnManager.PhaseTransitions+Skald.TurnManager.InitiativeSort+Skald.WorldMap.FindPath.Valid+Skald.WorldMap.FindPath.Blocked+Skald.TurnManager.ResourceAccumulation+Skald.GridBattle.ResolveAttackClamp+Skald.Multiplayer.DeployReplication+Skald.TurnManager.DeployableUnitsCalculation;Quit" -unattended -nop4 || exit 1
 else
   echo "UnrealEditor not found; cannot run tests." >&2
 fi

--- a/Source/Skald/Skald_GameMode.cpp
+++ b/Source/Skald/Skald_GameMode.cpp
@@ -449,7 +449,7 @@ void ASkaldGameMode::BeginArmyPlacementPhase() {
                         *GetNameSafe(ActiveController), *PhaseString));
   }
 
-  // Calculate army pools for each player based on owned territories and
+  // Calculate deployable units for each player based on owned territories and
   // update HUDs.
   for (ASkaldPlayerController *PC : TurnManager->GetControllers()) {
     if (ASkaldPlayerState *PS =
@@ -460,9 +460,9 @@ void ASkaldGameMode::BeginArmyPlacementPhase() {
           ++Owned;
         }
       }
-      PS->ArmyPool = FMath::CeilToInt(Owned / 3.f);
+      PS->DeployableUnits = FMath::CeilToInt(Owned / 3.f);
       PS->ForceNetUpdate();
-      TurnManager->BroadcastArmyPool(PS);
+      TurnManager->BroadcastDeployableUnits(PS);
     }
   }
 
@@ -527,7 +527,7 @@ void ASkaldGameMode::AdvanceArmyPlacement() {
       continue;
     }
 
-    if (PS->ArmyPool <= 0) {
+    if (PS->DeployableUnits <= 0) {
       ++PlacementIndex;
       continue;
     }
@@ -543,7 +543,7 @@ void ASkaldGameMode::AdvanceArmyPlacement() {
                           *PhaseString));
     }
 
-    TurnManager->BroadcastArmyPool(PS);
+    TurnManager->BroadcastDeployableUnits(PS);
 
     // Announce whose placement turn it is.
     const FString PlayerName = PS->PlayerDisplayName;
@@ -564,16 +564,16 @@ void ASkaldGameMode::AdvanceArmyPlacement() {
         }
       }
       int32 SpreadIndex = 0;
-      while (PS->ArmyPool > 0 && OwnedTerritories.Num() > 0) {
+      while (PS->DeployableUnits > 0 && OwnedTerritories.Num() > 0) {
         ATerritory *TargetTerritory =
             OwnedTerritories[SpreadIndex % OwnedTerritories.Num()];
         ++TargetTerritory->ArmyStrength;
         TargetTerritory->RefreshAppearance();
-        --PS->ArmyPool;
+        --PS->DeployableUnits;
         ++SpreadIndex;
       }
       PS->ForceNetUpdate();
-      TurnManager->BroadcastArmyPool(PS);
+      TurnManager->BroadcastDeployableUnits(PS);
       ++PlacementIndex;
       continue;
     }

--- a/Source/Skald/Skald_PlayerController.cpp
+++ b/Source/Skald/Skald_PlayerController.cpp
@@ -256,9 +256,9 @@ void ASkaldPlayerController::EndPhase() {
   ETurnPhase Phase = TurnManager->GetCurrentPhase();
   if (Phase == ETurnPhase::ArmyPlacement) {
     if (ASkaldPlayerState *PS = GetPlayerState<ASkaldPlayerState>()) {
-      PS->ArmyPool = 0;
+      PS->DeployableUnits = 0;
       PS->ForceNetUpdate();
-      TurnManager->BroadcastArmyPool(PS);
+      TurnManager->BroadcastDeployableUnits(PS);
     }
 
     if (!CachedGameMode) {
@@ -309,17 +309,17 @@ void ASkaldPlayerController::MakeAIDecision() {
       }
 
       int32 SpreadIndex = 0;
-      while (PS->ArmyPool > 0 && OwnedTerritories.Num() > 0) {
+      while (PS->DeployableUnits > 0 && OwnedTerritories.Num() > 0) {
         ATerritory *TargetTerritory =
             OwnedTerritories[SpreadIndex % OwnedTerritories.Num()];
         ++TargetTerritory->ArmyStrength;
         TargetTerritory->RefreshAppearance();
-        --PS->ArmyPool;
+        --PS->DeployableUnits;
         --PS->Resources;
         ++SpreadIndex;
       }
       PS->ForceNetUpdate();
-      TurnManager->BroadcastArmyPool(PS);
+      TurnManager->BroadcastDeployableUnits(PS);
       TurnManager->BroadcastResources(PS);
 
       TurnManager->AdvancePhase();
@@ -674,7 +674,7 @@ void ASkaldPlayerController::ServerDeployUnits_Implementation(int32 TerritoryID,
     return;
   }
 
-  if (!WorldMap->IsOwnedBy(Terr, PS) || PS->ArmyPool < Amount) {
+  if (!WorldMap->IsOwnedBy(Terr, PS) || PS->DeployableUnits < Amount) {
     return;
   }
 
@@ -682,11 +682,11 @@ void ASkaldPlayerController::ServerDeployUnits_Implementation(int32 TerritoryID,
   Terr->RefreshAppearance();
   Terr->ForceNetUpdate();
 
-  PS->ArmyPool -= Amount;
+  PS->DeployableUnits -= Amount;
   PS->ForceNetUpdate();
 
   if (TurnManager) {
-    TurnManager->BroadcastArmyPool(PS);
+    TurnManager->BroadcastDeployableUnits(PS);
   }
 }
 
@@ -907,7 +907,7 @@ void ASkaldPlayerController::HandleWorldStateChanged() {
 
   // Update deploy/phase banners.
   if (ASkaldPlayerState *PS = GetPlayerState<ASkaldPlayerState>()) {
-    MainHudWidget->UpdateDeployableUnits(PS->ArmyPool);
+    MainHudWidget->UpdateDeployableUnits(PS->DeployableUnits);
     MainHudWidget->UpdateResources(PS->Resources);
   }
   if (TurnManager) {

--- a/Source/Skald/Skald_PlayerState.cpp
+++ b/Source/Skald/Skald_PlayerState.cpp
@@ -6,7 +6,7 @@
 
 ASkaldPlayerState::ASkaldPlayerState()
     : bIsAI(false)
-    , ArmyPool(0)
+    , DeployableUnits(0)
     , InitiativeRoll(0)
     , Resources(0)
     , PlayerDisplayName(TEXT("Player"))
@@ -23,7 +23,7 @@ void ASkaldPlayerState::GetLifetimeReplicatedProps(
 
     DOREPLIFETIME(ASkaldPlayerState, PlayerDisplayName);
     DOREPLIFETIME(ASkaldPlayerState, Faction);
-    DOREPLIFETIME(ASkaldPlayerState, ArmyPool);
+    DOREPLIFETIME(ASkaldPlayerState, DeployableUnits);
     DOREPLIFETIME(ASkaldPlayerState, bIsAI);
     DOREPLIFETIME(ASkaldPlayerState, InitiativeRoll);
     DOREPLIFETIME(ASkaldPlayerState, Resources);

--- a/Source/Skald/Skald_PlayerState.h
+++ b/Source/Skald/Skald_PlayerState.h
@@ -19,9 +19,9 @@ public:
     UPROPERTY(BlueprintReadWrite, Replicated, Category="PlayerState")
     bool bIsAI;
 
-    /** Army units available for placement. */
+    /** Deployable units available for placement. */
     UPROPERTY(BlueprintReadWrite, Replicated, Category="PlayerState")
-    int32 ArmyPool;
+    int32 DeployableUnits;
 
     /** Initiative roll determining turn order. */
     UPROPERTY(BlueprintReadWrite, Replicated, Category="PlayerState")

--- a/Source/Skald/Skald_TurnManager.cpp
+++ b/Source/Skald/Skald_TurnManager.cpp
@@ -122,10 +122,10 @@ void ATurnManager::StartTurns() {
       }
     }
     const int32 Reinforcements = FMath::CeilToInt(Owned / 3.0f);
-    PS->ArmyPool = Reinforcements;
+    PS->DeployableUnits = Reinforcements;
     PS->Resources += ResourceGain;
     PS->ForceNetUpdate();
-    BroadcastArmyPool(PS);
+    BroadcastDeployableUnits(PS);
     BroadcastResources(PS);
   }
 
@@ -207,10 +207,10 @@ void ATurnManager::AdvanceTurn() {
         }
       }
       const int32 Reinforcements = FMath::CeilToInt(Owned / 3.0f);
-      PS->ArmyPool = Reinforcements;
+      PS->DeployableUnits = Reinforcements;
       PS->Resources += ResourceGain;
       PS->ForceNetUpdate();
-      BroadcastArmyPool(PS);
+      BroadcastDeployableUnits(PS);
       BroadcastResources(PS);
     }
 
@@ -426,7 +426,7 @@ void ATurnManager::AdvancePhase() {
   BroadcastCurrentPhase();
 }
 
-void ATurnManager::BroadcastArmyPool(ASkaldPlayerState *ForPlayer) {
+void ATurnManager::BroadcastDeployableUnits(ASkaldPlayerState *ForPlayer) {
   if (!ForPlayer) {
     return;
   }
@@ -435,7 +435,7 @@ void ATurnManager::BroadcastArmyPool(ASkaldPlayerState *ForPlayer) {
       ASkaldPlayerState *PS = Controller->GetPlayerState<ASkaldPlayerState>();
       if (PS == ForPlayer) {
         if (USkaldMainHUDWidget *HUD = Controller->GetHUDWidget()) {
-          HUD->UpdateDeployableUnits(ForPlayer->ArmyPool);
+          HUD->UpdateDeployableUnits(ForPlayer->DeployableUnits);
         }
       }
     }

--- a/Source/Skald/Skald_TurnManager.h
+++ b/Source/Skald/Skald_TurnManager.h
@@ -47,9 +47,9 @@ public:
     UFUNCTION(BlueprintCallable, Category="Turn")
     void AdvancePhase();
 
-    /** Update all players' HUDs with the specified player's army pool. */
+    /** Update all players' HUDs with the specified player's deployable units. */
     UFUNCTION(BlueprintCallable, Category="Turn")
-    void BroadcastArmyPool(class ASkaldPlayerState* ForPlayer);
+    void BroadcastDeployableUnits(class ASkaldPlayerState* ForPlayer);
 
     /** Update all HUDs with the specified player's resources. */
     UFUNCTION(BlueprintCallable, Category="Turn")

--- a/Source/Skald/Tests/AIDecisionFlowTest.cpp
+++ b/Source/Skald/Tests/AIDecisionFlowTest.cpp
@@ -37,7 +37,7 @@ bool FSkaldAIDecisionFlowTest::RunTest(const FString& Parameters)
 
     PC1->PlayerState = PS1;
     PS1->bIsAI = true;
-    PS1->ArmyPool = 4;
+    PS1->DeployableUnits = 4;
     PS1->Resources = 4;
     PC1->SetTurnManager(TM);
 
@@ -72,7 +72,7 @@ bool FSkaldAIDecisionFlowTest::RunTest(const FString& Parameters)
     FMath::RandInit(1);
     PC1->MakeAIDecision();
 
-    TestEqual(TEXT("Army pool spent"), PS1->ArmyPool, 0);
+    TestEqual(TEXT("Deployable units spent"), PS1->DeployableUnits, 0);
     TestEqual(TEXT("Resources spent"), PS1->Resources, 0);
     TestEqual(TEXT("Attack captured territory"), TB->OwningPlayer, PS1);
     TestTrue(TEXT("Movement reinforced"), TA->ArmyStrength > 1);

--- a/Source/Skald/Tests/DeployUnitsReplicationTest.cpp
+++ b/Source/Skald/Tests/DeployUnitsReplicationTest.cpp
@@ -52,7 +52,7 @@ bool FSkaldDeployReplicationTest::RunTest(const FString& Parameters)
     Terr->OwningPlayer = PS1;
     Terr->ArmyStrength = 5;
     WM->Territories = {Terr};
-    PS1->ArmyPool = 10;
+    PS1->DeployableUnits = 10;
 
     UDeployTestHUDWidget* HUD1 = NewObject<UDeployTestHUDWidget>(PC1);
     UDeployTestHUDWidget* HUD2 = NewObject<UDeployTestHUDWidget>(PC2);
@@ -62,7 +62,7 @@ bool FSkaldDeployReplicationTest::RunTest(const FString& Parameters)
     PC1->ServerDeployUnits(Terr->TerritoryID, 3);
 
     TestEqual(TEXT("Territory army updated"), Terr->ArmyStrength, 8);
-    TestEqual(TEXT("Player army pool updated"), PS1->ArmyPool, 7);
+    TestEqual(TEXT("Player deployable units updated"), PS1->DeployableUnits, 7);
     TestEqual(TEXT("HUD1 updated"), HUD1->LastUnits, 7);
     TestEqual(TEXT("HUD2 updated"), HUD2->LastUnits, 7);
 

--- a/Source/Skald/Tests/DeployUnitsReplicationTest.h
+++ b/Source/Skald/Tests/DeployUnitsReplicationTest.h
@@ -5,7 +5,7 @@
 #include "UI/SkaldMainHUDWidget.h"
 #include "DeployUnitsReplicationTest.generated.h"
 
-/** HUD widget capturing the last army pool value for tests. */
+/** HUD widget capturing the last deployable units value for tests. */
 UCLASS()
 class UDeployTestHUDWidget : public USkaldMainHUDWidget {
     GENERATED_BODY()

--- a/Source/Skald/Tests/DeployableUnitsCalculationTest.cpp
+++ b/Source/Skald/Tests/DeployableUnitsCalculationTest.cpp
@@ -7,8 +7,8 @@
 #include "WorldMap.h"
 #include "DeployUnitsReplicationTest.h"
 
-IMPLEMENT_SIMPLE_AUTOMATION_TEST(FSkaldArmyPoolCalculationTest, "Skald.TurnManager.ArmyPoolCalculation", EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
-bool FSkaldArmyPoolCalculationTest::RunTest(const FString& Parameters) {
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FSkaldDeployableUnitsCalculationTest, "Skald.TurnManager.DeployableUnitsCalculation", EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+bool FSkaldDeployableUnitsCalculationTest::RunTest(const FString& Parameters) {
   UWorld* World = FAutomationEditorCommonUtils::CreateNewMap();
   TestNotNull(TEXT("World created"), World);
   if (!World) {
@@ -46,7 +46,7 @@ bool FSkaldArmyPoolCalculationTest::RunTest(const FString& Parameters) {
   Map->Territories = Terrs;
 
   TM->StartTurns();
-  TestEqual(TEXT("Army pool after start"), PS->ArmyPool, 2);
+  TestEqual(TEXT("Deployable units after start"), PS->DeployableUnits, 2);
   TestEqual(TEXT("HUD after start"), HUD->LastUnits, 2);
 
   // add two more territories and advance turn to recalc
@@ -62,7 +62,7 @@ bool FSkaldArmyPoolCalculationTest::RunTest(const FString& Parameters) {
   Map->Territories = Terrs;
 
   TM->AdvanceTurn();
-  TestEqual(TEXT("Army pool after advance"), PS->ArmyPool, 3);
+  TestEqual(TEXT("Deployable units after advance"), PS->DeployableUnits, 3);
   TestEqual(TEXT("HUD after advance"), HUD->LastUnits, 3);
 
   return true;

--- a/Source/Skald/UI/DeployWidget.cpp
+++ b/Source/Skald/UI/DeployWidget.cpp
@@ -43,19 +43,19 @@ void UDeployWidget::HandleAccept() {
 
   const int32 Selected = AmountSelector
                               ? FMath::Clamp(FMath::RoundToInt(AmountSelector->GetValue()), 0,
-                                             PlayerState->ArmyPool)
+                                             PlayerState->DeployableUnits)
                               : 0;
   if (Selected > 0) {
     if (APlayerController *PC = OwningHUD->GetOwningPlayer()) {
       if (ASkaldPlayerController *SKPC = Cast<ASkaldPlayerController>(PC)) {
         SKPC->ServerDeployUnits(Territory->TerritoryID, Selected);
         if (ATurnManager *TM = SKPC->GetTurnManager()) {
-          TM->BroadcastArmyPool(PlayerState);
+          TM->BroadcastDeployableUnits(PlayerState);
         }
       }
     }
 
-    const int32 Remaining = PlayerState->ArmyPool - Selected;
+    const int32 Remaining = PlayerState->DeployableUnits - Selected;
     if (Remaining <= 0 && OwningHUD->DeployButton) {
       OwningHUD->DeployButton->SetVisibility(ESlateVisibility::Collapsed);
       bool bHandled = false;

--- a/Source/Skald/UI/SkaldMainHUDWidget.cpp
+++ b/Source/Skald/UI/SkaldMainHUDWidget.cpp
@@ -658,9 +658,9 @@ void USkaldMainHUDWidget::HandleDeployClicked() {
     ShowErrorMessage(TEXT("Missing player state"));
     return;
   }
-  if (PS->ArmyPool <= 0) {
+  if (PS->DeployableUnits <= 0) {
     UE_LOG(LogSkald, Warning,
-           TEXT("HandleDeployClicked failed: ArmyPool empty"));
+           TEXT("HandleDeployClicked failed: no deployable units"));
     ShowErrorMessage(TEXT("No troops to deploy"));
     return;
   }
@@ -695,7 +695,7 @@ void USkaldMainHUDWidget::HandleDeployClicked() {
   ActiveDeployWidget =
       CreateWidget<UDeployWidget>(GetWorld(), DeployWidgetClass);
   if (ActiveDeployWidget) {
-    ActiveDeployWidget->Setup(Territory, PS, this, PS->ArmyPool);
+    ActiveDeployWidget->Setup(Territory, PS, this, PS->DeployableUnits);
     ActiveDeployWidget->AddToViewport();
   } else {
     UE_LOG(LogSkald, Warning,


### PR DESCRIPTION
## Summary
- rename `ArmyPool` to `DeployableUnits` across player state and HUD
- rename turn manager broadcast method to `BroadcastDeployableUnits`
- update tests, scripts, and gameplay to track deployable units

## Testing
- `./Build/validate.sh`

------
https://chatgpt.com/codex/tasks/task_e_68b57d5764b08324b14bdc2f6e6dcb59