### PR TITLE
Use landscape height for grid positions

### DIFF
--- a/Source/Skald/FighterPawn.cpp
+++ b/Source/Skald/FighterPawn.cpp
@@ -6,10 +6,6 @@
 #include "Skald_GameInstance.h"
 #include "Blueprint/UserWidget.h"
 
-namespace {
-/** Size of a grid cell in world units. */
-constexpr float CellSize = 100.f;
-} // namespace
 
 AFighterPawn::AFighterPawn() {
   PrimaryActorTick.bCanEverTick = false;
@@ -48,19 +44,21 @@ void AFighterPawn::MoveToCell(FIntPoint TargetCell) {
   }
 
   CurrentCell = TargetCell;
-  FVector NewLocation(TargetCell.X * CellSize, TargetCell.Y * CellSize,
-                      GetActorLocation().Z);
-  SetActorLocation(NewLocation);
-  ActionsRemaining -= Distance;
-
+  FVector NewLocation = GetActorLocation();
+  UGridOverlayComponent *Grid = nullptr;
   if (UWorld *World = GetWorld()) {
     for (TActorIterator<AActor> It(World); It; ++It) {
-      if (UGridOverlayComponent *Grid =
-              It->FindComponentByClass<UGridOverlayComponent>()) {
-        Grid->ClearHighlights();
+      if ((Grid = It->FindComponentByClass<UGridOverlayComponent>())) {
+        NewLocation = Grid->GridToWorld(TargetCell);
         break;
       }
     }
+  }
+  SetActorLocation(NewLocation);
+  ActionsRemaining -= Distance;
+
+  if (Grid) {
+    Grid->ClearHighlights();
   }
 
   if (Stats.Health != OldHealth) {

--- a/Source/Skald/GridOverlayComponent.cpp
+++ b/Source/Skald/GridOverlayComponent.cpp
@@ -2,6 +2,8 @@
 #include "Containers/Queue.h"
 #include "DrawDebugHelpers.h"
 #include "FighterPawn.h"
+#include "Engine/World.h"
+#include "Engine/EngineTypes.h"
 
 UGridOverlayComponent::UGridOverlayComponent() {
   PrimaryComponentTick.bCanEverTick = false;
@@ -17,6 +19,25 @@ void UGridOverlayComponent::BeginPlay() {
   if (AActor *Owner = GetOwner()) {
     Origin = Owner->GetActorLocation();
   }
+
+  CellHeights.Init(Origin.Z, Width * Height);
+
+  if (UWorld *World = GetWorld()) {
+    for (int32 Y = 0; Y < Height; ++Y) {
+      for (int32 X = 0; X < Width; ++X) {
+        const int32 Idx = Index(FIntPoint(X, Y));
+        FVector Start =
+            Origin + FVector((X + 0.5f) * CellSize, (Y + 0.5f) * CellSize, 10000.f);
+        FVector End = Start - FVector(0.f, 0.f, 20000.f);
+        FHitResult Hit;
+        if (World->LineTraceSingleByChannel(Hit, Start, End, ECC_WorldStatic)) {
+          CellHeights[Idx] = Hit.Location.Z;
+        } else {
+          CellHeights[Idx] = Start.Z;
+        }
+      }
+    }
+  }
 }
 
 FIntPoint
@@ -28,8 +49,12 @@ UGridOverlayComponent::WorldToGrid(const FVector &WorldLocation) const {
 }
 
 FVector UGridOverlayComponent::GridToWorld(const FIntPoint &GridCoord) const {
-  return Origin + FVector((GridCoord.X + 0.5f) * CellSize,
-                          (GridCoord.Y + 0.5f) * CellSize, 0.f);
+  FVector World = Origin + FVector((GridCoord.X + 0.5f) * CellSize,
+                                   (GridCoord.Y + 0.5f) * CellSize, 0.f);
+  if (IsValidGrid(GridCoord) && CellHeights.IsValidIndex(Index(GridCoord))) {
+    World.Z = CellHeights[Index(GridCoord)];
+  }
+  return World;
 }
 
 bool UGridOverlayComponent::IsValidGrid(const FIntPoint &GridCoord) const {
@@ -65,6 +90,7 @@ void UGridOverlayComponent::HighlightCell(const FIntPoint &GridCoord,
 
   FVector Center = GridToWorld(GridCoord);
   FVector Extent(CellSize * 0.5f, CellSize * 0.5f, 10.f);
+  Center.Z += Extent.Z; // raise the box above the ground
   DrawDebugSolidBox(GetWorld(), Center, Extent, Color, bPersistent, Duration);
 }
 

--- a/Source/Skald/GridOverlayComponent.h
+++ b/Source/Skald/GridOverlayComponent.h
@@ -69,6 +69,10 @@ protected:
   UPROPERTY()
   TArray<bool> Cells;
 
+  /** Cached world-space Z for each grid cell. */
+  UPROPERTY()
+  TArray<float> CellHeights;
+
   /** Get linear array index for a grid coordinate. */
   int32 Index(const FIntPoint &GridCoord) const;
 


### PR DESCRIPTION
## Summary
- sample grid cell heights from the landscape during BeginPlay
- return sampled height in GridToWorld and highlight boxes
- move fighters using GridOverlayComponent so they follow terrain

## Testing
- `clang++ -std=c++17 -I../Engine/Source -ISource -c Source/Skald/GridOverlayComponent.cpp` *(fails: 'Components/ActorComponent.h' file not found)*
- `clang++ -std=c++17 -I../Engine/Source -ISource -c Source/Skald/FighterPawn.cpp` *(fails: 'CoreMinimal.h' file not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b77fc2645c832488e94d048b5d73cd