### PR TITLE
Use world map multicast for territory selection

### DIFF
--- a/Source/Skald/Territory.cpp
+++ b/Source/Skald/Territory.cpp
@@ -223,10 +223,14 @@ void ATerritory::HandleMouseLeave(UPrimitiveComponent *TouchedComponent) {
 
 void ATerritory::HandleClicked(UPrimitiveComponent *TouchedComponent,
                                FKey ButtonPressed) {
-  if (!bIsSelected) {
-    Select();
-  } else {
-    Deselect();
+  if (AWorldMap *WorldMap =
+          Cast<AWorldMap>(UGameplayStatics::GetActorOfClass(
+              this, AWorldMap::StaticClass()))) {
+    if (!bIsSelected) {
+      WorldMap->MulticastSelectTerritory(this);
+    } else {
+      WorldMap->MulticastSelectTerritory(nullptr);
+    }
   }
 }
 


### PR DESCRIPTION
## Summary
- Route territory click handling through the world map via `MulticastSelectTerritory`
- Broadcast null territory on deselection so HUD and systems clear state

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b8a8c7d1f483249236bdfcfa227746