### PR TITLE
Fix landscape component detection

### DIFF
--- a/Source/Skald/GridOverlayComponent.cpp
+++ b/Source/Skald/GridOverlayComponent.cpp
@@ -36,7 +36,7 @@ void UGridOverlayComponent::BeginPlay() {
         FHitResult Hit;
         if (World->LineTraceSingleByChannel(Hit, Start, End, ECC_WorldStatic)) {
           CellHeights[Idx] = Hit.Location.Z;
-          if (Hit.Component && Hit.Component->IsA<ULandscapeComponent>()) {
+          if (Cast<ULandscapeComponent>(Hit.GetComponent())) {
             HandleLandscapeHit(Hit, FIntPoint(X, Y), Idx);
           }
         } else {


### PR DESCRIPTION
## Summary
- avoid deleted bool conversion on FHitResult component by using Cast with GetComponent

## Testing
- `clang++ -std=c++17 -I../Engine/Source -ISource -c Source/Skald/GridOverlayComponent.cpp` *(fails: 'Components/ActorComponent.h' file not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b7f4cd2a5c83249a4b6a76395b65a1