### PR TITLE
Resolve RollInitiative Blueprint conflict

### DIFF
--- a/Source/Skald/GridBattleManager.cpp
+++ b/Source/Skald/GridBattleManager.cpp
@@ -71,14 +71,14 @@ void UGridBattleManager::InitBattle(const TArray<FFighter>& Attackers, const TAr
     CurrentRound = 1;
 }
 
-int32 UGridBattleManager::RollInitiative(FRandomStream& RandomStream)
+int32 UGridBattleManager::RollInitiativeDie(FRandomStream& RandomStream)
 {
     return RandomStream.RandRange(1, 6);
 }
 
 void UGridBattleManager::StartBattle(FRandomStream& RandomStream)
 {
-    bool bAttackerTurn = RollInitiative(RandomStream) >= RollInitiative(RandomStream);
+    bool bAttackerTurn = RollInitiativeDie(RandomStream) >= RollInitiativeDie(RandomStream);
 
     TArray<FIntPoint> PreviousAttackerPositions;
     PreviousAttackerPositions.Reserve(AttackerTeam.Num());

--- a/Source/Skald/GridBattleManager.h
+++ b/Source/Skald/GridBattleManager.h
@@ -113,7 +113,7 @@ public:
 
     /** Roll a D6 to determine initiative. */
     UFUNCTION(BlueprintCallable, Category="Battle")
-    static int32 RollInitiative(UPARAM(ref) FRandomStream& RandomStream);
+    static int32 RollInitiativeDie(UPARAM(ref) FRandomStream& RandomStream);
 
     /** Resolve an attack following strength/defence rules. Returns true if the defender is defeated. */
     UFUNCTION(BlueprintCallable, Category="Battle")


### PR DESCRIPTION
## Summary
- rename static initiative roll helper to RollInitiativeDie to avoid name clash with member function

## Testing
- `clang++ -std=c++17 -fsyntax-only Source/Skald/GridBattleManager.cpp` *(fails: 'CoreMinimal.h' file not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b5b9a27f44832499a121e0e9c69cbe