### PR TITLE
Fix test widget declaration

### DIFF
--- a/Source/Skald/Tests/DeploySelectionCachingTest.cpp
+++ b/Source/Skald/Tests/DeploySelectionCachingTest.cpp
@@ -1,3 +1,5 @@
+#include "DeploySelectionCachingTest.h"
+
 #include "Misc/AutomationTest.h"
 #include "Tests/AutomationEditorCommon.h"
 #include "Skald_PlayerController.h"
@@ -5,20 +7,7 @@
 #include "Skald_TurnManager.h"
 #include "WorldMap.h"
 #include "Territory.h"
-#include "UI/SkaldMainHUDWidget.h"
 #include "UI/DeployWidget.h"
-
-// Test-only subclass to expose protected functionality from USkaldMainHUDWidget
-UCLASS()
-class UTestSkaldMainHUDWidget : public USkaldMainHUDWidget
-{
-    GENERATED_BODY()
-
-public:
-    using USkaldMainHUDWidget::HandleDeployClicked;
-
-    UDeployWidget* GetActiveDeployWidget() const { return ActiveDeployWidget; }
-};
 
 // Verify that territory selection for deployment persists even if the
 // local player state is not yet assigned when the territory is clicked.

--- a/Source/Skald/Tests/DeploySelectionCachingTest.h
+++ b/Source/Skald/Tests/DeploySelectionCachingTest.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "UI/SkaldMainHUDWidget.h"
+#include "DeploySelectionCachingTest.generated.h"
+
+class UDeployWidget;
+
+/**
+ * Test-only subclass to expose protected functionality from USkaldMainHUDWidget
+ */
+UCLASS()
+class SKALD_API UTestSkaldMainHUDWidget : public USkaldMainHUDWidget
+{
+    GENERATED_BODY()
+
+public:
+    using USkaldMainHUDWidget::HandleDeployClicked;
+
+    UDeployWidget* GetActiveDeployWidget() const { return ActiveDeployWidget; }
+};
+


### PR DESCRIPTION
## Summary
- move DeploySelectionCaching test widget into header with proper UCLASS macros
- include new header and clean up test includes

## Testing
- `g++ -c Source/Skald/Tests/DeploySelectionCachingTest.cpp -I./Source -std=c++17` *(fails: CoreMinimal.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b5d36fb67c83248f5aea754957ead6