### PR TITLE
Stop dangling world map timer in ASkaldPlayerController

### DIFF
--- a/Source/Skald/Skald_PlayerController.cpp
+++ b/Source/Skald/Skald_PlayerController.cpp
@@ -17,13 +17,13 @@
 #include "Skald_PlayerState.h"
 #include "Skald_TurnManager.h"
 #include "Territory.h"
+#include "TimerManager.h"
 #include "UI/BattleHUDWidget.h"
 #include "UI/DeployWidget.h"
 #include "UI/FighterSelectionWidget.h"
 #include "UI/SkaldMainHUDWidget.h"
 #include "UObject/ConstructorHelpers.h"
 #include "WorldMap.h"
-#include "TimerManager.h"
 #include <limits>
 
 constexpr int32 MaxAIIterations = 100;
@@ -167,22 +167,25 @@ void ASkaldPlayerController::TryBindWorldMap() {
             this, &ASkaldPlayerController::HandleTerritorySelected)) {
       WorldMap->OnTerritorySelected.AddDynamic(
           this, &ASkaldPlayerController::HandleTerritorySelected);
-      ensureMsgf(
-          WorldMap->OnTerritorySelected.IsAlreadyBound(
-              this, &ASkaldPlayerController::HandleTerritorySelected),
-          TEXT("Failed to bind HandleTerritorySelected to WorldMap."));
+      ensureMsgf(WorldMap->OnTerritorySelected.IsAlreadyBound(
+                     this, &ASkaldPlayerController::HandleTerritorySelected),
+                 TEXT("Failed to bind HandleTerritorySelected to WorldMap."));
     }
     WorldMapSearchAttempts = 0;
+    GetWorldTimerManager().ClearTimer(WorldMapSearchHandle);
   } else {
     ++WorldMapSearchAttempts;
     if (WorldMapSearchAttempts >= MaxWorldMapSearchAttempts) {
       UE_LOG(LogSkald, Warning,
-             TEXT("ASkaldPlayerController could not find AWorldMap after %d attempts."),
+             TEXT("ASkaldPlayerController could not find AWorldMap after %d "
+                  "attempts."),
              WorldMapSearchAttempts);
+      GetWorldTimerManager().ClearTimer(WorldMapSearchHandle);
+    } else {
+      GetWorldTimerManager().SetTimer(WorldMapSearchHandle, this,
+                                      &ASkaldPlayerController::TryBindWorldMap,
+                                      0.5f, false);
     }
-    GetWorldTimerManager().SetTimer(
-        WorldMapSearchHandle, this,
-        &ASkaldPlayerController::TryBindWorldMap, 0.5f, false);
   }
 }
 
@@ -1025,9 +1028,7 @@ void ASkaldPlayerController::HandleWorldStateChanged() {
   }
 }
 
-void ASkaldPlayerController::HandlePlayerLockedIn() {
-  HandleFactionLockedIn();
-}
+void ASkaldPlayerController::HandlePlayerLockedIn() { HandleFactionLockedIn(); }
 
 void ASkaldPlayerController::HandleFactionLockedIn() {
   if (ChoosePlayerWidget) {


### PR DESCRIPTION
## Summary
- Clear world map search timer once the map is found
- Stop retry timer after exceeding the search attempt limit

## Testing
- `clang-format -i Source/Skald/Skald_PlayerController.cpp`

------
https://chatgpt.com/codex/tasks/task_e_68b9db0a849883248324754e55649d3b