### PR TITLE
Rename ArmyStrength to ArmyUnits

### DIFF
--- a/Source/Skald/SkaldTypes.h
+++ b/Source/Skald/SkaldTypes.h
@@ -81,7 +81,7 @@ struct SKALD_API FS_ArmyUnit
     int32 OwnerPlayerID = 0;
 
     UPROPERTY(BlueprintReadWrite, EditAnywhere)
-    int32 ArmyCount = 0;
+    int32 ArmyUnits = 0;
 
     UPROPERTY(BlueprintReadWrite, EditAnywhere)
     bool HasTreasure = false;
@@ -214,7 +214,7 @@ struct SKALD_API FS_Territory
     int32 CapitalOwner = 0;
 
     UPROPERTY(BlueprintReadWrite, EditAnywhere)
-    int32 ArmyCount = 0;
+    int32 ArmyUnits = 0;
 
     UPROPERTY(BlueprintReadWrite, EditAnywhere)
     TArray<int32> AdjacentIDs;

--- a/Source/Skald/Skald_GameMode.cpp
+++ b/Source/Skald/Skald_GameMode.cpp
@@ -390,7 +390,7 @@ void ASkaldGameMode::ApplyLoadedGame(USkaldSaveGame *LoadedGame) {
     }
 
     Territory->OwningPlayer = TerritoryOwner;
-    Territory->ArmyStrength = TerrData.ArmyCount;
+    Territory->ArmyUnits = TerrData.ArmyUnits;
     Territory->bIsCapital = TerrData.IsCapital;
     Territory->ContinentID = TerrData.ContinentID;
     Territory->BuiltSiegeID = TerrData.BuiltSiegeID;
