### PR TITLE
Validate world map assets and prerequisites

### DIFF
--- a/Source/Skald/Skald_GameMode.cpp
+++ b/Source/Skald/Skald_GameMode.cpp
@@ -81,12 +81,12 @@ void ASkaldGameMode::BeginPlay() {
   // Auto-select fighters for AI players on the battle map
   const FString CurrentLevel =
       UGameplayStatics::GetCurrentLevelName(this, true);
-  bool bIsBattleMap = CurrentLevel.Equals(TEXT("BattleMap"),
-                                         ESearchCase::IgnoreCase);
+  bool bIsBattleMap =
+      CurrentLevel.Equals(TEXT("BattleMap"), ESearchCase::IgnoreCase);
   if (!bIsBattleMap && TurnManager) {
     for (const TSoftObjectPtr<UWorld> &Map : TurnManager->BattleMaps) {
       if (CurrentLevel.Equals(Map.ToSoftObjectPath().GetAssetName(),
-                             ESearchCase::IgnoreCase)) {
+                              ESearchCase::IgnoreCase)) {
         bIsBattleMap = true;
         break;
       }
@@ -686,12 +686,14 @@ bool ASkaldGameMode::InitializeWorld() {
   }
   if (!WorldMap) {
     UE_LOG(LogSkald, Error,
-           TEXT("InitializeWorld failed: WorldMap missing in %s. Place a WorldMap actor in the level."),
+           TEXT("InitializeWorld failed: WorldMap missing in %s. Place a "
+                "WorldMap actor in the level."),
            *GetName());
     if (GEngine) {
       GEngine->AddOnScreenDebugMessage(
           -1, 5.f, FColor::Red,
-          FString::Printf(TEXT("InitializeWorld: WorldMap missing in %s. Place a WorldMap actor in the level."),
+          FString::Printf(TEXT("InitializeWorld: WorldMap missing in %s. Place "
+                               "a WorldMap actor in the level."),
                           *GetName()));
     }
     return false;
@@ -716,15 +718,41 @@ bool ASkaldGameMode::InitializeWorld() {
   }
 
   if (WorldMap->Territories.Num() == 0) {
-    if (!WorldMap->GenerateTerritoriesFromTable()) {
+    if (!WorldMap->TerritoryClass) {
       UE_LOG(LogSkald, Error,
-             TEXT("InitializeWorld failed: WorldMap %s could not generate territories"),
+             TEXT("InitializeWorld failed: WorldMap %s missing TerritoryClass"),
              *WorldMap->GetName());
       if (GEngine) {
         GEngine->AddOnScreenDebugMessage(
             -1, 5.f, FColor::Red,
-            FString::Printf(TEXT("InitializeWorld: %s could not generate territories"),
+            FString::Printf(TEXT("InitializeWorld: %s missing TerritoryClass"),
                             *WorldMap->GetName()));
+      }
+      return false;
+    }
+    if (!WorldMap->TerritoryTable) {
+      UE_LOG(LogSkald, Error,
+             TEXT("InitializeWorld failed: WorldMap %s missing TerritoryTable"),
+             *WorldMap->GetName());
+      if (GEngine) {
+        GEngine->AddOnScreenDebugMessage(
+            -1, 5.f, FColor::Red,
+            FString::Printf(TEXT("InitializeWorld: %s missing TerritoryTable"),
+                            *WorldMap->GetName()));
+      }
+      return false;
+    }
+    if (!WorldMap->GenerateTerritoriesFromTable()) {
+      UE_LOG(LogSkald, Error,
+             TEXT("InitializeWorld failed: WorldMap %s could not generate "
+                  "territories"),
+             *WorldMap->GetName());
+      if (GEngine) {
+        GEngine->AddOnScreenDebugMessage(
+            -1, 5.f, FColor::Red,
+            FString::Printf(
+                TEXT("InitializeWorld: %s could not generate territories"),
+                *WorldMap->GetName()));
       }
       return false;
     }

--- a/Source/Skald/WorldMap.cpp
+++ b/Source/Skald/WorldMap.cpp
@@ -4,12 +4,15 @@
 #include "Containers/Map.h"
 #include "Containers/Queue.h"
 #include "Engine/Engine.h"
+#include "Engine/StaticMesh.h"
 #include "Engine/World.h"
+#include "Materials/MaterialInterface.h"
 #include "Skald.h"
 #include "Skald_GameMode.h"
 #include "Skald_PlayerState.h"
 #include "Templates/Function.h"
 #include "Territory.h"
+#include "UObject/ConstructorHelpers.h"
 #include <cfloat>
 
 // Constructor sets default properties but leaves TerritoryTable unassigned so
@@ -57,20 +60,67 @@ bool AWorldMap::GenerateTerritoriesFromTable() {
       DefaultTerritory
           ? DefaultTerritory->FindComponentByClass<UStaticMeshComponent>()
           : nullptr;
-  if (!MeshComp || !MeshComp->GetStaticMesh() ||
-      MeshComp->GetNumMaterials() == 0) {
-    const FString MissingAsset = (!MeshComp || !MeshComp->GetStaticMesh())
-                                     ? TEXT("mesh")
-                                     : TEXT("material");
-    UE_LOG(LogSkald, Error, TEXT("WorldMap %s TerritoryClass %s missing %s"),
-           *GetName(), *TerritoryClass->GetName(), *MissingAsset);
+  if (!MeshComp) {
+    UE_LOG(LogSkald, Error,
+           TEXT("WorldMap %s TerritoryClass %s missing StaticMeshComponent"),
+           *GetName(), *TerritoryClass->GetName());
     if (GEngine) {
       GEngine->AddOnScreenDebugMessage(
           -1, 5.f, FColor::Red,
-          FString::Printf(TEXT("%s missing %s"), *TerritoryClass->GetName(),
-                          *MissingAsset));
+          FString::Printf(TEXT("%s missing StaticMeshComponent"),
+                          *TerritoryClass->GetName()));
     }
     return false;
+  }
+
+  if (!MeshComp->GetStaticMesh()) {
+    if (UStaticMesh *FallbackMesh = LoadObject<UStaticMesh>(
+            nullptr, TEXT("/Engine/BasicShapes/Cube.Cube"))) {
+      MeshComp->SetStaticMesh(FallbackMesh);
+      UE_LOG(
+          LogSkald, Warning,
+          TEXT(
+              "WorldMap %s TerritoryClass %s missing mesh; using default cube"),
+          *GetName(), *TerritoryClass->GetName());
+    } else {
+      UE_LOG(
+          LogSkald, Error,
+          TEXT(
+              "WorldMap %s TerritoryClass %s missing mesh and fallback failed"),
+          *GetName(), *TerritoryClass->GetName());
+      if (GEngine) {
+        GEngine->AddOnScreenDebugMessage(
+            -1, 5.f, FColor::Red,
+            FString::Printf(TEXT("%s missing mesh"),
+                            *TerritoryClass->GetName()));
+      }
+      return false;
+    }
+  }
+
+  if (MeshComp->GetNumMaterials() == 0) {
+    if (UMaterialInterface *FallbackMat = LoadObject<UMaterialInterface>(
+            nullptr,
+            TEXT(
+                "/Engine/BasicShapes/BasicShapeMaterial.BasicShapeMaterial"))) {
+      MeshComp->SetMaterial(0, FallbackMat);
+      UE_LOG(LogSkald, Warning,
+             TEXT("WorldMap %s TerritoryClass %s missing material; using basic "
+                  "material"),
+             *GetName(), *TerritoryClass->GetName());
+    } else {
+      UE_LOG(LogSkald, Error,
+             TEXT("WorldMap %s TerritoryClass %s missing material and fallback "
+                  "failed"),
+             *GetName(), *TerritoryClass->GetName());
+      if (GEngine) {
+        GEngine->AddOnScreenDebugMessage(
+            -1, 5.f, FColor::Red,
+            FString::Printf(TEXT("%s missing material"),
+                            *TerritoryClass->GetName()));
+      }
+      return false;
+    }
   }
 
   // Spawn territories defined in the data table at random locations.


### PR DESCRIPTION
## Summary
- check world map has TerritoryClass and TerritoryTable before generating territories
- provide fallback cube mesh and basic material for territory class

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b8a733852c8324afaa23b47798a981