### PR TITLE
Add HandlePlayerLockedIn alias in player controller

### DIFF
--- a/Source/Skald/Skald_PlayerController.cpp
+++ b/Source/Skald/Skald_PlayerController.cpp
@@ -999,6 +999,10 @@ void ASkaldPlayerController::HandleWorldStateChanged() {
   }
 }
 
+void ASkaldPlayerController::HandlePlayerLockedIn() {
+  HandleFactionLockedIn();
+}
+
 void ASkaldPlayerController::HandleFactionLockedIn() {
   if (ChoosePlayerWidget) {
     ChoosePlayerWidget->OnPlayerLockedIn.RemoveDynamic(

--- a/Source/Skald/Skald_PlayerController.h
+++ b/Source/Skald/Skald_PlayerController.h
@@ -201,6 +201,13 @@ public:
   UFUNCTION()
   void HandleWorldStateChanged();
 
+  /**
+   * Legacy alias for HandleFactionLockedIn.
+   * Enables player movement and look input after locking in their faction.
+   */
+  UFUNCTION()
+  void HandlePlayerLockedIn();
+
   /** React to the player finishing their pre-game selection. */
   UFUNCTION()
   void HandleFactionLockedIn();


### PR DESCRIPTION
## Summary
- expose `HandlePlayerLockedIn` in `ASkaldPlayerController` as a wrapper for `HandleFactionLockedIn`
- allows tests to re-enable movement/look input after a player locks in

## Testing
- `clang++ -std=c++17 -I../Engine/Source -ISource -ISource/Skald -c Source/Skald/Tests/PlayerControllerLockInMovementTest.cpp` *(fails: 'CoreMinimal.h' file not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b895046ff483248c484567800957e7