### PR TITLE
Compute battle losses using fighter cost

### DIFF
--- a/Source/Skald/GridBattleManager.cpp
+++ b/Source/Skald/GridBattleManager.cpp
@@ -261,6 +261,32 @@ int32 UGridBattleManager::GetDefenderSurvivors() const
     return DefenderSurvivorCount;
 }
 
+int32 UGridBattleManager::GetAttackerSurvivorCost() const
+{
+    int32 Cost = 0;
+    for (const FFighter& Fighter : AttackerTeam)
+    {
+        if (Fighter.Stats.Health > 0)
+        {
+            Cost += Fighter.Stats.ArmyCost;
+        }
+    }
+    return Cost;
+}
+
+int32 UGridBattleManager::GetDefenderSurvivorCost() const
+{
+    int32 Cost = 0;
+    for (const FFighter& Fighter : DefenderTeam)
+    {
+        if (Fighter.Stats.Health > 0)
+        {
+            Cost += Fighter.Stats.ArmyCost;
+        }
+    }
+    return Cost;
+}
+
 void UGridBattleManager::RollInitiative()
 {
     struct FInitiativeEntry

--- a/Source/Skald/GridBattleManager.h
+++ b/Source/Skald/GridBattleManager.h
@@ -143,6 +143,14 @@ public:
     UFUNCTION(BlueprintCallable, BlueprintPure, Category="Battle")
     int32 GetDefenderSurvivors() const;
 
+    /** Total army cost of surviving attackers. */
+    UFUNCTION(BlueprintCallable, BlueprintPure, Category="Battle")
+    int32 GetAttackerSurvivorCost() const;
+
+    /** Total army cost of surviving defenders. */
+    UFUNCTION(BlueprintCallable, BlueprintPure, Category="Battle")
+    int32 GetDefenderSurvivorCost() const;
+
     /** Event fired when the battle ends reporting winner and casualties. */
     UPROPERTY(BlueprintAssignable, Category="Battle|Events")
     FOnBattleEnded OnBattleEnded;

--- a/Source/Skald/Skald_TurnManager.cpp
+++ b/Source/Skald/Skald_TurnManager.cpp
@@ -312,8 +312,10 @@ void ATurnManager::ResolveGridBattleResult() {
   const int32 InitialSourceArmy = Source->ArmyUnits;
   const int32 InitialTargetArmy = Target->ArmyUnits;
 
-  const int32 AttackerSurvivors = GI->GridBattleManager->GetAttackerSurvivors();
-  const int32 DefenderSurvivors = GI->GridBattleManager->GetDefenderSurvivors();
+  const int32 AttackerSurvivors =
+      GI->GridBattleManager->GetAttackerSurvivorCost();
+  const int32 DefenderSurvivors =
+      GI->GridBattleManager->GetDefenderSurvivorCost();
 
   Source->ArmyUnits -= Battle.ArmyCountSent;
 
@@ -328,14 +330,31 @@ void ATurnManager::ResolveGridBattleResult() {
     Target->ArmyUnits = DefenderSurvivors;
   }
 
-  const int32 AttackerCasualties = Battle.ArmyCountSent - AttackerSurvivors;
-  const int32 DefenderCasualties = InitialTargetArmy - DefenderSurvivors;
+  const int32 AttackerCasualties =
+      Battle.ArmyCountSent - AttackerSurvivors;
+  const int32 DefenderCasualties =
+      InitialTargetArmy - DefenderSurvivors;
 
   Source->RefreshAppearance();
   Target->RefreshAppearance();
 
   GI->PendingBattle = FS_BattlePayload();
   GI->GridBattleManager = nullptr;
+  PendingBattle = FS_BattlePayload();
+
+  // Resume the saved turn sequence now that the battle has been resolved.
+  if (GI->bResumeTurns) {
+    CurrentIndex = GI->SavedTurnIndex;
+    CurrentPhase = GI->SavedTurnPhase;
+    GI->bResumeTurns = false;
+
+    if (Controllers.IsValidIndex(CurrentIndex)) {
+      if (ASkaldPlayerController *Controller = Controllers[CurrentIndex].Get()) {
+        Controller->StartTurn();
+        BroadcastCurrentPhase();
+      }
+    }
+  }
 
   if (ASkaldGameMode *GM =
           GetWorld()->GetAuthGameMode<ASkaldGameMode>()) {


### PR DESCRIPTION
## Summary
- track surviving fighters' total ArmyCost in the grid battle manager
- resolve battles on world map using ArmyCost-based casualties and resume turns

## Testing
- `pytest`
- `npm test` *(fails: ENOENT: no such file or directory, open 'package.json')*


------
https://chatgpt.com/codex/tasks/task_e_68b5b575c2288324bb11ff0fe034bfa3