### PR TITLE
Add landscape support to grid overlay

### DIFF
--- a/Source/Skald/GridOverlayComponent.cpp
+++ b/Source/Skald/GridOverlayComponent.cpp
@@ -5,6 +5,8 @@
 #include "Engine/World.h"
 #include "FighterPawn.h"
 #include "GridObstacleComponent.h"
+#include "Landscape.h"
+#include "LandscapeComponent.h"
 
 UGridOverlayComponent::UGridOverlayComponent() {
   PrimaryComponentTick.bCanEverTick = false;
@@ -34,6 +36,9 @@ void UGridOverlayComponent::BeginPlay() {
         FHitResult Hit;
         if (World->LineTraceSingleByChannel(Hit, Start, End, ECC_WorldStatic)) {
           CellHeights[Idx] = Hit.Location.Z;
+          if (Hit.Component && Hit.Component->IsA<ULandscapeComponent>()) {
+            HandleLandscapeHit(Hit, FIntPoint(X, Y), Idx);
+          }
         } else {
           CellHeights[Idx] = Origin.Z;
         }
@@ -144,6 +149,21 @@ void UGridOverlayComponent::RegisterObstacle(UGridObstacleComponent *Obstacle) {
         }
       }
     }
+  }
+}
+
+void UGridOverlayComponent::HandleLandscapeHit(const FHitResult &Hit,
+                                               const FIntPoint &Cell,
+                                               int32 CellIndex) {
+  if (!bTreatLandscapeAsObstacle) {
+    return;
+  }
+  const FVector Normal = Hit.Normal.GetSafeNormal();
+  const float Slope = FMath::RadiansToDegrees(
+      FMath::Acos(FVector::DotProduct(Normal, FVector::UpVector)));
+  if (Slope >= LandscapeSlopeThreshold) {
+    Cells[CellIndex] = true;
+    ObscuredCells[CellIndex] = true;
   }
 }
 

--- a/Source/Skald/GridOverlayComponent.h
+++ b/Source/Skald/GridOverlayComponent.h
@@ -6,6 +6,7 @@
 
 class AFighterPawn;
 class UGridObstacleComponent;
+struct FHitResult;
 
 /**
  * Component that tracks grid cell occupancy and provides world/grid conversion.
@@ -65,6 +66,15 @@ public:
     UFUNCTION(BlueprintCallable, Category = "Grid")
     void RegisterObstacle(UGridObstacleComponent *Obstacle);
 
+  /** Whether landscape should be treated as an obstacle based on slope. */
+  UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Grid|Landscape")
+  bool bTreatLandscapeAsObstacle = true;
+
+  /** Minimum slope angle for landscape to block movement or sight. */
+  UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Grid|Landscape",
+            meta = (EditCondition = "bTreatLandscapeAsObstacle"))
+  float LandscapeSlopeThreshold = 45.f;
+
 protected:
   /** Width of the grid in cells. */
   int32 Width = 0;
@@ -99,4 +109,8 @@ protected:
     /** Obstacles currently registered with this grid. */
     UPROPERTY()
     TArray<UGridObstacleComponent *> Obstacles;
+
+    /** Process a landscape hit to potentially flag a cell as blocked. */
+    void HandleLandscapeHit(const FHitResult &Hit, const FIntPoint &Cell,
+                            int32 CellIndex);
 };


### PR DESCRIPTION
## Summary
- support landscapes contributing to grid occupancy and line-of-sight
- allow tuning landscape obstacle behavior via Blueprint properties

## Testing
- `bash Build/validate.sh > /tmp/validate.log 2>&1 && tail -n 20 /tmp/validate.log`


------
https://chatgpt.com/codex/tasks/task_e_68b7d40f3d088324929c9b55e0c52b5d