### PR TITLE
Implement multi-dice attack resolution

### DIFF
--- a/Source/Skald/FighterPawn.cpp
+++ b/Source/Skald/FighterPawn.cpp
@@ -2,6 +2,7 @@
 #include "Components/StaticMeshComponent.h"
 #include "EngineUtils.h"
 #include "GridOverlayComponent.h"
+#include "Skald_GameInstance.h"
 
 namespace {
 /** Size of a grid cell in world units. */
@@ -50,9 +51,36 @@ void AFighterPawn::PerformAttack(AFighterPawn *Target) {
     return;
   }
 
-  Target->Stats.Health =
-      FMath::Max(0, Target->Stats.Health - Stats.AttackDamage);
+  FRandomStream *RandomStream = nullptr;
+  if (UWorld *World = GetWorld()) {
+    if (USkaldGameInstance *GameInstance =
+            Cast<USkaldGameInstance>(World->GetGameInstance())) {
+      RandomStream = &GameInstance->CombatRandomStream;
+    }
+  }
+  static FRandomStream FallbackStream;
+  if (!RandomStream) {
+    FallbackStream.Initialize(FMath::Rand());
+    RandomStream = &FallbackStream;
+  }
+
+  const int32 RequiredRoll =
+      Stats.Strength > Target->Stats.Defence
+          ? 3
+          : (Stats.Strength < Target->Stats.Defence ? 5 : 4);
+
+  for (int32 i = 0; i < Stats.AttackDice && Target->IsAlive(); ++i) {
+    int32 Roll = RandomStream->RandRange(1, 6);
+    if (Roll >= RequiredRoll) {
+      Target->Stats.Health =
+          FMath::Max(0, Target->Stats.Health - Stats.AttackDamage);
+    }
+  }
+
   Target->OnHealthChanged.Broadcast(Target->Stats.Health);
+  if (!Target->IsAlive()) {
+    Target->Destroy();
+  }
   --ActionsRemaining;
 
   if (UWorld *World = GetWorld()) {


### PR DESCRIPTION
## Summary
- Expand FighterPawn attacks to roll multiple dice with deterministic random stream
- Calculate hit thresholds from attacker strength and defender defence
- Apply per-hit damage and kill targets when health is depleted

## Testing
- `g++ -fsyntax-only -std=c++17 Source/Skald/FighterPawn.cpp` *(fails: CoreMinimal.h: No such file or directory)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b5b2f659f48324ae5f791c62c09f17