### PR TITLE
Use deterministic random stream for AI faction selection

### DIFF
--- a/Source/Skald/Skald_GameMode.cpp
+++ b/Source/Skald/Skald_GameMode.cpp
@@ -304,10 +304,11 @@ void ASkaldGameMode::PopulateAIPlayers() {
       }
     }
     if (Available.Num() > 0) {
-      FRandomStream RandStream;
-      RandStream.Initialize(FMath::Rand());
-      AIState->Faction =
-          Available[RandStream.RandRange(0, Available.Num() - 1)];
+      // Use the game instance's deterministic random stream so that AI faction
+      // selection is reproducible across runs and clients.
+      const int32 FactionIndex =
+          GI->CombatRandomStream.RandRange(0, Available.Num() - 1);
+      AIState->Faction = Available[FactionIndex];
       GI->TakenFactions.AddUnique(AIState->Faction);
     } else {
       UE_LOG(LogSkald, Error,


### PR DESCRIPTION
## Summary
- Use deterministic random stream from `USkaldGameInstance` when choosing AI faction to ensure reproducible results

## Testing
- `bash Build/validate.sh` *(fails: UnrealBuildTool not found; skipping compile check. UnrealEditor not found; cannot run tests.)*

------
https://chatgpt.com/codex/tasks/task_e_68b9d9dc280c8324acd4e1293e8e3465