### PR TITLE
Add grid obstacle component

### DIFF
--- a/Source/Skald/GridObstacleComponent.cpp
+++ b/Source/Skald/GridObstacleComponent.cpp
@@ -1,0 +1,22 @@
+#include "GridObstacleComponent.h"
+#include "GridOverlayComponent.h"
+#include "EngineUtils.h"
+
+UGridObstacleComponent::UGridObstacleComponent() {
+  PrimaryComponentTick.bCanEverTick = false;
+}
+
+void UGridObstacleComponent::BeginPlay() {
+  Super::BeginPlay();
+
+  if (UWorld *World = GetWorld()) {
+    for (TActorIterator<AActor> It(World); It; ++It) {
+      if (UGridOverlayComponent *Grid =
+              It->FindComponentByClass<UGridOverlayComponent>()) {
+        Grid->RegisterObstacle(this);
+        break;
+      }
+    }
+  }
+}
+

--- a/Source/Skald/GridObstacleComponent.h
+++ b/Source/Skald/GridObstacleComponent.h
@@ -1,0 +1,34 @@
+#pragma once
+
+#include "Components/ActorComponent.h"
+#include "CoreMinimal.h"
+#include "GridObstacleComponent.generated.h"
+
+class UGridOverlayComponent;
+
+/**
+ * Component that marks an actor as a grid obstacle.
+ * Can be added to static mesh actors to control movement and line-of-sight blocking behaviour.
+ */
+UCLASS(ClassGroup = (Custom), meta = (BlueprintSpawnableComponent))
+class SKALD_API UGridObstacleComponent : public UActorComponent {
+  GENERATED_BODY()
+
+public:
+  UGridObstacleComponent();
+
+  virtual void BeginPlay() override;
+
+  /** Whether this obstacle blocks unit movement. */
+  UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Grid")
+  bool bBlocksMovement = true;
+
+  /** Whether this obstacle blocks line of sight. */
+  UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Grid")
+  bool bBlocksLineOfSight = true;
+
+  /** Whether units can climb over this obstacle. */
+  UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Grid")
+  bool bClimbable = false;
+};
+

--- a/Source/Skald/GridOverlayComponent.cpp
+++ b/Source/Skald/GridOverlayComponent.cpp
@@ -2,6 +2,7 @@
 #include "Containers/Queue.h"
 #include "DrawDebugHelpers.h"
 #include "FighterPawn.h"
+#include "GridObstacleComponent.h"
 #include "Engine/World.h"
 #include "Engine/EngineTypes.h"
 
@@ -97,6 +98,19 @@ void UGridOverlayComponent::HighlightCell(const FIntPoint &GridCoord,
 void UGridOverlayComponent::ClearHighlights() const {
   if (GetWorld()) {
     FlushPersistentDebugLines(GetWorld());
+  }
+}
+
+void UGridOverlayComponent::RegisterObstacle(UGridObstacleComponent *Obstacle) {
+  if (!Obstacle) {
+    return;
+  }
+  Obstacles.Add(Obstacle);
+  if (AActor *Owner = Obstacle->GetOwner()) {
+    FIntPoint Cell = WorldToGrid(Owner->GetActorLocation());
+    if (Obstacle->bBlocksMovement) {
+      SetOccupied(Cell, true);
+    }
   }
 }
 

--- a/Source/Skald/GridOverlayComponent.h
+++ b/Source/Skald/GridOverlayComponent.h
@@ -5,6 +5,7 @@
 #include "GridOverlayComponent.generated.h"
 
 class AFighterPawn;
+class UGridObstacleComponent;
 
 /**
  * Component that tracks grid cell occupancy and provides world/grid conversion.
@@ -50,7 +51,11 @@ public:
 
   /** Remove any persistent highlights. */
   UFUNCTION(BlueprintCallable, Category = "Grid")
-  void ClearHighlights() const;
+    void ClearHighlights() const;
+
+    /** Register an obstacle component so it can affect grid behaviour. */
+    UFUNCTION(BlueprintCallable, Category = "Grid")
+    void RegisterObstacle(UGridObstacleComponent *Obstacle);
 
 protected:
   /** Width of the grid in cells. */
@@ -77,5 +82,9 @@ protected:
   int32 Index(const FIntPoint &GridCoord) const;
 
   /** Check whether grid coordinate is inside bounds. */
-  bool IsValidGrid(const FIntPoint &GridCoord) const;
+    bool IsValidGrid(const FIntPoint &GridCoord) const;
+
+    /** Obstacles currently registered with this grid. */
+    UPROPERTY()
+    TArray<UGridObstacleComponent *> Obstacles;
 };


### PR DESCRIPTION
## Summary
- add UGridObstacleComponent to tag obstacles and configure blocking behavior
- allow grid overlay to register obstacles and mark their grid cells occupied

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b782fad00c83249b86eb7b63b65da3