### PR TITLE
Add battle HUD widget and fighter action hooks

### DIFF
--- a/Source/Skald/Skald_PlayerController.cpp
+++ b/Source/Skald/Skald_PlayerController.cpp
@@ -15,6 +15,7 @@
 #include "UI/DeployWidget.h"
 #include "UI/FighterSelectionWidget.h"
 #include "UI/SkaldMainHUDWidget.h"
+#include "UI/BattleHUDWidget.h"
 #include "UObject/ConstructorHelpers.h"
 #include "WorldMap.h"
 #include <limits>
@@ -30,6 +31,7 @@ ASkaldPlayerController::ASkaldPlayerController() {
   TurnManager = nullptr;
   HUDRef = nullptr;
   MainHudWidget = nullptr;
+  BattleHudWidget = nullptr;
 
   bShowMouseCursor = true;
   bEnableClickEvents = true;
@@ -38,6 +40,7 @@ ASkaldPlayerController::ASkaldPlayerController() {
   // Default to the native HUD widget class. This avoids loading a
   // blueprint-derived widget that may not exist or may be corrupt.
   HUDWidgetClass = USkaldMainHUDWidget::StaticClass();
+  BattleHUDWidgetClass = UBattleHUDWidget::StaticClass();
 
   static ConstructorHelpers::FClassFinder<UChoosePlayerWidget> ChooseBP(
       TEXT("/Game/Blueprints/UI/Skald_ChoosePlayerWidget"));
@@ -968,6 +971,16 @@ void ASkaldPlayerController::HandlePlayerLockedIn() {
         }
       }
       CachedGameInstance->GridBattleManager->InitBattle(Fighters, Fighters);
+
+      if (BattleHUDWidgetClass) {
+        BattleHudWidget =
+            CreateWidget<UBattleHUDWidget>(this, BattleHUDWidgetClass);
+        if (BattleHudWidget) {
+          BattleHudWidget->AddToViewport();
+          BattleHudWidget->BindToFighter(
+              CachedGameInstance->GridBattleManager->ActiveFighter);
+        }
+      }
     }
     GFighterSelectionWidget = nullptr;
   }
@@ -978,6 +991,6 @@ void ASkaldPlayerController::HandlePlayerLockedIn() {
   SetIgnoreLookInput(false);
 
   if (MainHudWidget) {
-    MainHudWidget->SetVisibility(ESlateVisibility::Visible);
+    MainHudWidget->SetVisibility(ESlateVisibility::Collapsed);
   }
 }

--- a/Source/Skald/Skald_PlayerController.h
+++ b/Source/Skald/Skald_PlayerController.h
@@ -9,6 +9,7 @@ class ATurnManager;
 class UUserWidget;
 class USkaldMainHUDWidget;
 class UChoosePlayerWidget;
+class UBattleHUDWidget;
 class ATerritory;
 class ASkaldGameMode;
 class ASkaldGameState;
@@ -75,6 +76,10 @@ protected:
   UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category = "UI")
   TSubclassOf<UUserWidget> HUDWidgetClass;
 
+  /** Widget class used for in-battle HUD. */
+  UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category = "UI")
+  TSubclassOf<UBattleHUDWidget> BattleHUDWidgetClass;
+
   /** Widget class used for the player faction selection screen. */
   UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category = "UI")
   TSubclassOf<UChoosePlayerWidget> ChoosePlayerWidgetClass;
@@ -88,6 +93,11 @@ protected:
   UPROPERTY(BlueprintReadOnly, Category = "UI",
             meta = (AllowPrivateAccess = "true"))
   TObjectPtr<USkaldMainHUDWidget> MainHudWidget;
