### PR TITLE
Fix assignment within conditional expressions in FighterPawn

### DIFF
--- a/Source/Skald/FighterPawn.cpp
+++ b/Source/Skald/FighterPawn.cpp
@@ -45,7 +45,8 @@ void AFighterPawn::MoveToCell(FIntPoint TargetCell) {
   UGridOverlayComponent *Grid = nullptr;
   if (UWorld *World = GetWorld()) {
     for (TActorIterator<AActor> It(World); It; ++It) {
-      if ((Grid = It->FindComponentByClass<UGridOverlayComponent>())) {
+      Grid = It->FindComponentByClass<UGridOverlayComponent>();
+      if (Grid != nullptr) {
         break;
       }
     }
@@ -86,7 +87,8 @@ void AFighterPawn::PerformAttack(AFighterPawn *Target) {
   UGridOverlayComponent *Grid = nullptr;
   if (UWorld *World = GetWorld()) {
     for (TActorIterator<AActor> It(World); It; ++It) {
-      if ((Grid = It->FindComponentByClass<UGridOverlayComponent>())) {
+      Grid = It->FindComponentByClass<UGridOverlayComponent>();
+      if (Grid != nullptr) {
         break;
       }
     }


### PR DESCRIPTION
## Summary
- Avoid assignment in conditional expressions when locating the grid overlay component

## Testing
- `g++ -std=c++17 -c Source/Skald/FighterPawn.cpp` *(fails: CoreMinimal.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b78f79c49c8324a20c9da6fd74f5c0