### PR TITLE
Fix duplicate AI property declaration causing build failure

### DIFF
--- a/Source/Skald/Skald_PlayerState.cpp
+++ b/Source/Skald/Skald_PlayerState.cpp
@@ -30,7 +30,6 @@ void ASkaldPlayerState::GetLifetimeReplicatedProps(
     DOREPLIFETIME(ASkaldPlayerState, Resources);
     DOREPLIFETIME(ASkaldPlayerState, bHasLockedIn);
     DOREPLIFETIME(ASkaldPlayerState, IsEliminated);
-    DOREPLIFETIME(ASkaldPlayerState, bIsAI);
 }
 
 void ASkaldPlayerState::OnRep_DeployableUnits()

--- a/Source/Skald/Skald_PlayerState.h
+++ b/Source/Skald/Skald_PlayerState.h
@@ -37,7 +37,6 @@ public:
     ESkaldFaction Faction;
 
     /** Whether this player is controlled by AI. */
-    UPROPERTY(BlueprintReadWrite, Replicated, Category="PlayerState")
     UPROPERTY(BlueprintReadWrite, ReplicatedUsing = OnRep_IsAI, Category="PlayerState")
     bool bIsAI;
 


### PR DESCRIPTION
## Summary
- remove duplicate UPROPERTY on `bIsAI` and clean up redundant replication

## Testing
- `g++ -std=c++17 -I../Engine/Source -ISource -c Source/Skald/Skald_PlayerState.cpp` *(fails: CoreMinimal.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68ba434cad108324a72cd859ee3c197d