### PR TITLE
Refactor world map initialization and lock-in flow

### DIFF
--- a/Source/Skald/Skald_GameMode.cpp
+++ b/Source/Skald/Skald_GameMode.cpp
@@ -261,6 +261,12 @@ void ASkaldGameMode::PopulateAIPlayers() {
       AIState->Faction =
           Available[RandStream.RandRange(0, Available.Num() - 1)];
       GI->TakenFactions.AddUnique(AIState->Faction);
+    } else {
+      UE_LOG(LogSkald, Error,
+             TEXT("PopulateAIPlayers: no available factions for AI"));
+      AIController->Destroy();
+      AIState->Destroy();
+      break;
     }
 
     AIState->bHasLockedIn = true;
@@ -674,21 +680,18 @@ void ASkaldGameMode::AdvanceArmyPlacement() {
 
 bool ASkaldGameMode::InitializeWorld() {
   if (!WorldMap) {
-    // Try to locate an existing world map actor in the level.
+    // Look for an existing world map actor placed in the level.
     WorldMap = Cast<AWorldMap>(UGameplayStatics::GetActorOfClass(
         GetWorld(), AWorldMap::StaticClass()));
-    // If none exists, spawn a default instance so setup can continue.
-    if (!WorldMap) {
-      WorldMap = GetWorld()->SpawnActor<AWorldMap>();
-    }
   }
   if (!WorldMap) {
     UE_LOG(LogSkald, Error,
-           TEXT("InitializeWorld failed: WorldMap missing in %s"), *GetName());
+           TEXT("InitializeWorld failed: WorldMap missing in %s. Place a WorldMap actor in the level."),
+           *GetName());
     if (GEngine) {
       GEngine->AddOnScreenDebugMessage(
           -1, 5.f, FColor::Red,
-          FString::Printf(TEXT("InitializeWorld: WorldMap missing in %s"),
+          FString::Printf(TEXT("InitializeWorld: WorldMap missing in %s. Place a WorldMap actor in the level."),
                           *GetName()));
     }
     return false;
@@ -712,36 +715,18 @@ bool ASkaldGameMode::InitializeWorld() {
     return false;
   }
 
-  // If the world map has not spawned territories yet or only contains a
-  // placeholder, create basic ones.
-  if (WorldMap->Territories.Num() == 0 ||
-      (WorldMap->Territories.Num() > 0 && WorldMap->Territories[0] &&
-       WorldMap->Territories[0]->TerritoryID == -1)) {
-    ATerritory *Placeholder = nullptr;
-    if (WorldMap->Territories.Num() > 0) {
-      Placeholder = WorldMap->Territories[0];
-      WorldMap->Territories.Empty();
-    } else {
-      TArray<AActor *> Found;
-      UGameplayStatics::GetAllActorsOfClass(GetWorld(),
-                                            ATerritory::StaticClass(), Found);
-      for (AActor *Actor : Found) {
-        ATerritory *Terr = Cast<ATerritory>(Actor);
-        if (Terr && Terr->TerritoryID == -1) {
-          Placeholder = Terr;
-          break;
-        }
+  if (WorldMap->Territories.Num() == 0) {
+    if (!WorldMap->GenerateTerritoriesFromTable()) {
+      UE_LOG(LogSkald, Error,
+             TEXT("InitializeWorld failed: WorldMap %s could not generate territories"),
+             *WorldMap->GetName());
+      if (GEngine) {
+        GEngine->AddOnScreenDebugMessage(
+            -1, 5.f, FColor::Red,
+            FString::Printf(TEXT("InitializeWorld: %s could not generate territories"),
+                            *WorldMap->GetName()));
       }
-    }
-    if (Placeholder) {
-      Placeholder->Destroy();
-    }
-    for (int32 Id = 0; Id < 43; ++Id) {
-      ATerritory *Territory = GetWorld()->SpawnActor<ATerritory>();
-      if (Territory) {
-        Territory->TerritoryID = Id;
-        WorldMap->RegisterTerritory(Territory);
-      }
+      return false;
     }
   }
   if (WorldMap->Territories.Num() == 0) {

--- a/Source/Skald/Skald_PlayerController.cpp
+++ b/Source/Skald/Skald_PlayerController.cpp
@@ -140,7 +140,7 @@ void ASkaldPlayerController::BeginPlay() {
           CreateWidget<UChoosePlayerWidget>(this, ChoosePlayerWidgetClass);
       if (ChoosePlayerWidget) {
         ChoosePlayerWidget->OnPlayerLockedIn.AddDynamic(
-            this, &ASkaldPlayerController::HandlePlayerLockedIn);
+            this, &ASkaldPlayerController::HandleFactionLockedIn);
         ChoosePlayerWidget->AddToViewport();
         // While the player is choosing their faction, restrict controls to the
         // UI
@@ -258,7 +258,7 @@ void ASkaldPlayerController::InitializeFighterSelectionIfNeeded() {
               PlayerFaction);
     }
     Selection->OnLockedIn.AddDynamic(
-        this, &ASkaldPlayerController::HandlePlayerLockedIn);
+        this, &ASkaldPlayerController::HandleFighterSelectionLockedIn);
     Selection->AddToViewport();
     SetIgnoreMoveInput(true);
   }
@@ -999,29 +999,51 @@ void ASkaldPlayerController::HandleWorldStateChanged() {
   }
 }
 
-void ASkaldPlayerController::HandlePlayerLockedIn() {
+void ASkaldPlayerController::HandleFactionLockedIn() {
   if (ChoosePlayerWidget) {
     ChoosePlayerWidget->OnPlayerLockedIn.RemoveDynamic(
-        this, &ASkaldPlayerController::HandlePlayerLockedIn);
+        this, &ASkaldPlayerController::HandleFactionLockedIn);
     ChoosePlayerWidget->RemoveFromParent();
+    ChoosePlayerWidget = nullptr;
   }
+
+  if (MainHudWidget) {
+    MainHudWidget->SetVisibility(ESlateVisibility::Visible);
+    if (CachedGameState) {
+      TArray<FS_PlayerData> Players;
+      BuildPlayerDataArray(Players);
+      MainHudWidget->RefreshPlayerList(Players);
+    }
+    if (ASkaldPlayerState *PS = GetPlayerState<ASkaldPlayerState>()) {
+      MainHudWidget->UpdateDeployableUnits(PS->DeployableUnits);
+      MainHudWidget->UpdateResources(PS->Resources);
+    }
+    if (TurnManager) {
+      MainHudWidget->UpdatePhaseBanner(TurnManager->GetCurrentPhase());
+    }
+  }
+
+  SetInputMode(FInputModeGameAndUI());
+  SetIgnoreMoveInput(false);
+  SetIgnoreLookInput(false);
+}
+
+void ASkaldPlayerController::HandleFighterSelectionLockedIn() {
   if (FighterSelectionWidget) {
     UFighterSelectionWidget *Selection = FighterSelectionWidget;
     Selection->OnLockedIn.RemoveDynamic(
-        this, &ASkaldPlayerController::HandlePlayerLockedIn);
+        this, &ASkaldPlayerController::HandleFighterSelectionLockedIn);
     Selection->RemoveFromParent();
 
     if (CachedGameInstance && CachedGameInstance->GridBattleManager) {
       TArray<FFighter> Fighters;
-      if (Selection) {
-        for (const FFighterDefinition &Def : Selection->ChosenFighters) {
-          FFighter Fighter;
-          Fighter.Stats = Def.Stats;
-          if (ASkaldPlayerState *PS = GetPlayerState<ASkaldPlayerState>()) {
-            Fighter.Faction = PS->Faction;
-          }
-          Fighters.Add(Fighter);
+      for (const FFighterDefinition &Def : Selection->ChosenFighters) {
+        FFighter Fighter;
+        Fighter.Stats = Def.Stats;
+        if (ASkaldPlayerState *PS = GetPlayerState<ASkaldPlayerState>()) {
+          Fighter.Faction = PS->Faction;
         }
+        Fighters.Add(Fighter);
       }
       CachedGameInstance->GridBattleManager->InitBattle(Fighters, Fighters);
       CachedGameInstance->GridBattleManager->RollInitiative();
@@ -1046,27 +1068,10 @@ void ASkaldPlayerController::HandlePlayerLockedIn() {
     }
     FighterSelectionWidget = nullptr;
     if (MainHudWidget) {
-      // Transitioning to battle HUD; collapse the main HUD.
       MainHudWidget->SetVisibility(ESlateVisibility::Collapsed);
-    }
-  } else if (MainHudWidget) {
-    // Normal map flow: ensure the main HUD is visible and up to date.
-    MainHudWidget->SetVisibility(ESlateVisibility::Visible);
-    if (CachedGameState) {
-      TArray<FS_PlayerData> Players;
-      BuildPlayerDataArray(Players);
-      MainHudWidget->RefreshPlayerList(Players);
-    }
-    if (ASkaldPlayerState *PS = GetPlayerState<ASkaldPlayerState>()) {
-      MainHudWidget->UpdateDeployableUnits(PS->DeployableUnits);
-      MainHudWidget->UpdateResources(PS->Resources);
-    }
-    if (TurnManager) {
-      MainHudWidget->UpdatePhaseBanner(TurnManager->GetCurrentPhase());
     }
   }
 
-  // Restore game controls now that the player has locked in
   SetInputMode(FInputModeGameAndUI());
   SetIgnoreMoveInput(false);
   SetIgnoreLookInput(false);

--- a/Source/Skald/Skald_PlayerController.h
+++ b/Source/Skald/Skald_PlayerController.h
@@ -203,7 +203,9 @@ public:
 
   /** React to the player finishing their pre-game selection. */
   UFUNCTION()
-  void HandlePlayerLockedIn();
+  void HandleFactionLockedIn();
+
+  void HandleFighterSelectionLockedIn();
 
   /** React to the end of a battle. */
   UFUNCTION()

--- a/Source/Skald/Tests/WorldMapDefaultTableTest.cpp
+++ b/Source/Skald/Tests/WorldMapDefaultTableTest.cpp
@@ -3,7 +3,7 @@
 #include "Tests/AutomationEditorCommon.h"
 #include "Engine\\World.h"
 
-IMPLEMENT_SIMPLE_AUTOMATION_TEST(FWorldMapDefaultTableTest, "Skald.WorldMap.DefaultTableAssigned", EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FWorldMapDefaultTableTest, "Skald.WorldMap.DefaultTableUnset", EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
 
 bool FWorldMapDefaultTableTest::RunTest(const FString& Parameters)
 {
@@ -21,6 +21,6 @@ bool FWorldMapDefaultTableTest::RunTest(const FString& Parameters)
         return false;
     }
 
-    TestNotNull(TEXT("TerritoryTable defaulted"), Map->TerritoryTable);
+    TestNull(TEXT("TerritoryTable should be unset"), Map->TerritoryTable);
     return true;
 }

--- a/Source/Skald/WorldMap.cpp
+++ b/Source/Skald/WorldMap.cpp
@@ -10,25 +10,20 @@
 #include "Skald_PlayerState.h"
 #include "Templates/Function.h"
 #include "Territory.h"
-#include "UObject/ConstructorHelpers.h"
 #include <cfloat>
 
+// Constructor sets default properties but leaves TerritoryTable unassigned so
+// designers must configure it manually.
 AWorldMap::AWorldMap() {
   PrimaryActorTick.bCanEverTick = false;
   bReplicates = true;
   SelectedTerritory = nullptr;
   TerritoryClass = ATerritory::StaticClass();
-
-  static ConstructorHelpers::FObjectFinder<UDataTable> TerritoryTableFinder(
-      TEXT("/Game/DataTables/TerritoriesDataTable.TerritoriesDataTable"));
-  if (TerritoryTableFinder.Succeeded()) {
-    TerritoryTable = TerritoryTableFinder.Object;
-  }
 }
 
-void AWorldMap::BeginPlay() {
-  Super::BeginPlay();
+void AWorldMap::BeginPlay() { Super::BeginPlay(); }
 
+bool AWorldMap::GenerateTerritoriesFromTable() {
   if (!TerritoryClass) {
     UE_LOG(LogSkald, Error, TEXT("WorldMap %s missing TerritoryClass"),
            *GetName());
@@ -38,7 +33,7 @@ void AWorldMap::BeginPlay() {
           FString::Printf(TEXT("WorldMap %s has no TerritoryClass"),
                           *GetName()));
     }
-    return;
+    return false;
   }
 
   if (!TerritoryTable) {
@@ -52,19 +47,10 @@ void AWorldMap::BeginPlay() {
                    " Expected /Game/DataTables/TerritoriesDataTable"),
               *GetName()));
     }
-
-    FActorSpawnParameters Params;
-    Params.Owner = this;
-    ATerritory *Placeholder = GetWorld()->SpawnActor<ATerritory>(
-        TerritoryClass, GetActorLocation(), FRotator::ZeroRotator, Params);
-    if (Placeholder) {
-      Placeholder->TerritoryID = -1;
-      Placeholder->TerritoryName = TEXT("Placeholder Territory");
-      RegisterTerritory(Placeholder);
-    }
-
-    return;
+    return false;
   }
+
+  Territories.Empty();
 
   ATerritory *DefaultTerritory = TerritoryClass->GetDefaultObject<ATerritory>();
   UStaticMeshComponent *MeshComp =
@@ -84,7 +70,7 @@ void AWorldMap::BeginPlay() {
           FString::Printf(TEXT("%s missing %s"), *TerritoryClass->GetName(),
                           *MissingAsset));
     }
-    return;
+    return false;
   }
 
   // Spawn territories defined in the data table at random locations.
@@ -250,6 +236,8 @@ void AWorldMap::BeginPlay() {
       --ComponentCount;
     }
   }
+
+  return Territories.Num() > 0;
 }
 
 void AWorldMap::RegisterTerritory(ATerritory *Territory) {

--- a/Source/Skald/WorldMap.h
+++ b/Source/Skald/WorldMap.h
@@ -91,6 +91,10 @@ public:
   UFUNCTION(NetMulticast, Reliable)
   void MulticastSelectTerritory(ATerritory *Territory);
 
+  /** Generate territories from the assigned data table. */
+  UFUNCTION(BlueprintCallable, Category = "WorldMap")
+  bool GenerateTerritoriesFromTable();
+
   /** Find a path across friendly territories from one territory to another. */
   UFUNCTION(BlueprintCallable, Category = "WorldMap")
   bool FindPath(ATerritory *From, ATerritory *To,


### PR DESCRIPTION
## Summary
- Require a pre-placed WorldMap and generate territories from its data table on game start
- Guard AI spawning when no factions remain and split UI lock-in handlers for clarity
- Adjust tests to expect manual territory-table assignment

## Testing
- `npm test` *(fails: Could not read package.json)*


------
https://chatgpt.com/codex/tasks/task_e_68b88e56932c8324b7148ccd92de6993