### PR TITLE
Cache deployment selection when player state not yet set

### DIFF
--- a/Source/Skald/Tests/DeploySelectionCachingTest.cpp
+++ b/Source/Skald/Tests/DeploySelectionCachingTest.cpp
@@ -1,0 +1,70 @@
+#include "Misc/AutomationTest.h"
+#include "Tests/AutomationEditorCommon.h"
+#include "Skald_PlayerController.h"
+#include "Skald_PlayerState.h"
+#include "Skald_TurnManager.h"
+#include "WorldMap.h"
+#include "Territory.h"
+#include "UI/SkaldMainHUDWidget.h"
+#include "UI/DeployWidget.h"
+
+// Verify that territory selection for deployment persists even if the
+// local player state is not yet assigned when the territory is clicked.
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(
+    FSkaldDeploySelectionCachingTest,
+    "Skald.UI.DeploySelectionCaching",
+    EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+
+bool FSkaldDeploySelectionCachingTest::RunTest(const FString& Parameters)
+{
+    UWorld* World = FAutomationEditorCommonUtils::CreateNewMap();
+    TestNotNull(TEXT("World created"), World);
+    if (!World)
+    {
+        return false;
+    }
+
+    ATurnManager* TM = World->SpawnActor<ATurnManager>();
+    ASkaldPlayerController* PC = World->SpawnActor<ASkaldPlayerController>();
+    ASkaldPlayerState* PS = World->SpawnActor<ASkaldPlayerState>();
+    AWorldMap* Map = World->SpawnActor<AWorldMap>();
+    ATerritory* Terr = World->SpawnActor<ATerritory>();
+
+    TestNotNull(TEXT("TurnManager"), TM);
+    TestNotNull(TEXT("PlayerController"), PC);
+    TestNotNull(TEXT("PlayerState"), PS);
+    TestNotNull(TEXT("WorldMap"), Map);
+    TestNotNull(TEXT("Territory"), Terr);
+    if (!TM || !PC || !PS || !Map || !Terr)
+    {
+        return false;
+    }
+
+    PC->SetTurnManager(TM);
+    TM->RegisterController(PC);
+
+    USkaldMainHUDWidget* HUD = NewObject<USkaldMainHUDWidget>(PC);
+    HUD->SetOwningPlayer(PC);
+    HUD->DeployWidgetClass = UDeployWidget::StaticClass();
+
+    Terr->TerritoryID = 7;
+    Terr->OwningPlayer = PS;
+    Terr->ArmyUnits = 2;
+    Map->Territories = {Terr};
+
+    // Simulate clicking the territory before the player state is assigned to the controller
+    HUD->OnTerritoryClickedUI(Terr);
+    TestEqual(TEXT("Selection stored without local player state"), HUD->SelectedSourceID, Terr->TerritoryID);
+
+    // Assign player state and give deployable units
+    PC->PlayerState = PS;
+    PS->SetPlayerId(1);
+    PS->DeployableUnits = 1;
+
+    HUD->HandleDeployClicked();
+    TestNotNull(TEXT("Deploy widget created"), HUD->ActiveDeployWidget);
+
+    return true;
+}
+

--- a/Source/Skald/UI/SkaldMainHUDWidget.cpp
+++ b/Source/Skald/UI/SkaldMainHUDWidget.cpp
@@ -481,11 +481,10 @@ void USkaldMainHUDWidget::OnTerritoryClickedUI(ATerritory *Territory) {
         SelectedTargetID = Territory->TerritoryID;
       }
     }
-  } else if ((CurrentPhase == ETurnPhase::Reinforcement ||
-              CurrentPhase == ETurnPhase::ArmyPlacement) &&
-             bOwnedByLocal) {
+  } else if (CurrentPhase == ETurnPhase::Reinforcement ||
+             CurrentPhase == ETurnPhase::ArmyPlacement) {
     SelectedSourceID = Territory->TerritoryID;
-    if (DeployButton) {
+    if (bOwnedByLocal && DeployButton) {
       DeployButton->SetVisibility(ESlateVisibility::Visible);
     }
   } else if (CurrentPhase == ETurnPhase::Engineering && bOwnedByLocal &&


### PR DESCRIPTION
## Summary
- ensure deploy selection stores territory even when local player state is missing
- add regression test for deploy selection caching

## Testing
- `./Build/validate.sh` *(fails: UnrealBuildTool not found; UnrealEditor not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b59416cee0832491107f84aae71a3f