### PR TITLE
Track side membership when computing casualties

### DIFF
--- a/Source/Skald/FighterPawn.h
+++ b/Source/Skald/FighterPawn.h
@@ -41,6 +41,10 @@ public:
   UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "Fighter")
   FFighterStats Stats;
 
+  /** True if this fighter belongs to the attacking side. */
+  UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "Fighter")
+  bool bIsAttacker = false;
+
   /** Actions remaining for the current activation. */
   UPROPERTY(BlueprintReadOnly, Category = "Fighter")
   int32 ActionsRemaining;

--- a/Source/Skald/GridBattleManager.cpp
+++ b/Source/Skald/GridBattleManager.cpp
@@ -89,6 +89,7 @@ void UGridBattleManager::InitBattle(const TArray<FFighter>& Attackers, const TAr
 
     AttackerSurvivorCount = 0;
     DefenderSurvivorCount = 0;
+    bTeamsAssigned = false;
 }
 
 int32 UGridBattleManager::RollInitiativeDie(FRandomStream& RandomStream)
@@ -414,10 +415,22 @@ void UGridBattleManager::RollInitiative()
 void UGridBattleManager::StartRound(FRandomStream& RandomStream)
 {
     const int32 EdgeRange = 3;
-    const int32 Half = InitiativeOrder.Num() / 2;
-    for (int32 Index = 0; Index < InitiativeOrder.Num(); ++Index)
+    if (!bTeamsAssigned)
     {
-        AFighterPawn* Fighter = InitiativeOrder[Index];
+        const int32 Half = InitiativeOrder.Num() / 2;
+        for (int32 Index = 0; Index < InitiativeOrder.Num(); ++Index)
+        {
+            AFighterPawn* Fighter = InitiativeOrder[Index];
+            if (Fighter)
+            {
+                Fighter->bIsAttacker = Index < Half;
+            }
+        }
+        bTeamsAssigned = true;
+    }
+
+    for (AFighterPawn* Fighter : InitiativeOrder)
+    {
         if (!Fighter)
         {
             continue;
@@ -427,7 +440,7 @@ void UGridBattleManager::StartRound(FRandomStream& RandomStream)
 
         FIntPoint Cell;
         Cell.Y = RandomStream.RandRange(0, GridSize - 1);
-        if (Index < Half)
+        if (Fighter->bIsAttacker)
         {
             Cell.X = RandomStream.RandRange(0, EdgeRange - 1);
         }
@@ -476,15 +489,13 @@ void UGridBattleManager::AdvanceTurn()
 
 void UGridBattleManager::EndBattle()
 {
-    const int32 Half = InitiativeOrder.Num() / 2;
     AttackerSurvivorCount = 0;
     DefenderSurvivorCount = 0;
-    for (int32 Index = 0; Index < InitiativeOrder.Num(); ++Index)
+    for (AFighterPawn* Fighter : InitiativeOrder)
     {
-        AFighterPawn* Fighter = InitiativeOrder[Index];
         if (Fighter && Fighter->IsAlive())
         {
-            if (Index < Half)
+            if (Fighter->bIsAttacker)
             {
                 AttackerSurvivorCount += Fighter->Stats.ArmyCost;
             }

--- a/Source/Skald/GridBattleManager.h
+++ b/Source/Skald/GridBattleManager.h
@@ -218,5 +218,8 @@ protected:
 
     UPROPERTY(BlueprintReadOnly, Category="Battle")
     int32 DefenderSurvivorCount = 0;
+
+    /** Whether fighters have been assigned to attacker or defender sides. */
+    bool bTeamsAssigned = false;
 };
 


### PR DESCRIPTION
## Summary
- Mark fighter pawns as attackers or defenders and remember if teams have been assigned
- Use each pawn's side to place units at round start and to total surviving army cost
- Reset team assignment when starting a new battle

## Testing
- `./Build/validate.sh` *(fails: UnrealBuildTool not found; skipping compile check. UnrealEditor not found; cannot run tests.)*

------
https://chatgpt.com/codex/tasks/task_e_68b7ec2f62208324aaae2bd9082ea5aa