### PR TITLE
Track initial army cost to report casualties

### DIFF
--- a/Source/Skald/GridBattleManager.cpp
+++ b/Source/Skald/GridBattleManager.cpp
@@ -69,25 +69,26 @@ void UGridBattleManager::InitBattle(const TArray<FFighter>& Attackers, const TAr
     AttackerTeam = Attackers;
     DefenderTeam = Defenders;
     CurrentRound = 1;
-
-    AttackerSurvivorCount = 0;
+    AttackerInitialArmyCost = 0;
     for (const FFighter& Fighter : AttackerTeam)
     {
         if (Fighter.Stats.Health > 0)
         {
-            AttackerSurvivorCount += Fighter.Stats.ArmyCost;
-            ++AttackerSurvivorCount;
+            AttackerInitialArmyCost += Fighter.Stats.ArmyCost;
         }
     }
-    DefenderSurvivorCount = 0;
+
+    DefenderInitialArmyCost = 0;
     for (const FFighter& Fighter : DefenderTeam)
     {
         if (Fighter.Stats.Health > 0)
         {
-            DefenderSurvivorCount += Fighter.Stats.ArmyCost;
-            ++DefenderSurvivorCount;
+            DefenderInitialArmyCost += Fighter.Stats.ArmyCost;
         }
     }
+
+    AttackerSurvivorCount = 0;
+    DefenderSurvivorCount = 0;
 }
 
 int32 UGridBattleManager::RollInitiativeDie(FRandomStream& RandomStream)
@@ -504,23 +505,8 @@ void UGridBattleManager::EndBattle()
         Winner = DefenderTeam.Num() > 0 ? DefenderTeam[0].Faction : ESkaldFaction::None;
     }
 
-    int32 AttackerCasualties = 0;
-    int32 DefenderCasualties = 0;
-    for (int32 Index = 0; Index < InitiativeOrder.Num(); ++Index)
-    {
-        AFighterPawn* Fighter = InitiativeOrder[Index];
-        if (Fighter && !Fighter->IsAlive())
-        {
-            if (Index < Half)
-            {
-                AttackerCasualties += Fighter->Stats.ArmyCost;
-            }
-            else
-            {
-                DefenderCasualties += Fighter->Stats.ArmyCost;
-            }
-        }
-    }
+    int32 AttackerCasualties = AttackerInitialArmyCost - AttackerSurvivorCount;
+    int32 DefenderCasualties = DefenderInitialArmyCost - DefenderSurvivorCount;
 
     OnBattleEnded.Broadcast(Winner, AttackerCasualties, DefenderCasualties);
 }

--- a/Source/Skald/GridBattleManager.h
+++ b/Source/Skald/GridBattleManager.h
@@ -204,6 +204,14 @@ protected:
     UPROPERTY(BlueprintReadOnly, Category="Battle")
     int32 CurrentTurn = 0;
 
+    /** Total starting army cost for attackers. */
+    UPROPERTY(BlueprintReadOnly, Category="Battle")
+    int32 AttackerInitialArmyCost = 0;
+
+    /** Total starting army cost for defenders. */
+    UPROPERTY(BlueprintReadOnly, Category="Battle")
+    int32 DefenderInitialArmyCost = 0;
+
     /** Cached surviving army-cost totals for each side. */
     UPROPERTY(BlueprintReadOnly, Category="Battle")
     int32 AttackerSurvivorCount = 0;


### PR DESCRIPTION
## Summary
- Track initial attacker and defender army costs when a battle is initialised
- Derive casualty totals from the stored starting costs instead of from the pruned initiative order

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b7e8d1a47c8324b96e2df9bb3bac11