### PR TITLE
Accumulate deployable units across turns

### DIFF
--- a/Source/Skald/Skald_TurnManager.cpp
+++ b/Source/Skald/Skald_TurnManager.cpp
@@ -122,7 +122,7 @@ void ATurnManager::StartTurns() {
       }
     }
     const int32 Reinforcements = FMath::CeilToInt(Owned / 3.0f);
-    PS->DeployableUnits = Reinforcements;
+    PS->DeployableUnits += Reinforcements;
     PS->Resources += ResourceGain;
     PS->ForceNetUpdate();
     BroadcastDeployableUnits(PS);
@@ -207,7 +207,7 @@ void ATurnManager::AdvanceTurn() {
         }
       }
       const int32 Reinforcements = FMath::CeilToInt(Owned / 3.0f);
-      PS->DeployableUnits = Reinforcements;
+      PS->DeployableUnits += Reinforcements;
       PS->Resources += ResourceGain;
       PS->ForceNetUpdate();
       BroadcastDeployableUnits(PS);

--- a/Source/Skald/Tests/DeployableUnitsCalculationTest.cpp
+++ b/Source/Skald/Tests/DeployableUnitsCalculationTest.cpp
@@ -62,8 +62,8 @@ bool FSkaldDeployableUnitsCalculationTest::RunTest(const FString& Parameters) {
   Map->Territories = Terrs;
 
   TM->AdvanceTurn();
-  TestEqual(TEXT("Deployable units after advance"), PS->DeployableUnits, 3);
-  TestEqual(TEXT("HUD after advance"), HUD->LastUnits, 3);
+  TestEqual(TEXT("Deployable units after advance"), PS->DeployableUnits, 5);
+  TestEqual(TEXT("HUD after advance"), HUD->LastUnits, 5);
 
   return true;
 }


### PR DESCRIPTION
## Summary
- accumulate reinforcement units instead of resetting each turn
- adjust deployable unit calculation test for cumulative reinforcement

## Testing
- `bash Build/validate.sh` *(fails: UnrealEditor not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b5878ee9d083248356fd6de1151a1d