@@ -567,7 +567,7 @@ void ASkaldGameMode::AdvanceArmyPlacement() {
       while (PS->DeployableUnits > 0 && OwnedTerritories.Num() > 0) {
         ATerritory *TargetTerritory =
             OwnedTerritories[SpreadIndex % OwnedTerritories.Num()];
-        ++TargetTerritory->ArmyStrength;
+        ++TargetTerritory->ArmyUnits;
         TargetTerritory->RefreshAppearance();
         --PS->DeployableUnits;
         ++SpreadIndex;
@@ -720,7 +720,7 @@ bool ASkaldGameMode::InitializeWorld() {
           Cast<ASkaldPlayerState>(GS->PlayerArray[Index % PlayerCount]);
       Territory->OwningPlayer = TerritoryOwner;
       Territory->bIsCapital = false;
-      Territory->ArmyStrength = 1;
+      Territory->ArmyUnits = 1;
       Territory->RefreshAppearance();
       Territory->ForceNetUpdate();
       ++Index;
@@ -859,7 +859,7 @@ void ASkaldGameMode::FillSaveGame(USkaldSaveGame *SaveGameObject) const {
           Territory->OwningPlayer ? Territory->OwningPlayer->GetPlayerId() : 0;
       TerrData.IsCapital = Territory->bIsCapital;
       TerrData.CapitalOwner = TerrData.OwnerPlayerID;
-      TerrData.ArmyCount = Territory->ArmyStrength;
+      TerrData.ArmyUnits = Territory->ArmyUnits;
       TerrData.ContinentID = Territory->ContinentID;
       for (ATerritory *Adj : Territory->AdjacentTerritories) {
         if (Adj) {

--- a/Source/Skald/Skald_PlayerController.cpp
+++ b/Source/Skald/Skald_PlayerController.cpp
@@ -312,7 +312,7 @@ void ASkaldPlayerController::MakeAIDecision() {
       while (PS->DeployableUnits > 0 && OwnedTerritories.Num() > 0) {
         ATerritory *TargetTerritory =
             OwnedTerritories[SpreadIndex % OwnedTerritories.Num()];
-        ++TargetTerritory->ArmyStrength;
+        ++TargetTerritory->ArmyUnits;
         TargetTerritory->RefreshAppearance();
         --PS->DeployableUnits;
         --PS->Resources;
@@ -330,7 +330,7 @@ void ASkaldPlayerController::MakeAIDecision() {
 
       for (ATerritory *Source : WorldMap->Territories) {
         if (!Source || Source->OwningPlayer != PS ||
-            Source->ArmyStrength <= 1) {
+            Source->ArmyUnits <= 1) {
           continue;
         }
 
@@ -339,16 +339,16 @@ void ASkaldPlayerController::MakeAIDecision() {
             continue;
           }
 
-          if (Neighbor->ArmyStrength < WeakestStrength) {
+          if (Neighbor->ArmyUnits < WeakestStrength) {
             BestSource = Source;
             BestTarget = Neighbor;
-            WeakestStrength = Neighbor->ArmyStrength;
+            WeakestStrength = Neighbor->ArmyUnits;
           }
         }
       }
 
-      if (BestSource && BestTarget && BestSource->ArmyStrength > 1) {
-        const int32 ArmySent = BestSource->ArmyStrength - 1;
+      if (BestSource && BestTarget && BestSource->ArmyUnits > 1) {
+        const int32 ArmySent = BestSource->ArmyUnits - 1;
         HandleAttackRequested(BestSource->TerritoryID, BestTarget->TerritoryID,
                               ArmySent, false);
       }
@@ -364,7 +364,7 @@ void ASkaldPlayerController::MakeAIDecision() {
 
       for (ATerritory *Source : WorldMap->Territories) {
         if (!Source || Source->OwningPlayer != PS ||
-            Source->ArmyStrength <= 1) {
+            Source->ArmyUnits <= 1) {
           continue;
         }
 
@@ -373,18 +373,18 @@ void ASkaldPlayerController::MakeAIDecision() {
             continue;
           }
 
-          if (Neighbor->ArmyStrength < WeakestStrength) {
+          if (Neighbor->ArmyUnits < WeakestStrength) {
             BestSource = Source;
             BestTarget = Neighbor;
-            WeakestStrength = Neighbor->ArmyStrength;
+            WeakestStrength = Neighbor->ArmyUnits;
           }
         }
       }
 
       if (BestSource && BestTarget) {
-        int32 TroopsToMove = BestSource->ArmyStrength / 2;
+        int32 TroopsToMove = BestSource->ArmyUnits / 2;
         TroopsToMove =
-            FMath::Clamp(TroopsToMove, 1, BestSource->ArmyStrength - 1);
+            FMath::Clamp(TroopsToMove, 1, BestSource->ArmyUnits - 1);
         HandleMoveRequested(BestSource->TerritoryID, BestTarget->TerritoryID,
                             TroopsToMove);
       }
@@ -448,7 +448,7 @@ bool ASkaldPlayerController::ValidateAttack(int32 FromID, int32 ToID,
     return false;
   }
 
-  if (ArmySent <= 0 || ArmySent >= Source->ArmyStrength) {
+  if (ArmySent <= 0 || ArmySent >= Source->ArmyUnits) {
     if (OutError) {
       *OutError = TEXT("Invalid army count for attack");
     }
@@ -520,12 +520,12 @@ void ASkaldPlayerController::ServerHandleAttack_Implementation(int32 FromID,
   }
 
   int32 AttackingForces = ArmySent;
-  int32 DefendingForces = Target->ArmyStrength;
+  int32 DefendingForces = Target->ArmyUnits;
   if (bUseSiege && CachedGameMode) {
     CachedGameMode->ConsumeSiege(FromID);
   }
 
-  Source->ArmyStrength -= ArmySent;
+  Source->ArmyUnits -= ArmySent;
 
   FRandomStream *CombatStream = nullptr;
   if (CachedGameInstance) {
@@ -549,9 +549,9 @@ void ASkaldPlayerController::ServerHandleAttack_Implementation(int32 FromID,
 
   if (DefendingForces <= 0) {
     Target->OwningPlayer = AttackerPS;
-    Target->ArmyStrength = AttackingForces;
+    Target->ArmyUnits = AttackingForces;
   } else {
-    Target->ArmyStrength = DefendingForces;
+    Target->ArmyUnits = DefendingForces;
   }
 
   Source->RefreshAppearance();
@@ -568,7 +568,7 @@ void ASkaldPlayerController::ServerHandleAttack_Implementation(int32 FromID,
                                 ? Target->OwningPlayer->PlayerDisplayName
                                 : TEXT("Neutral");
         HUD->UpdateTerritoryInfo(Target->TerritoryName, OwnerName,
-                                 Target->ArmyStrength);
+                                 Target->ArmyUnits);
       }
     }
   }
@@ -599,7 +599,7 @@ void ASkaldPlayerController::HandleMoveRequested(int32 FromID, int32 ToID,
     return;
   }
 
-  if (Troops <= 0 || Troops >= Source->ArmyStrength) {
+  if (Troops <= 0 || Troops >= Source->ArmyUnits) {
     NotifyActionError(TEXT("Invalid troop count for movement"));
     return;
   }
@@ -622,7 +622,7 @@ void ASkaldPlayerController::ServerHandleMove_Implementation(int32 FromID,
     return;
   }
 
-  if (Troops <= 0 || Troops >= Source->ArmyStrength) {
+  if (Troops <= 0 || Troops >= Source->ArmyUnits) {
     return;
   }
 
@@ -638,12 +638,12 @@ void ASkaldPlayerController::ServerHandleMove_Implementation(int32 FromID,
                                   ? Source->OwningPlayer->PlayerDisplayName
                                   : TEXT("Neutral");
         HUD->UpdateTerritoryInfo(Source->TerritoryName, SourceOwner,
-                                 Source->ArmyStrength);
+                                 Source->ArmyUnits);
         FString TargetOwner = Target->OwningPlayer
                                   ? Target->OwningPlayer->PlayerDisplayName
                                   : TEXT("Neutral");
         HUD->UpdateTerritoryInfo(Target->TerritoryName, TargetOwner,
-                                 Target->ArmyStrength);
+                                 Target->ArmyUnits);
       }
     }
   }
@@ -678,7 +678,7 @@ void ASkaldPlayerController::ServerDeployUnits_Implementation(int32 TerritoryID,
     return;
   }
 
-  Terr->ArmyStrength += Amount;
+  Terr->ArmyUnits += Amount;
   Terr->RefreshAppearance();
   Terr->ForceNetUpdate();
 
@@ -818,7 +818,7 @@ void ASkaldPlayerController::HandleTerritorySelected(ATerritory *Terr) {
                             ? Terr->OwningPlayer->PlayerDisplayName
                             : TEXT("Neutral");
     MainHudWidget->UpdateTerritoryInfo(Terr->TerritoryName, OwnerName,
-                                       Terr->ArmyStrength);
+                                       Terr->ArmyUnits);
     MainHudWidget->OnTerritoryClickedUI(Terr);
   }
 }
@@ -894,7 +894,7 @@ void ASkaldPlayerController::HandleWorldStateChanged() {
                               ? Terr->OwningPlayer->PlayerDisplayName
                               : TEXT("Neutral");
       MainHudWidget->UpdateTerritoryInfo(Terr->TerritoryName, OwnerName,
-                                         Terr->ArmyStrength);
+                                         Terr->ArmyUnits);
     }
   }
 

--- a/Source/Skald/Skald_TurnManager.cpp
+++ b/Source/Skald/Skald_TurnManager.cpp
@@ -311,23 +311,23 @@ void ATurnManager::ResolveGridBattleResult() {
       Source->OwningPlayer ? Source->OwningPlayer->GetPlayerId() : -1;
   const int32 DefenderID =
       Target->OwningPlayer ? Target->OwningPlayer->GetPlayerId() : -1;
-  const int32 InitialSourceArmy = Source->ArmyStrength;
-  const int32 InitialTargetArmy = Target->ArmyStrength;
+  const int32 InitialSourceArmy = Source->ArmyUnits;
+  const int32 InitialTargetArmy = Target->ArmyUnits;
 
   const int32 AttackerSurvivors = GI->GridBattleManager->GetAttackerSurvivors();
   const int32 DefenderSurvivors = GI->GridBattleManager->GetDefenderSurvivors();
 
-  Source->ArmyStrength -= Battle.ArmyCountSent;
+  Source->ArmyUnits -= Battle.ArmyCountSent;
 
   int32 WinningPlayerID = DefenderID;
   int32 NewOwnerPlayerID = DefenderID;
   if (AttackerSurvivors > 0 && DefenderSurvivors <= 0) {
     Target->OwningPlayer = Source->OwningPlayer;
-    Target->ArmyStrength = AttackerSurvivors;
+    Target->ArmyUnits = AttackerSurvivors;
     WinningPlayerID = AttackerID;
     NewOwnerPlayerID = AttackerID;
   } else {
-    Target->ArmyStrength = DefenderSurvivors;
+    Target->ArmyUnits = DefenderSurvivors;
   }
 
   const int32 AttackerCasualties = Battle.ArmyCountSent - AttackerSurvivors;
@@ -350,7 +350,7 @@ void ATurnManager::ResolveGridBattleResult() {
   ClientBattleResolved(WinningPlayerID, AttackerCasualties,
                        DefenderCasualties, Source->TerritoryID,
                        Target->TerritoryID, NewOwnerPlayerID,
-                       Source->ArmyStrength, Target->ArmyStrength);
+                       Source->ArmyUnits, Target->ArmyUnits);
 }
 
 void ATurnManager::ClientBattleResolved_Implementation(
@@ -361,7 +361,7 @@ void ATurnManager::ClientBattleResolved_Implementation(
     ATerritory *Source = CachedWorldMap->GetTerritoryById(FromTerritoryID);
     ATerritory *Target = CachedWorldMap->GetTerritoryById(TargetTerritoryID);
     if (Source) {
-      Source->ArmyStrength = SourceArmy;
+      Source->ArmyUnits = SourceArmy;
       Source->RefreshAppearance();
       Source->ForceNetUpdate();
     }
@@ -374,7 +374,7 @@ void ATurnManager::ClientBattleResolved_Implementation(
         }
       }
       Target->OwningPlayer = NewOwner;
-      Target->ArmyStrength = TargetArmy;
+      Target->ArmyUnits = TargetArmy;
       Target->RefreshAppearance();
       Target->ForceNetUpdate();
     }

--- a/Source/Skald/Territory.cpp
+++ b/Source/Skald/Territory.cpp
@@ -70,7 +70,7 @@ ATerritory::ATerritory() {
   TerritoryName = TEXT("");
   bIsCapital = false;
   ContinentID = 0;
-  ArmyStrength = 0;
+  ArmyUnits = 0;
 }
 
 void ATerritory::BeginPlay() {
@@ -140,7 +140,7 @@ void ATerritory::GetLifetimeReplicatedProps(
   DOREPLIFETIME(ATerritory, bIsCapital);
   DOREPLIFETIME(ATerritory, ContinentID);
   DOREPLIFETIME(ATerritory, AdjacentTerritories);
-  DOREPLIFETIME(ATerritory, ArmyStrength);
+  DOREPLIFETIME(ATerritory, ArmyUnits);
   DOREPLIFETIME(ATerritory, BuiltSiegeID);
   DOREPLIFETIME(ATerritory, bHasTreasure);
 }
@@ -179,7 +179,7 @@ bool ATerritory::IsAdjacentTo(const ATerritory *Other) const {
 }
 
 bool ATerritory::MoveTo(ATerritory *TargetTerritory, int32 Troops) {
-  if (!TargetTerritory || Troops <= 0 || Troops >= ArmyStrength) {
+  if (!TargetTerritory || Troops <= 0 || Troops >= ArmyUnits) {
     return false;
   }
 
@@ -188,8 +188,8 @@ bool ATerritory::MoveTo(ATerritory *TargetTerritory, int32 Troops) {
     return false;
   }
 
-  ArmyStrength -= Troops;
-  TargetTerritory->ArmyStrength += Troops;
+  ArmyUnits -= Troops;
+  TargetTerritory->ArmyUnits += Troops;
 
   RefreshAppearance();
   ForceNetUpdate();
@@ -237,7 +237,7 @@ void ATerritory::OnRep_OwningPlayer() { RefreshAppearance(); }
 
 void ATerritory::OnRep_IsCapital() { RefreshAppearance(); }
 
-void ATerritory::OnRep_ArmyStrength() { UpdateLabel(); }
+void ATerritory::OnRep_ArmyUnits() { UpdateLabel(); }
 
 void ATerritory::UpdateTerritoryColor() {
   if (DynamicMaterial) {
@@ -258,7 +258,7 @@ void ATerritory::UpdateLabel() {
   const FString OwnerName =
       OwningPlayer ? OwningPlayer->PlayerDisplayName : TEXT("Neutral");
   const FString Text =
-      FString::Printf(TEXT("%s\nOwner: %s\nArmy: %d"), *TerritoryName,
-                      *OwnerName, ArmyStrength);
+      FString::Printf(TEXT("%s\nOwner: %s\nUnits: %d"), *TerritoryName,
+                      *OwnerName, ArmyUnits);
   LabelComponent->SetText(FText::FromString(Text));
 }

--- a/Source/Skald/Territory.h
+++ b/Source/Skald/Territory.h
@@ -63,9 +63,9 @@ public:
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Territory", Replicated)
     TArray<ATerritory*> AdjacentTerritories;
 
-    /** Number of armies stationed in this territory. */
-    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Territory", ReplicatedUsing = OnRep_ArmyStrength)
-    int32 ArmyStrength = 0;
+    /** Number of units stationed in this territory. */
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Territory", ReplicatedUsing = OnRep_ArmyUnits)
+    int32 ArmyUnits = 0;
 
     /** ID of siege equipment built in this territory, 0 if none. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Territory", Replicated)
@@ -115,7 +115,7 @@ public:
     void OnRep_OwningPlayer();
 
     UFUNCTION()
-    void OnRep_ArmyStrength();
+    void OnRep_ArmyUnits();
 
     UFUNCTION()
     void OnRep_IsCapital();

--- a/Source/Skald/Tests/AIDecisionFlowTest.cpp
+++ b/Source/Skald/Tests/AIDecisionFlowTest.cpp
@@ -59,9 +59,9 @@ bool FSkaldAIDecisionFlowTest::RunTest(const FString& Parameters)
         return false;
     }
 
-    TA->TerritoryID = 1; TA->OwningPlayer = PS1; TA->ArmyStrength = 10;
-    TB->TerritoryID = 2; TB->OwningPlayer = PS2; TB->ArmyStrength = 1;
-    TC->TerritoryID = 3; TC->OwningPlayer = PS1; TC->ArmyStrength = 1;
+    TA->TerritoryID = 1; TA->OwningPlayer = PS1; TA->ArmyUnits = 10;
+    TB->TerritoryID = 2; TB->OwningPlayer = PS2; TB->ArmyUnits = 1;
+    TC->TerritoryID = 3; TC->OwningPlayer = PS1; TC->ArmyUnits = 1;
 
     TA->AdjacentTerritories = {TB, TC};
     TB->AdjacentTerritories = {TA};
@@ -75,7 +75,7 @@ bool FSkaldAIDecisionFlowTest::RunTest(const FString& Parameters)
     TestEqual(TEXT("Deployable units spent"), PS1->DeployableUnits, 0);
     TestEqual(TEXT("Resources spent"), PS1->Resources, 0);
     TestEqual(TEXT("Attack captured territory"), TB->OwningPlayer, PS1);
-    TestTrue(TEXT("Movement reinforced"), TA->ArmyStrength > 1);
+    TestTrue(TEXT("Movement reinforced"), TA->ArmyUnits > 1);
     TestEqual(TEXT("Turn advanced"), TM->GetCurrentPhase(), ETurnPhase::Reinforcement);
 
     return true;

--- a/Source/Skald/Tests/BattleResolutionSyncTest.cpp
+++ b/Source/Skald/Tests/BattleResolutionSyncTest.cpp
@@ -37,11 +37,11 @@ bool FSkaldBattleResolutionSyncTest::RunTest(const FString& Parameters) {
   PS2->SetPlayerId(2);
 
   Source->TerritoryID = 1;
-  Source->ArmyStrength = 10;
+  Source->ArmyUnits = 10;
   Source->OwningPlayer = PS1;
 
   Target->TerritoryID = 2;
-  Target->ArmyStrength = 5;
+  Target->ArmyUnits = 5;
   Target->OwningPlayer = PS2;
 
   WM->Territories.Add(Source);
@@ -55,8 +55,8 @@ bool FSkaldBattleResolutionSyncTest::RunTest(const FString& Parameters) {
   TM->ClientBattleResolved(1, 3, 5, 1, 2, 1, 5, 2);
 
   TestTrue(TEXT("Broadcast fired"), Listener->bBroadcasted);
-  TestEqual(TEXT("Source army"), Source->ArmyStrength, 5);
-  TestEqual(TEXT("Target army"), Target->ArmyStrength, 2);
+  TestEqual(TEXT("Source army"), Source->ArmyUnits, 5);
+  TestEqual(TEXT("Target army"), Target->ArmyUnits, 2);
   TestTrue(TEXT("Target owner"), Target->OwningPlayer == PS1);
 
   return true;

--- a/Source/Skald/Tests/DeployUnitsReplicationTest.cpp
+++ b/Source/Skald/Tests/DeployUnitsReplicationTest.cpp
@@ -50,7 +50,7 @@ bool FSkaldDeployReplicationTest::RunTest(const FString& Parameters)
 
     Terr->TerritoryID = 1;
     Terr->OwningPlayer = PS1;
-    Terr->ArmyStrength = 5;
+    Terr->ArmyUnits = 5;
     WM->Territories = {Terr};
     PS1->DeployableUnits = 10;
 
@@ -61,7 +61,7 @@ bool FSkaldDeployReplicationTest::RunTest(const FString& Parameters)
 
     PC1->ServerDeployUnits(Terr->TerritoryID, 3);
 
-    TestEqual(TEXT("Territory army updated"), Terr->ArmyStrength, 8);
+    TestEqual(TEXT("Territory army updated"), Terr->ArmyUnits, 8);
     TestEqual(TEXT("Player deployable units updated"), PS1->DeployableUnits, 7);
     TestEqual(TEXT("HUD1 updated"), HUD1->LastUnits, 7);
     TestEqual(TEXT("HUD2 updated"), HUD2->LastUnits, 7);

--- a/Source/Skald/Tests/FullTurnFlowTest.cpp
+++ b/Source/Skald/Tests/FullTurnFlowTest.cpp
@@ -69,10 +69,10 @@ bool FSkaldFullTurnFlowTest::RunTest(const FString &Parameters) {
   T1->bIsCapital = true;
   T1->OwningPlayer = PS;
   T1->bHasTreasure = true;
-  T1->ArmyStrength = 5;
+  T1->ArmyUnits = 5;
   T2->TerritoryID = 2;
   T2->OwningPlayer = PS;
-  T2->ArmyStrength = 0;
+  T2->ArmyUnits = 0;
   T1->AdjacentTerritories = {T2};
   T2->AdjacentTerritories = {T1};
   Map->Territories = {T1, T2};
@@ -103,8 +103,8 @@ bool FSkaldFullTurnFlowTest::RunTest(const FString &Parameters) {
   HUD->OnTerritoryClickedUI(T1);
   HUD->OnTerritoryClickedUI(T2);
   HUD->SubmitMove(T1->TerritoryID, T2->TerritoryID, 2);
-  TestEqual(TEXT("Source after move"), T1->ArmyStrength, 3);
-  TestEqual(TEXT("Target after move"), T2->ArmyStrength, 2);
+  TestEqual(TEXT("Source after move"), T1->ArmyUnits, 3);
+  TestEqual(TEXT("Target after move"), T2->ArmyUnits, 2);
 
   PC->EndPhase(); // to end turn
   TestEqual(TEXT("EndTurn phase"), TM->GetCurrentPhase(), ETurnPhase::EndTurn);

--- a/Source/Skald/Tests/TerritoryMoveTest.cpp
+++ b/Source/Skald/Tests/TerritoryMoveTest.cpp
@@ -32,22 +32,22 @@ bool FSkaldTerritoryMoveValidTest::RunTest(const FString& Parameters)
     B->OwningPlayer = Player;
     A->AdjacentTerritories = {B};
     B->AdjacentTerritories = {A};
-    A->ArmyStrength = 10;
-    B->ArmyStrength = 0;
+    A->ArmyUnits = 10;
+    B->ArmyUnits = 0;
 
     bool bMoved = A->MoveTo(B, 5);
     TestTrue(TEXT("Move succeeds"), bMoved);
-    TestEqual(TEXT("Origin army reduced"), A->ArmyStrength, 5);
-    TestEqual(TEXT("Target army increased"), B->ArmyStrength, 5);
+    TestEqual(TEXT("Origin army reduced"), A->ArmyUnits, 5);
+    TestEqual(TEXT("Target army increased"), B->ArmyUnits, 5);
 
     UTextRenderComponent* ALabel = A->FindComponentByClass<UTextRenderComponent>();
     UTextRenderComponent* BLabel = B->FindComponentByClass<UTextRenderComponent>();
-    TestTrue(TEXT("Source label updated"), ALabel && ALabel->Text.ToString().Contains("Army: 5"));
-    TestTrue(TEXT("Target label updated"), BLabel && BLabel->Text.ToString().Contains("Army: 5"));
+    TestTrue(TEXT("Source label updated"), ALabel && ALabel->Text.ToString().Contains("Units: 5"));
+    TestTrue(TEXT("Target label updated"), BLabel && BLabel->Text.ToString().Contains("Units: 5"));
     TestTrue(TEXT("Source label updated"),
-             ALabel && ALabel->Text.ToString().Contains("Army: 5"));
+             ALabel && ALabel->Text.ToString().Contains("Units: 5"));
     TestTrue(TEXT("Target label updated"),
-             BLabel && BLabel->Text.ToString().Contains("Army: 5"));
+             BLabel && BLabel->Text.ToString().Contains("Units: 5"));
 
     return true;
 }
@@ -79,16 +79,16 @@ bool FSkaldTerritoryMoveInvalidTest::RunTest(const FString& Parameters)
     B->OwningPlayer = Player1;
     A->AdjacentTerritories = {};
     B->AdjacentTerritories = {};
-    A->ArmyStrength = 10;
-    B->ArmyStrength = 0;
+    A->ArmyUnits = 10;
+    B->ArmyUnits = 0;
     UTextRenderComponent* ALabel = A->FindComponentByClass<UTextRenderComponent>();
     UTextRenderComponent* BLabel = B->FindComponentByClass<UTextRenderComponent>();
     const FString ALabelBefore = ALabel ? ALabel->Text.ToString() : FString();
     const FString BLabelBefore = BLabel ? BLabel->Text.ToString() : FString();
     bool bMoved = A->MoveTo(B, 5);
     TestFalse(TEXT("Non-adjacent move fails"), bMoved);
-    TestEqual(TEXT("Origin army unchanged"), A->ArmyStrength, 10);
-    TestEqual(TEXT("Target army unchanged"), B->ArmyStrength, 0);
+    TestEqual(TEXT("Origin army unchanged"), A->ArmyUnits, 10);
+    TestEqual(TEXT("Target army unchanged"), B->ArmyUnits, 0);
     TestEqual(TEXT("Source label unchanged"), ALabel ? ALabel->Text.ToString() : FString(), ALabelBefore);
     TestEqual(TEXT("Target label unchanged"), BLabel ? BLabel->Text.ToString() : FString(), BLabelBefore);
     TestEqual(TEXT("Source label unchanged"),
@@ -104,8 +104,8 @@ bool FSkaldTerritoryMoveInvalidTest::RunTest(const FString& Parameters)
     const FString BLabelBefore2 = BLabel ? BLabel->Text.ToString() : FString();
     bMoved = A->MoveTo(B, 5);
     TestFalse(TEXT("Move to enemy territory fails"), bMoved);
-    TestEqual(TEXT("Origin army unchanged"), A->ArmyStrength, 10);
-    TestEqual(TEXT("Target army unchanged"), B->ArmyStrength, 0);
+    TestEqual(TEXT("Origin army unchanged"), A->ArmyUnits, 10);
+    TestEqual(TEXT("Target army unchanged"), B->ArmyUnits, 0);
     TestEqual(TEXT("Source label unchanged"), ALabel ? ALabel->Text.ToString() : FString(), ALabelBefore2);
     TestEqual(TEXT("Target label unchanged"), BLabel ? BLabel->Text.ToString() : FString(), BLabelBefore2);
     TestEqual(TEXT("Source label unchanged"),

--- a/Source/Skald/UI/SkaldMainHUDWidget.cpp
+++ b/Source/Skald/UI/SkaldMainHUDWidget.cpp
@@ -403,7 +403,7 @@ void USkaldMainHUDWidget::OnTerritoryClickedUI(ATerritory *Territory) {
 
   if (bSelectingForAttack) {
     if (SelectedSourceID == -1) {
-      if (bOwnedByLocal && Territory->ArmyStrength > 1) {
+      if (bOwnedByLocal && Territory->ArmyUnits > 1) {
         SelectedSourceID = Territory->TerritoryID;
         Territory->Select();
         if (SelectionPrompt) {
@@ -441,7 +441,7 @@ void USkaldMainHUDWidget::OnTerritoryClickedUI(ATerritory *Territory) {
                       GetWorld(), AWorldMap::StaticClass()))) {
             if (ATerritory *Source =
                     WorldMap->GetTerritoryById(SelectedSourceID)) {
-              MaxUnits = Source->ArmyStrength - 1;
+              MaxUnits = Source->ArmyUnits - 1;
             }
           }
           ActiveConfirmWidget->Setup(MaxUnits);
@@ -578,7 +578,7 @@ void USkaldMainHUDWidget::HandleAttackApproved() {
   if (AWorldMap *WorldMap = Cast<AWorldMap>(UGameplayStatics::GetActorOfClass(
           GetWorld(), AWorldMap::StaticClass()))) {
     if (ATerritory *Source = WorldMap->GetTerritoryById(SourceID)) {
-      ArmyCount = FMath::Clamp(ArmyCount, 1, Source->ArmyStrength);
+      ArmyCount = FMath::Clamp(ArmyCount, 1, Source->ArmyUnits);
     }
     if (ATerritory *Target = WorldMap->GetTerritoryById(TargetID)) {
       bTargetIsCapital = Target->bIsCapital;

--- a/Source/Skald/WorldMap.cpp
+++ b/Source/Skald/WorldMap.cpp
@@ -333,7 +333,7 @@ bool AWorldMap::MoveBetween(ATerritory *From, ATerritory *To, int32 Troops) {
     return false;
   }
 
-  if (Troops <= 0 || Troops >= From->ArmyStrength) {
+  if (Troops <= 0 || Troops >= From->ArmyUnits) {
     return false;
   }
 


### PR DESCRIPTION
## Summary
- rename `ArmyStrength` property and replication hooks to `ArmyUnits`
- update world/map logic, HUD, and controllers to use `ArmyUnits`
- adjust save data structures and tests for new naming

## Testing
- `pytest`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b57ee052548324bdbb91b83a3d586b