### PR TITLE
Refactor turn flow and cleanup player controller

### DIFF
--- a/Source/Skald/Skald_GameState.cpp
+++ b/Source/Skald/Skald_GameState.cpp
@@ -32,3 +32,15 @@ ASkaldPlayerState* ASkaldGameState::GetCurrentPlayer() const
     return Players.IsValidIndex(CurrentTurnIndex) ? Players[CurrentTurnIndex] : nullptr;
 }
 
+ASkaldPlayerState* ASkaldGameState::GetPlayerById(int32 PlayerID) const
+{
+    for (ASkaldPlayerState* PS : Players)
+    {
+        if (PS && PS->GetPlayerId() == PlayerID)
+        {
+            return PS;
+        }
+    }
+    return nullptr;
+}
+

--- a/Source/Skald/Skald_GameState.h
+++ b/Source/Skald/Skald_GameState.h
@@ -37,5 +37,9 @@ public:
 
     UFUNCTION(BlueprintCallable, BlueprintPure, Category="GameState")
     ASkaldPlayerState* GetCurrentPlayer() const;
+
+    /** Retrieve a player state by its PlayerID. */
+    UFUNCTION(BlueprintCallable, BlueprintPure, Category="GameState")
+    ASkaldPlayerState* GetPlayerById(int32 PlayerID) const;
 };
 

--- a/Source/Skald/Skald_PlayerController.cpp
+++ b/Source/Skald/Skald_PlayerController.cpp
@@ -27,10 +27,6 @@
 
 constexpr int32 MaxAIIterations = 100;
 
