### PR TITLE
Add UI bind points for tactical fighter selection and HUD

### DIFF
--- a/Source/Skald/UI/BattleHUDWidget.cpp
+++ b/Source/Skald/UI/BattleHUDWidget.cpp
@@ -71,6 +71,18 @@ void UBattleHUDWidget::UpdateStatPanel() {
   if (MoveText) {
     MoveText->SetText(FText::AsNumber(BoundFighter->Stats.Movement));
   }
+  if (StrengthText) {
+    StrengthText->SetText(FText::AsNumber(BoundFighter->Stats.Strength));
+  }
+  if (DefenceText) {
+    DefenceText->SetText(FText::AsNumber(BoundFighter->Stats.Defence));
+  }
+  if (AttackRangeText) {
+    AttackRangeText->SetText(FText::AsNumber(BoundFighter->Stats.AttackRange));
+  }
+  if (AttackDiceText) {
+    AttackDiceText->SetText(FText::AsNumber(BoundFighter->Stats.AttackDice));
+  }
 }
 
 UGridOverlayComponent *UBattleHUDWidget::FindGridOverlay() const {

--- a/Source/Skald/UI/BattleHUDWidget.h
+++ b/Source/Skald/UI/BattleHUDWidget.h
@@ -52,6 +52,22 @@ public:
   UPROPERTY(BlueprintReadOnly, meta = (BindWidget))
   UTextBlock *MoveText;
 
+  /** Text displaying strength value. */
+  UPROPERTY(BlueprintReadOnly, meta = (BindWidget))
+  UTextBlock *StrengthText;
+
+  /** Text displaying defence value. */
+  UPROPERTY(BlueprintReadOnly, meta = (BindWidget))
+  UTextBlock *DefenceText;
+
+  /** Text displaying attack range. */
+  UPROPERTY(BlueprintReadOnly, meta = (BindWidget))
+  UTextBlock *AttackRangeText;
+
+  /** Text displaying number of attack dice. */
+  UPROPERTY(BlueprintReadOnly, meta = (BindWidget))
+  UTextBlock *AttackDiceText;
+
 private:
   /** Callback when MoveButton is pressed. */
   UFUNCTION()

--- a/Source/Skald/UI/FighterSelectionWidget.cpp
+++ b/Source/Skald/UI/FighterSelectionWidget.cpp
@@ -2,6 +2,7 @@
 
 #include "Components/Button.h"
 #include "Components/ScrollBox.h"
+#include "Components/TextBlock.h"
 
 void UFighterEntryWidget::NativeConstruct() {
   Super::NativeConstruct();
@@ -15,6 +16,33 @@ void UFighterEntryWidget::Init(const FFighterDefinition &InFighter,
                                UFighterSelectionWidget *InOwner) {
   Fighter = InFighter;
   Owner = InOwner;
+  if (NameText) {
+    NameText->SetText(FText::FromName(Fighter.Id));
+  }
+  if (StrengthText) {
+    StrengthText->SetText(FText::AsNumber(Fighter.Stats.Strength));
+  }
+  if (DefenceText) {
+    DefenceText->SetText(FText::AsNumber(Fighter.Stats.Defence));
+  }
+  if (HealthText) {
+    HealthText->SetText(FText::AsNumber(Fighter.Stats.Health));
+  }
+  if (AttackRangeText) {
+    AttackRangeText->SetText(FText::AsNumber(Fighter.Stats.AttackRange));
+  }
+  if (AttackDamageText) {
+    AttackDamageText->SetText(FText::AsNumber(Fighter.Stats.AttackDamage));
+  }
+  if (AttackDiceText) {
+    AttackDiceText->SetText(FText::AsNumber(Fighter.Stats.AttackDice));
+  }
+  if (MovementText) {
+    MovementText->SetText(FText::AsNumber(Fighter.Stats.Movement));
+  }
+  if (CostText) {
+    CostText->SetText(FText::AsNumber(Fighter.Stats.ArmyCost));
+  }
 }
 
 void UFighterEntryWidget::HandleClicked() {
@@ -25,6 +53,10 @@ void UFighterEntryWidget::HandleClicked() {
 
 void UFighterSelectionWidget::NativeConstruct() {
   Super::NativeConstruct();
+  if (LockInButton) {
+    LockInButton->OnClicked.AddDynamic(this, &UFighterSelectionWidget::LockIn);
+  }
+  UpdateCostDisplay();
   PopulateFighterList();
 }
 
@@ -54,7 +86,16 @@ bool UFighterSelectionWidget::ChooseFighter(const FFighterDefinition &Fighter) {
   ChosenFighters.Add(Fighter);
   CurrentCost += Fighter.Stats.ArmyCost;
   OnFighterChosen.Broadcast(Fighter);
+  UpdateCostDisplay();
   return true;
 }
 
 void UFighterSelectionWidget::LockIn() { OnLockedIn.Broadcast(); }
+
+void UFighterSelectionWidget::UpdateCostDisplay() {
+  if (CostDisplayText) {
+    CostDisplayText->SetText(FText::Format(FText::FromString("{0} / {1}"),
+                                          FText::AsNumber(CurrentCost),
+                                          FText::AsNumber(MaxCost)));
+  }
+}

--- a/Source/Skald/UI/FighterSelectionWidget.h
+++ b/Source/Skald/UI/FighterSelectionWidget.h
@@ -6,6 +6,7 @@
 
 class UButton;
 class UScrollBox;
+class UTextBlock;
 class UFighterSelectionWidget; // forward declare for entry widget
 
 /**
@@ -27,6 +28,42 @@ public:
   /** Button bound from the blueprint used to choose this fighter. */
   UPROPERTY(BlueprintReadOnly, meta = (BindWidget))
   UButton *SelectButton;
+
+  /** Name text bound from the blueprint. */
+  UPROPERTY(BlueprintReadOnly, meta = (BindWidget))
+  UTextBlock *NameText;
+
+  /** Strength display text. */
+  UPROPERTY(BlueprintReadOnly, meta = (BindWidget))
+  UTextBlock *StrengthText;
+
+  /** Defence display text. */
+  UPROPERTY(BlueprintReadOnly, meta = (BindWidget))
+  UTextBlock *DefenceText;
+
+  /** Health display text. */
+  UPROPERTY(BlueprintReadOnly, meta = (BindWidget))
+  UTextBlock *HealthText;
+
+  /** Attack range display text. */
+  UPROPERTY(BlueprintReadOnly, meta = (BindWidget))
+  UTextBlock *AttackRangeText;
+
+  /** Attack damage display text. */
+  UPROPERTY(BlueprintReadOnly, meta = (BindWidget))
+  UTextBlock *AttackDamageText;
+
+  /** Attack dice display text. */
+  UPROPERTY(BlueprintReadOnly, meta = (BindWidget))
+  UTextBlock *AttackDiceText;
+
+  /** Movement display text. */
+  UPROPERTY(BlueprintReadOnly, meta = (BindWidget))
+  UTextBlock *MovementText;
+
+  /** Army cost display text. */
+  UPROPERTY(BlueprintReadOnly, meta = (BindWidget))
+  UTextBlock *CostText;
 
   /** Fighter definition represented by this entry. */
   UPROPERTY(BlueprintReadOnly, Category = "Skald|Fighter")
@@ -84,6 +121,14 @@ public:
   UPROPERTY(BlueprintReadOnly, meta = (BindWidget))
   UScrollBox *FighterList;
 
+  /** Button that finalises the fighter selection. */
+  UPROPERTY(BlueprintReadOnly, meta = (BindWidget))
+  UButton *LockInButton;
+
+  /** Text displaying the current/maximum cost. */
+  UPROPERTY(BlueprintReadOnly, meta = (BindWidget))
+  UTextBlock *CostDisplayText;
+
   /** Blueprint class used for each fighter entry. */
   UPROPERTY(EditAnywhere, Category = "Skald|Fighter")
   TSubclassOf<UFighterEntryWidget> FighterEntryClass;
@@ -112,4 +157,8 @@ protected:
   /** Check whether a fighter can be afforded with remaining cost. */
   UFUNCTION(BlueprintCallable, Category = "Skald|Fighter")
   bool CanAfford(const FFighterDefinition &Fighter) const;
+
+  /** Update cost display text from current/max cost. */
+  UFUNCTION(BlueprintCallable, Category = "Skald|Fighter")
+  void UpdateCostDisplay();
 };


### PR DESCRIPTION
## Summary
- expose full fighter stat widgets in `UFighterEntryWidget`
- add lock-in button and cost display to fighter selection screen
- show additional stats (strength, defence, range, dice) on battle HUD

## Testing
- `clang++ -std=c++17 -c Source/Skald/UI/FighterSelectionWidget.cpp` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b5a679f3cc83248382cdc0331451d3