### PR TITLE
Add getter for active fighter

### DIFF
--- a/Source/Skald/GridBattleManager.cpp
+++ b/Source/Skald/GridBattleManager.cpp
@@ -287,6 +287,11 @@ int32 UGridBattleManager::GetDefenderSurvivorCost() const
     return Cost;
 }
 
+AFighterPawn* UGridBattleManager::GetActiveFighter() const
+{
+    return ActiveFighter;
+}
+
 void UGridBattleManager::RollInitiative()
 {
     struct FInitiativeEntry

--- a/Source/Skald/GridBattleManager.h
+++ b/Source/Skald/GridBattleManager.h
@@ -147,9 +147,13 @@ public:
     UFUNCTION(BlueprintCallable, BlueprintPure, Category="Battle")
     int32 GetAttackerSurvivorCost() const;
 
-    /** Total army cost of surviving defenders. */
-    UFUNCTION(BlueprintCallable, BlueprintPure, Category="Battle")
-    int32 GetDefenderSurvivorCost() const;
+      /** Total army cost of surviving defenders. */
+      UFUNCTION(BlueprintCallable, BlueprintPure, Category="Battle")
+      int32 GetDefenderSurvivorCost() const;
+
+      /** Fighter currently taking its turn. */
+      UFUNCTION(BlueprintCallable, BlueprintPure, Category="Battle")
+      AFighterPawn* GetActiveFighter() const;
 
     /** Event fired when the battle ends reporting winner and casualties. */
     UPROPERTY(BlueprintAssignable, Category="Battle|Events")

--- a/Source/Skald/Skald_PlayerController.cpp
+++ b/Source/Skald/Skald_PlayerController.cpp
@@ -977,8 +977,8 @@ void ASkaldPlayerController::HandlePlayerLockedIn() {
             CreateWidget<UBattleHUDWidget>(this, BattleHUDWidgetClass);
         if (BattleHudWidget) {
           BattleHudWidget->AddToViewport();
-          BattleHudWidget->BindToFighter(
-              CachedGameInstance->GridBattleManager->ActiveFighter);
+            BattleHudWidget->BindToFighter(
+                CachedGameInstance->GridBattleManager->GetActiveFighter());
         }
       }
     }


### PR DESCRIPTION
## Summary
- expose ActiveFighter via new GetActiveFighter() accessor in GridBattleManager
- update player controller to use the new accessor when binding HUD to current fighter

## Testing
- `g++ -fsyntax-only Source/Skald/GridBattleManager.cpp` *(fails: CoreMinimal.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b5bbb825688324bbb18988d58f4298