### PR TITLE
Add obstacle height and obscuration tracking to grid overlay

### DIFF
--- a/Source/Skald/GridOverlayComponent.cpp
+++ b/Source/Skald/GridOverlayComponent.cpp
@@ -16,6 +16,7 @@ void UGridOverlayComponent::BeginPlay() {
   Width = 50;
   Height = 50;
   Cells.Init(false, Width * Height);
+  ObscuredCells.Init(false, Width * Height);
 
   if (AActor *Owner = GetOwner()) {
     Origin = Owner->GetActorLocation();
@@ -74,6 +75,20 @@ bool UGridOverlayComponent::IsOccupied(const FIntPoint &GridCoord) const {
   return Cells[Index(GridCoord)];
 }
 
+bool UGridOverlayComponent::IsObscured(const FIntPoint &GridCoord) const {
+  if (!IsValidGrid(GridCoord)) {
+    return false;
+  }
+  return ObscuredCells[Index(GridCoord)];
+}
+
+float UGridOverlayComponent::GetCellHeight(const FIntPoint &GridCoord) const {
+  if (!IsValidGrid(GridCoord)) {
+    return Origin.Z;
+  }
+  return CellHeights[Index(GridCoord)];
+}
+
 void UGridOverlayComponent::SetOccupied(const FIntPoint &GridCoord,
                                         bool bOccupied) {
   if (!IsValidGrid(GridCoord)) {
@@ -107,9 +122,25 @@ void UGridOverlayComponent::RegisterObstacle(UGridObstacleComponent *Obstacle) {
   }
   Obstacles.Add(Obstacle);
   if (AActor *Owner = Obstacle->GetOwner()) {
-    FIntPoint Cell = WorldToGrid(Owner->GetActorLocation());
-    if (Obstacle->bBlocksMovement) {
-      SetOccupied(Cell, true);
+    const FBox Bounds = Owner->GetComponentsBoundingBox(true);
+    const FIntPoint Min = WorldToGrid(Bounds.Min);
+    const FIntPoint Max = WorldToGrid(Bounds.Max);
+    for (int32 Y = Min.Y; Y <= Max.Y; ++Y) {
+      for (int32 X = Min.X; X <= Max.X; ++X) {
+        const FIntPoint Cell(X, Y);
+        if (!IsValidGrid(Cell)) {
+          continue;
+        }
+        const int32 Idx = Index(Cell);
+        if (Obstacle->bBlocksMovement && !Obstacle->bClimbable) {
+          Cells[Idx] = true;
+        }
+        ObscuredCells[Idx] = true;
+        if (Obstacle->bClimbable) {
+          CellHeights[Idx] = Bounds.Max.Z;
+          ObscuredCells[Idx] = false;
+        }
+      }
     }
   }
 }

--- a/Source/Skald/GridOverlayComponent.h
+++ b/Source/Skald/GridOverlayComponent.h
@@ -32,6 +32,14 @@ public:
   UFUNCTION(BlueprintCallable, BlueprintPure, Category = "Grid")
   bool IsOccupied(const FIntPoint &GridCoord) const;
 
+  /** Query whether a grid cell is obscured. */
+  UFUNCTION(BlueprintCallable, BlueprintPure, Category = "Grid")
+  bool IsObscured(const FIntPoint &GridCoord) const;
+
+  /** Get the cached height for a grid cell. */
+  UFUNCTION(BlueprintCallable, BlueprintPure, Category = "Grid")
+  float GetCellHeight(const FIntPoint &GridCoord) const;
+
   /** Mark a grid cell as occupied or free. */
   UFUNCTION(BlueprintCallable, Category = "Grid")
   void SetOccupied(const FIntPoint &GridCoord, bool bOccupied);
@@ -73,6 +81,10 @@ protected:
   /** Occupancy array; true if the cell is occupied. */
   UPROPERTY()
   TArray<bool> Cells;
+
+  /** Obscured array; true if the cell is blocked by an obstacle. */
+  UPROPERTY()
+  TArray<bool> ObscuredCells;
 
   /** Cached world-space Z for each grid cell. */
   UPROPERTY()


### PR DESCRIPTION
## Summary
- track obscured grid cells and per-cell heights
- expose grid queries for cell obscuration and height
- register obstacles by bounds, updating obscured cells and climbable heights

## Testing
- `clang++ -std=c++17 -fsyntax-only Source/Skald/GridOverlayComponent.cpp` *(fails: 'Components/ActorComponent.h' file not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b783c6203483248949a13f2c480a06