### PR TITLE
Add health widget and damage float for fighter pawns

### DIFF
--- a/Source/Skald/FighterPawn.cpp
+++ b/Source/Skald/FighterPawn.cpp
@@ -1,8 +1,10 @@
 #include "FighterPawn.h"
 #include "Components/StaticMeshComponent.h"
+#include "Components/TextBlock.h"
 #include "EngineUtils.h"
 #include "GridOverlayComponent.h"
 #include "Skald_GameInstance.h"
+#include "Blueprint/UserWidget.h"
 
 namespace {
 /** Size of a grid cell in world units. */
@@ -16,13 +18,29 @@ AFighterPawn::AFighterPawn() {
       CreateDefaultSubobject<UStaticMeshComponent>(TEXT("DisplayMesh"));
   RootComponent = DisplayMesh;
 
+  HealthWidget =
+      CreateDefaultSubobject<UWidgetComponent>(TEXT("HealthWidget"));
+  HealthWidget->SetupAttachment(DisplayMesh);
+
   ActionsRemaining = 0;
   CurrentCell = FIntPoint::ZeroValue;
+}
+
+void AFighterPawn::BeginPlay() {
+  Super::BeginPlay();
+
+  if (HealthWidget && HealthWidgetTemplate) {
+    HealthWidget->SetWidgetClass(HealthWidgetTemplate);
+  }
+
+  OnHealthChanged.AddDynamic(this, &AFighterPawn::UpdateHealthDisplay);
+  OnHealthChanged.Broadcast(Stats.Health);
 }
 
 void AFighterPawn::BeginActivation() { ActionsRemaining = Stats.Movement; }
 
 void AFighterPawn::MoveToCell(FIntPoint TargetCell) {
+  int32 OldHealth = Stats.Health;
   int32 Distance = FMath::Abs(TargetCell.X - CurrentCell.X) +
                    FMath::Abs(TargetCell.Y - CurrentCell.Y);
   if (Distance > ActionsRemaining) {
@@ -43,6 +61,10 @@ void AFighterPawn::MoveToCell(FIntPoint TargetCell) {
         break;
       }
     }
+  }
+
+  if (Stats.Health != OldHealth) {
+    OnHealthChanged.Broadcast(Stats.Health);
   }
 }
 
@@ -74,6 +96,20 @@ void AFighterPawn::PerformAttack(AFighterPawn *Target) {
     if (Roll >= RequiredRoll) {
       Target->Stats.Health =
           FMath::Max(0, Target->Stats.Health - Stats.AttackDamage);
+
+      if (DamageFloatWidgetTemplate && Target) {
+        if (UWorld *World = GetWorld()) {
+          if (UUserWidget *DamageWidget =
+                  CreateWidget<UUserWidget>(World, DamageFloatWidgetTemplate)) {
+            if (UTextBlock *Text =
+                    Cast<UTextBlock>(DamageWidget->GetWidgetFromName(
+                        TEXT("DamageText")))) {
+              Text->SetText(FText::AsNumber(Stats.AttackDamage));
+            }
+            DamageWidget->AddToViewport();
+          }
+        }
+      }
     }
   }
 
@@ -95,3 +131,15 @@ void AFighterPawn::PerformAttack(AFighterPawn *Target) {
 }
 
 bool AFighterPawn::IsAlive() const { return Stats.Health > 0; }
+
+void AFighterPawn::UpdateHealthDisplay(int32 NewHealth) {
+  if (!HealthWidget) {
+    return;
+  }
+  if (UUserWidget *Widget = HealthWidget->GetUserWidgetObject()) {
+    if (UTextBlock *Text =
+            Cast<UTextBlock>(Widget->GetWidgetFromName(TEXT("HealthText")))) {
+      Text->SetText(FText::AsNumber(NewHealth));
+    }
+  }
+}

--- a/Source/Skald/FighterPawn.h
+++ b/Source/Skald/FighterPawn.h
@@ -3,6 +3,8 @@
 #include "CoreMinimal.h"
 #include "GameFramework/Pawn.h"
 #include "GridBattleManager.h"
+#include "Components/WidgetComponent.h"
+#include "Blueprint/UserWidget.h"
 #include "FighterPawn.generated.h"
 
 DECLARE_DYNAMIC_MULTICAST_DELEGATE_OneParam(FOnHealthChanged, int32, NewHealth);
@@ -15,6 +17,8 @@ class SKALD_API AFighterPawn : public APawn
 
 public:
     AFighterPawn();
+
+    virtual void BeginPlay() override;
 
     /** Prepare the fighter for its activation. */
     UFUNCTION(BlueprintCallable, Category="Fighter")
@@ -44,11 +48,27 @@ public:
     UPROPERTY(VisibleAnywhere, BlueprintReadOnly)
     UStaticMeshComponent* DisplayMesh;
 
+    /** Widget displaying the current health. */
+    UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category="Fighter|UI")
+    UWidgetComponent* HealthWidget;
+
+    /** Widget class used for the health display. */
+    UPROPERTY(EditDefaultsOnly, Category="Fighter|UI")
+    TSubclassOf<UUserWidget> HealthWidgetTemplate;
+
+    /** Widget class used for optional damage float indicators. */
+    UPROPERTY(EditDefaultsOnly, Category="Fighter|UI")
+    TSubclassOf<UUserWidget> DamageFloatWidgetTemplate;
+
     /** Event broadcast when health changes. */
     UPROPERTY(BlueprintAssignable, Category="Fighter|Events")
     FOnHealthChanged OnHealthChanged;
 
 private:
+    /** Update the health widget with a new value. */
+    UFUNCTION()
+    void UpdateHealthDisplay(int32 NewHealth);
+
     /** Current cell occupied by the fighter. */
     FIntPoint CurrentCell;
 };


### PR DESCRIPTION
## Summary
- display fighter health via attached `UWidgetComponent`
- bind health change delegate to update widget text and show optional damage float widgets

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b77d7699b48324ba256448dda21a43