### PR TITLE
Add grid obstacle actor and respect line-of-sight blocking

### DIFF
--- a/Source/Skald/GridObstacleActor.cpp
+++ b/Source/Skald/GridObstacleActor.cpp
@@ -1,0 +1,14 @@
+#include "GridObstacleActor.h"
+#include "Components/StaticMeshComponent.h"
+#include "GridObstacleComponent.h"
+
+AGridObstacleActor::AGridObstacleActor()
+{
+    PrimaryActorTick.bCanEverTick = false;
+
+    MeshComponent = CreateDefaultSubobject<UStaticMeshComponent>(TEXT("Mesh"));
+    RootComponent = MeshComponent;
+
+    GridObstacle = CreateDefaultSubobject<UGridObstacleComponent>(TEXT("GridObstacle"));
+}
+

--- a/Source/Skald/GridObstacleActor.h
+++ b/Source/Skald/GridObstacleActor.h
@@ -1,0 +1,30 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "GameFramework/Actor.h"
+#include "GridObstacleActor.generated.h"
+
+class UStaticMeshComponent;
+class UGridObstacleComponent;
+
+/**
+ * Actor wrapper for a static mesh that participates in grid obstacle logic.
+ * Place in a level for walls or props that block movement or line of sight.
+ */
+UCLASS()
+class SKALD_API AGridObstacleActor : public AActor
+{
+    GENERATED_BODY()
+
+public:
+    AGridObstacleActor();
+
+    /** Mesh representing the obstacle. */
+    UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "Obstacle")
+    UStaticMeshComponent* MeshComponent;
+
+    /** Component controlling movement and vision blocking behaviour. */
+    UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "Obstacle")
+    UGridObstacleComponent* GridObstacle;
+};
+

--- a/Source/Skald/GridOverlayComponent.cpp
+++ b/Source/Skald/GridOverlayComponent.cpp
@@ -130,13 +130,17 @@ void UGridOverlayComponent::RegisterObstacle(UGridObstacleComponent *Obstacle) {
           continue;
         }
         const int32 Idx = Index(Cell);
-        if (Obstacle->bBlocksMovement && !Obstacle->bClimbable) {
-          Cells[Idx] = true;
-        }
-        ObscuredCells[Idx] = true;
         if (Obstacle->bClimbable) {
           CellHeights[Idx] = Bounds.Max.Z;
+          Cells[Idx] = false;
           ObscuredCells[Idx] = false;
+        } else {
+          if (Obstacle->bBlocksMovement) {
+            Cells[Idx] = true;
+          }
+          if (Obstacle->bBlocksLineOfSight) {
+            ObscuredCells[Idx] = true;
+          }
         }
       }
     }


### PR DESCRIPTION
## Summary
- introduce `AGridObstacleActor` combining a static mesh with `UGridObstacleComponent`
- update grid overlay obstacle registration to honour line-of-sight and climbable flags

## Testing
- `bash Build/validate.sh` *(fails: UnrealBuildTool not found; UnrealEditor not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b7a761a28083249e486ddb0c95fd02