### PR TITLE
Clear grid occupancy when fighters are destroyed

### DIFF
--- a/Source/Skald/FighterPawn.cpp
+++ b/Source/Skald/FighterPawn.cpp
@@ -198,3 +198,11 @@ void AFighterPawn::UpdateHealthDisplay(int32 NewHealth) {
     }
   }
 }
+
+void AFighterPawn::Destroyed() {
+  if (UGridOverlayComponent *Grid = GetGrid()) {
+    Grid->SetOccupied(CurrentCell, false);
+  }
+  CurrentCell = FIntPoint::ZeroValue;
+  Super::Destroyed();
+}

--- a/Source/Skald/FighterPawn.h
+++ b/Source/Skald/FighterPawn.h
@@ -65,6 +65,10 @@ public:
   UPROPERTY(BlueprintAssignable, Category = "Fighter|Events")
   FOnHealthChanged OnHealthChanged;
 
+protected:
+  /** Clear grid occupancy when the fighter is destroyed. */
+  virtual void Destroyed() override;
+
 private:
   /** Update the health widget with a new value. */
   UFUNCTION()


### PR DESCRIPTION
## Summary
- Unset a fighter's occupied grid cell when the pawn is destroyed so other units can use the tile

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b7e7fea3748324adfd5a386d26a32d