### PR TITLE
Register AI controllers immediately

### DIFF
--- a/Source/Skald/Skald_GameMode.cpp
+++ b/Source/Skald/Skald_GameMode.cpp
@@ -290,6 +290,13 @@ void ASkaldGameMode::PopulateAIPlayers() {
 
     AIController->FinishSpawning(SpawnTransform);
 
+    if (TurnManager) {
+      TurnManager->RegisterController(AIController);
+      UE_LOG(LogSkald, Log,
+             TEXT("PopulateAIPlayers: ControllerCount=%d"),
+             TurnManager->GetControllerCount());
+    }
+
     TArray<ESkaldFaction> Taken;
     for (APlayerState *ExistingPS : GS->PlayerArray) {
       if (ASkaldPlayerState *EPS = Cast<ASkaldPlayerState>(ExistingPS)) {
@@ -464,27 +471,6 @@ void ASkaldGameMode::TryInitializeWorldAndStart() {
     } else {
       bAllLockedIn = false;
       break;
-    }
-  }
-
-  if (PendingControllers.Num() > 0) {
-    for (ASkaldPlayerController *PC : PendingControllers) {
-      if (TurnManager) {
-        TurnManager->RegisterController(PC);
-      }
-    }
-    PendingControllers.Empty();
-  }
-
-  // Fallback: ensure any existing player controllers are registered with the
-  // turn manager even if RegisterPlayer was not called for them.
-  if (TurnManager) {
-    for (FConstPlayerControllerIterator It =
-             GetWorld()->GetPlayerControllerIterator();
-         It; ++It) {
-      if (ASkaldPlayerController *PC = Cast<ASkaldPlayerController>(*It)) {
-        TurnManager->RegisterController(PC);
-      }
     }
   }
 

--- a/Source/Skald/Skald_GameMode.h
+++ b/Source/Skald/Skald_GameMode.h
@@ -117,7 +117,7 @@ private:
   /** Whether AI players have already been spawned. */
   bool bAIPlayersSpawned;
 
-  /** Controllers waiting for world initialization before registration. */
+  /** Controllers whose PlayerState is not yet valid, queued for retry. */
   TArray<ASkaldPlayerController *> PendingControllers;
 
   /** Index of the controller currently placing armies. */


### PR DESCRIPTION
## Summary
- register AI controllers with the TurnManager at spawn
- drop redundant controller registration loops in `TryInitializeWorldAndStart`
- log the TurnManager controller count after each AI spawn

## Testing
- `g++ -std=c++17 -I../Engine/Source -ISource -c Source/Skald/Skald_GameMode.cpp` *(fails: CoreMinimal.h: No such file or directory)*
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ba1897c3e08324bb33a4cb45a670e4