### PR TITLE
Implement BFS-based movement and attack grid highlighting

### DIFF
--- a/Source/Skald/FighterPawn.cpp
+++ b/Source/Skald/FighterPawn.cpp
@@ -1,56 +1,69 @@
 #include "FighterPawn.h"
 #include "Components/StaticMeshComponent.h"
+#include "EngineUtils.h"
+#include "GridOverlayComponent.h"
 
-namespace
-{
-    /** Size of a grid cell in world units. */
-    constexpr float CellSize = 100.f;
+namespace {
+/** Size of a grid cell in world units. */
+constexpr float CellSize = 100.f;
+} // namespace
+
+AFighterPawn::AFighterPawn() {
+  PrimaryActorTick.bCanEverTick = false;
+
+  DisplayMesh =
+      CreateDefaultSubobject<UStaticMeshComponent>(TEXT("DisplayMesh"));
+  RootComponent = DisplayMesh;
+
+  ActionsRemaining = 0;
+  CurrentCell = FIntPoint::ZeroValue;
 }
 
-AFighterPawn::AFighterPawn()
-{
-    PrimaryActorTick.bCanEverTick = false;
+void AFighterPawn::BeginActivation() { ActionsRemaining = Stats.Movement; }
 
-    DisplayMesh = CreateDefaultSubobject<UStaticMeshComponent>(TEXT("DisplayMesh"));
-    RootComponent = DisplayMesh;
+void AFighterPawn::MoveToCell(FIntPoint TargetCell) {
+  int32 Distance = FMath::Abs(TargetCell.X - CurrentCell.X) +
+                   FMath::Abs(TargetCell.Y - CurrentCell.Y);
+  if (Distance > ActionsRemaining) {
+    return;
+  }
 
-    ActionsRemaining = 0;
-    CurrentCell = FIntPoint::ZeroValue;
-}
+  CurrentCell = TargetCell;
+  FVector NewLocation(TargetCell.X * CellSize, TargetCell.Y * CellSize,
+                      GetActorLocation().Z);
+  SetActorLocation(NewLocation);
+  ActionsRemaining -= Distance;
 
-void AFighterPawn::BeginActivation()
-{
-    ActionsRemaining = Stats.Movement;
-}
-
-void AFighterPawn::MoveToCell(FIntPoint TargetCell)
-{
-    int32 Distance = FMath::Abs(TargetCell.X - CurrentCell.X) + FMath::Abs(TargetCell.Y - CurrentCell.Y);
-    if (Distance > ActionsRemaining)
-    {
-        return;
+  if (UWorld *World = GetWorld()) {
+    for (TActorIterator<AActor> It(World); It; ++It) {
+      if (UGridOverlayComponent *Grid =
+              It->FindComponentByClass<UGridOverlayComponent>()) {
+        Grid->ClearHighlights();
+        break;
+      }
     }
-
-    CurrentCell = TargetCell;
-    FVector NewLocation(TargetCell.X * CellSize, TargetCell.Y * CellSize, GetActorLocation().Z);
-    SetActorLocation(NewLocation);
-    ActionsRemaining -= Distance;
+  }
 }
 
-void AFighterPawn::PerformAttack(AFighterPawn* Target)
-{
-    if (!Target || ActionsRemaining <= 0 || !Target->IsAlive())
-    {
-        return;
+void AFighterPawn::PerformAttack(AFighterPawn *Target) {
+  if (!Target || ActionsRemaining <= 0 || !Target->IsAlive()) {
+    return;
+  }
+
+  Target->Stats.Health =
+      FMath::Max(0, Target->Stats.Health - Stats.AttackDamage);
+  Target->OnHealthChanged.Broadcast(Target->Stats.Health);
+  --ActionsRemaining;
+
+  if (UWorld *World = GetWorld()) {
+    for (TActorIterator<AActor> It(World); It; ++It) {
+      if (UGridOverlayComponent *Grid =
+              It->FindComponentByClass<UGridOverlayComponent>()) {
+        Grid->ClearHighlights();
+        break;
+      }
     }
-
-    Target->Stats.Health = FMath::Max(0, Target->Stats.Health - Stats.AttackDamage);
-    Target->OnHealthChanged.Broadcast(Target->Stats.Health);
-    --ActionsRemaining;
+  }
 }
 
-bool AFighterPawn::IsAlive() const
-{
-    return Stats.Health > 0;
-}
-
+bool AFighterPawn::IsAlive() const { return Stats.Health > 0; }

--- a/Source/Skald/GridOverlayComponent.cpp
+++ b/Source/Skald/GridOverlayComponent.cpp
@@ -1,5 +1,7 @@
 #include "GridOverlayComponent.h"
+#include "Containers/Queue.h"
 #include "DrawDebugHelpers.h"
+#include "FighterPawn.h"
 
 UGridOverlayComponent::UGridOverlayComponent() {
   PrimaryComponentTick.bCanEverTick = false;
@@ -55,13 +57,105 @@ void UGridOverlayComponent::SetOccupied(const FIntPoint &GridCoord,
 }
 
 void UGridOverlayComponent::HighlightCell(const FIntPoint &GridCoord,
-                                          const FColor &Color,
-                                          float Duration) const {
+                                          const FColor &Color, float Duration,
+                                          bool bPersistent) const {
   if (!IsValidGrid(GridCoord) || !GetWorld()) {
     return;
   }
 
   FVector Center = GridToWorld(GridCoord);
   FVector Extent(CellSize * 0.5f, CellSize * 0.5f, 10.f);
-  DrawDebugSolidBox(GetWorld(), Center, Extent, Color, false, Duration);
+  DrawDebugSolidBox(GetWorld(), Center, Extent, Color, bPersistent, Duration);
+}
+
+void UGridOverlayComponent::ClearHighlights() const {
+  if (GetWorld()) {
+    FlushPersistentDebugLines(GetWorld());
+  }
+}
+
+void UGridOverlayComponent::HighlightMovement(AFighterPawn *Fighter) {
+  if (!Fighter) {
+    return;
+  }
+
+  ClearHighlights();
+
+  FIntPoint Origin = WorldToGrid(Fighter->GetActorLocation());
+  const int32 Range = Fighter->Stats.Movement;
+
+  TSet<FIntPoint> Visited;
+  TQueue<TPair<FIntPoint, int32>> Frontier;
+  Visited.Add(Origin);
+  Frontier.Enqueue(TPair<FIntPoint, int32>(Origin, 0));
+
+  while (!Frontier.IsEmpty()) {
+    TPair<FIntPoint, int32> Node;
+    Frontier.Dequeue(Node);
+    const FIntPoint Cell = Node.Key;
+    const int32 Distance = Node.Value;
+
+    if (Distance > 0) {
+      HighlightCell(Cell, FColor::Green, 0.f, true);
+    }
+
+    if (Distance >= Range) {
+      continue;
+    }
+
+    static const FIntPoint Directions[4] = {FIntPoint(1, 0), FIntPoint(-1, 0),
+                                            FIntPoint(0, 1), FIntPoint(0, -1)};
+
+    for (const FIntPoint &Dir : Directions) {
+      const FIntPoint Next = Cell + Dir;
+      if (!IsValidGrid(Next) || IsOccupied(Next) || Visited.Contains(Next)) {
+        continue;
+      }
+      Visited.Add(Next);
+      Frontier.Enqueue(TPair<FIntPoint, int32>(Next, Distance + 1));
+    }
+  }
+}
+
+void UGridOverlayComponent::HighlightAttack(AFighterPawn *Fighter) {
+  if (!Fighter) {
+    return;
+  }
+
+  ClearHighlights();
+
+  FIntPoint Origin = WorldToGrid(Fighter->GetActorLocation());
+  const int32 Range = Fighter->Stats.AttackRange;
+
+  TSet<FIntPoint> Visited;
+  TQueue<TPair<FIntPoint, int32>> Frontier;
+  Visited.Add(Origin);
+  Frontier.Enqueue(TPair<FIntPoint, int32>(Origin, 0));
+
+  while (!Frontier.IsEmpty()) {
+    TPair<FIntPoint, int32> Node;
+    Frontier.Dequeue(Node);
+    const FIntPoint Cell = Node.Key;
+    const int32 Distance = Node.Value;
+
+    if (Distance > 0) {
+      HighlightCell(Cell, FColor::Red, 0.f, true);
+    }
+
+    if (Distance >= Range) {
+      continue;
+    }
+
+    static const FIntPoint Directions[4] = {FIntPoint(1, 0), FIntPoint(-1, 0),
+                                            FIntPoint(0, 1), FIntPoint(0, -1)};
+
+    for (const FIntPoint &Dir : Directions) {
+      const FIntPoint Next = Cell + Dir;
+      if (!IsValidGrid(Next) || Visited.Contains(Next)) {
+        continue;
+      }
+      Visited.Add(Next);
+      Frontier.Enqueue(TPair<FIntPoint, int32>(Next, Distance + 1));
+    }
+  }
 }

--- a/Source/Skald/GridOverlayComponent.h
+++ b/Source/Skald/GridOverlayComponent.h
@@ -4,6 +4,8 @@
 #include "CoreMinimal.h"
 #include "GridOverlayComponent.generated.h"
 
+class AFighterPawn;
+
 /**
  * Component that tracks grid cell occupancy and provides world/grid conversion.
  * Designed to be attached to the battle map floor actor.
@@ -36,7 +38,19 @@ public:
   /** Draw a debug highlight box for a grid cell. */
   UFUNCTION(BlueprintCallable, Category = "Grid")
   void HighlightCell(const FIntPoint &GridCoord, const FColor &Color,
-                     float Duration = 0.f) const;
+                     float Duration = 0.f, bool bPersistent = false) const;
+
+  /** Highlight all reachable movement cells for the fighter. */
+  UFUNCTION(BlueprintCallable, Category = "Grid")
+  void HighlightMovement(AFighterPawn *Fighter);
+
+  /** Highlight attack range for the fighter. */
+  UFUNCTION(BlueprintCallable, Category = "Grid")
+  void HighlightAttack(AFighterPawn *Fighter);
+
+  /** Remove any persistent highlights. */
+  UFUNCTION(BlueprintCallable, Category = "Grid")
+  void ClearHighlights() const;
 
 protected:
   /** Width of the grid in cells. */

--- a/Source/Skald/UI/BattleHUDWidget.cpp
+++ b/Source/Skald/UI/BattleHUDWidget.cpp
@@ -1,31 +1,33 @@
 #include "UI/BattleHUDWidget.h"
 #include "Components/Button.h"
 #include "Components/TextBlock.h"
-#include "FighterPawn.h"
-#include "GridOverlayComponent.h"
 #include "Engine/World.h"
 #include "EngineUtils.h"
+#include "FighterPawn.h"
+#include "GridOverlayComponent.h"
 
 void UBattleHUDWidget::NativeConstruct() {
   Super::NativeConstruct();
 
   if (MoveButton) {
-    MoveButton->OnClicked.AddDynamic(this, &UBattleHUDWidget::HandleMovePressed);
+    MoveButton->OnClicked.AddDynamic(this,
+                                     &UBattleHUDWidget::HandleMovePressed);
   }
   if (AttackButton) {
-    AttackButton->OnClicked.AddDynamic(this, &UBattleHUDWidget::HandleAttackPressed);
+    AttackButton->OnClicked.AddDynamic(this,
+                                       &UBattleHUDWidget::HandleAttackPressed);
   }
 }
 
 void UBattleHUDWidget::BindToFighter(AFighterPawn *Fighter) {
   if (BoundFighter) {
-    BoundFighter->OnHealthChanged.RemoveDynamic(this,
-                                                &UBattleHUDWidget::HandleHealthChanged);
+    BoundFighter->OnHealthChanged.RemoveDynamic(
+        this, &UBattleHUDWidget::HandleHealthChanged);
   }
   BoundFighter = Fighter;
   if (BoundFighter) {
-    BoundFighter->OnHealthChanged.AddDynamic(this,
-                                             &UBattleHUDWidget::HandleHealthChanged);
+    BoundFighter->OnHealthChanged.AddDynamic(
+        this, &UBattleHUDWidget::HandleHealthChanged);
     UpdateStatPanel();
   }
 }
@@ -36,15 +38,7 @@ void UBattleHUDWidget::HandleMovePressed() {
     return;
   }
   if (UGridOverlayComponent *Grid = FindGridOverlay()) {
-    FIntPoint Origin = Grid->WorldToGrid(BoundFighter->GetActorLocation());
-    int32 Range = BoundFighter->Stats.Movement;
-    for (int32 X = -Range; X <= Range; ++X) {
-      for (int32 Y = -Range; Y <= Range; ++Y) {
-        if (FMath::Abs(X) + FMath::Abs(Y) <= Range) {
-          Grid->HighlightCell(Origin + FIntPoint(X, Y), FColor::Green, 1.f);
-        }
-      }
-    }
+    Grid->HighlightMovement(BoundFighter);
   }
 }
 
@@ -54,15 +48,7 @@ void UBattleHUDWidget::HandleAttackPressed() {
     return;
   }
   if (UGridOverlayComponent *Grid = FindGridOverlay()) {
-    FIntPoint Origin = Grid->WorldToGrid(BoundFighter->GetActorLocation());
-    int32 Range = BoundFighter->Stats.AttackRange;
-    for (int32 X = -Range; X <= Range; ++X) {
-      for (int32 Y = -Range; Y <= Range; ++Y) {
-        if (FMath::Abs(X) + FMath::Abs(Y) <= Range) {
-          Grid->HighlightCell(Origin + FIntPoint(X, Y), FColor::Red, 1.f);
-        }
-      }
-    }
+    Grid->HighlightAttack(BoundFighter);
   }
 }
 


### PR DESCRIPTION
## Summary
- add persistent grid highlighting for movement and attack using BFS/Manhattan distance
- expose ClearHighlights and apply it after fighter actions
- update Battle HUD to use new highlight helpers

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b5b1fe20e48324b5d788b14b4be3ae