### PR TITLE
Create battle manager on demand

### DIFF
--- a/Source/Skald/Skald_GameInstance.cpp
+++ b/Source/Skald/Skald_GameInstance.cpp
@@ -1,4 +1,5 @@
 #include "Skald_GameInstance.h"
+#include "GridBattleManager.h"
 
 void USkaldGameInstance::Init()
 {
@@ -9,5 +10,14 @@ void USkaldGameInstance::Init()
 void USkaldGameInstance::SeedCombatRandomStream(int32 Seed)
 {
     CombatRandomStream.Initialize(Seed);
+}
+
+UGridBattleManager* USkaldGameInstance::GetGridBattleManager()
+{
+    if (!GridBattleManager)
+    {
+        GridBattleManager = NewObject<UGridBattleManager>(this);
+    }
+    return GridBattleManager;
 }
 

--- a/Source/Skald/Skald_GameInstance.h
+++ b/Source/Skald/Skald_GameInstance.h
@@ -47,6 +47,10 @@ public:
     UPROPERTY(BlueprintReadWrite, Category="Battle")
     class UGridBattleManager* GridBattleManager = nullptr;
 
+    /** Accessor that lazily creates the grid battle manager when first requested. */
+    UFUNCTION(BlueprintCallable, Category="Battle")
+    UGridBattleManager* GetGridBattleManager();
+
     /** Random stream used for deterministic combat rolls. */
     UPROPERTY()
     FRandomStream CombatRandomStream;

--- a/Source/Skald/Skald_TurnManager.cpp
+++ b/Source/Skald/Skald_TurnManager.cpp
@@ -269,9 +269,7 @@ void ATurnManager::TriggerGridBattle(const FS_BattlePayload &Battle) {
   if (USkaldGameInstance *GI = GetGameInstance<USkaldGameInstance>()) {
     GI->SeedCombatRandomStream(SeededBattle.RandomSeed);
     GI->PendingBattle = SeededBattle;
-    if (!GI->GridBattleManager) {
-      GI->GridBattleManager = NewObject<UGridBattleManager>(GI);
-    }
+    GI->GetGridBattleManager();
   }
 
   // Save the current turn state so it can be restored after travelling.


### PR DESCRIPTION
## Summary
- Add `GetGridBattleManager` to lazily instantiate the grid battle manager in `USkaldGameInstance`
- Use new accessor from turn manager when triggering grid battles

## Testing
- `npm test` *(fails: package.json missing)*
- `pytest` *(no tests found)*
- `clang++ -std=c++17 -I./Source -c Source/Skald/Skald_GameInstance.cpp -o /tmp/Skald_GameInstance.o` *(fails: 'CoreMinimal.h' file not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b7b60c9ee8832492856ef8393d82de