### PR TITLE
Replicate deployable units with HUD refresh

### DIFF
--- a/Source/Skald/Skald_GameMode.cpp
+++ b/Source/Skald/Skald_GameMode.cpp
@@ -396,7 +396,6 @@ void ASkaldGameMode::ApplyLoadedGame(USkaldSaveGame *LoadedGame) {
     Territory->BuiltSiegeID = TerrData.BuiltSiegeID;
     Territory->SetActorLocation(TerrData.Location);
     Territory->RefreshAppearance();
-    Territory->ForceNetUpdate();
   }
 
   if (APlayerController *PC = UGameplayStatics::GetPlayerController(this, 0)) {
@@ -461,7 +460,6 @@ void ASkaldGameMode::BeginArmyPlacementPhase() {
         }
       }
       PS->DeployableUnits = FMath::CeilToInt(Owned / 3.f);
-      PS->ForceNetUpdate();
       TurnManager->BroadcastDeployableUnits(PS);
     }
   }
@@ -485,7 +483,6 @@ int32 ASkaldGameMode::BuildSiegeAtTerritory(int32 TerritoryID,
   NewSiege.BuiltAtTerritoryID = TerritoryID;
   SiegePool.Add(NewSiege);
   Terr->BuiltSiegeID = NewSiege.SiegeID;
-  Terr->ForceNetUpdate();
   return NewSiege.SiegeID;
 }
 
@@ -503,7 +500,6 @@ int32 ASkaldGameMode::ConsumeSiege(int32 TerritoryID) {
           [SiegeID](const FS_Siege &S) { return S.SiegeID == SiegeID; })) {
     Siege->AssignedToUnitID = TerritoryID;
   }
-  Terr->ForceNetUpdate();
   return SiegeID;
 }
 
@@ -572,7 +568,6 @@ void ASkaldGameMode::AdvanceArmyPlacement() {
         --PS->DeployableUnits;
         ++SpreadIndex;
       }
-      PS->ForceNetUpdate();
       TurnManager->BroadcastDeployableUnits(PS);
       ++PlacementIndex;
       continue;
@@ -722,7 +717,6 @@ bool ASkaldGameMode::InitializeWorld() {
       Territory->bIsCapital = false;
       Territory->ArmyUnits = 1;
       Territory->RefreshAppearance();
-      Territory->ForceNetUpdate();
       ++Index;
     }
   }

