### PR TITLE
Export test listener class

### DIFF
--- a/Source/Skald/Tests/BattleResolutionSyncTest.h
+++ b/Source/Skald/Tests/BattleResolutionSyncTest.h
@@ -7,7 +7,7 @@
  * Helper object to listen for world state change broadcasts.
  */
 UCLASS()
-class UWorldStateChangedListener : public UObject
+class SKALD_API UWorldStateChangedListener : public UObject
 {
     GENERATED_BODY()
 


### PR DESCRIPTION
## Summary
- export UWorldStateChangedListener so its StaticClass is available across modules

## Testing
- `clang++ -std=c++17 -I../Engine/Source -ISource -c Source/Skald/Tests/BattleResolutionSyncTest.cpp` *(fails: 'CoreMinimal.h' file not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b58f2f6eb083249dbd37c1839301b5