### PR TITLE
Add FighterPawn class

### DIFF
--- a/Source/Skald/FighterPawn.cpp
+++ b/Source/Skald/FighterPawn.cpp
@@ -1,0 +1,56 @@
+#include "FighterPawn.h"
+#include "Components/StaticMeshComponent.h"
+
+namespace
+{
+    /** Size of a grid cell in world units. */
+    constexpr float CellSize = 100.f;
+}
+
+AFighterPawn::AFighterPawn()
+{
+    PrimaryActorTick.bCanEverTick = false;
+
+    DisplayMesh = CreateDefaultSubobject<UStaticMeshComponent>(TEXT("DisplayMesh"));
+    RootComponent = DisplayMesh;
+
+    ActionsRemaining = 0;
+    CurrentCell = FIntPoint::ZeroValue;
+}
+
+void AFighterPawn::BeginActivation()
+{
+    ActionsRemaining = Stats.Movement;
+}
+
+void AFighterPawn::MoveToCell(FIntPoint TargetCell)
+{
+    int32 Distance = FMath::Abs(TargetCell.X - CurrentCell.X) + FMath::Abs(TargetCell.Y - CurrentCell.Y);
+    if (Distance > ActionsRemaining)
+    {
+        return;
+    }
+
+    CurrentCell = TargetCell;
+    FVector NewLocation(TargetCell.X * CellSize, TargetCell.Y * CellSize, GetActorLocation().Z);
+    SetActorLocation(NewLocation);
+    ActionsRemaining -= Distance;
+}
+
+void AFighterPawn::PerformAttack(AFighterPawn* Target)
+{
+    if (!Target || ActionsRemaining <= 0 || !Target->IsAlive())
+    {
+        return;
+    }
+
+    Target->Stats.Health = FMath::Max(0, Target->Stats.Health - Stats.AttackDamage);
+    Target->OnHealthChanged.Broadcast(Target->Stats.Health);
+    --ActionsRemaining;
+}
+
+bool AFighterPawn::IsAlive() const
+{
+    return Stats.Health > 0;
+}
+

--- a/Source/Skald/FighterPawn.h
+++ b/Source/Skald/FighterPawn.h
@@ -1,0 +1,55 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "GameFramework/Pawn.h"
+#include "GridBattleManager.h"
+#include "FighterPawn.generated.h"
+
+DECLARE_DYNAMIC_MULTICAST_DELEGATE_OneParam(FOnHealthChanged, int32, NewHealth);
+
+/** Pawn representing a fighter in grid battles. */
+UCLASS()
+class SKALD_API AFighterPawn : public APawn
+{
+    GENERATED_BODY()
+
+public:
+    AFighterPawn();
+
+    /** Prepare the fighter for its activation. */
+    UFUNCTION(BlueprintCallable, Category="Fighter")
+    void BeginActivation();
+
+    /** Move to the specified grid cell if actions remain. */
+    UFUNCTION(BlueprintCallable, Category="Fighter")
+    void MoveToCell(FIntPoint TargetCell);
+
+    /** Perform an attack against another fighter. */
+    UFUNCTION(BlueprintCallable, Category="Fighter")
+    void PerformAttack(AFighterPawn* Target);
+
+    /** Check whether this fighter is still alive. */
+    UFUNCTION(BlueprintCallable, BlueprintPure, Category="Fighter")
+    bool IsAlive() const;
+
+    /** Statistics describing this fighter. */
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category="Fighter")
+    FFighterStats Stats;
+
+    /** Actions remaining for the current activation. */
+    UPROPERTY(BlueprintReadOnly, Category="Fighter")
+    int32 ActionsRemaining;
+
+    /** Mesh used to display the fighter. */
+    UPROPERTY(VisibleAnywhere, BlueprintReadOnly)
+    UStaticMeshComponent* DisplayMesh;
+
+    /** Event broadcast when health changes. */
+    UPROPERTY(BlueprintAssignable, Category="Fighter|Events")
+    FOnHealthChanged OnHealthChanged;
+
+private:
+    /** Current cell occupied by the fighter. */
+    FIntPoint CurrentCell;
+};
+


### PR DESCRIPTION
## Summary
- add FighterPawn pawn with stats, actions and mesh
- implement activation, movement, attack, and health check with event broadcast

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b5acb6d9bc8324943b35f8e84c9b9d