### PR TITLE
Handle battle resolution UI and server logic

### DIFF
--- a/Source/Skald/Skald_PlayerController.cpp
+++ b/Source/Skald/Skald_PlayerController.cpp
@@ -1084,9 +1084,18 @@ void ASkaldPlayerController::HandleGridClick() {
 void ASkaldPlayerController::HandleBattleEnded(ESkaldFaction WinningFaction,
                                                int32 AttackerCasualties,
                                                int32 DefenderCasualties) {
+  if (BattleHudWidget) {
+    BattleHudWidget->RemoveFromParent();
+    BattleHudWidget = nullptr;
+  }
+
   if (VictoryWidgetClass) {
     if (UUserWidget *Widget = CreateWidget<UUserWidget>(this, VictoryWidgetClass)) {
       Widget->AddToViewport();
     }
+  }
+
+  if (TurnManager) {
+    TurnManager->ResolveGridBattleResult();
   }
 }

--- a/Source/Skald/Skald_TurnManager.cpp
+++ b/Source/Skald/Skald_TurnManager.cpp
@@ -286,7 +286,7 @@ void ATurnManager::TriggerGridBattle(const FS_BattlePayload &Battle) {
   }
 }
 
-void ATurnManager::ResolveGridBattleResult() {
+void ATurnManager::ResolveGridBattleResult_Implementation() {
   USkaldGameInstance *GI = GetGameInstance<USkaldGameInstance>();
   if (!GI || !GI->GridBattleManager) {
     return;

--- a/Source/Skald/Skald_TurnManager.h
+++ b/Source/Skald/Skald_TurnManager.h
@@ -63,7 +63,7 @@ public:
     void TriggerGridBattle(const FS_BattlePayload& Battle);
 
     /** Apply the outcome of a completed grid battle to the world map. */
-    UFUNCTION(BlueprintCallable, Category="Battle")
+    UFUNCTION(Server, Reliable, BlueprintCallable, Category="Battle")
     void ResolveGridBattleResult();
 
     /** Multicast the results of a resolved battle to all clients. */


### PR DESCRIPTION
## Summary
- Remove battle HUD and show victory widget on battle end
- Mark `ATurnManager::ResolveGridBattleResult` as a server RPC and hook up client call

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b77efbbcbc8324864930046058ef12