### PR TITLE
Allow dynamic player counts for game start

### DIFF
--- a/Source/Skald/Skald_GameMode.cpp
+++ b/Source/Skald/Skald_GameMode.cpp
@@ -154,7 +154,9 @@ void ASkaldGameMode::PostLogin(APlayerController *NewPlayer) {
 
   if (ASkaldGameState *GS = GetGameState<ASkaldGameState>()) {
     if (GS->PlayerArray.Num() >= ExpectedPlayerCount) {
-      PC->ClientMessage(TEXT("Game is full."));
+      PC->ClientMessage(
+          FString::Printf(TEXT("Game is full (%d players max)."),
+                          ExpectedPlayerCount));
       PC->Destroy();
       return;
     }
@@ -456,9 +458,17 @@ void ASkaldGameMode::TryInitializeWorldAndStart() {
     }
   }
 
-  const bool bReadyToStart =
-      bAllLockedIn && GS->PlayerArray.Num() >= ExpectedPlayerCount &&
-      TurnManager && TurnManager->GetControllerCount() >= ExpectedPlayerCount;
+  const int32 CurrentPlayerCount = GS->PlayerArray.Num();
+  const bool bReadyToStart = bAllLockedIn &&
+                             CurrentPlayerCount >= MinPlayerCount && TurnManager &&
+                             TurnManager->GetControllerCount() >= CurrentPlayerCount;
+
+  if (GEngine && CurrentPlayerCount < MinPlayerCount) {
+    GEngine->AddOnScreenDebugMessage(
+        -1, 4.f, FColor::Yellow,
+        FString::Printf(TEXT("Waiting for players: %d/%d ready"),
+                        CurrentPlayerCount, MinPlayerCount));
+  }
 
   if (!bWorldInitialized && bReadyToStart) {
     if (InitializeWorld()) {
@@ -783,7 +793,7 @@ bool ASkaldGameMode::InitializeWorld() {
   int32 TotalPlayerCount = GS->PlayerArray.Num();
   if (TotalPlayerCount > ExpectedPlayerCount) {
     UE_LOG(LogSkald, Warning,
-           TEXT("InitializeWorld: expected %d players but found %d; proceeding "
+           TEXT("InitializeWorld: maximum %d players supported but found %d; proceeding "
                 "with first %d players"),
            ExpectedPlayerCount, TotalPlayerCount, ExpectedPlayerCount);
     while (GS->PlayerArray.Num() > ExpectedPlayerCount) {
@@ -795,18 +805,16 @@ bool ASkaldGameMode::InitializeWorld() {
     }
     TotalPlayerCount = ExpectedPlayerCount;
   }
-  if (TotalPlayerCount < ExpectedPlayerCount) {
+  if (TotalPlayerCount < MinPlayerCount) {
     UE_LOG(LogSkald, Warning,
-           TEXT("InitializeWorld aborted: expected at least %d players but "
-                "found %d"),
-           ExpectedPlayerCount, TotalPlayerCount);
+           TEXT("InitializeWorld aborted: need at least %d players but found %d"),
+           MinPlayerCount, TotalPlayerCount);
     if (GEngine) {
       GEngine->AddOnScreenDebugMessage(
           -1, 5.f, FColor::Yellow,
           FString::Printf(
-              TEXT(
-                  "InitializeWorld: expected at least %d players but found %d"),
-              ExpectedPlayerCount, TotalPlayerCount));
+              TEXT("InitializeWorld: need at least %d players but found %d"),
+              MinPlayerCount, TotalPlayerCount));
     }
     return false;
   }

--- a/Source/Skald/Skald_GameMode.h
+++ b/Source/Skald/Skald_GameMode.h
@@ -69,6 +69,10 @@ protected:
   UPROPERTY(BlueprintReadOnly, Category = "Players")
   TArray<FS_PlayerData> PlayerDataArray;
 
+  /** Minimum number of players required to start the match. */
+  UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "Players", meta = (ClampMin = "1"))
+  int32 MinPlayerCount = 1;
+
   /** All siege equipment constructed on the map. */
   UPROPERTY(BlueprintReadOnly, Category = "Siege")
   TArray<FS_Siege> SiegePool;


### PR DESCRIPTION
## Summary
- add configurable `MinPlayerCount` for flexible match sizes
- base world initialization and start readiness on actual player count
- show player count info in UI messages

## Testing
- `npm test` *(fails: Could not read package.json)*
- `python -m pytest` *(no tests ran)*

------
https://chatgpt.com/codex/tasks/task_e_68b9c3ac824c832486353aa8c82ac66e