### PR TITLE
Ensure AI players replicate names before HUD refresh

### DIFF
--- a/Source/Skald/Skald_GameMode.cpp
+++ b/Source/Skald/Skald_GameMode.cpp
@@ -209,6 +209,13 @@ void ASkaldGameMode::RegisterPlayer(ASkaldPlayerController *PC) {
       PlayerDataArray[Index].Faction = PS->Faction;
       PlayerDataArray[Index].Resources = PS->Resources;
     }
+
+    // Notify listeners that player data has changed and refresh HUDs on the
+    // next tick once replication has a chance to update clients.
+    GS->OnPlayersUpdated.Broadcast();
+    FTimerDelegate RefreshDelegate = FTimerDelegate::CreateUObject(
+        this, &ASkaldGameMode::RefreshHUDs);
+    GetWorldTimerManager().SetTimerForNextTick(RefreshDelegate);
   }
 }
 
@@ -257,10 +264,13 @@ void ASkaldGameMode::PopulateAIPlayers() {
 
     AIController->SetIsAIController(true);
     AIController->SetPlayerState(AIState);
-    AIController->FinishSpawning(SpawnTransform);
 
+    // Assign a display name before the controller finishes spawning to ensure
+    // PostLogin sees a valid name.
     AIState->PlayerDisplayName =
         FString::Printf(TEXT("AI_%d"), GS->PlayerArray.Num());
+
+    AIController->FinishSpawning(SpawnTransform);
 
     TArray<ESkaldFaction> Taken;
     for (APlayerState *ExistingPS : GS->PlayerArray) {
@@ -352,6 +362,17 @@ void ASkaldGameMode::RefreshHUDs() {
   ASkaldGameState *GS = GetGameState<ASkaldGameState>();
   if (!GS) {
     return;
+  }
+
+  // Ensure all AI players have valid names before refreshing any HUDs.
+  for (APlayerState *PSBase : GS->PlayerArray) {
+    if (ASkaldPlayerState *SPS = Cast<ASkaldPlayerState>(PSBase)) {
+      if (SPS->bIsAI && SPS->PlayerDisplayName.IsEmpty()) {
+        UE_LOG(LogSkald, Error,
+               TEXT("AI PlayerState missing display name before RefreshHUDs"));
+        ensure(!SPS->PlayerDisplayName.IsEmpty());
+      }
+    }
   }
 
   TArray<FS_PlayerData> AllPlayers;

--- a/Source/Skald/Skald_PlayerState.cpp
+++ b/Source/Skald/Skald_PlayerState.cpp
@@ -68,3 +68,14 @@ void ASkaldPlayerState::OnRep_IsEliminated()
     }
 }
 
+void ASkaldPlayerState::OnRep_PlayerDisplayName()
+{
+    if (UWorld* World = GetWorld())
+    {
+        if (ASkaldGameState* GS = World->GetGameState<ASkaldGameState>())
+        {
+            GS->OnPlayersUpdated.Broadcast();
+        }
+    }
+}
+

--- a/Source/Skald/Skald_PlayerState.h
+++ b/Source/Skald/Skald_PlayerState.h
@@ -32,7 +32,7 @@ public:
     int32 Resources;
 
     /** Player chosen display name. */
-    UPROPERTY(BlueprintReadWrite, Replicated, Category="PlayerState")
+    UPROPERTY(BlueprintReadWrite, ReplicatedUsing = OnRep_PlayerDisplayName, Category="PlayerState")
     FString PlayerDisplayName;
 
     /** Selected faction for this player. */
@@ -55,6 +55,9 @@ public:
 
     UFUNCTION()
     void OnRep_IsEliminated();
+
+    UFUNCTION()
+    void OnRep_PlayerDisplayName();
 
     virtual void GetLifetimeReplicatedProps(TArray<FLifetimeProperty>& OutLifetimeProps) const override;
 };


### PR DESCRIPTION
## Summary
- Assign AI display names before spawn completion to avoid HUD refresh with empty names
- Broadcast player updates and schedule HUD refresh after registration
- Add replication hook and assertions to ensure AI players have non-empty names

## Testing
- `./Build/validate.sh` *(UnrealBuildTool not found; skipping compile check. UnrealEditor not found; cannot run tests.)*

------
https://chatgpt.com/codex/tasks/task_e_68b9beb97db083249000353bae561cc7