### PR TITLE
Add AttackDamage and ArmyCost fighter stats

### DIFF
--- a/Source/Skald/GridBattleManager.cpp
+++ b/Source/Skald/GridBattleManager.cpp
@@ -221,14 +221,14 @@ bool UGridBattleManager::ResolveAttack(FFighter& Attacker, FFighter& Defender, i
         int32 Roll = RandomStream.RandRange(1, 6);
         if (Roll == 6)
         {
-            int32 Damage = RandomStream.RandRange(1, Attacker.Stats.DamageDie) + 3;
+            int32 Damage = Attacker.Stats.AttackDamage + 3;
             Defender.Stats.Health -= Damage;
             Defender.Stats.Health = FMath::Max(Defender.Stats.Health, 0);
             OutDamage += Damage;
         }
         else if (Roll >= RequiredRoll)
         {
-            int32 Damage = RandomStream.RandRange(1, Attacker.Stats.DamageDie);
+            int32 Damage = Attacker.Stats.AttackDamage;
             Defender.Stats.Health -= Damage;
             Defender.Stats.Health = FMath::Max(Defender.Stats.Health, 0);
             OutDamage += Damage;

--- a/Source/Skald/GridBattleManager.h
+++ b/Source/Skald/GridBattleManager.h
@@ -35,6 +35,14 @@ struct FFighterStats
     /** Sides of the damage dice rolled on a successful hit. */
     UPROPERTY(BlueprintReadWrite, EditAnywhere, Category="Stats")
     int32 DamageDie = 6;
+
+    /** Damage dealt on a successful hit. */
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category="Stats")
+    int32 AttackDamage = 1;
+
+    /** Cost to include this fighter in an army. */
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category="Stats")
+    int32 ArmyCost = 1;
 };
 
 USTRUCT(BlueprintType)

--- a/Source/Skald/Tests/ResolveAttackClampTest.cpp
+++ b/Source/Skald/Tests/ResolveAttackClampTest.cpp
@@ -5,7 +5,7 @@ IMPLEMENT_SIMPLE_AUTOMATION_TEST(FSkaldResolveAttackClampTest, "Skald.GridBattle
 bool FSkaldResolveAttackClampTest::RunTest(const FString& Parameters) {
   FFighter Attacker;
   Attacker.Stats.AttackDice = 1;
-  Attacker.Stats.DamageDie = 6;
+  Attacker.Stats.AttackDamage = 6;
 
   FFighter Defender;
   Defender.Stats.Health = 5;


### PR DESCRIPTION
## Summary
- Expose new AttackDamage and ArmyCost stats for fighters
- Use AttackDamage when resolving attacks instead of DamageDie
- Adjust ResolveAttack test for new damage stat

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b5a72981dc8324a956879dc71c55b0