### PR TITLE
feat: randomize battle maps

### DIFF
--- a/Source/Skald/Skald_GameMode.cpp
+++ b/Source/Skald/Skald_GameMode.cpp
@@ -81,7 +81,18 @@ void ASkaldGameMode::BeginPlay() {
   // Auto-select fighters for AI players on the battle map
   const FString CurrentLevel =
       UGameplayStatics::GetCurrentLevelName(this, true);
-  if (CurrentLevel.Equals(TEXT("BattleMap"), ESearchCase::IgnoreCase)) {
+  bool bIsBattleMap = CurrentLevel.Equals(TEXT("BattleMap"),
+                                         ESearchCase::IgnoreCase);
+  if (TurnManager) {
+    for (const TSoftObjectPtr<UWorld> &Map : TurnManager->BattleMaps) {
+      if (CurrentLevel.Equals(Map.ToSoftObjectPath().GetAssetName(),
+                             ESearchCase::IgnoreCase)) {
+        bIsBattleMap = true;
+        break;
+      }
+    }
+  }
+  if (bIsBattleMap) {
     if (USkaldGameInstance *GI = GetGameInstance<USkaldGameInstance>()) {
       if (GI->GridBattleManager) {
         ASkaldGameState *GS = GetGameState<ASkaldGameState>();

--- a/Source/Skald/Skald_PlayerController.cpp
+++ b/Source/Skald/Skald_PlayerController.cpp
@@ -144,19 +144,30 @@ void ASkaldPlayerController::BeginPlay() {
   }
 
   const FString CurrentMap = UGameplayStatics::GetCurrentLevelName(this, true);
-  if (CurrentMap.Equals(TEXT("BattleMap"), ESearchCase::IgnoreCase)) {
+  bool bIsBattleMap = CurrentMap.Equals(TEXT("BattleMap"),
+                                        ESearchCase::IgnoreCase);
+  if (ATurnManager *TM = Cast<ATurnManager>(UGameplayStatics::GetActorOfClass(
+          GetWorld(), ATurnManager::StaticClass()))) {
+    for (const TSoftObjectPtr<UWorld> &Map : TM->BattleMaps) {
+      if (CurrentMap.Equals(Map.ToSoftObjectPath().GetAssetName(),
+                           ESearchCase::IgnoreCase)) {
+        bIsBattleMap = true;
+        break;
+      }
+    }
+  }
+
+  if (bIsBattleMap && CachedGameInstance && CachedGameInstance->GridBattleManager) {
     if (UFighterSelectionWidget *Selection =
             CreateWidget<UFighterSelectionWidget>(
                 this, UFighterSelectionWidget::StaticClass())) {
       FighterSelectionWidget = Selection;
-      if (CachedGameInstance && CachedGameInstance->GridBattleManager) {
-        if (ASkaldPlayerState *PS = GetPlayerState<ASkaldPlayerState>()) {
-          const ESkaldFaction PlayerFaction = PS->Faction;
-          Selection->PlayerFaction = PlayerFaction;
-          Selection->AvailableFighters =
-              CachedGameInstance->GridBattleManager->GetFightersForFaction(
-                  PlayerFaction);
-        }
+      if (ASkaldPlayerState *PS = GetPlayerState<ASkaldPlayerState>()) {
+        const ESkaldFaction PlayerFaction = PS->Faction;
+        Selection->PlayerFaction = PlayerFaction;
+        Selection->AvailableFighters =
+            CachedGameInstance->GridBattleManager->GetFightersForFaction(
+                PlayerFaction);
       }
       Selection->OnLockedIn.AddDynamic(
           this, &ASkaldPlayerController::HandlePlayerLockedIn);

--- a/Source/Skald/Skald_TurnManager.cpp
+++ b/Source/Skald/Skald_TurnManager.cpp
@@ -13,12 +13,19 @@
 #include "Skald_GameMode.h"
 #include "Engine/World.h"
 #include "EngineUtils.h"
+#include "Net/UnrealNetwork.h"
 
 ATurnManager::ATurnManager() {
   PrimaryActorTick.bCanEverTick = false;
   bReplicates = true;
   CurrentIndex = 0;
   CachedWorldMap = nullptr;
+}
+
+void ATurnManager::GetLifetimeReplicatedProps(
+    TArray<FLifetimeProperty>& OutLifetimeProps) const {
+  Super::GetLifetimeReplicatedProps(OutLifetimeProps);
+  DOREPLIFETIME(ATurnManager, BattleMaps);
 }
 
 void ATurnManager::BeginPlay() {
@@ -283,7 +290,16 @@ void ATurnManager::TriggerGridBattle(const FS_BattlePayload &Battle) {
 
   // Load a battle map where the grid based combat takes place.
   if (UWorld *World = GetWorld()) {
-    World->ServerTravel(TEXT("BattleMap"));
+    FString MapToLoad = TEXT("BattleMap");
+    if (BattleMaps.Num() > 0) {
+      const int32 Index = FMath::RandRange(0, BattleMaps.Num() - 1);
+      const FString Selected =
+          BattleMaps[Index].ToSoftObjectPath().GetLongPackageName();
+      if (!Selected.IsEmpty()) {
+        MapToLoad = Selected;
+      }
+    }
+    World->ServerTravel(MapToLoad);
   }
 }
 

--- a/Source/Skald/Skald_TurnManager.h
+++ b/Source/Skald/Skald_TurnManager.h
@@ -8,6 +8,7 @@
 class ASkaldPlayerController;
 class ASkaldPlayerState;
 class AWorldMap;
+class UWorld;
 
 // Broadcast whenever the overall world state changes so HUDs can refresh.
 DECLARE_DYNAMIC_MULTICAST_DELEGATE(FSkaldWorldStateChanged);
@@ -24,6 +25,9 @@ public:
     ATurnManager();
 
     virtual void BeginPlay() override;
+
+    virtual void GetLifetimeReplicatedProps(
+        TArray<FLifetimeProperty>& OutLifetimeProps) const override;
 
     UFUNCTION(BlueprintCallable, Category="Turn")
     void RegisterController(ASkaldPlayerController* Controller);
@@ -88,6 +92,10 @@ public:
     /** Event fired when the world state has changed. */
     UPROPERTY(BlueprintAssignable, Category="Turn")
     FSkaldWorldStateChanged OnWorldStateChanged;
+
+    /** Maps that can be used for grid based battles. */
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Replicated, Category="Battle")
+    TArray<TSoftObjectPtr<UWorld>> BattleMaps;
 
 protected:
     UPROPERTY()


### PR DESCRIPTION
## Summary
- add configurable list of battle maps
- travel to a random battle map when a grid battle starts
- detect battle maps dynamically for player and AI setup

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b7d6a69d188324862ee413b0ba40fc