-namespace {
-TWeakObjectPtr<UFighterSelectionWidget> GFighterSelectionWidget;
-}
-
 ASkaldPlayerController::ASkaldPlayerController() {
   bIsAI = false;
   TurnManager = nullptr;
@@ -152,7 +148,7 @@ void ASkaldPlayerController::BeginPlay() {
     if (UFighterSelectionWidget *Selection =
             CreateWidget<UFighterSelectionWidget>(
                 this, UFighterSelectionWidget::StaticClass())) {
-      GFighterSelectionWidget = Selection;
+      FighterSelectionWidget = Selection;
       if (CachedGameInstance && CachedGameInstance->GridBattleManager) {
         if (ASkaldPlayerState *PS = GetPlayerState<ASkaldPlayerState>()) {
           const ESkaldFaction PlayerFaction = PS->Faction;
@@ -244,50 +240,16 @@ void ASkaldPlayerController::StartTurn() {
 
 void ASkaldPlayerController::EndTurn() {
   SetInputMode(FInputModeGameOnly());
-
-  if (!TurnManager) {
-    UE_LOG(
-        LogSkald, Warning,
-        TEXT("EndTurn called without a TurnManager. Attempting to reacquire."));
-
-    if (!CachedGameMode) {
-      CachedGameMode = GetWorld()->GetAuthGameMode<ASkaldGameMode>();
-    }
-
-    if (CachedGameMode) {
-      SetTurnManager(CachedGameMode->GetTurnManager());
-    }
-
-    if (!TurnManager) {
-      UE_LOG(LogSkald, Warning,
-             TEXT("TurnManager still missing; aborting EndTurn."));
-      return;
-    }
+  if (!EnsureTurnManager(TEXT("EndTurn"))) {
+    return;
   }
 
   TurnManager->AdvanceTurn();
 }
 
 void ASkaldPlayerController::EndPhase() {
-  if (!TurnManager) {
-    UE_LOG(
-        LogSkald, Warning,
-        TEXT(
-            "EndPhase called without a TurnManager. Attempting to reacquire."));
-
-    if (!CachedGameMode) {
-      CachedGameMode = GetWorld()->GetAuthGameMode<ASkaldGameMode>();
-    }
-
-    if (CachedGameMode) {
-      SetTurnManager(CachedGameMode->GetTurnManager());
-    }
-
-    if (!TurnManager) {
-      UE_LOG(LogSkald, Warning,
-             TEXT("TurnManager still missing; aborting EndPhase."));
-      return;
-    }
+  if (!EnsureTurnManager(TEXT("EndPhase"))) {
+    return;
   }
 
   ETurnPhase Phase = TurnManager->GetCurrentPhase();
@@ -879,6 +841,32 @@ void ASkaldPlayerController::NotifyActionError_Implementation(
   }
 }
 
+bool ASkaldPlayerController::EnsureTurnManager(const TCHAR *Caller) {
+  if (TurnManager) {
+    return true;
+  }
+
+  UE_LOG(LogSkald, Warning,
+         TEXT("%s called without a TurnManager. Attempting to reacquire."),
+         Caller);
+
+  if (!CachedGameMode) {
+    CachedGameMode = GetWorld()->GetAuthGameMode<ASkaldGameMode>();
+  }
+
+  if (CachedGameMode) {
+    SetTurnManager(CachedGameMode->GetTurnManager());
+  }
+
+  if (!TurnManager) {
+    UE_LOG(LogSkald, Warning,
+           TEXT("TurnManager still missing; aborting %s."), Caller);
+    return false;
+  }
+
+  return true;
+}
+
 void ASkaldPlayerController::BuildPlayerDataArray(
     TArray<FS_PlayerData> &OutPlayers) const {
   OutPlayers.Reset();
@@ -967,8 +955,8 @@ void ASkaldPlayerController::HandlePlayerLockedIn() {
         this, &ASkaldPlayerController::HandlePlayerLockedIn);
     ChoosePlayerWidget->RemoveFromParent();
   }
-  if (GFighterSelectionWidget.IsValid()) {
-    UFighterSelectionWidget *Selection = GFighterSelectionWidget.Get();
+  if (FighterSelectionWidget) {
+    UFighterSelectionWidget *Selection = FighterSelectionWidget;
     Selection->OnLockedIn.RemoveDynamic(
         this, &ASkaldPlayerController::HandlePlayerLockedIn);
     Selection->RemoveFromParent();
@@ -1006,7 +994,7 @@ void ASkaldPlayerController::HandlePlayerLockedIn() {
         }
       }
     }
-    GFighterSelectionWidget = nullptr;
+    FighterSelectionWidget = nullptr;
   }
 
   // Restore game controls now that the player has locked in

--- a/Source/Skald/Skald_PlayerController.h
+++ b/Source/Skald/Skald_PlayerController.h
@@ -14,6 +14,7 @@ class ATerritory;
 class ASkaldGameMode;
 class ASkaldGameState;
 class USkaldGameInstance;
+class UFighterSelectionWidget;
 
 /** Command issued by the player during a battle. */
 UENUM()
@@ -110,6 +111,11 @@ protected:
   UPROPERTY(BlueprintReadOnly, Category = "UI",
             meta = (AllowPrivateAccess = "true"))
   TObjectPtr<UBattleHUDWidget> BattleHudWidget;
+
+  /** Fighter selection widget used during battle setup. */
+  UPROPERTY(BlueprintReadOnly, Category = "UI",
+            meta = (AllowPrivateAccess = "true"))
+  TObjectPtr<UFighterSelectionWidget> FighterSelectionWidget;
 
   /** Player selection widget instance. */
   UPROPERTY(BlueprintReadOnly, Category = "UI",
@@ -269,4 +275,7 @@ private:
 
   UFUNCTION(Client, Reliable)
   void NotifyActionError(const FString &Message);
+
+  /** Ensure a valid TurnManager is available, attempting reacquisition if needed. */
+  bool EnsureTurnManager(const TCHAR *Caller);
 };

--- a/Source/Skald/Skald_TurnManager.cpp
+++ b/Source/Skald/Skald_TurnManager.cpp
@@ -5,6 +5,7 @@
 #include "Skald_GameInstance.h"
 #include "Skald_PlayerController.h"
 #include "Skald_PlayerState.h"
+#include "Skald_GameState.h"
 #include "GridBattleManager.h"
 #include "Territory.h"
 #include "UI/SkaldMainHUDWidget.h"
@@ -380,11 +381,8 @@ void ATurnManager::ClientBattleResolved_Implementation(
     }
     if (Target) {
       ASkaldPlayerState *NewOwner = nullptr;
-      for (TActorIterator<ASkaldPlayerState> It(GetWorld()); It; ++It) {
-        if (It->GetPlayerId() == NewOwnerPlayerID) {
-          NewOwner = *It;
-          break;
-        }
+      if (ASkaldGameState *GS = GetWorld()->GetGameState<ASkaldGameState>()) {
+        NewOwner = GS->GetPlayerById(NewOwnerPlayerID);
       }
       Target->OwningPlayer = NewOwner;
       Target->ArmyUnits = TargetArmy;
@@ -421,17 +419,23 @@ void ATurnManager::AdvancePhase() {
     return;
   }
 
-  if (CurrentPhase == ETurnPhase::Attack) {
+  switch (CurrentPhase) {
+  case ETurnPhase::Attack:
     CurrentPhase = ETurnPhase::Engineering;
-  } else if (CurrentPhase == ETurnPhase::Engineering) {
+    break;
+  case ETurnPhase::Engineering:
     CurrentPhase = ETurnPhase::Treasure;
-  } else if (CurrentPhase == ETurnPhase::Treasure) {
+    break;
+  case ETurnPhase::Treasure:
     CurrentPhase = ETurnPhase::Movement;
-  } else if (CurrentPhase == ETurnPhase::Movement) {
+    break;
+  case ETurnPhase::Movement:
     CurrentPhase = ETurnPhase::EndTurn;
-  } else if (CurrentPhase == ETurnPhase::EndTurn) {
+    break;
+  case ETurnPhase::EndTurn:
     CurrentPhase = ETurnPhase::Revolt;
-  } else {
+    break;
+  default:
     return;
   }
 

--- a/Source/Skald/WorldMap.cpp
+++ b/Source/Skald/WorldMap.cpp
@@ -39,7 +39,8 @@ void AWorldMap::BeginPlay() {
     if (GEngine) {
       GEngine->AddOnScreenDebugMessage(
           -1, 5.f, FColor::Red,
-          FString::Printf(TEXT("WorldMap %s missing TerritoryTable"),
+          FString::Printf(TEXT("WorldMap %s missing TerritoryTable."
+                               " Expected /Game/DataTables/TerritoriesDataTable"),
                           *GetName()));
     }
 
@@ -50,6 +51,7 @@ void AWorldMap::BeginPlay() {
     if (Placeholder) {
       Placeholder->TerritoryID = -1;
       Placeholder->TerritoryName = TEXT("Placeholder Territory");
+      RegisterTerritory(Placeholder);
     }
 
     return;


### PR DESCRIPTION
## Summary
- streamline phase advancement with a switch and use game state lookup for battle resolution
- introduce player-id lookup on the game state and encapsulate turn manager reacquisition
- remove global fighter selection widget and register placeholder territories when data table is missing

## Testing
- `clang++ -fsyntax-only Source/Skald/Skald_TurnManager.cpp Source/Skald/Skald_GameState.cpp Source/Skald/Skald_PlayerController.cpp Source/Skald/WorldMap.cpp` *(fails: 'CoreMinimal.h' file not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b7904e4ffc8324aecdbb0813b72bec