### PR TITLE
Stop retrying player registration after controller destruction

### DIFF
--- a/Source/Skald/Skald_GameMode.cpp
+++ b/Source/Skald/Skald_GameMode.cpp
@@ -168,13 +168,16 @@ void ASkaldGameMode::PostLogin(APlayerController *NewPlayer) {
 }
 
 void ASkaldGameMode::RegisterPlayer(ASkaldPlayerController *PC) {
-  if (!PC) {
+  // Bail out if the controller has been destroyed or is otherwise invalid.
+  if (!IsValid(PC)) {
+    PendingControllers.Remove(PC);
     return;
   }
 
   ASkaldPlayerState *PS = PC->GetPlayerState<ASkaldPlayerState>();
   if (!PS) {
-    // Player state not yet replicated; queue a retry next tick.
+    // Player state not yet replicated; queue a retry next tick, but only
+    // while the controller remains valid.
     PendingControllers.AddUnique(PC);
     FTimerDelegate RetryDelegate = FTimerDelegate::CreateUObject(
         this, &ASkaldGameMode::RegisterPlayer, PC);


### PR DESCRIPTION
## Summary
- ensure RegisterPlayer stops retrying once its controller is invalid
- clean up PendingControllers when a controller disappears

## Testing
- `npm test` *(fails: package.json missing)*
- `pytest` *(fails: no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_68b9c1f154c08324b3c88f5621804a90