### PR TITLE
fix: wait for turn manager before starting

### DIFF
--- a/Source/Skald/Skald_GameMode.cpp
+++ b/Source/Skald/Skald_GameMode.cpp
@@ -214,6 +214,10 @@ void ASkaldGameMode::RegisterPlayer(ASkaldPlayerController *PC) {
       TurnManager->RegisterController(PC);
       UE_LOG(LogSkald, Log, TEXT("RegisterPlayer: ControllerCount=%d"),
              TurnManager->GetControllerCount());
+    } else {
+      // Defer final registration until the turn manager is available.
+      PendingControllers.AddUnique(PC);
+      return;
     }
 
     if (PlayerDataArray.Num() < GS->PlayerArray.Num()) {
@@ -450,8 +454,13 @@ void ASkaldGameMode::UpdatePlayerResources(ASkaldPlayerState *Player) {
 
 void ASkaldGameMode::TryInitializeWorldAndStart() {
   ASkaldGameState *GS = GetGameState<ASkaldGameState>();
-  if (!GS) {
+  if (!GS || !TurnManager) {
     return;
+  }
+
+  // Register any controllers that joined before the turn manager was ready.
+  for (int32 Index = PendingControllers.Num() - 1; Index >= 0; --Index) {
+    RegisterPlayer(PendingControllers[Index]);
   }
 
   PopulateAIPlayers();


### PR DESCRIPTION
## Summary
- avoid initializing world before turn manager exists
- defer player registration until turn manager ready

## Testing
- `npm test` *(fails: Could not read package.json: ENOENT)*

------
https://chatgpt.com/codex/tasks/task_e_68ba5246f3208324af59c38afecdc832