### PR TITLE
Add fighter definition data table to GridBattleManager

### DIFF
--- a/Source/Skald/GridBattleManager.cpp
+++ b/Source/Skald/GridBattleManager.cpp
@@ -1,4 +1,6 @@
 #include "GridBattleManager.h"
+#include "Engine/DataTable.h"
+#include "UObject/ConstructorHelpers.h"
 
 namespace
 {
@@ -54,6 +56,11 @@ namespace
     {
         return Distance(Attacker.Position, Defender.Position) <= Attacker.Stats.AttackRange;
     }
+}
+
+UGridBattleManager::UGridBattleManager()
+{
+    FighterDefinitions = LoadObject<UDataTable>(nullptr, TEXT("/Game/DataTables/FighterTable.FighterTable"));
 }
 
 void UGridBattleManager::InitBattle(const TArray<FFighter>& Attackers, const TArray<FFighter>& Defenders)

--- a/Source/Skald/GridBattleManager.h
+++ b/Source/Skald/GridBattleManager.h
@@ -2,6 +2,8 @@
 
 #include "CoreMinimal.h"
 #include "UObject/NoExportTypes.h"
+#include "Engine/DataTable.h"
+#include "GameFramework/Actor.h"
 #include "SkaldTypes.h"
 #include "GridBattleManager.generated.h"
 
@@ -43,6 +45,27 @@ struct FFighterStats
     /** Cost to include this fighter in an army. */
     UPROPERTY(BlueprintReadWrite, EditAnywhere, Category="Stats")
     int32 ArmyCost = 1;
+};
+
+/** Definition of a fighter type used by data tables. */
+USTRUCT(BlueprintType)
+struct FFighterDefinition : public FTableRowBase
+{
+    GENERATED_BODY();
+
+    FFighterDefinition()
+        : Id(NAME_None), MeshClass(nullptr), Stats()
+    {
+    }
+
+    UPROPERTY(EditAnywhere, BlueprintReadOnly, Category="Fighter")
+    FName Id;
+
+    UPROPERTY(EditAnywhere, BlueprintReadOnly, Category="Fighter")
+    TSubclassOf<AActor> MeshClass;
+
+    UPROPERTY(EditAnywhere, BlueprintReadOnly, Category="Fighter")
+    FFighterStats Stats;
 };
 
 USTRUCT(BlueprintType)
@@ -104,6 +127,10 @@ public:
     /** Event fired when the battle ends reporting winner and casualties. */
     UPROPERTY(BlueprintAssignable, Category="Battle|Events")
     FOnBattleEnded OnBattleEnded;
+
+    /** Table containing fighter definitions. */
+    UPROPERTY(BlueprintReadOnly, Category="Battle")
+    UDataTable* FighterDefinitions;
 
     /** Size of the square grid used in battle. */
     static const int32 GridSize = 48;


### PR DESCRIPTION
## Summary
- define `FFighterDefinition` for data-driven fighter info
- load `/Game/DataTables/FighterTable` into `FighterDefinitions`

## Testing
- `bash Build/validate.sh` *(fails: UnrealBuildTool not found; UnrealEditor not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b5a7e6d46c8324b72f9d875264b736