+
+  /** Typed reference to the battle HUD widget. */
+  UPROPERTY(BlueprintReadOnly, Category = "UI",
+            meta = (AllowPrivateAccess = "true"))
+  TObjectPtr<UBattleHUDWidget> BattleHudWidget;
 
   /** Player selection widget instance. */
   UPROPERTY(BlueprintReadOnly, Category = "UI",

--- a/Source/Skald/UI/BattleHUDWidget.cpp
+++ b/Source/Skald/UI/BattleHUDWidget.cpp
@@ -1,0 +1,100 @@
+#include "UI/BattleHUDWidget.h"
+#include "Components/Button.h"
+#include "Components/TextBlock.h"
+#include "FighterPawn.h"
+#include "GridOverlayComponent.h"
+#include "Engine/World.h"
+#include "EngineUtils.h"
+
+void UBattleHUDWidget::NativeConstruct() {
+  Super::NativeConstruct();
+
+  if (MoveButton) {
+    MoveButton->OnClicked.AddDynamic(this, &UBattleHUDWidget::HandleMovePressed);
+  }
+  if (AttackButton) {
+    AttackButton->OnClicked.AddDynamic(this, &UBattleHUDWidget::HandleAttackPressed);
+  }
+}
+
+void UBattleHUDWidget::BindToFighter(AFighterPawn *Fighter) {
+  if (BoundFighter) {
+    BoundFighter->OnHealthChanged.RemoveDynamic(this,
+                                                &UBattleHUDWidget::HandleHealthChanged);
+  }
+  BoundFighter = Fighter;
+  if (BoundFighter) {
+    BoundFighter->OnHealthChanged.AddDynamic(this,
+                                             &UBattleHUDWidget::HandleHealthChanged);
+    UpdateStatPanel();
+  }
+}
+
+void UBattleHUDWidget::HandleMovePressed() {
+  OnMovePressed.Broadcast();
+  if (!BoundFighter) {
+    return;
+  }
+  if (UGridOverlayComponent *Grid = FindGridOverlay()) {
+    FIntPoint Origin = Grid->WorldToGrid(BoundFighter->GetActorLocation());
+    int32 Range = BoundFighter->Stats.Movement;
+    for (int32 X = -Range; X <= Range; ++X) {
+      for (int32 Y = -Range; Y <= Range; ++Y) {
+        if (FMath::Abs(X) + FMath::Abs(Y) <= Range) {
+          Grid->HighlightCell(Origin + FIntPoint(X, Y), FColor::Green, 1.f);
+        }
+      }
+    }
+  }
+}
+
+void UBattleHUDWidget::HandleAttackPressed() {
+  OnAttackPressed.Broadcast();
+  if (!BoundFighter) {
+    return;
+  }
+  if (UGridOverlayComponent *Grid = FindGridOverlay()) {
+    FIntPoint Origin = Grid->WorldToGrid(BoundFighter->GetActorLocation());
+    int32 Range = BoundFighter->Stats.AttackRange;
+    for (int32 X = -Range; X <= Range; ++X) {
+      for (int32 Y = -Range; Y <= Range; ++Y) {
+        if (FMath::Abs(X) + FMath::Abs(Y) <= Range) {
+          Grid->HighlightCell(Origin + FIntPoint(X, Y), FColor::Red, 1.f);
+        }
+      }
+    }
+  }
+}
+
+void UBattleHUDWidget::HandleHealthChanged(int32 NewHealth) {
+  if (HealthText) {
+    HealthText->SetText(FText::AsNumber(NewHealth));
+  }
+}
+
+void UBattleHUDWidget::UpdateStatPanel() {
+  if (!BoundFighter) {
+    return;
+  }
+  if (HealthText) {
+    HealthText->SetText(FText::AsNumber(BoundFighter->Stats.Health));
+  }
+  if (AttackText) {
+    AttackText->SetText(FText::AsNumber(BoundFighter->Stats.AttackDamage));
+  }
+  if (MoveText) {
+    MoveText->SetText(FText::AsNumber(BoundFighter->Stats.Movement));
+  }
+}
+
+UGridOverlayComponent *UBattleHUDWidget::FindGridOverlay() const {
+  if (UWorld *World = GetWorld()) {
+    for (TActorIterator<AActor> It(World); It; ++It) {
+      if (UGridOverlayComponent *Comp =
+              It->FindComponentByClass<UGridOverlayComponent>()) {
+        return Comp;
+      }
+    }
+  }
+  return nullptr;
+}

--- a/Source/Skald/UI/BattleHUDWidget.h
+++ b/Source/Skald/UI/BattleHUDWidget.h
@@ -1,0 +1,78 @@
+#pragma once
+
+#include "Blueprint/UserWidget.h"
+#include "BattleHUDWidget.generated.h"
+
+class UButton;
+class UTextBlock;
+class AFighterPawn;
+class UGridOverlayComponent;
+
+/**
+ * HUD widget displayed during grid battles.
+ */
+UCLASS(BlueprintType, Blueprintable)
+class SKALD_API UBattleHUDWidget : public UUserWidget {
+  GENERATED_BODY()
+
+public:
+  virtual void NativeConstruct() override;
+
+  /** Bind this HUD to a fighter so its stats are displayed. */
+  UFUNCTION(BlueprintCallable, Category = "Skald|Battle")
+  void BindToFighter(AFighterPawn *Fighter);
+
+  /** Delegate fired when the Move button is pressed. */
+  DECLARE_DYNAMIC_MULTICAST_DELEGATE(FOnMovePressed);
+  UPROPERTY(BlueprintAssignable, Category = "Skald|Battle|Events")
+  FOnMovePressed OnMovePressed;
+
+  /** Delegate fired when the Attack button is pressed. */
+  DECLARE_DYNAMIC_MULTICAST_DELEGATE(FOnAttackPressed);
+  UPROPERTY(BlueprintAssignable, Category = "Skald|Battle|Events")
+  FOnAttackPressed OnAttackPressed;
+
+  /** Move action button bound from the blueprint. */
+  UPROPERTY(BlueprintReadOnly, meta = (BindWidget))
+  UButton *MoveButton;
+
+  /** Attack action button bound from the blueprint. */
+  UPROPERTY(BlueprintReadOnly, meta = (BindWidget))
+  UButton *AttackButton;
+
+  /** Text displaying current health. */
+  UPROPERTY(BlueprintReadOnly, meta = (BindWidget))
+  UTextBlock *HealthText;
+
+  /** Text displaying attack damage. */
+  UPROPERTY(BlueprintReadOnly, meta = (BindWidget))
+  UTextBlock *AttackText;
+
+  /** Text displaying movement range. */
+  UPROPERTY(BlueprintReadOnly, meta = (BindWidget))
+  UTextBlock *MoveText;
+
+private:
+  /** Callback when MoveButton is pressed. */
+  UFUNCTION()
+  void HandleMovePressed();
+
+  /** Callback when AttackButton is pressed. */
+  UFUNCTION()
+  void HandleAttackPressed();
+
+  /** Update all stat text panels from the bound fighter. */
+  void UpdateStatPanel();
+
+  /** Respond to health changes from the fighter. */
+  UFUNCTION()
+  void HandleHealthChanged(int32 NewHealth);
+
+  /** Find the grid overlay component in the world. */
+  UGridOverlayComponent *FindGridOverlay() const;
+
+  /** Fighter currently bound to the HUD. */
+  UPROPERTY()
+  AFighterPawn *BoundFighter;
+};
+


### PR DESCRIPTION
## Summary
- add UBattleHUDWidget with fighter stat binding and move/attack delegates
- highlight grid cells on move and attack actions
- spawn battle HUD and hide world map HUD after fighter selection

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b5b0d981b0832496de1172f79343a1