### PR TITLE
Fix world map registration call

### DIFF
--- a/Source/Skald/Territory.cpp
+++ b/Source/Skald/Territory.cpp
@@ -121,8 +121,9 @@ void ATerritory::BeginPlay() {
   // Ensure this territory is registered with the world map. When territories
   // are placed manually in a level they may not have been added during map
   // initialization, so register here if needed.
-  if (AWorldMap *WorldMap = Cast<AWorldMap>(UGameplayStatics::GetActorOfClass(
-          GetWorld(), AWorldMap::StaticClass()))) {
+  if (AWorldMap *WorldMap =
+          Cast<AWorldMap>(UGameplayStatics::GetActorOfClass(
+              this, AWorldMap::StaticClass()))) {
     if (!WorldMap->Territories.Contains(this)) {
       WorldMap->RegisterTerritory(this);
     }


### PR DESCRIPTION
## Summary
- fix `GetActorOfClass` call in `ATerritory::BeginPlay` to use `this` as context, resolving conversion error

## Testing
- `bash Build/validate.sh` *(fails: UnrealBuildTool not found; skipping compile check. UnrealEditor not found; cannot run tests.)*

------
https://chatgpt.com/codex/tasks/task_e_68b586b8b6cc8324afdce959a6ba2bed