### PR TITLE
Add debug logs for player lock-in flow

### DIFF
--- a/Source/Skald/Skald_GameMode.cpp
+++ b/Source/Skald/Skald_GameMode.cpp
@@ -351,6 +351,14 @@ void ASkaldGameMode::HandlePlayerLockedIn(ASkaldPlayerState *PS) {
     return;
   }
 
+  UE_LOG(LogSkald, Log,
+         TEXT("HandlePlayerLockedIn: Player=%s bIsAI=%d"),
+         *PS->PlayerDisplayName, PS->bIsAI);
+  UE_LOG(LogSkald, Log,
+         TEXT("HandlePlayerLockedIn: TurnManager=%s ControllerCount=%d"),
+         TurnManager ? *TurnManager->GetName() : TEXT("null"),
+         TurnManager ? TurnManager->GetControllerCount() : 0);
+
   FS_PlayerData *PlayerData =
       PlayerDataArray.FindByPredicate([PS](const FS_PlayerData &Data) {
         return Data.PlayerID == PS->GetPlayerId();
@@ -431,6 +439,11 @@ void ASkaldGameMode::TryInitializeWorldAndStart() {
     return;
   }
 
+  UE_LOG(LogSkald, Log,
+         TEXT("TryInitializeWorldAndStart: TurnManager=%s PlayerCount=%d"),
+         TurnManager ? *TurnManager->GetName() : TEXT("null"),
+         GS->PlayerArray.Num());
+
   bool bAllLockedIn = true;
   for (APlayerState *PSBase : GS->PlayerArray) {
     if (ASkaldPlayerState *PS = Cast<ASkaldPlayerState>(PSBase)) {
@@ -470,6 +483,12 @@ void ASkaldGameMode::TryInitializeWorldAndStart() {
                              CurrentPlayerCount >= MinPlayerCount && TurnManager &&
                              TurnManager->GetControllerCount() >= CurrentPlayerCount;
 
+  UE_LOG(LogSkald, Log,
+         TEXT("TryInitializeWorldAndStart: bAllLockedIn=%s CurrentPlayerCount=%d ControllerCount=%d bReadyToStart=%s"),
+         bAllLockedIn ? TEXT("true") : TEXT("false"), CurrentPlayerCount,
+         TurnManager ? TurnManager->GetControllerCount() : 0,
+         bReadyToStart ? TEXT("true") : TEXT("false"));
+
   if (GEngine && CurrentPlayerCount < MinPlayerCount) {
     GEngine->AddOnScreenDebugMessage(
         -1, 4.f, FColor::Yellow,
@@ -478,6 +497,8 @@ void ASkaldGameMode::TryInitializeWorldAndStart() {
   }
 
   if (!bWorldInitialized && bReadyToStart) {
+    UE_LOG(LogSkald, Log,
+           TEXT("TryInitializeWorldAndStart: Initializing world"));
     if (InitializeWorld()) {
       bWorldInitialized = true;
       BeginArmyPlacementPhase();
@@ -491,6 +512,8 @@ void ASkaldGameMode::TryInitializeWorldAndStart() {
     TurnManager->SortControllersByInitiative();
     TurnManager->StartTurns();
 
+    UE_LOG(LogSkald, Log,
+           TEXT("TryInitializeWorldAndStart: Turns started"));
     if (GEngine) {
       GEngine->AddOnScreenDebugMessage(-1, 4.f, FColor::Green,
                                        TEXT("Game started"));

--- a/Source/Skald/Skald_PlayerController.cpp
+++ b/Source/Skald/Skald_PlayerController.cpp
@@ -210,14 +210,30 @@ void ASkaldPlayerController::OnRep_PlayerState() {
 
 void ASkaldPlayerController::ServerInitPlayerState_Implementation(
     const FString &Name, ESkaldFaction Faction) {
+  UE_LOG(LogSkald, Log,
+         TEXT("ServerInitPlayerState_Implementation: Name=%s Faction=%d"),
+         *Name, static_cast<int32>(Faction));
+
   if (ASkaldPlayerState *PS = GetPlayerState<ASkaldPlayerState>()) {
+    UE_LOG(LogSkald, Log,
+           TEXT("ServerInitPlayerState_Implementation: PlayerState=%s"),
+           *PS->GetName());
     PS->PlayerDisplayName = Name;
     PS->Faction = Faction;
     PS->bHasLockedIn = true;
 
     if (ASkaldGameMode *GM = GetWorld()->GetAuthGameMode<ASkaldGameMode>()) {
+      UE_LOG(LogSkald, Log,
+             TEXT("ServerInitPlayerState_Implementation: Notify GameMode %s"),
+             *GM->GetName());
       GM->HandlePlayerLockedIn(PS);
+    } else {
+      UE_LOG(LogSkald, Warning,
+             TEXT("ServerInitPlayerState_Implementation: GameMode is null"));
     }
+  } else {
+    UE_LOG(LogSkald, Warning,
+           TEXT("ServerInitPlayerState_Implementation: PlayerState is null"));
   }
 }
 


### PR DESCRIPTION
## Summary
- log player state initialization from the controller
- log game mode lock-in handling and TurnManager status
- log world start checks, controller counts, and turn start events

## Testing
- `./Build/validate.sh` *(fails: UnrealBuildTool not found; UnrealEditor not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ba0977d26483248875b6fb46dac110