### PR TITLE
Fallback grid height when terrain trace fails

### DIFF
--- a/Source/Skald/GridOverlayComponent.cpp
+++ b/Source/Skald/GridOverlayComponent.cpp
@@ -33,7 +33,7 @@ void UGridOverlayComponent::BeginPlay() {
         if (World->LineTraceSingleByChannel(Hit, Start, End, ECC_WorldStatic)) {
           CellHeights[Idx] = Hit.Location.Z;
         } else {
-          CellHeights[Idx] = Start.Z;
+          CellHeights[Idx] = Origin.Z;
         }
       }
     }


### PR DESCRIPTION
## Summary
- Use grid origin height instead of trace start height when terrain line trace fails

## Testing
- `bash Build/validate.sh`

------
https://chatgpt.com/codex/tasks/task_e_68b7823d7b888324a6c2b941a0a7a171