### PR TITLE
Register controllers before world init and tighten readiness check

### DIFF
--- a/Source/Skald/Skald_GameMode.cpp
+++ b/Source/Skald/Skald_GameMode.cpp
@@ -369,39 +369,36 @@ void ASkaldGameMode::TryInitializeWorldAndStart() {
     return;
   }
 
-  // Ensure all expected players have locked in before starting the game.
+  bool bAllLockedIn = true;
   for (APlayerState *PSBase : GS->PlayerArray) {
     if (ASkaldPlayerState *PS = Cast<ASkaldPlayerState>(PSBase)) {
       if (!PS->bHasLockedIn) {
-        return;
+        bAllLockedIn = false;
+        break;
       }
     } else {
-      return;
+      bAllLockedIn = false;
+      break;
     }
   }
 
-  const bool bReadyToStart = GS->PlayerArray.Num() >= ExpectedPlayerCount;
+  const bool bReadyToStart =
+      bAllLockedIn && GS->PlayerArray.Num() == ExpectedPlayerCount;
 
-  if (!bWorldInitialized && bReadyToStart && InitializeWorld()) {
-    bWorldInitialized = true;
-
+  if (PendingControllers.Num() > 0) {
     for (ASkaldPlayerController *PC : PendingControllers) {
       if (TurnManager) {
         TurnManager->RegisterController(PC);
       }
     }
     PendingControllers.Empty();
-
-    BeginArmyPlacementPhase();
   }
 
-  if (bWorldInitialized && PendingControllers.Num() > 0) {
-    for (ASkaldPlayerController *PC : PendingControllers) {
-      if (TurnManager) {
-        TurnManager->RegisterController(PC);
-      }
+  if (!bWorldInitialized && bReadyToStart) {
+    if (InitializeWorld()) {
+      bWorldInitialized = true;
+      BeginArmyPlacementPhase();
     }
-    PendingControllers.Empty();
   }
 
   if (bWorldInitialized && bReadyToStart && !bTurnsStarted && TurnManager &&


### PR DESCRIPTION
## Summary
- Require player count to match expected and all players to lock in before starting
- Register pending controllers before world initialization

## Testing
- `g++ -c Source/Skald/Skald_GameMode.cpp` *(fails: CoreMinimal.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b8cf0130d083249c69a9e4e287dc14