### PR TITLE
Ensure widgets only spawn for local human players

### DIFF
--- a/Source/Skald/Skald_PlayerController.cpp
+++ b/Source/Skald/Skald_PlayerController.cpp
@@ -80,7 +80,8 @@ void ASkaldPlayerController::BeginPlay() {
     bIsAI = PS->bIsAI;
   }
 
-  if (IsLocalPlayerController() && !IsAIController()) {
+  if (IsLocalPlayerController() && !IsAIController() &&
+      GetLocalPlayer() != nullptr) {
     // Create and show the HUD widget if a class has been assigned (expected via
     // blueprint or constructor).
     if (HUDWidgetClass) {
@@ -157,7 +158,6 @@ void ASkaldPlayerController::BeginPlay() {
     WorldMap->OnTerritorySelected.AddDynamic(
         this, &ASkaldPlayerController::HandleTerritorySelected);
   }
-
 }
 
 void ASkaldPlayerController::OnRep_PlayerState() {
@@ -199,12 +199,16 @@ void ASkaldPlayerController::SetTurnManager(ATurnManager *Manager) {
   if (TurnManager) {
     TurnManager->OnWorldStateChanged.AddDynamic(
         this, &ASkaldPlayerController::HandleWorldStateChanged);
-    InitializeFighterSelectionIfNeeded();
+    if (IsLocalPlayerController() && !IsAIController() &&
+        GetLocalPlayer() != nullptr) {
+      InitializeFighterSelectionIfNeeded();
+    }
   }
 }
 
 void ASkaldPlayerController::InitializeFighterSelectionIfNeeded() {
-  if (FighterSelectionWidget) {
+  if (FighterSelectionWidget || IsAIController() ||
+      GetLocalPlayer() == nullptr || !IsLocalPlayerController()) {
     return;
   }
 


### PR DESCRIPTION
## Summary
- Guard HUD and ChoosePlayer widget creation with a valid local player check
- Prevent FighterSelection widget creation for AI or remote controllers

## Testing
- `./Build/validate.sh`

------
https://chatgpt.com/codex/tasks/task_e_68b88771805c83248d5c807bdf50ed94