### PR TITLE
Bind world map selection event when map loads

### DIFF
--- a/Source/Skald/Skald_PlayerController.cpp
+++ b/Source/Skald/Skald_PlayerController.cpp
@@ -23,6 +23,7 @@
 #include "UI/SkaldMainHUDWidget.h"
 #include "UObject/ConstructorHelpers.h"
 #include "WorldMap.h"
+#include "TimerManager.h"
 #include <limits>
 
 constexpr int32 MaxAIIterations = 100;
@@ -153,10 +154,18 @@ void ASkaldPlayerController::BeginPlay() {
     InitializeFighterSelectionIfNeeded();
   }
 
+  TryBindWorldMap();
+}
+
+void ASkaldPlayerController::TryBindWorldMap() {
   if (AWorldMap *WorldMap = Cast<AWorldMap>(UGameplayStatics::GetActorOfClass(
           GetWorld(), AWorldMap::StaticClass()))) {
     WorldMap->OnTerritorySelected.AddDynamic(
         this, &ASkaldPlayerController::HandleTerritorySelected);
+  } else {
+    GetWorldTimerManager().SetTimer(
+        WorldMapSearchHandle, this,
+        &ASkaldPlayerController::TryBindWorldMap, 0.5f, false);
   }
 }
 

--- a/Source/Skald/Skald_PlayerController.h
+++ b/Source/Skald/Skald_PlayerController.h
@@ -15,6 +15,8 @@ class ASkaldGameMode;
 class ASkaldGameState;
 class USkaldGameInstance;
 class UFighterSelectionWidget;
+class AWorldMap;
+struct FTimerHandle;
 
 /** Command issued by the player during a battle. */
 UENUM()
@@ -269,13 +271,19 @@ public:
    *  turn events without keeping an external pointer that might be
    *  uninitialised.
    */
-protected:
-  UPROPERTY(EditInstanceOnly, BlueprintReadOnly, Category = "Turn",
-            meta = (ExposeOnSpawn = true))
-  TObjectPtr<ATurnManager> TurnManager;
+  protected:
+    UPROPERTY(EditInstanceOnly, BlueprintReadOnly, Category = "Turn",
+              meta = (ExposeOnSpawn = true))
+    TObjectPtr<ATurnManager> TurnManager;
 
-private:
-  void BuildPlayerDataArray(TArray<FS_PlayerData> &OutPlayers) const;
+  private:
+    /** Attempt to locate the world map and bind to its selection event. */
+    void TryBindWorldMap();
+
+    /** Timer used to poll for the world map actor until it exists. */
+    FTimerHandle WorldMapSearchHandle;
+
+    void BuildPlayerDataArray(TArray<FS_PlayerData> &OutPlayers) const;
 
   bool ValidateAttack(int32 FromID, int32 ToID, int32 ArmySent, bool bUseSiege,
                       FString *OutError);


### PR DESCRIPTION
## Summary
- Poll for a WorldMap actor until it exists
- Once found, bind territory selection handler to the map

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b8a82ea01c8324a9b112d6dbf830ee