### PR TITLE
Ensure turn flow waits for registered players

### DIFF
--- a/Source/Skald/Skald_GameMode.cpp
+++ b/Source/Skald/Skald_GameMode.cpp
@@ -297,13 +297,6 @@ void ASkaldGameMode::PopulateAIPlayers() {
 
     AIController->FinishSpawning(SpawnTransform);
 
-    if (TurnManager) {
-      TurnManager->RegisterController(AIController);
-      UE_LOG(LogSkald, Log,
-             TEXT("PopulateAIPlayers: ControllerCount=%d"),
-             TurnManager->GetControllerCount());
-    }
-
     TArray<ESkaldFaction> Taken;
     for (APlayerState *ExistingPS : GS->PlayerArray) {
       if (ASkaldPlayerState *EPS = Cast<ASkaldPlayerState>(ExistingPS)) {
@@ -342,6 +335,13 @@ void ASkaldGameMode::PopulateAIPlayers() {
     AIState->bHasLockedIn = true;
 
     RegisterPlayer(AIController);
+
+    if (TurnManager) {
+      TurnManager->RegisterController(AIController);
+      UE_LOG(LogSkald, Log,
+             TEXT("PopulateAIPlayers: ControllerCount=%d PlayerCount=%d"),
+             TurnManager->GetControllerCount(), GS->PlayerArray.Num());
+    }
 
     if (!AIController->GetPawn() && DefaultPawnClass) {
       FActorSpawnParameters PawnParams;
@@ -469,28 +469,41 @@ void ASkaldGameMode::TryInitializeWorldAndStart() {
          GS->PlayerArray.Num());
 
   bool bAllLockedIn = true;
+  bool bAllHaveControllers = true;
+  TArray<ASkaldPlayerController *> RegisteredControllers =
+      TurnManager ? TurnManager->GetControllers()
+                  : TArray<ASkaldPlayerController *>();
   for (APlayerState *PSBase : GS->PlayerArray) {
-    if (ASkaldPlayerState *PS = Cast<ASkaldPlayerState>(PSBase)) {
-      if (!PS->bHasLockedIn) {
-        bAllLockedIn = false;
-        break;
-      }
-    } else {
+    ASkaldPlayerState *PS = Cast<ASkaldPlayerState>(PSBase);
+    if (!PS || !PS->bHasLockedIn) {
       bAllLockedIn = false;
+    }
+    ASkaldPlayerController *Owner =
+        PS ? Cast<ASkaldPlayerController>(PS->GetOwner()) : nullptr;
+    if (!Owner || !RegisteredControllers.Contains(Owner)) {
+      bAllHaveControllers = false;
+      UE_LOG(LogSkald, Warning,
+             TEXT("TryInitializeWorldAndStart: PlayerState %s missing controller"),
+             *GetNameSafe(PS));
+    }
+    if (!bAllLockedIn || !bAllHaveControllers) {
       break;
     }
   }
 
   const int32 CurrentPlayerCount = GS->PlayerArray.Num();
-  const bool bReadyToStart = bAllLockedIn &&
+  const bool bReadyToStart = bAllLockedIn && bAllHaveControllers &&
                              CurrentPlayerCount >= MinPlayerCount && TurnManager &&
                              TurnManager->GetControllerCount() >= CurrentPlayerCount;
 
-  UE_LOG(LogSkald, Log,
-         TEXT("TryInitializeWorldAndStart: bAllLockedIn=%s CurrentPlayerCount=%d ControllerCount=%d bReadyToStart=%s"),
-         bAllLockedIn ? TEXT("true") : TEXT("false"), CurrentPlayerCount,
-         TurnManager ? TurnManager->GetControllerCount() : 0,
-         bReadyToStart ? TEXT("true") : TEXT("false"));
+  UE_LOG(
+      LogSkald, Log,
+      TEXT(
+          "TryInitializeWorldAndStart: bAllLockedIn=%s bAllHaveControllers=%s CurrentPlayerCount=%d ControllerCount=%d bReadyToStart=%s"),
+      bAllLockedIn ? TEXT("true") : TEXT("false"),
+      bAllHaveControllers ? TEXT("true") : TEXT("false"), CurrentPlayerCount,
+      TurnManager ? TurnManager->GetControllerCount() : 0,
+      bReadyToStart ? TEXT("true") : TEXT("false"));
 
   if (GEngine && CurrentPlayerCount < MinPlayerCount) {
     GEngine->AddOnScreenDebugMessage(

--- a/Source/Skald/Skald_TurnManager.cpp
+++ b/Source/Skald/Skald_TurnManager.cpp
@@ -193,6 +193,12 @@ void ATurnManager::AdvanceTurn() {
     return;
   }
 
+  if (!CachedWorldMap || CachedWorldMap->Territories.Num() == 0) {
+    UE_LOG(LogSkald, Warning,
+           TEXT("AdvanceTurn aborted: WorldMap missing or has no territories"));
+    return;
+  }
+
   int32 FoundIndex = Controllers.IndexOfByPredicate(
       [PreviousController](const TWeakObjectPtr<ASkaldPlayerController> &Ptr) {
         return Ptr.Get() == PreviousController;


### PR DESCRIPTION
## Summary
- Check that every PlayerState has a registered PlayerController before starting the world
- Register AI controllers during population so controller and player counts stay in sync
- Halt turn advancement if the world map lacks territories

## Testing
- `pre-commit run --files Source/Skald/Skald_GameMode.cpp Source/Skald/Skald_TurnManager.cpp` *(fails: .pre-commit-config.yaml is not a file)*

------
https://chatgpt.com/codex/tasks/task_e_68ba26aeff0c8324b045cb6b87c4d374