### PR TITLE
Prevent battle map flag redefinition

### DIFF
--- a/Source/Skald/Skald_GameMode.cpp
+++ b/Source/Skald/Skald_GameMode.cpp
@@ -83,8 +83,7 @@ void ASkaldGameMode::BeginPlay() {
       UGameplayStatics::GetCurrentLevelName(this, true);
   bool bIsBattleMap = CurrentLevel.Equals(TEXT("BattleMap"),
                                          ESearchCase::IgnoreCase);
-  bool bIsBattleMap = false;
-  if (TurnManager) {
+  if (!bIsBattleMap && TurnManager) {
     for (const TSoftObjectPtr<UWorld> &Map : TurnManager->BattleMaps) {
       if (CurrentLevel.Equals(Map.ToSoftObjectPath().GetAssetName(),
                              ESearchCase::IgnoreCase)) {


### PR DESCRIPTION
## Summary
- Avoid duplicate declaration of `bIsBattleMap` in `ASkaldGameMode::BeginPlay`
- Only search battle map list when not already on the default "BattleMap"

## Testing
- `g++ -std=c++17 -I../Engine/Source -ISource -c Source/Skald/Skald_GameMode.cpp` *(fails: CoreMinimal.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b7f1c8304c8324b3a89d13cf8d196a