--- a/Source/Skald/Skald_PlayerController.cpp
+++ b/Source/Skald/Skald_PlayerController.cpp
@@ -257,7 +257,6 @@ void ASkaldPlayerController::EndPhase() {
   if (Phase == ETurnPhase::ArmyPlacement) {
     if (ASkaldPlayerState *PS = GetPlayerState<ASkaldPlayerState>()) {
       PS->DeployableUnits = 0;
-      PS->ForceNetUpdate();
       TurnManager->BroadcastDeployableUnits(PS);
     }
 
@@ -318,7 +317,6 @@ void ASkaldPlayerController::MakeAIDecision() {
         --PS->Resources;
         ++SpreadIndex;
       }
-      PS->ForceNetUpdate();
       TurnManager->BroadcastDeployableUnits(PS);
       TurnManager->BroadcastResources(PS);
 
@@ -557,9 +555,6 @@ void ASkaldPlayerController::ServerHandleAttack_Implementation(int32 FromID,
   Source->RefreshAppearance();
   Target->RefreshAppearance();
 
-  Source->ForceNetUpdate();
-  Target->ForceNetUpdate();
-
   if (TurnManager) {
     for (ASkaldPlayerController *Controller : TurnManager->GetControllers()) {
       if (USkaldMainHUDWidget *HUD =
@@ -700,10 +695,8 @@ void ASkaldPlayerController::ServerDeployUnits_Implementation(int32 TerritoryID,
 
   Terr->ArmyUnits += Amount;
   Terr->RefreshAppearance();
-  Terr->ForceNetUpdate();
 
   PS->DeployableUnits -= Amount;
-  PS->ForceNetUpdate();
 
   if (TurnManager) {
     TurnManager->BroadcastDeployableUnits(PS);
@@ -741,7 +734,6 @@ void ASkaldPlayerController::HandleEngineeringRequested(int32 CapitalID,
   if (ASkaldPlayerState *PS = GetPlayerState<ASkaldPlayerState>()) {
     const int32 Cost = 10;
     PS->Resources = FMath::Max(0, PS->Resources - Cost);
-    PS->ForceNetUpdate();
     if (TurnManager) {
       TurnManager->BroadcastResources(PS);
     }
@@ -775,7 +767,6 @@ void ASkaldPlayerController::ServerDigTreasure_Implementation(
       Terr->bHasTreasure = false;
       Terr->RefreshAppearance();
       PS->Resources += 5;
-      PS->ForceNetUpdate();
       if (TurnManager) {
         TurnManager->BroadcastResources(PS);
       }

--- a/Source/Skald/Skald_PlayerState.cpp
+++ b/Source/Skald/Skald_PlayerState.cpp
@@ -2,7 +2,8 @@
 #include "Net/UnrealNetwork.h"
 #include "Engine/World.h"
 #include "Skald_GameState.h"
-#include "Engine/World.h"
+#include "Skald_PlayerController.h"
+#include "UI/SkaldMainHUDWidget.h"
 
 ASkaldPlayerState::ASkaldPlayerState()
     : bIsAI(false)
@@ -29,6 +30,20 @@ void ASkaldPlayerState::GetLifetimeReplicatedProps(
     DOREPLIFETIME(ASkaldPlayerState, Resources);
     DOREPLIFETIME(ASkaldPlayerState, bHasLockedIn);
     DOREPLIFETIME(ASkaldPlayerState, IsEliminated);
+}
+
+void ASkaldPlayerState::OnRep_DeployableUnits()
+{
+    if (APlayerController* PC = GetOwner<APlayerController>())
+    {
+        if (ASkaldPlayerController* SkaldPC = Cast<ASkaldPlayerController>(PC))
+        {
+            if (USkaldMainHUDWidget* HUD = SkaldPC->GetHUDWidget())
+            {
+                HUD->UpdateDeployableUnits(DeployableUnits);
+            }
+        }
+    }
 }
 
 void ASkaldPlayerState::OnRep_HasLockedIn()

--- a/Source/Skald/Skald_PlayerState.h
+++ b/Source/Skald/Skald_PlayerState.h
@@ -20,7 +20,7 @@ public:
     bool bIsAI;
 
     /** Deployable units available for placement. */
-    UPROPERTY(BlueprintReadWrite, Replicated, Category="PlayerState")
+    UPROPERTY(BlueprintReadWrite, ReplicatedUsing = OnRep_DeployableUnits, Category="PlayerState")
     int32 DeployableUnits;
 
     /** Initiative roll determining turn order. */
@@ -46,6 +46,9 @@ public:
     /** Whether this player has been eliminated from the match. */
     UPROPERTY(BlueprintReadWrite, ReplicatedUsing = OnRep_IsEliminated, Category="PlayerState")
     bool IsEliminated;
+
+    UFUNCTION()
+    void OnRep_DeployableUnits();
 
     UFUNCTION()
     void OnRep_HasLockedIn();

--- a/Source/Skald/Skald_TurnManager.cpp
+++ b/Source/Skald/Skald_TurnManager.cpp
@@ -124,7 +124,6 @@ void ATurnManager::StartTurns() {
     const int32 Reinforcements = FMath::CeilToInt(Owned / 3.0f);
     PS->DeployableUnits += Reinforcements;
     PS->Resources += ResourceGain;
-    PS->ForceNetUpdate();
     BroadcastDeployableUnits(PS);
     BroadcastResources(PS);
   }
@@ -209,7 +208,6 @@ void ATurnManager::AdvanceTurn() {
       const int32 Reinforcements = FMath::CeilToInt(Owned / 3.0f);
       PS->DeployableUnits += Reinforcements;
       PS->Resources += ResourceGain;
-      PS->ForceNetUpdate();
       BroadcastDeployableUnits(PS);
       BroadcastResources(PS);
     }
@@ -336,9 +334,6 @@ void ATurnManager::ResolveGridBattleResult() {
   Source->RefreshAppearance();
   Target->RefreshAppearance();
 
-  Source->ForceNetUpdate();
-  Target->ForceNetUpdate();
-
   GI->PendingBattle = FS_BattlePayload();
   GI->GridBattleManager = nullptr;
 
@@ -363,7 +358,6 @@ void ATurnManager::ClientBattleResolved_Implementation(
     if (Source) {
       Source->ArmyUnits = SourceArmy;
       Source->RefreshAppearance();
-      Source->ForceNetUpdate();
     }
     if (Target) {
       ASkaldPlayerState *NewOwner = nullptr;
@@ -376,7 +370,6 @@ void ATurnManager::ClientBattleResolved_Implementation(
       Target->OwningPlayer = NewOwner;
       Target->ArmyUnits = TargetArmy;
       Target->RefreshAppearance();
-      Target->ForceNetUpdate();
     }
   }
 

--- a/Source/Skald/Territory.cpp
+++ b/Source/Skald/Territory.cpp
@@ -192,9 +192,7 @@ bool ATerritory::MoveTo(ATerritory *TargetTerritory, int32 Troops) {
   TargetTerritory->ArmyUnits += Troops;
 
   RefreshAppearance();
-  ForceNetUpdate();
   TargetTerritory->RefreshAppearance();
-  TargetTerritory->ForceNetUpdate();
 
   Deselect();
   TargetTerritory->Select();

--- a/Source/Skald/WorldMap.cpp
+++ b/Source/Skald/WorldMap.cpp
@@ -350,8 +350,6 @@ bool AWorldMap::MoveBetween(ATerritory *From, ATerritory *To, int32 Troops) {
     }
     Curr->RefreshAppearance();
     Next->RefreshAppearance();
-    Curr->ForceNetUpdate();
-    Next->ForceNetUpdate();
   }
 
   if (ASkaldGameMode *GM = GetWorld()->GetAuthGameMode<ASkaldGameMode>()) {


### PR DESCRIPTION
## Summary
- Replicate deployable unit count with an OnRep handler
- Refresh owning HUD when deployable units update
- Remove unnecessary ForceNetUpdate calls that replication covers

## Testing
- `./Build/validate.sh` *(fails: UnrealBuildTool not found; UnrealEditor not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b589ecdf248324bf3be1656b03be1b