### PR TITLE
Fix AI controller StartTurn override and AI decision flow test

### DIFF
--- a/Source/Skald/Skald_AIController.cpp
+++ b/Source/Skald/Skald_AIController.cpp
@@ -1,4 +1,5 @@
 #include "Skald_AIController.h"
+#include "Engine/World.h"
 #include "Kismet/GameplayStatics.h"
 #include "Skald.h"
 #include "Skald_PlayerState.h"

--- a/Source/Skald/Skald_PlayerController.h
+++ b/Source/Skald/Skald_PlayerController.h
@@ -37,7 +37,7 @@ public:
   virtual void OnRep_PlayerState() override;
 
   UFUNCTION(BlueprintCallable, Category = "Turn")
-  void StartTurn();
+  virtual void StartTurn();
 
   UFUNCTION(BlueprintCallable, Category = "Turn")
   void EndTurn();

--- a/Source/Skald/Tests/AIDecisionFlowTest.cpp
+++ b/Source/Skald/Tests/AIDecisionFlowTest.cpp
@@ -21,6 +21,7 @@ bool FSkaldAIDecisionFlowTest::RunTest(const FString& Parameters)
     // Create core actors
     ATurnManager* TM = World->SpawnActor<ATurnManager>();
     ASkaldAIController* PC1 = World->SpawnActor<ASkaldAIController>();
+    ASkaldAIController* PC2 = World->SpawnActor<ASkaldAIController>();
     ASkaldPlayerState* PS1 = World->SpawnActor<ASkaldPlayerState>();
     ASkaldPlayerState* PS2 = World->SpawnActor<ASkaldPlayerState>();
     AWorldMap* Map = World->SpawnActor<AWorldMap>();
@@ -43,6 +44,7 @@ bool FSkaldAIDecisionFlowTest::RunTest(const FString& Parameters)
     // Dummy opponent to prevent infinite turn loop
     PC2->PlayerState = PS2;
     PS2->SetOwner(PC2);
+    PC2->SetTurnManager(TM);
     TM->RegisterController(PC1);
     TM->RegisterController(PC2);
 


### PR DESCRIPTION
## Summary
- make base `StartTurn` virtual so AI controller can override it
- include `Engine/World.h` to resolve gameplay statics call
- spawn and register second AI controller in decision flow test

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ba4d80295c8324b0e3d0499662997e