### PR TITLE
Stop late joins after world initialization

### DIFF
--- a/Source/Skald/Skald_GameMode.cpp
+++ b/Source/Skald/Skald_GameMode.cpp
@@ -152,6 +152,12 @@ void ASkaldGameMode::PostLogin(APlayerController *NewPlayer) {
     return;
   }
 
+  if (bWorldInitialized) {
+    PC->ClientMessage(TEXT("Game already in progress."));
+    PC->Destroy();
+    return;
+  }
+
   if (ASkaldGameState *GS = GetGameState<ASkaldGameState>()) {
     if (GS->PlayerArray.Num() >= ExpectedPlayerCount) {
       PC->ClientMessage(


### PR DESCRIPTION
## Summary
- reject new player connections once the world has been initialized to avoid uninitialized late joiners

## Testing
- `npm test` (fails: ENOENT package.json)
- `make test` (fails: No rule to make target 'test')

------
https://chatgpt.com/codex/tasks/task_e_68b9d2e8e8f88324a5f04f362a885e79