### PR TITLE
Add faction-based fighter lookup

### DIFF
--- a/Source/Skald/GridBattleManager.cpp
+++ b/Source/Skald/GridBattleManager.cpp
@@ -292,6 +292,26 @@ AFighterPawn* UGridBattleManager::GetActiveFighter() const
     return ActiveFighter;
 }
 
+TArray<FFighterDefinition> UGridBattleManager::GetFightersForFaction(ESkaldFaction Faction) const
+{
+    TArray<FFighterDefinition> Fighters;
+    if (!FighterDefinitions)
+    {
+        return Fighters;
+    }
+
+    for (const TPair<FName, uint8*>& Pair : FighterDefinitions->GetRowMap())
+    {
+        const FFighterDefinition* Definition = reinterpret_cast<const FFighterDefinition*>(Pair.Value);
+        if (Definition && Definition->Faction == Faction)
+        {
+            Fighters.Add(*Definition);
+        }
+    }
+
+    return Fighters;
+}
+
 void UGridBattleManager::RollInitiative()
 {
     struct FInitiativeEntry

--- a/Source/Skald/GridBattleManager.h
+++ b/Source/Skald/GridBattleManager.h
@@ -164,6 +164,10 @@ public:
       UFUNCTION(BlueprintCallable, BlueprintPure, Category="Battle")
       AFighterPawn* GetActiveFighter() const;
 
+    /** Get fighter definitions for the specified faction. */
+    UFUNCTION(BlueprintCallable, BlueprintPure, Category="Battle")
+    TArray<FFighterDefinition> GetFightersForFaction(ESkaldFaction Faction) const;
+
     /** Event fired when the battle ends reporting winner and casualties. */
     UPROPERTY(BlueprintAssignable, Category="Battle|Events")
     FOnBattleEnded OnBattleEnded;


### PR DESCRIPTION
## Summary
- Add `GetFightersForFaction` to `GridBattleManager` for retrieving definitions by faction

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b5fea7bfb48324bfce08480539eae4