### PR TITLE
Fix duplicate UPROPERTY causing compile error

### DIFF
--- a/Source/Skald/Skald_TurnManager.h
+++ b/Source/Skald/Skald_TurnManager.h
@@ -95,7 +95,6 @@ public:
 
     /** Maps that can be used for grid based battles. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Replicated, Category="Battle")
-    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="Battle")
     TArray<TSoftObjectPtr<UWorld>> BattleMaps;
 
 protected:


### PR DESCRIPTION
## Summary
- remove duplicate `UPROPERTY` annotation for `BattleMaps`

## Testing
- `clang++ -fsyntax-only -std=c++17 Source/Skald/Skald_TurnManager.cpp` *(fails: command not found: clang++)*


------
https://chatgpt.com/codex/tasks/task_e_68b7efa388e483248134f5cda7993dd6