### PR TITLE
Fix missing headers for territory mesh initialization

### DIFF
--- a/Source/Skald/Territory.cpp
+++ b/Source/Skald/Territory.cpp
@@ -4,6 +4,8 @@
 #include "Components/TextRenderComponent.h"
 #include "Kismet/GameplayStatics.h"
 #include "Materials/MaterialInstanceDynamic.h"
+#include "Engine/StaticMesh.h"
+#include "Materials/MaterialInterface.h"
 #include "Net/UnrealNetwork.h"
 #include "Skald.h"
 #include "SkaldTypes.h"


### PR DESCRIPTION
## Summary
- include Engine/StaticMesh.h and MaterialInterface in Territory

## Testing
- `g++ -c Source/Skald/Territory.cpp` (fails: CoreMinimal.h: No such file or directory)

------
https://chatgpt.com/codex/tasks/task_e_68b5913499c083248120129176de2cd7