### PR TITLE
Refactor attack mechanics for grid fighters

### DIFF
--- a/Source/Skald/FighterPawn.cpp
+++ b/Source/Skald/FighterPawn.cpp
@@ -5,6 +5,7 @@
 #include "EngineUtils.h"
 #include "GridOverlayComponent.h"
 #include "Skald_GameInstance.h"
+#include "TimerManager.h"
 
 AFighterPawn::AFighterPawn() {
   PrimaryActorTick.bCanEverTick = false;
@@ -52,6 +53,24 @@ UGridOverlayComponent *AFighterPawn::GetGrid() {
   return CachedGrid;
 }
 
+UUserWidget *AFighterPawn::GetDamageWidgetFromPool() {
+  for (UUserWidget *Widget : DamageWidgetPool) {
+    if (Widget && !Widget->IsInViewport()) {
+      return Widget;
+    }
+  }
+  if (DamageFloatWidgetTemplate) {
+    if (UWorld *World = GetWorld()) {
+      if (UUserWidget *NewWidget =
+              CreateWidget<UUserWidget>(World, DamageFloatWidgetTemplate)) {
+        DamageWidgetPool.Add(NewWidget);
+        return NewWidget;
+      }
+    }
+  }
+  return nullptr;
+}
+
 void AFighterPawn::MoveToCell(FIntPoint TargetCell) {
   int32 Distance = FMath::Abs(TargetCell.X - CurrentCell.X) +
                    FMath::Abs(TargetCell.Y - CurrentCell.Y);
@@ -93,46 +112,9 @@ void AFighterPawn::PerformAttack(AFighterPawn *Target) {
     return;
   }
 
-  UGridOverlayComponent *Grid = nullptr;
-  if (UWorld *World = GetWorld()) {
-    for (TActorIterator<AActor> It(World); It; ++It) {
-      Grid = It->FindComponentByClass<UGridOverlayComponent>();
-      if (Grid != nullptr) {
-        break;
-      }
-    }
-  }
-  if (Grid) {
-    FIntPoint StartCell = CurrentCell;
-    FIntPoint TargetCell = Target->CurrentCell;
-    int32 x0 = StartCell.X;
-    int32 y0 = StartCell.Y;
-    int32 x1 = TargetCell.X;
-    int32 y1 = TargetCell.Y;
-    int32 dx = FMath::Abs(x1 - x0);
-    int32 sx = x0 < x1 ? 1 : -1;
-    int32 dy = -FMath::Abs(y1 - y0);
-    int32 sy = y0 < y1 ? 1 : -1;
-    int32 err = dx + dy;
-    FIntPoint Current(x0, y0);
-
-    while (true) {
-      if (Current != StartCell && Grid->IsObscured(Current)) {
-        return;
-      }
-      if (Current.X == x1 && Current.Y == y1) {
-        break;
-      }
-      int32 e2 = 2 * err;
-      if (e2 >= dy) {
-        err += dy;
-        Current.X += sx;
-      }
-      if (e2 <= dx) {
-        err += dx;
-        Current.Y += sy;
-      }
-    }
+  UGridOverlayComponent *Grid = GetGrid();
+  if (Grid && !Grid->HasLineOfSight(CurrentCell, Target->CurrentCell)) {
+    return;
   }
 
   FRandomStream *RandomStream = nullptr;
@@ -142,10 +124,8 @@ void AFighterPawn::PerformAttack(AFighterPawn *Target) {
       RandomStream = &GameInstance->CombatRandomStream;
     }
   }
-  static FRandomStream FallbackStream;
   if (!RandomStream) {
-    FallbackStream.Initialize(FMath::Rand());
-    RandomStream = &FallbackStream;
+    return;
   }
 
   const int32 RequiredRoll =
@@ -159,16 +139,20 @@ void AFighterPawn::PerformAttack(AFighterPawn *Target) {
       Target->Stats.Health =
           FMath::Max(0, Target->Stats.Health - Stats.AttackDamage);
 
-      if (DamageFloatWidgetTemplate && Target) {
+      if (UUserWidget *DamageWidget = GetDamageWidgetFromPool()) {
+        if (UTextBlock *Text = Cast<UTextBlock>(
+                DamageWidget->GetWidgetFromName(TEXT("DamageText")))) {
+          Text->SetText(FText::AsNumber(Stats.AttackDamage));
+        }
+        DamageWidget->AddToViewport();
         if (UWorld *World = GetWorld()) {
-          if (UUserWidget *DamageWidget =
-                  CreateWidget<UUserWidget>(World, DamageFloatWidgetTemplate)) {
-            if (UTextBlock *Text = Cast<UTextBlock>(
-                    DamageWidget->GetWidgetFromName(TEXT("DamageText")))) {
-              Text->SetText(FText::AsNumber(Stats.AttackDamage));
-            }
-            DamageWidget->AddToViewport();
-          }
+          FTimerHandle Timer;
+          World->GetTimerManager().SetTimer(
+              Timer,
+              FTimerDelegate::CreateLambda([DamageWidget]() {
+                DamageWidget->RemoveFromParent();
+              }),
+              1.f, false);
         }
       }
     }

--- a/Source/Skald/FighterPawn.h
+++ b/Source/Skald/FighterPawn.h
@@ -81,6 +81,13 @@ private:
   /** Get the grid overlay component, caching the result. */
   UGridOverlayComponent *GetGrid();
 
+  /** Retrieve or create a damage widget from the pool. */
+  UUserWidget *GetDamageWidgetFromPool();
+
+  /** Pool of reusable damage widgets to avoid repeated allocations. */
+  UPROPERTY()
+  TArray<UUserWidget *> DamageWidgetPool;
+
   /** Current cell occupied by the fighter. */
   FIntPoint CurrentCell;
 

--- a/Source/Skald/GridOverlayComponent.cpp
+++ b/Source/Skald/GridOverlayComponent.cpp
@@ -85,6 +85,37 @@ bool UGridOverlayComponent::IsObscured(const FIntPoint &GridCoord) const {
   return ObscuredCells[Index(GridCoord)];
 }
 
+bool UGridOverlayComponent::HasLineOfSight(const FIntPoint &Start,
+                                           const FIntPoint &End) const {
+  FIntPoint Current = Start;
+  const int32 x1 = End.X;
+  const int32 y1 = End.Y;
+  int32 dx = FMath::Abs(x1 - Current.X);
+  int32 sx = Current.X < x1 ? 1 : -1;
+  int32 dy = -FMath::Abs(y1 - Current.Y);
+  int32 sy = Current.Y < y1 ? 1 : -1;
+  int32 err = dx + dy;
+
+  while (true) {
+    if (Current != Start && IsObscured(Current)) {
+      return false;
+    }
+    if (Current.X == x1 && Current.Y == y1) {
+      break;
+    }
+    int32 e2 = 2 * err;
+    if (e2 >= dy) {
+      err += dy;
+      Current.X += sx;
+    }
+    if (e2 <= dx) {
+      err += dx;
+      Current.Y += sy;
+    }
+  }
+  return true;
+}
+
 float UGridOverlayComponent::GetCellHeight(const FIntPoint &GridCoord) const {
   if (!IsValidGrid(GridCoord)) {
     return Origin.Z;
@@ -231,38 +262,7 @@ void UGridOverlayComponent::HighlightAttack(AFighterPawn *Fighter) {
         continue;
       }
 
-      int32 x0 = StartCell.X;
-      int32 y0 = StartCell.Y;
-      int32 x1 = Target.X;
-      int32 y1 = Target.Y;
-      int32 dx = FMath::Abs(x1 - x0);
-      int32 sx = x0 < x1 ? 1 : -1;
-      int32 dy = -FMath::Abs(y1 - y0);
-      int32 sy = y0 < y1 ? 1 : -1;
-      int32 err = dx + dy;
-      FIntPoint Current(x0, y0);
-      bool bBlocked = false;
-
-      while (true) {
-        if (Current != StartCell && IsObscured(Current)) {
-          bBlocked = true;
-          break;
-        }
-        if (Current.X == x1 && Current.Y == y1) {
-          break;
-        }
-        int32 e2 = 2 * err;
-        if (e2 >= dy) {
-          err += dy;
-          Current.X += sx;
-        }
-        if (e2 <= dx) {
-          err += dx;
-          Current.Y += sy;
-        }
-      }
-
-      if (!bBlocked) {
+      if (HasLineOfSight(StartCell, Target)) {
         HighlightCell(Target, FColor::Red, 0.f, true);
       }
     }

--- a/Source/Skald/GridOverlayComponent.h
+++ b/Source/Skald/GridOverlayComponent.h
@@ -37,6 +37,10 @@ public:
   UFUNCTION(BlueprintCallable, BlueprintPure, Category = "Grid")
   bool IsObscured(const FIntPoint &GridCoord) const;
 
+  /** Check if there is line of sight between two grid cells. */
+  UFUNCTION(BlueprintCallable, BlueprintPure, Category = "Grid")
+  bool HasLineOfSight(const FIntPoint &Start, const FIntPoint &End) const;
+
   /** Get the cached height for a grid cell. */
   UFUNCTION(BlueprintCallable, BlueprintPure, Category = "Grid")
   float GetCellHeight(const FIntPoint &GridCoord) const;


### PR DESCRIPTION
## Summary
- Use cached GetGrid and a new UGridOverlayComponent::HasLineOfSight to avoid redundant world scans
- Pool damage widgets with deferred removal instead of creating new widgets for each hit
- Remove nondeterministic fallback RNG and rely on the game instance's combat stream

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b9d9a4e0f883248a41f4335c53270b