### PR TITLE
Fix compile error accessing bIsAI

### DIFF
--- a/Source/Skald/Skald_GameMode.cpp
+++ b/Source/Skald/Skald_GameMode.cpp
@@ -223,7 +223,7 @@ void ASkaldGameMode::PopulateAIPlayers() {
       break;
     }
 
-    AIController->bIsAI = true;
+    AIController->SetIsAIController(true);
     AIController->SetPlayerState(AIState);
 
     AIState->bIsAI = true;

--- a/Source/Skald/Skald_PlayerController.cpp
+++ b/Source/Skald/Skald_PlayerController.cpp
@@ -452,6 +452,10 @@ void ASkaldPlayerController::MakeAIDecision() {
 
 bool ASkaldPlayerController::IsAIController() const { return bIsAI; }
 
+void ASkaldPlayerController::SetIsAIController(bool bInIsAI) {
+  bIsAI = bInIsAI;
+}
+
 bool ASkaldPlayerController::ValidateAttack(int32 FromID, int32 ToID,
                                             int32 ArmySent, bool bUseSiege,
                                             FString *OutError) {

--- a/Source/Skald/Skald_PlayerController.h
+++ b/Source/Skald/Skald_PlayerController.h
@@ -49,6 +49,9 @@ public:
   UFUNCTION(BlueprintCallable, BlueprintPure, Category = "Turn")
   bool IsAIController() const;
 
+  UFUNCTION(BlueprintCallable, Category = "Turn")
+  void SetIsAIController(bool bInIsAI);
+
   /** Set the turn manager responsible for sequencing play. */
   UFUNCTION(BlueprintCallable, Category = "Turn")
   void SetTurnManager(ATurnManager *Manager);


### PR DESCRIPTION
## Summary
- Expose a SetIsAIController function on ASkaldPlayerController
- Use the setter in Skald_GameMode to mark spawned controllers as AI

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b80da046ac832494126fb9910729ba