### PR TITLE
Add initiative-based turn management

### DIFF
--- a/Source/Skald/GridBattleManager.cpp
+++ b/Source/Skald/GridBattleManager.cpp
@@ -1,6 +1,7 @@
 #include "GridBattleManager.h"
 #include "Engine/DataTable.h"
 #include "UObject/ConstructorHelpers.h"
+#include "FighterPawn.h"
 
 namespace
 {
@@ -252,27 +253,149 @@ bool UGridBattleManager::ResolveAttack(FFighter& Attacker, FFighter& Defender, i
 
 int32 UGridBattleManager::GetAttackerSurvivors() const
 {
-    int32 Count = 0;
-    for (const FFighter& Fighter : AttackerTeam)
-    {
-        if (Fighter.Stats.Health > 0)
-        {
-            ++Count;
-        }
-    }
-    return Count;
+    return AttackerSurvivorCount;
 }
 
 int32 UGridBattleManager::GetDefenderSurvivors() const
 {
-    int32 Count = 0;
-    for (const FFighter& Fighter : DefenderTeam)
+    return DefenderSurvivorCount;
+}
+
+void UGridBattleManager::RollInitiative()
+{
+    struct FInitiativeEntry
     {
-        if (Fighter.Stats.Health > 0)
+        AFighterPawn* Fighter;
+        int32 Roll;
+    };
+
+    TArray<FInitiativeEntry> Rolls;
+    Rolls.Reserve(InitiativeOrder.Num());
+    for (AFighterPawn* Fighter : InitiativeOrder)
+    {
+        if (!Fighter)
         {
-            ++Count;
+            continue;
+        }
+        FInitiativeEntry Entry{Fighter, FMath::RandRange(1, 20)};
+        Rolls.Add(Entry);
+    }
+
+    Rolls.Sort([](const FInitiativeEntry& A, const FInitiativeEntry& B)
+    {
+        return A.Roll > B.Roll;
+    });
+
+    InitiativeOrder.Empty(Rolls.Num());
+    for (const FInitiativeEntry& Entry : Rolls)
+    {
+        InitiativeOrder.Add(Entry.Fighter);
+    }
+
+    CurrentTurn = 0;
+    ActiveFighter = InitiativeOrder.Num() > 0 ? InitiativeOrder[0] : nullptr;
+    if (ActiveFighter)
+    {
+        ActiveFighter->BeginActivation();
+    }
+}
+
+void UGridBattleManager::StartRound(FRandomStream& RandomStream)
+{
+    const int32 EdgeRange = 3;
+    const int32 Half = InitiativeOrder.Num() / 2;
+    for (int32 Index = 0; Index < InitiativeOrder.Num(); ++Index)
+    {
+        AFighterPawn* Fighter = InitiativeOrder[Index];
+        if (!Fighter)
+        {
+            continue;
+        }
+
+        Fighter->BeginActivation();
+
+        FIntPoint Cell;
+        Cell.Y = RandomStream.RandRange(0, GridSize - 1);
+        if (Index < Half)
+        {
+            Cell.X = RandomStream.RandRange(0, EdgeRange - 1);
+        }
+        else
+        {
+            Cell.X = RandomStream.RandRange(GridSize - EdgeRange, GridSize - 1);
+        }
+
+        Fighter->MoveToCell(Cell);
+        Fighter->ActionsRemaining = 0;
+    }
+
+    CurrentTurn = 0;
+    ActiveFighter = InitiativeOrder.Num() > 0 ? InitiativeOrder[0] : nullptr;
+    if (ActiveFighter)
+    {
+        ActiveFighter->BeginActivation();
+    }
+}
+
+void UGridBattleManager::AdvanceTurn()
+{
+    if (ActiveFighter && ActiveFighter->IsAlive() && ActiveFighter->ActionsRemaining > 0)
+    {
+        return;
+    }
+
+    InitiativeOrder.RemoveAll([](AFighterPawn* Fighter)
+    {
+        return !Fighter || !Fighter->IsAlive();
+    });
+
+    if (InitiativeOrder.Num() == 0)
+    {
+        ActiveFighter = nullptr;
+        return;
+    }
+
+    CurrentTurn = (CurrentTurn + 1) % InitiativeOrder.Num();
+    ActiveFighter = InitiativeOrder[CurrentTurn];
+    if (ActiveFighter)
+    {
+        ActiveFighter->BeginActivation();
+    }
+}
+
+void UGridBattleManager::EndBattle()
+{
+    const int32 Half = InitiativeOrder.Num() / 2;
+    AttackerSurvivorCount = 0;
+    DefenderSurvivorCount = 0;
+    for (int32 Index = 0; Index < InitiativeOrder.Num(); ++Index)
+    {
+        AFighterPawn* Fighter = InitiativeOrder[Index];
+        if (Fighter && Fighter->IsAlive())
+        {
+            if (Index < Half)
+            {
+                ++AttackerSurvivorCount;
+            }
+            else
+            {
+                ++DefenderSurvivorCount;
+            }
         }
     }
-    return Count;
+
+    ESkaldFaction Winner = ESkaldFaction::None;
+    if (AttackerSurvivorCount > 0 && DefenderSurvivorCount <= 0)
+    {
+        Winner = AttackerTeam.Num() > 0 ? AttackerTeam[0].Faction : ESkaldFaction::None;
+    }
+    else if (DefenderSurvivorCount > 0 && AttackerSurvivorCount <= 0)
+    {
+        Winner = DefenderTeam.Num() > 0 ? DefenderTeam[0].Faction : ESkaldFaction::None;
+    }
+
+    const int32 AttackerCasualties = AttackerTeam.Num() - AttackerSurvivorCount;
+    const int32 DefenderCasualties = DefenderTeam.Num() - DefenderSurvivorCount;
+    OnBattleEnded.Broadcast(Winner, AttackerCasualties, DefenderCasualties);
 }
 

--- a/Source/Skald/GridBattleManager.h
+++ b/Source/Skald/GridBattleManager.h
@@ -5,6 +5,9 @@
 #include "Engine/DataTable.h"
 #include "GameFramework/Actor.h"
 #include "SkaldTypes.h"
+
+class AFighterPawn;
+
 #include "GridBattleManager.generated.h"
 
 /** Statistics for a fighter in grid battle mode. */
@@ -116,6 +119,22 @@ public:
     UFUNCTION(BlueprintCallable, Category="Battle")
     static bool ResolveAttack(FFighter& Attacker, FFighter& Defender, int32& OutDamage, UPARAM(ref) FRandomStream& RandomStream);
 
+    /** Roll initiative for all fighters participating in the battle. */
+    UFUNCTION(BlueprintCallable, Category="Battle")
+    void RollInitiative();
+
+    /** Randomly place all fighters at the start of a round. */
+    UFUNCTION(BlueprintCallable, Category="Battle")
+    void StartRound(UPARAM(ref) FRandomStream& RandomStream);
+
+    /** Advance to the next fighter in the initiative order. */
+    UFUNCTION(BlueprintCallable, Category="Battle")
+    void AdvanceTurn();
+
+    /** Conclude the battle and broadcast the results. */
+    UFUNCTION(BlueprintCallable, Category="Battle")
+    void EndBattle();
+
     /** Number of surviving attackers after the battle concludes. */
     UFUNCTION(BlueprintCallable, BlueprintPure, Category="Battle")
     int32 GetAttackerSurvivors() const;
@@ -147,5 +166,24 @@ protected:
 
     UPROPERTY(BlueprintReadWrite, EditAnywhere, Category="Battle")
     int32 MaxRounds = 100;
+
+    /** Ordered list of fighters based on their initiative rolls. */
+    UPROPERTY(BlueprintReadOnly, Category="Battle")
+    TArray<AFighterPawn*> InitiativeOrder;
+
+    /** Fighter currently taking its turn. */
+    UPROPERTY(BlueprintReadOnly, Category="Battle")
+    AFighterPawn* ActiveFighter = nullptr;
+
+    /** Index of the fighter whose turn is active. */
+    UPROPERTY(BlueprintReadOnly, Category="Battle")
+    int32 CurrentTurn = 0;
+
+    /** Cached surviving counts for each side. */
+    UPROPERTY(BlueprintReadOnly, Category="Battle")
+    int32 AttackerSurvivorCount = 0;
+
+    UPROPERTY(BlueprintReadOnly, Category="Battle")
+    int32 DefenderSurvivorCount = 0;
 };
 


### PR DESCRIPTION
## Summary
- Introduce initiative-based fighter sequencing with turn tracking
- Randomize round start positions and switch turns automatically
- Report battle results and survivor counts

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b5af89f9808324b77ae47fcb925e1c