### PR TITLE
Add colors for new factions

### DIFF
--- a/Source/Skald/Territory.cpp
+++ b/Source/Skald/Territory.cpp
@@ -33,6 +33,12 @@ FLinearColor GetFactionColor(ESkaldFaction Faction) {
     return FLinearColor(1.0f, 0.55f, 0.0f, 1.f); // Orange
   case ESkaldFaction::Empire:
     return FLinearColor(0.5f, 0.0f, 0.5f, 1.f); // Purple
+  case ESkaldFaction::Inflicted:
+    return FLinearColor(0.99f, 0.14f, 0.14f, 1.f); // Scarlet
+  case ESkaldFaction::FrogFolk:
+    return FLinearColor(1.f, 0.31f, 0.55f, 1.f); // Rose
+  case ESkaldFaction::Ravpack:
+    return FLinearColor(0.54f, 0.f, 0.54f, 1.f); // Violet
   default:
     return FLinearColor::White;
   }


### PR DESCRIPTION
## Summary
- map new factions Inflicted, FrogFolk, and Ravpack to scarlet, rose, and violet colors

## Testing
- `make test` *(fails: No rule to make target 'test')*

------
https://chatgpt.com/codex/tasks/task_e_68b5f84b07c88324a2546e913307bf18