### PR TITLE
Log deployment failures and notify players

### DIFF
--- a/Source/Skald/Skald_PlayerController.cpp
+++ b/Source/Skald/Skald_PlayerController.cpp
@@ -659,22 +659,42 @@ void ASkaldPlayerController::ServerBuildSiege_Implementation(
 void ASkaldPlayerController::ServerDeployUnits_Implementation(int32 TerritoryID,
                                                               int32 Amount) {
   if (Amount <= 0) {
+    UE_LOG(LogSkald, Warning,
+           TEXT("ServerDeployUnits called with non-positive amount: %d"), Amount);
+    NotifyActionError(TEXT("Invalid deploy amount"));
     return;
   }
 
   AWorldMap *WorldMap = Cast<AWorldMap>(
       UGameplayStatics::GetActorOfClass(GetWorld(), AWorldMap::StaticClass()));
   if (!WorldMap) {
+    UE_LOG(LogSkald, Warning, TEXT("ServerDeployUnits: World map not found"));
+    NotifyActionError(TEXT("World map not found"));
     return;
   }
 
   ATerritory *Terr = WorldMap->GetTerritoryById(TerritoryID);
   ASkaldPlayerState *PS = GetPlayerState<ASkaldPlayerState>();
   if (!Terr || !PS) {
+    UE_LOG(LogSkald, Warning, TEXT("ServerDeployUnits: Invalid territory %d"),
+           TerritoryID);
+    NotifyActionError(TEXT("Invalid territory selection"));
     return;
   }
 
-  if (!WorldMap->IsOwnedBy(Terr, PS) || PS->DeployableUnits < Amount) {
+  if (!WorldMap->IsOwnedBy(Terr, PS)) {
+    UE_LOG(LogSkald, Warning,
+           TEXT("ServerDeployUnits: Player %d does not own territory %d"),
+           PS->GetPlayerId(), TerritoryID);
+    NotifyActionError(TEXT("You do not own this territory"));
+    return;
+  }
+
+  if (PS->DeployableUnits < Amount) {
+    UE_LOG(LogSkald, Warning,
+           TEXT("ServerDeployUnits: Insufficient units. Have %d need %d"),
+           PS->DeployableUnits, Amount);
+    NotifyActionError(TEXT("Not enough deployable units"));
     return;
   }
 

--- a/Source/Skald/Tests/DeployUnitsValidationTest.cpp
+++ b/Source/Skald/Tests/DeployUnitsValidationTest.cpp
@@ -1,0 +1,70 @@
+#include "PlayerControllerValidationTest.h"
+
+#include "Misc/AutomationTest.h"
+#include "Tests/AutomationEditorCommon.h"
+#include "WorldMap.h"
+#include "Territory.h"
+#include "Skald_PlayerState.h"
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(
+    FSkaldDeployUnitsValidationFeedbackTest,
+    "Skald.PlayerController.DeployValidationFeedback",
+    EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+
+bool FSkaldDeployUnitsValidationFeedbackTest::RunTest(const FString&)
+{
+    UWorld* World = FAutomationEditorCommonUtils::CreateNewMap();
+    TestNotNull(TEXT("World created"), World);
+    if (!World)
+    {
+        return false;
+    }
+
+    ATestPlayerController* PC = World->SpawnActor<ATestPlayerController>();
+    TestNotNull(TEXT("PlayerController"), PC);
+    if (!PC)
+    {
+        return false;
+    }
+
+    UTestHUDWidget* HUD = NewObject<UTestHUDWidget>(PC);
+    PC->SetHUD(HUD);
+
+    // Missing world map
+    PC->ServerDeployUnits(1, 1);
+    TestTrue(TEXT("Missing map error"), HUD->LastError.Contains(TEXT("World map")));
+
+    // World map exists but territory invalid
+    HUD->LastError.Empty();
+    AWorldMap* WM = World->SpawnActor<AWorldMap>();
+    PC->ServerDeployUnits(1, 1);
+    TestTrue(TEXT("Invalid territory error"),
+             HUD->LastError.Contains(TEXT("Invalid territory")));
+
+    // Setup players and territory for ownership/units tests
+    HUD->LastError.Empty();
+    ATerritory* Terr = World->SpawnActor<ATerritory>();
+    ASkaldPlayerState* PS1 = World->SpawnActor<ASkaldPlayerState>();
+    ASkaldPlayerState* PS2 = World->SpawnActor<ASkaldPlayerState>();
+    PC->PlayerState = PS1;
+    PS1->SetPlayerId(1);
+    PS2->SetPlayerId(2);
+    Terr->TerritoryID = 42;
+    Terr->OwningPlayer = PS2;
+    WM->Territories = {Terr};
+    PS1->DeployableUnits = 5;
+
+    PC->ServerDeployUnits(Terr->TerritoryID, 1);
+    TestTrue(TEXT("Not owner error"), HUD->LastError.Contains(TEXT("own")));
+
+    // Insufficient units
+    HUD->LastError.Empty();
+    Terr->OwningPlayer = PS1;
+    PS1->DeployableUnits = 0;
+    PC->ServerDeployUnits(Terr->TerritoryID, 1);
+    TestTrue(TEXT("Insufficient units error"),
+             HUD->LastError.Contains(TEXT("deployable units")));
+
+    return true;
+}
+


### PR DESCRIPTION
## Summary
- log specific reasons for deploy-unit failures and notify the client via HUD
- add automation test covering missing map, invalid territory, unowned territory, and insufficient units

## Testing
- `npm test` *(fails: package.json missing)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b5887c869483248b327df00ed61149