### PR TITLE
Reset player data arrays on BeginPlay

### DIFF
--- a/Source/Skald/Skald_GameMode.cpp
+++ b/Source/Skald/Skald_GameMode.cpp
@@ -50,6 +50,12 @@ ASkaldGameMode::ASkaldGameMode() {
 void ASkaldGameMode::BeginPlay() {
   Super::BeginPlay();
 
+  if (ASkaldGameState *GS = GetGameState<ASkaldGameState>()) {
+    GS->Players.Empty();
+    GS->PlayerArray.Empty();
+  }
+  PlayerDataArray.Empty();
+
   if (!TurnManager) {
     TurnManager = GetWorld()->SpawnActor<ATurnManager>();
   }


### PR DESCRIPTION
## Summary
- Clear ASkaldGameState player arrays and GameMode player data at startup
- Reset player data array so registration and AI spawning operate on a clean state

## Testing
- `cmake .` *(fails: The source directory does not appear to contain CMakeLists.txt)*

------
https://chatgpt.com/codex/tasks/task_e_68ba16cc1030832485eb3f01b76938f1