### PR TITLE
Maintain accurate survivor counts in grid battles

### DIFF
--- a/Source/Skald/GridBattleManager.cpp
+++ b/Source/Skald/GridBattleManager.cpp
@@ -69,6 +69,23 @@ void UGridBattleManager::InitBattle(const TArray<FFighter>& Attackers, const TAr
     AttackerTeam = Attackers;
     DefenderTeam = Defenders;
     CurrentRound = 1;
+
+    AttackerSurvivorCount = 0;
+    for (const FFighter& Fighter : AttackerTeam)
+    {
+        if (Fighter.Stats.Health > 0)
+        {
+            ++AttackerSurvivorCount;
+        }
+    }
+    DefenderSurvivorCount = 0;
+    for (const FFighter& Fighter : DefenderTeam)
+    {
+        if (Fighter.Stats.Health > 0)
+        {
+            ++DefenderSurvivorCount;
+        }
+    }
 }
 
 int32 UGridBattleManager::RollInitiativeDie(FRandomStream& RandomStream)
@@ -79,6 +96,9 @@ int32 UGridBattleManager::RollInitiativeDie(FRandomStream& RandomStream)
 void UGridBattleManager::StartBattle(FRandomStream& RandomStream)
 {
     bool bAttackerTurn = RollInitiativeDie(RandomStream) >= RollInitiativeDie(RandomStream);
+
+    int32 AttackerSurvivors = AttackerSurvivorCount;
+    int32 DefenderSurvivors = DefenderSurvivorCount;
 
     TArray<FIntPoint> PreviousAttackerPositions;
     PreviousAttackerPositions.Reserve(AttackerTeam.Num());
@@ -95,7 +115,7 @@ void UGridBattleManager::StartBattle(FRandomStream& RandomStream)
 
     int32 StalemateTurns = 0;
 
-    while (GetAttackerSurvivors() > 0 && GetDefenderSurvivors() > 0 && CurrentRound <= MaxRounds)
+    while (AttackerSurvivors > 0 && DefenderSurvivors > 0 && CurrentRound <= MaxRounds)
     {
         bool bDamageDealt = false;
         TArray<FFighter>& ActingTeam = bAttackerTurn ? AttackerTeam : DefenderTeam;
@@ -126,14 +146,25 @@ void UGridBattleManager::StartBattle(FRandomStream& RandomStream)
             if (IsInRange(Fighter, *Target))
             {
                 int32 Damage = 0;
-                ResolveAttack(Fighter, *Target, Damage, RandomStream);
+                bool bDefeated = ResolveAttack(Fighter, *Target, Damage, RandomStream);
                 if (Damage > 0)
                 {
                     bDamageDealt = true;
                 }
+                if (bDefeated)
+                {
+                    if (bAttackerTurn)
+                    {
+                        --DefenderSurvivors;
+                    }
+                    else
+                    {
+                        --AttackerSurvivors;
+                    }
+                }
             }
 
-            if (GetAttackerSurvivors() <= 0 || GetDefenderSurvivors() <= 0)
+            if (AttackerSurvivors <= 0 || DefenderSurvivors <= 0)
             {
                 break;
             }
@@ -187,12 +218,15 @@ void UGridBattleManager::StartBattle(FRandomStream& RandomStream)
         ++CurrentRound;
     }
 
+    AttackerSurvivorCount = AttackerSurvivors;
+    DefenderSurvivorCount = DefenderSurvivors;
+
     ESkaldFaction Winner = ESkaldFaction::None;
-    if (GetAttackerSurvivors() > 0 && GetDefenderSurvivors() <= 0)
+    if (AttackerSurvivors > 0 && DefenderSurvivors <= 0)
     {
         Winner = AttackerTeam.Num() > 0 ? AttackerTeam[0].Faction : ESkaldFaction::None;
     }
-    else if (GetDefenderSurvivors() > 0 && GetAttackerSurvivors() <= 0)
+    else if (DefenderSurvivors > 0 && AttackerSurvivors <= 0)
     {
         Winner = DefenderTeam.Num() > 0 ? DefenderTeam[0].Faction : ESkaldFaction::None;
     }
@@ -251,13 +285,29 @@ bool UGridBattleManager::ResolveAttack(FFighter& Attacker, FFighter& Defender, i
     return bDefeated;
 }
 
-int32 UGridBattleManager::GetAttackerSurvivors() const
+int32 UGridBattleManager::GetAttackerSurvivors()
 {
+    AttackerSurvivorCount = 0;
+    for (const FFighter& Fighter : AttackerTeam)
+    {
+        if (Fighter.Stats.Health > 0)
+        {
+            ++AttackerSurvivorCount;
+        }
+    }
     return AttackerSurvivorCount;
 }
 
-int32 UGridBattleManager::GetDefenderSurvivors() const
+int32 UGridBattleManager::GetDefenderSurvivors()
 {
+    DefenderSurvivorCount = 0;
+    for (const FFighter& Fighter : DefenderTeam)
+    {
+        if (Fighter.Stats.Health > 0)
+        {
+            ++DefenderSurvivorCount;
+        }
+    }
     return DefenderSurvivorCount;
 }
 

--- a/Source/Skald/GridBattleManager.h
+++ b/Source/Skald/GridBattleManager.h
@@ -146,11 +146,11 @@ public:
 
     /** Number of surviving attackers after the battle concludes. */
     UFUNCTION(BlueprintCallable, BlueprintPure, Category="Battle")
-    int32 GetAttackerSurvivors() const;
+    int32 GetAttackerSurvivors();
 
     /** Number of surviving defenders after the battle concludes. */
     UFUNCTION(BlueprintCallable, BlueprintPure, Category="Battle")
-    int32 GetDefenderSurvivors() const;
+    int32 GetDefenderSurvivors();
 
     /** Total army cost of surviving attackers. */
     UFUNCTION(BlueprintCallable, BlueprintPure, Category="Battle")


### PR DESCRIPTION
## Summary
- Track surviving fighters during battle with local counters
- Initialize and expose survivor counts based on fighter health
- Recompute survivor queries from team data

## Testing
- `g++ -fsyntax-only Source/Skald/GridBattleManager.cpp` *(fails: CoreMinimal.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b7e1dba67c8324a62bb0a33dbcb261