### PR TITLE
Fix grid manager constructor and overlay variable naming

### DIFF
--- a/Source/Skald/GridBattleManager.h
+++ b/Source/Skald/GridBattleManager.h
@@ -103,6 +103,9 @@ class SKALD_API UGridBattleManager : public UObject
     GENERATED_BODY()
 
 public:
+    /** Load fighter definitions and set default state. */
+    UGridBattleManager();
+
     /** Initialise a battle with attackers and defenders. */
     UFUNCTION(BlueprintCallable, Category="Battle")
     void InitBattle(const TArray<FFighter>& Attackers, const TArray<FFighter>& Defenders);

--- a/Source/Skald/GridOverlayComponent.cpp
+++ b/Source/Skald/GridOverlayComponent.cpp
@@ -81,13 +81,13 @@ void UGridOverlayComponent::HighlightMovement(AFighterPawn *Fighter) {
 
   ClearHighlights();
 
-  FIntPoint Origin = WorldToGrid(Fighter->GetActorLocation());
+  FIntPoint StartCell = WorldToGrid(Fighter->GetActorLocation());
   const int32 Range = Fighter->Stats.Movement;
 
   TSet<FIntPoint> Visited;
   TQueue<TPair<FIntPoint, int32>> Frontier;
-  Visited.Add(Origin);
-  Frontier.Enqueue(TPair<FIntPoint, int32>(Origin, 0));
+  Visited.Add(StartCell);
+  Frontier.Enqueue(TPair<FIntPoint, int32>(StartCell, 0));
 
   while (!Frontier.IsEmpty()) {
     TPair<FIntPoint, int32> Node;
@@ -124,13 +124,13 @@ void UGridOverlayComponent::HighlightAttack(AFighterPawn *Fighter) {
 
   ClearHighlights();
 
-  FIntPoint Origin = WorldToGrid(Fighter->GetActorLocation());
+  FIntPoint StartCell = WorldToGrid(Fighter->GetActorLocation());
   const int32 Range = Fighter->Stats.AttackRange;
 
   TSet<FIntPoint> Visited;
   TQueue<TPair<FIntPoint, int32>> Frontier;
-  Visited.Add(Origin);
-  Frontier.Enqueue(TPair<FIntPoint, int32>(Origin, 0));
+  Visited.Add(StartCell);
+  Frontier.Enqueue(TPair<FIntPoint, int32>(StartCell, 0));
 
   while (!Frontier.IsEmpty()) {
     TPair<FIntPoint, int32> Node;


### PR DESCRIPTION
## Summary
- declare `UGridBattleManager` constructor so the fighter data table loads
- rename local Origin variables in grid overlay helper to prevent hiding the component origin

## Testing
- `g++ -std=c++20 -c Source/Skald/GridBattleManager.cpp` *(fails: CoreMinimal.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b5bf560df083249e9b241d4c85eb95