### PR TITLE
Default territory data table

### DIFF
--- a/Source/Skald/Tests/WorldMapDefaultTableTest.cpp
+++ b/Source/Skald/Tests/WorldMapDefaultTableTest.cpp
@@ -1,11 +1,11 @@
 #include "Misc/AutomationTest.h"
 #include "WorldMap.h"
 #include "Tests/AutomationEditorCommon.h"
-#include "Engine\World.h"
+#include "Engine\\World.h"
 
-IMPLEMENT_SIMPLE_AUTOMATION_TEST(FWorldMapMissingAssetsTest, "Skald.WorldMap.MissingAssetsLogged", EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FWorldMapDefaultTableTest, "Skald.WorldMap.DefaultTableAssigned", EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
 
-bool FWorldMapMissingAssetsTest::RunTest(const FString& Parameters)
+bool FWorldMapDefaultTableTest::RunTest(const FString& Parameters)
 {
     UWorld* World = FAutomationEditorCommonUtils::CreateNewMap();
     TestNotNull(TEXT("World should be created"), World);
@@ -21,7 +21,6 @@ bool FWorldMapMissingAssetsTest::RunTest(const FString& Parameters)
         return false;
     }
 
-    AddExpectedError(TEXT("WorldMap requires valid TerritoryClass and TerritoryTable."), EAutomationExpectedErrorFlags::Contains);
-    Map->BeginPlay();
+    TestNotNull(TEXT("TerritoryTable defaulted"), Map->TerritoryTable);
     return true;
 }

--- a/Source/Skald/WorldMap.cpp
+++ b/Source/Skald/WorldMap.cpp
@@ -10,6 +10,7 @@
 #include "Skald_PlayerState.h"
 #include "Templates/Function.h"
 #include "Territory.h"
+#include "UObject/ConstructorHelpers.h"
 #include <cfloat>
 
 AWorldMap::AWorldMap() {
@@ -17,6 +18,12 @@ AWorldMap::AWorldMap() {
   bReplicates = true;
   SelectedTerritory = nullptr;
   TerritoryClass = ATerritory::StaticClass();
+
+  static ConstructorHelpers::FObjectFinder<UDataTable> TerritoryTableFinder(
+      TEXT("/Game/DataTables/TerritoriesDataTable.TerritoriesDataTable"));
+  if (TerritoryTableFinder.Succeeded()) {
+    TerritoryTable = TerritoryTableFinder.Object;
+  }
 }
 
 void AWorldMap::BeginPlay() {


### PR DESCRIPTION
## Summary
- Automatically load the TerritoriesDataTable asset in `AWorldMap` so territories spawn without manual table assignment
- Add automation test to verify the world map assigns a default territory table

## Testing
- `bash Build/validate.sh`

------
https://chatgpt.com/codex/tasks/task_e_68b804d22aa883249ba29542b298faf8