### PR TITLE
Initialize transform for deferred AI controller spawn

### DIFF
--- a/Source/Skald/Skald_GameMode.cpp
+++ b/Source/Skald/Skald_GameMode.cpp
@@ -218,7 +218,7 @@ void ASkaldGameMode::PopulateAIPlayers() {
 
     AIState->bIsAI = true;
 
-    FTransform SpawnTransform;
+    FTransform SpawnTransform = FTransform::Identity;
     ASkaldPlayerController *AIController =
         GetWorld()->SpawnActorDeferred<ASkaldPlayerController>(
             PlayerControllerClass, SpawnTransform, nullptr, nullptr,


### PR DESCRIPTION
## Summary
- Initialize the spawn transform to FTransform::Identity before deferred spawning AI controllers

## Testing
- `clang++ -std=c++17 -c Source/Skald/Skald_GameMode.cpp` *(fails: command not found: clang++)*

------
https://chatgpt.com/codex/tasks/task_e_68b8747de79c8324bec84df1b1dc7d1c