### PR TITLE
Fix Owner variable shadowing in game mode

### DIFF
--- a/Source/Skald/Skald_GameMode.cpp
+++ b/Source/Skald/Skald_GameMode.cpp
@@ -478,9 +478,9 @@ void ASkaldGameMode::TryInitializeWorldAndStart() {
     if (!PS || !PS->bHasLockedIn) {
       bAllLockedIn = false;
     }
-    ASkaldPlayerController *Owner =
+    ASkaldPlayerController *OwningController =
         PS ? Cast<ASkaldPlayerController>(PS->GetOwner()) : nullptr;
-    if (!Owner || !RegisteredControllers.Contains(Owner)) {
+    if (!OwningController || !RegisteredControllers.Contains(OwningController)) {
       bAllHaveControllers = false;
       UE_LOG(LogSkald, Warning,
              TEXT("TryInitializeWorldAndStart: PlayerState %s missing controller"),


### PR DESCRIPTION
## Summary
- rename local `Owner` variable to `OwningController` to avoid hiding `AActor::Owner`

## Testing
- `g++ -fsyntax-only Source/Skald/Skald_GameMode.cpp` *(fails: CoreMinimal.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68ba290a44c48324a50b244d3b71ac58