### PR TITLE
Expose widget class options in editor

### DIFF
--- a/Source/Skald/FighterPawn.h
+++ b/Source/Skald/FighterPawn.h
@@ -53,11 +53,11 @@ public:
     UWidgetComponent* HealthWidget;
 
     /** Widget class used for the health display. */
-    UPROPERTY(EditDefaultsOnly, Category="Fighter|UI")
+    UPROPERTY(EditDefaultsOnly, BlueprintReadWrite, Category="Fighter|UI")
     TSubclassOf<UUserWidget> HealthWidgetTemplate;
 
     /** Widget class used for optional damage float indicators. */
-    UPROPERTY(EditDefaultsOnly, Category="Fighter|UI")
+    UPROPERTY(EditDefaultsOnly, BlueprintReadWrite, Category="Fighter|UI")
     TSubclassOf<UUserWidget> DamageFloatWidgetTemplate;
 
     /** Event broadcast when health changes. */

--- a/Source/Skald/GridBattleManager.h
+++ b/Source/Skald/GridBattleManager.h
@@ -67,7 +67,7 @@ struct FFighterDefinition : public FTableRowBase
     UPROPERTY(EditAnywhere, BlueprintReadOnly, Category="Fighter")
     FName Id;
 
-    UPROPERTY(EditAnywhere, BlueprintReadOnly, Category="Fighter")
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="Fighter")
     TSubclassOf<AActor> MeshClass;
 
     UPROPERTY(EditAnywhere, BlueprintReadOnly, Category="Fighter")

--- a/Source/Skald/LobbyGameMode.h
+++ b/Source/Skald/LobbyGameMode.h
@@ -18,7 +18,7 @@ public:
     virtual void BeginPlay() override;
 
 protected:
-    UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category = "UI")
+    UPROPERTY(EditDefaultsOnly, BlueprintReadWrite, Category = "UI")
     TSubclassOf<class UUserWidget> LobbyWidgetClass;
 };
 

--- a/Source/Skald/LobbyMenuWidget.h
+++ b/Source/Skald/LobbyMenuWidget.h
@@ -36,13 +36,13 @@ public:
     UPROPERTY(BlueprintReadOnly, Category="Skald|Widgets", meta=(BindWidgetOptional))
     UButton* ExitButton;
 
-    UPROPERTY(EditAnywhere, Category="Lobby")
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="Lobby")
     TSubclassOf<ULoadGameWidget> LoadGameWidgetClass;
 
-    UPROPERTY(EditAnywhere, Category="Lobby")
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="Lobby")
     TSubclassOf<USettingsWidget> SettingsWidgetClass;
 
-    UPROPERTY(EditAnywhere, Category="Lobby")
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="Lobby")
     TSubclassOf<UStartGameWidget> StartGameWidgetClass;
 
 protected:

--- a/Source/Skald/Skald_PlayerController.h
+++ b/Source/Skald/Skald_PlayerController.h
@@ -81,19 +81,19 @@ protected:
 
   /** Widget class to instantiate for the player's HUD.
    *  Settable via Blueprint or loaded in the constructor. */
-  UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category = "UI")
+  UPROPERTY(EditDefaultsOnly, BlueprintReadWrite, Category = "UI")
   TSubclassOf<UUserWidget> HUDWidgetClass;
 
   /** Widget class used for in-battle HUD. */
-  UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category = "UI")
+  UPROPERTY(EditDefaultsOnly, BlueprintReadWrite, Category = "UI")
   TSubclassOf<UBattleHUDWidget> BattleHUDWidgetClass;
 
   /** Widget class used for the player faction selection screen. */
-  UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category = "UI")
+  UPROPERTY(EditDefaultsOnly, BlueprintReadWrite, Category = "UI")
   TSubclassOf<UChoosePlayerWidget> ChoosePlayerWidgetClass;
 
   /** Widget class used for displaying battle victory. */
-  UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category = "UI")
+  UPROPERTY(EditDefaultsOnly, BlueprintReadWrite, Category = "UI")
   TSubclassOf<UUserWidget> VictoryWidgetClass;
 
   /** Reference to the HUD widget instance. */

--- a/Source/Skald/UI/FighterSelectionWidget.h
+++ b/Source/Skald/UI/FighterSelectionWidget.h
@@ -130,7 +130,7 @@ public:
   UTextBlock *CostDisplayText;
 
   /** Blueprint class used for each fighter entry. */
-  UPROPERTY(EditAnywhere, Category = "Skald|Fighter")
+  UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Skald|Fighter")
   TSubclassOf<UFighterEntryWidget> FighterEntryClass;
 
   /** Delegate fired when Lock In is triggered. */

--- a/Source/Skald/WorldMap.h
+++ b/Source/Skald/WorldMap.h
@@ -101,7 +101,7 @@ public:
   bool MoveBetween(ATerritory *From, ATerritory *To, int32 Troops);
 
   /** Actor class used when spawning territory instances. */
-  UPROPERTY(EditAnywhere, Category = "WorldMap")
+  UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "WorldMap")
   TSubclassOf<ATerritory> TerritoryClass;
 
   /** Data table defining territories to spawn. */


### PR DESCRIPTION
## Summary
- expose fighter, lobby, and world map widget subclasses for selection in class defaults
- allow controller and pawn HUD widget templates to be set in editor

## Testing
- `clang++ -std=c++17 -I../Engine/Source -ISource -c Source/Skald/UI/FighterSelectionWidget.cpp` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b78914bb248324bdb3add44e537f65