### PR TITLE
refactor: derive AI status from controller

### DIFF
--- a/Source/Skald/SkaldTypes.h
+++ b/Source/Skald/SkaldTypes.h
@@ -265,9 +265,6 @@ struct SKALD_API FPlayerSaveStruct
     FString PlayerName;
 
     UPROPERTY(BlueprintReadWrite, EditAnywhere)
-    bool IsAI = false;
-
-    UPROPERTY(BlueprintReadWrite, EditAnywhere)
     ESkaldFaction Faction = ESkaldFaction::Human;
 
     UPROPERTY(BlueprintReadWrite, EditAnywhere)

--- a/Source/Skald/Skald_GameMode.cpp
+++ b/Source/Skald/Skald_GameMode.cpp
@@ -108,7 +108,7 @@ void ASkaldGameMode::BeginPlay() {
         if (GS) {
           for (APlayerState *BasePS : GS->PlayerArray) {
             ASkaldPlayerState *PS = Cast<ASkaldPlayerState>(BasePS);
-            if (!PS || !PS->bIsAI) {
+            if (!PS || !Cast<ASkaldAIController>(PS->GetOwner())) {
               continue;
             }
 
@@ -230,7 +230,8 @@ void ASkaldGameMode::RegisterPlayer(ASkaldPlayerController *PC) {
     if (PlayerDataArray.IsValidIndex(Index)) {
       PlayerDataArray[Index].PlayerID = PS->GetPlayerId();
       PlayerDataArray[Index].PlayerName = PS->PlayerDisplayName;
-      PlayerDataArray[Index].IsAI = PS->bIsAI;
+      PlayerDataArray[Index].IsAI =
+          Cast<ASkaldAIController>(PS->GetOwner()) != nullptr;
       PlayerDataArray[Index].Faction = PS->Faction;
       PlayerDataArray[Index].Resources = PS->Resources;
     }
@@ -254,7 +255,7 @@ void ASkaldGameMode::PopulateAIPlayers() {
   bool bHasHuman = false;
   for (APlayerState *ExistingPS : GS->PlayerArray) {
     if (ASkaldPlayerState *EPS = Cast<ASkaldPlayerState>(ExistingPS)) {
-      if (!EPS->bIsAI) {
+      if (!Cast<ASkaldAIController>(EPS->GetOwner())) {
         bHasHuman = true;
         break;
       }
@@ -275,7 +276,6 @@ void ASkaldGameMode::PopulateAIPlayers() {
       break;
     }
 
-    AIState->bIsAI = true;
     AIState->bHasLockedIn = true;
 
     FTransform SpawnTransform = FTransform::Identity;
@@ -364,7 +364,8 @@ void ASkaldGameMode::HandlePlayerLockedIn(ASkaldPlayerState *PS) {
   }
 
   UE_LOG(LogSkald, Log, TEXT("HandlePlayerLockedIn: Player=%s bIsAI=%d"),
-         *PS->PlayerDisplayName, PS->bIsAI);
+         *PS->PlayerDisplayName,
+         Cast<ASkaldAIController>(PS->GetOwner()) ? 1 : 0);
   ASkaldGameState *GS = GetGameState<ASkaldGameState>();
   UE_LOG(LogSkald, Log,
          TEXT("HandlePlayerLockedIn: TurnManager=%s ControllerCount=%d "
@@ -399,7 +400,8 @@ void ASkaldGameMode::RefreshHUDs() {
   // Ensure all AI players have valid names before refreshing any HUDs.
   for (APlayerState *PSBase : GS->PlayerArray) {
     if (ASkaldPlayerState *SPS = Cast<ASkaldPlayerState>(PSBase)) {
-      if (SPS->bIsAI && SPS->PlayerDisplayName.IsEmpty()) {
+      if (Cast<ASkaldAIController>(SPS->GetOwner()) &&
+          SPS->PlayerDisplayName.IsEmpty()) {
         UE_LOG(LogSkald, Error,
                TEXT("AI PlayerState missing display name before RefreshHUDs"));
         ensure(!SPS->PlayerDisplayName.IsEmpty());
@@ -413,7 +415,7 @@ void ASkaldGameMode::RefreshHUDs() {
       FS_PlayerData Data;
       Data.PlayerID = SPS->GetPlayerId();
       Data.PlayerName = SPS->PlayerDisplayName;
-      Data.IsAI = SPS->bIsAI;
+      Data.IsAI = Cast<ASkaldAIController>(SPS->GetOwner()) != nullptr;
       Data.Faction = SPS->Faction;
       Data.Resources = SPS->Resources;
       AllPlayers.Add(Data);
@@ -552,7 +554,6 @@ void ASkaldGameMode::ApplyLoadedGame(USkaldSaveGame *LoadedGame) {
     }
     PS->SetPlayerId(PlayerSave.PlayerID);
     PS->PlayerDisplayName = PlayerSave.PlayerName;
-    PS->bIsAI = PlayerSave.IsAI;
     PS->Faction = PlayerSave.Faction;
     PS->Resources = PlayerSave.Resources;
     if (GS) {
@@ -562,7 +563,6 @@ void ASkaldGameMode::ApplyLoadedGame(USkaldSaveGame *LoadedGame) {
     FS_PlayerData Data;
     Data.PlayerID = PlayerSave.PlayerID;
     Data.PlayerName = PlayerSave.PlayerName;
-    Data.IsAI = PlayerSave.IsAI;
     Data.Faction = PlayerSave.Faction;
     Data.Resources = PlayerSave.Resources;
     Data.CapitalTerritoryIDs = PlayerSave.CapitalTerritoryIDs;
@@ -759,7 +759,7 @@ void ASkaldGameMode::AdvanceArmyPlacement() {
     }
 
     // AI players automatically distribute their armies evenly.
-    if (PS->bIsAI) {
+    if (Cast<ASkaldAIController>(PS->GetOwner())) {
       TArray<ATerritory *> OwnedTerritories;
       for (ATerritory *Territory : WorldMap->Territories) {
         if (Territory && Territory->OwningPlayer == PS) {
@@ -1075,7 +1075,6 @@ void ASkaldGameMode::FillSaveGame(USkaldSaveGame *SaveGameObject) const {
     FPlayerSaveStruct PlayerSave;
     PlayerSave.PlayerID = Data.PlayerID;
     PlayerSave.PlayerName = Data.PlayerName;
-    PlayerSave.IsAI = Data.IsAI;
     PlayerSave.Faction = Data.Faction;
     PlayerSave.Resources = Data.Resources;
     PlayerSave.CapitalTerritoryIDs = Data.CapitalTerritoryIDs;

--- a/Source/Skald/Skald_PlayerController.cpp
+++ b/Source/Skald/Skald_PlayerController.cpp
@@ -15,6 +15,7 @@
 #include "Skald_GameMode.h"
 #include "Skald_GameState.h"
 #include "Skald_PlayerState.h"
+#include "Skald_AIController.h"
 #include "Skald_TurnManager.h"
 #include "Territory.h"
 #include "TimerManager.h"
@@ -821,7 +822,7 @@ void ASkaldPlayerController::BuildPlayerDataArray(
       FS_PlayerData Data;
       Data.PlayerID = PS->GetPlayerId();
       Data.PlayerName = PS->PlayerDisplayName;
-      Data.IsAI = PS->bIsAI;
+      Data.IsAI = Cast<ASkaldAIController>(PS->GetOwner()) != nullptr;
       Data.Faction = PS->Faction;
       Data.Resources = PS->Resources;
       Data.IsEliminated = PS->IsEliminated;

--- a/Source/Skald/Skald_PlayerState.cpp
+++ b/Source/Skald/Skald_PlayerState.cpp
@@ -6,8 +6,7 @@
 #include "UI/SkaldMainHUDWidget.h"
 
 ASkaldPlayerState::ASkaldPlayerState()
-    : bIsAI(false)
-    , DeployableUnits(0)
+    : DeployableUnits(0)
     , InitiativeRoll(0)
     , Resources(0)
     , PlayerDisplayName(TEXT("Player"))
@@ -25,7 +24,6 @@ void ASkaldPlayerState::GetLifetimeReplicatedProps(
     DOREPLIFETIME(ASkaldPlayerState, PlayerDisplayName);
     DOREPLIFETIME(ASkaldPlayerState, Faction);
     DOREPLIFETIME(ASkaldPlayerState, DeployableUnits);
-    DOREPLIFETIME(ASkaldPlayerState, bIsAI);
     DOREPLIFETIME(ASkaldPlayerState, InitiativeRoll);
     DOREPLIFETIME(ASkaldPlayerState, Resources);
     DOREPLIFETIME(ASkaldPlayerState, bHasLockedIn);

--- a/Source/Skald/Skald_PlayerState.h
+++ b/Source/Skald/Skald_PlayerState.h
@@ -16,9 +16,6 @@ class SKALD_API ASkaldPlayerState : public APlayerState
 public:
     ASkaldPlayerState();
 
-    UPROPERTY(BlueprintReadWrite, Replicated, Category="PlayerState")
-    bool bIsAI;
-
     /** Deployable units available for placement. */
     UPROPERTY(BlueprintReadWrite, ReplicatedUsing = OnRep_DeployableUnits, Category="PlayerState")
     int32 DeployableUnits;

--- a/Source/Skald/Tests/AIDecisionFlowTest.cpp
+++ b/Source/Skald/Tests/AIDecisionFlowTest.cpp
@@ -37,14 +37,14 @@ bool FSkaldAIDecisionFlowTest::RunTest(const FString& Parameters)
     }
 
     PC1->PlayerState = PS1;
-    PS1->bIsAI = true;
+    PS1->SetOwner(PC1);
     PS1->DeployableUnits = 4;
     PS1->Resources = 4;
     PC1->SetTurnManager(TM);
 
     // Dummy opponent to prevent infinite turn loop
     PC2->PlayerState = PS2;
-    PS2->bIsAI = false;
+    PS2->SetOwner(PC2);
     TM->RegisterController(PC1);
     TM->RegisterController(PC2);
 

--- a/Source/Skald/UI/SkaldMainHUDWidget.cpp
+++ b/Source/Skald/UI/SkaldMainHUDWidget.cpp
@@ -12,6 +12,7 @@
 #include "Skald_GameState.h"
 #include "Skald_PlayerController.h"
 #include "Skald_PlayerState.h"
+#include "Skald_AIController.h"
 #include "Skald_TurnManager.h"
 #include "Territory.h"
 #include "UI/ConfirmAttackWidget.h"
@@ -516,7 +517,7 @@ void USkaldMainHUDWidget::HandlePlayersUpdated() {
       FS_PlayerData Data;
       Data.PlayerID = PS->GetPlayerId();
       Data.PlayerName = PS->PlayerDisplayName;
-      Data.IsAI = PS->bIsAI;
+      Data.IsAI = Cast<ASkaldAIController>(PS->GetOwner()) != nullptr;
       Data.Faction = PS->Faction;
       Players.Add(Data);
     }


### PR DESCRIPTION
## Summary
- derive AI state from owning controller instead of replicated bIsAI flag
- drop IsAI from player save data
- update UI, game mode, and tests to use controller cast checks

## Testing
- `g++ -std=c++17 -I../Engine/Source -ISource -c Source/Skald/Skald_PlayerState.cpp` *(fails: CoreMinimal.h missing)*
- `g++ -std=c++17 -I../Engine/Source -ISource -c Source/Skald/Skald_GameMode.cpp` *(fails: CoreMinimal.h missing)*

------
https://chatgpt.com/codex/tasks/task_e_68ba36068d488324a2d76d3eb9153363