### PR TITLE
Initialize battle round on lock-in

### DIFF
--- a/Source/Skald/Skald_PlayerController.cpp
+++ b/Source/Skald/Skald_PlayerController.cpp
@@ -967,19 +967,24 @@ void ASkaldPlayerController::HandlePlayerLockedIn() {
         this, &ASkaldPlayerController::HandlePlayerLockedIn);
     Selection->RemoveFromParent();
 
-    if (CachedGameInstance && CachedGameInstance->GridBattleManager) {
-      TArray<FFighter> Fighters;
-      if (Selection) {
-        for (const FFighterDefinition &Def : Selection->ChosenFighters) {
-          FFighter Fighter;
-          Fighter.Stats = Def.Stats;
-          if (ASkaldPlayerState *PS = GetPlayerState<ASkaldPlayerState>()) {
-            Fighter.Faction = PS->Faction;
+      if (CachedGameInstance && CachedGameInstance->GridBattleManager) {
+        TArray<FFighter> Fighters;
+        if (Selection) {
+          for (const FFighterDefinition &Def : Selection->ChosenFighters) {
+            FFighter Fighter;
+            Fighter.Stats = Def.Stats;
+            if (ASkaldPlayerState *PS = GetPlayerState<ASkaldPlayerState>()) {
+              Fighter.Faction = PS->Faction;
+            }
+            Fighters.Add(Fighter);
           }
-          Fighters.Add(Fighter);
         }
-      }
       CachedGameInstance->GridBattleManager->InitBattle(Fighters, Fighters);
+      CachedGameInstance->GridBattleManager->RollInitiative();
+      CachedGameInstance->GridBattleManager->OnBattleEnded.AddDynamic(
+          this, &ASkaldPlayerController::HandleBattleEnded);
+      CachedGameInstance->GridBattleManager->StartRound(
+          CachedGameInstance->CombatRandomStream);
 
       if (BattleHUDWidgetClass) {
         BattleHudWidget =
@@ -1001,5 +1006,15 @@ void ASkaldPlayerController::HandlePlayerLockedIn() {
 
   if (MainHudWidget) {
     MainHudWidget->SetVisibility(ESlateVisibility::Collapsed);
+  }
+}
+
+void ASkaldPlayerController::HandleBattleEnded(ESkaldFaction WinningFaction,
+                                               int32 AttackerCasualties,
+                                               int32 DefenderCasualties) {
+  if (VictoryWidgetClass) {
+    if (UUserWidget *Widget = CreateWidget<UUserWidget>(this, VictoryWidgetClass)) {
+      Widget->AddToViewport();
+    }
   }
 }

--- a/Source/Skald/Skald_PlayerController.h
+++ b/Source/Skald/Skald_PlayerController.h
@@ -84,6 +84,10 @@ protected:
   UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category = "UI")
   TSubclassOf<UChoosePlayerWidget> ChoosePlayerWidgetClass;
 
+  /** Widget class used for displaying battle victory. */
+  UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category = "UI")
+  TSubclassOf<UUserWidget> VictoryWidgetClass;
+
   /** Reference to the HUD widget instance. */
   UPROPERTY(BlueprintReadOnly, Category = "UI",
             meta = (AllowPrivateAccess = "true"))
@@ -170,6 +174,12 @@ public:
   /** React to the player finishing their pre-game selection. */
   UFUNCTION()
   void HandlePlayerLockedIn();
+
+  /** React to the end of a battle. */
+  UFUNCTION()
+  void HandleBattleEnded(ESkaldFaction WinningFaction,
+                         int32 AttackerCasualties,
+                         int32 DefenderCasualties);
 
   /** Server-side processing of an attack request. */
   UFUNCTION(Server, Reliable)


### PR DESCRIPTION
## Summary
- roll initiative and start combat round after fighters are locked in
- bind battle-end delegate and handle with victory widget

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b779b76b548324b8b507ab08487cef