### PR TITLE
Replicate AI flag via player state

### DIFF
--- a/Source/Skald/Skald_GameMode.cpp
+++ b/Source/Skald/Skald_GameMode.cpp
@@ -108,7 +108,7 @@ void ASkaldGameMode::BeginPlay() {
         if (GS) {
           for (APlayerState *BasePS : GS->PlayerArray) {
             ASkaldPlayerState *PS = Cast<ASkaldPlayerState>(BasePS);
-            if (!PS || !Cast<ASkaldAIController>(PS->GetOwner())) {
+            if (!PS || !PS->bIsAI) {
               continue;
             }
 
@@ -202,6 +202,8 @@ void ASkaldGameMode::RegisterPlayer(ASkaldPlayerController *PC) {
   // Player state is valid; perform normal registration.
   PendingControllers.Remove(PC);
 
+  PS->bIsAI = PC->IsA<ASkaldAIController>();
+
   if (ASkaldGameState *GS = GetGameState<ASkaldGameState>()) {
     if (!GS->PlayerArray.Contains(PS)) {
       GS->AddPlayerState(PS);
@@ -230,8 +232,7 @@ void ASkaldGameMode::RegisterPlayer(ASkaldPlayerController *PC) {
     if (PlayerDataArray.IsValidIndex(Index)) {
       PlayerDataArray[Index].PlayerID = PS->GetPlayerId();
       PlayerDataArray[Index].PlayerName = PS->PlayerDisplayName;
-      PlayerDataArray[Index].IsAI =
-          Cast<ASkaldAIController>(PS->GetOwner()) != nullptr;
+      PlayerDataArray[Index].IsAI = PS->bIsAI;
       PlayerDataArray[Index].Faction = PS->Faction;
       PlayerDataArray[Index].Resources = PS->Resources;
     }
@@ -255,7 +256,7 @@ void ASkaldGameMode::PopulateAIPlayers() {
   bool bHasHuman = false;
   for (APlayerState *ExistingPS : GS->PlayerArray) {
     if (ASkaldPlayerState *EPS = Cast<ASkaldPlayerState>(ExistingPS)) {
-      if (!Cast<ASkaldAIController>(EPS->GetOwner())) {
+      if (!EPS->bIsAI) {
         bHasHuman = true;
         break;
       }
@@ -364,8 +365,7 @@ void ASkaldGameMode::HandlePlayerLockedIn(ASkaldPlayerState *PS) {
   }
 
   UE_LOG(LogSkald, Log, TEXT("HandlePlayerLockedIn: Player=%s bIsAI=%d"),
-         *PS->PlayerDisplayName,
-         Cast<ASkaldAIController>(PS->GetOwner()) ? 1 : 0);
+         *PS->PlayerDisplayName, PS->bIsAI ? 1 : 0);
   ASkaldGameState *GS = GetGameState<ASkaldGameState>();
   UE_LOG(LogSkald, Log,
          TEXT("HandlePlayerLockedIn: TurnManager=%s ControllerCount=%d "
@@ -400,8 +400,7 @@ void ASkaldGameMode::RefreshHUDs() {
   // Ensure all AI players have valid names before refreshing any HUDs.
   for (APlayerState *PSBase : GS->PlayerArray) {
     if (ASkaldPlayerState *SPS = Cast<ASkaldPlayerState>(PSBase)) {
-      if (Cast<ASkaldAIController>(SPS->GetOwner()) &&
-          SPS->PlayerDisplayName.IsEmpty()) {
+      if (SPS->bIsAI && SPS->PlayerDisplayName.IsEmpty()) {
         UE_LOG(LogSkald, Error,
                TEXT("AI PlayerState missing display name before RefreshHUDs"));
         ensure(!SPS->PlayerDisplayName.IsEmpty());
@@ -415,7 +414,7 @@ void ASkaldGameMode::RefreshHUDs() {
       FS_PlayerData Data;
       Data.PlayerID = SPS->GetPlayerId();
       Data.PlayerName = SPS->PlayerDisplayName;
-      Data.IsAI = Cast<ASkaldAIController>(SPS->GetOwner()) != nullptr;
+      Data.IsAI = SPS->bIsAI;
       Data.Faction = SPS->Faction;
       Data.Resources = SPS->Resources;
       AllPlayers.Add(Data);
@@ -759,7 +758,7 @@ void ASkaldGameMode::AdvanceArmyPlacement() {
     }
 
     // AI players automatically distribute their armies evenly.
-    if (Cast<ASkaldAIController>(PS->GetOwner())) {
+    if (PS->bIsAI) {
       TArray<ATerritory *> OwnedTerritories;
       for (ATerritory *Territory : WorldMap->Territories) {
         if (Territory && Territory->OwningPlayer == PS) {

--- a/Source/Skald/Skald_PlayerController.cpp
+++ b/Source/Skald/Skald_PlayerController.cpp
@@ -822,7 +822,7 @@ void ASkaldPlayerController::BuildPlayerDataArray(
       FS_PlayerData Data;
       Data.PlayerID = PS->GetPlayerId();
       Data.PlayerName = PS->PlayerDisplayName;
-      Data.IsAI = Cast<ASkaldAIController>(PS->GetOwner()) != nullptr;
+      Data.IsAI = PS->bIsAI;
       Data.Faction = PS->Faction;
       Data.Resources = PS->Resources;
       Data.IsEliminated = PS->IsEliminated;

--- a/Source/Skald/Skald_PlayerState.cpp
+++ b/Source/Skald/Skald_PlayerState.cpp
@@ -11,6 +11,7 @@ ASkaldPlayerState::ASkaldPlayerState()
     , Resources(0)
     , PlayerDisplayName(TEXT("Player"))
     , Faction(ESkaldFaction::None)
+    , bIsAI(false)
     , bHasLockedIn(false)
     , IsEliminated(false)
 {
@@ -28,6 +29,7 @@ void ASkaldPlayerState::GetLifetimeReplicatedProps(
     DOREPLIFETIME(ASkaldPlayerState, Resources);
     DOREPLIFETIME(ASkaldPlayerState, bHasLockedIn);
     DOREPLIFETIME(ASkaldPlayerState, IsEliminated);
+    DOREPLIFETIME(ASkaldPlayerState, bIsAI);
 }
 
 void ASkaldPlayerState::OnRep_DeployableUnits()
@@ -67,6 +69,17 @@ void ASkaldPlayerState::OnRep_IsEliminated()
 }
 
 void ASkaldPlayerState::OnRep_PlayerDisplayName()
+{
+    if (UWorld* World = GetWorld())
+    {
+        if (ASkaldGameState* GS = World->GetGameState<ASkaldGameState>())
+        {
+            GS->OnPlayersUpdated.Broadcast();
+        }
+    }
+}
+
+void ASkaldPlayerState::OnRep_IsAI()
 {
     if (UWorld* World = GetWorld())
     {

--- a/Source/Skald/Skald_PlayerState.h
+++ b/Source/Skald/Skald_PlayerState.h
@@ -36,6 +36,10 @@ public:
     UPROPERTY(BlueprintReadWrite, Replicated, Category="PlayerState")
     ESkaldFaction Faction;
 
+    /** Whether this player is controlled by AI. */
+    UPROPERTY(BlueprintReadWrite, ReplicatedUsing = OnRep_IsAI, Category="PlayerState")
+    bool bIsAI;
+
     /** Whether the player has locked in their actions for the current turn. */
     UPROPERTY(BlueprintReadWrite, ReplicatedUsing = OnRep_HasLockedIn, Category="PlayerState")
     bool bHasLockedIn;
@@ -55,6 +59,9 @@ public:
 
     UFUNCTION()
     void OnRep_PlayerDisplayName();
+
+    UFUNCTION()
+    void OnRep_IsAI();
 
     virtual void GetLifetimeReplicatedProps(TArray<FLifetimeProperty>& OutLifetimeProps) const override;
 };

--- a/Source/Skald/UI/SkaldMainHUDWidget.cpp
+++ b/Source/Skald/UI/SkaldMainHUDWidget.cpp
@@ -517,7 +517,7 @@ void USkaldMainHUDWidget::HandlePlayersUpdated() {
       FS_PlayerData Data;
       Data.PlayerID = PS->GetPlayerId();
       Data.PlayerName = PS->PlayerDisplayName;
-      Data.IsAI = Cast<ASkaldAIController>(PS->GetOwner()) != nullptr;
+      Data.IsAI = PS->bIsAI;
       Data.Faction = PS->Faction;
       Players.Add(Data);
     }


### PR DESCRIPTION
## Summary
- add replicated `bIsAI` flag to `Skald_PlayerState`
- use `bIsAI` instead of controller ownership to identify AI players

## Testing
- `clang++ -c Source/Skald/Skald_PlayerState.cpp` *(fails: 'CoreMinimal.h' file not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ba39b0e11c832483b17a9c6a530a8d