### PR TITLE
Add faction field to fighter definitions

### DIFF
--- a/Content/DataTables/FighterTable.csv
+++ b/Content/DataTables/FighterTable.csv
@@ -1,0 +1,4 @@
+Id,MeshClass,Faction,Stats.Health,Stats.Defence,Stats.Strength,Stats.AttackDice,Stats.AttackRange,Stats.Movement,Stats.DamageDie,Stats.AttackDamage,Stats.ArmyCost
+HumanSoldier,,Human,10,5,5,1,1,5,6,1,1
+OrcGrunt,,Orc,12,4,6,1,1,5,8,1,1
+SkeletonWarrior,,Undead,8,3,4,1,1,5,6,1,1

--- a/Source/Skald/GridBattleManager.h
+++ b/Source/Skald/GridBattleManager.h
@@ -57,7 +57,10 @@ struct FFighterDefinition : public FTableRowBase
     GENERATED_BODY();
 
     FFighterDefinition()
-        : Id(NAME_None), MeshClass(nullptr), Stats()
+        : Id(NAME_None)
+        , MeshClass(nullptr)
+        , Faction(ESkaldFaction::None)
+        , Stats()
     {
     }
 
@@ -66,6 +69,9 @@ struct FFighterDefinition : public FTableRowBase
 
     UPROPERTY(EditAnywhere, BlueprintReadOnly, Category="Fighter")
     TSubclassOf<AActor> MeshClass;
+
+    UPROPERTY(EditAnywhere, BlueprintReadOnly, Category="Fighter")
+    ESkaldFaction Faction = ESkaldFaction::None;
 
     UPROPERTY(EditAnywhere, BlueprintReadOnly, Category="Fighter")
     FFighterStats Stats;


### PR DESCRIPTION
## Summary
- track a fighter's faction in FFighterDefinition
- seed FighterTable with faction-aware rows

## Testing
- `ctest`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b5fd8acc8c8324aca08849d663dced