### PR TITLE
Spawn AI players only once after human lock-in

### DIFF
--- a/Source/Skald/Skald_GameMode.cpp
+++ b/Source/Skald/Skald_GameMode.cpp
@@ -39,6 +39,7 @@ ASkaldGameMode::ASkaldGameMode() {
   WorldMap = nullptr;
   bTurnsStarted = false;
   bWorldInitialized = false;
+  bAIPlayersSpawned = false;
 
   // Preallocate slots so blueprint scripts can safely write
   // player data to indices without hitting "invalid index" warnings.
@@ -370,10 +371,11 @@ void ASkaldGameMode::HandlePlayerLockedIn(ASkaldPlayerState *PS) {
     PlayerData->Faction = PS->Faction;
   }
 
-  // If a human player has locked in and there are still open slots,
-  // populate them with AI players so the match can start.
-  if (!PS->bIsAI) {
+  // If a human player has locked in and AI players have not yet been spawned,
+  // populate remaining slots so the match can start.
+  if (!PS->bIsAI && !bAIPlayersSpawned) {
     PopulateAIPlayers();
+    bAIPlayersSpawned = true;
   }
 
   RefreshHUDs();

--- a/Source/Skald/Skald_GameMode.h
+++ b/Source/Skald/Skald_GameMode.h
@@ -114,6 +114,9 @@ private:
   /** Whether the world has been initialized and territories assigned. */
   bool bWorldInitialized;
 
+  /** Whether AI players have already been spawned. */
+  bool bAIPlayersSpawned;
+
   /** Controllers waiting for world initialization before registration. */
   TArray<ASkaldPlayerController *> PendingControllers;
 


### PR DESCRIPTION
## Summary
- Track whether AI players have been spawned using `bAIPlayersSpawned`
- Only call `PopulateAIPlayers` when the first human player locks in

## Testing
- ⚠️ `bash Build/validate.sh` *(UnrealBuildTool and UnrealEditor not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ba161ce5a88324870bd01826125abe