### PR TITLE
Populate fighter selection widget

### DIFF
--- a/Source/Skald/Skald_PlayerController.cpp
+++ b/Source/Skald/Skald_PlayerController.cpp
@@ -147,6 +147,15 @@ void ASkaldPlayerController::BeginPlay() {
             CreateWidget<UFighterSelectionWidget>(
                 this, UFighterSelectionWidget::StaticClass())) {
       GFighterSelectionWidget = Selection;
+      if (CachedGameInstance && CachedGameInstance->GridBattleManager) {
+        if (ASkaldPlayerState *PS = GetPlayerState<ASkaldPlayerState>()) {
+          const ESkaldFaction PlayerFaction = PS->Faction;
+          Selection->PlayerFaction = PlayerFaction;
+          Selection->AvailableFighters =
+              CachedGameInstance->GridBattleManager->GetFightersForFaction(
+                  PlayerFaction);
+        }
+      }
       Selection->OnLockedIn.AddDynamic(
           this, &ASkaldPlayerController::HandlePlayerLockedIn);
       Selection->AddToViewport();

--- a/Source/Skald/UI/FighterSelectionWidget.h
+++ b/Source/Skald/UI/FighterSelectionWidget.h
@@ -60,6 +60,10 @@ class SKALD_API UFighterSelectionWidget : public UUserWidget {
 public:
   virtual void NativeConstruct() override;
 
+  /** Faction of the player owning this selection widget. */
+  UPROPERTY(BlueprintReadOnly, Category = "Skald|Fighter")
+  ESkaldFaction PlayerFaction = ESkaldFaction::None;
+
   /** Fighters that can be chosen. */
   UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Skald|Fighter")
   TArray<FFighterDefinition> AvailableFighters;


### PR DESCRIPTION
## Summary
- Load fighters for the player's faction when creating the fighter selection screen
- Track the player's faction on the fighter selection widget for later use

## Testing
- `clang++ -std=c++17 -I../Engine/Source -ISource -c Source/Skald/Skald_PlayerController.cpp` *(fails: 'CoreMinimal.h' file not found)*
- `clang++ -std=c++17 -I../Engine/Source -ISource/Skald -c Source/Skald/UI/FighterSelectionWidget.cpp` *(fails: 'Blueprint/UserWidget.h' file not found)*


------
https://chatgpt.com/codex/tasks/task_e_68b6008d49cc83248cadee13e2dc2184