### PR TITLE
Add configurable AI player count and delayed world setup

### DIFF
--- a/Source/Skald/ChoosePlayerWidget.cpp
+++ b/Source/Skald/ChoosePlayerWidget.cpp
@@ -3,6 +3,7 @@
 #include "Components/Button.h"
 #include "Components/ComboBoxString.h"
 #include "Components/EditableTextBox.h"
+#include "Components/SpinBox.h"
 #include "Skald_GameInstance.h"
 #include "Skald_PlayerController.h"
 
@@ -50,6 +51,15 @@ void UChoosePlayerWidget::NativeConstruct()
         DisplayNameBox->OnTextChanged.AddDynamic(this, &UChoosePlayerWidget::HandleDisplayNameChanged);
     }
 
+    if (AICountSpinBox)
+    {
+        AICountSpinBox->SetMinValue(0.f);
+        AICountSpinBox->SetMaxValue(3.f);
+        AICountSpinBox->SetDelta(1.f);
+        AICountSpinBox->SetValue(0.f);
+        AICountSpinBox->OnValueChanged.AddDynamic(this, &UChoosePlayerWidget::HandleAICountChanged);
+    }
+
     if (LockInButton)
     {
         LockInButton->OnClicked.AddDynamic(this, &UChoosePlayerWidget::OnLockIn);
@@ -80,12 +90,19 @@ void UChoosePlayerWidget::OnLockIn()
         }
     }
 
+    int32 AICount = 1;
+    if (AICountSpinBox)
+    {
+        AICount = FMath::Clamp(FMath::RoundToInt(AICountSpinBox->GetValue()), 1, 3);
+    }
+
     if (UWorld* World = GetWorld())
     {
         if (USkaldGameInstance* GI = World->GetGameInstance<USkaldGameInstance>())
         {
             GI->DisplayName = Name;
             GI->Faction = Faction;
+            GI->AIPlayersToSpawn = AICount;
             if (Faction != ESkaldFaction::None)
             {
                 GI->TakenFactions.AddUnique(Faction);
@@ -95,7 +112,7 @@ void UChoosePlayerWidget::OnLockIn()
 
     if (ASkaldPlayerController* PC = Cast<ASkaldPlayerController>(GetOwningPlayer()))
     {
-        PC->ServerInitPlayerState(Name, Faction);
+        PC->ServerInitPlayerState(Name, Faction, AICount);
     }
 
     OnPlayerLockedIn.Broadcast();
@@ -111,13 +128,19 @@ void UChoosePlayerWidget::HandleFactionSelected(FString /*SelectedItem*/, ESelec
     UpdateLockInEnabled();
 }
 
+void UChoosePlayerWidget::HandleAICountChanged(float /*Value*/)
+{
+    UpdateLockInEnabled();
+}
+
 void UChoosePlayerWidget::UpdateLockInEnabled()
 {
     const bool bHasName = DisplayNameBox && !DisplayNameBox->GetText().IsEmpty();
     const bool bHasFaction = FactionComboBox && !FactionComboBox->GetSelectedOption().IsEmpty();
+    const bool bHasAI = AICountSpinBox && AICountSpinBox->GetValue() >= 1.f;
     if (LockInButton)
     {
-        LockInButton->SetIsEnabled(bHasName && bHasFaction);
+        LockInButton->SetIsEnabled(bHasName && bHasFaction && bHasAI);
     }
 }
 

--- a/Source/Skald/ChoosePlayerWidget.h
+++ b/Source/Skald/ChoosePlayerWidget.h
@@ -8,6 +8,7 @@
 class UEditableTextBox;
 class UComboBoxString;
 class UButton;
+class USpinBox;
 namespace ESelectInfo
 {
     enum Type;
@@ -38,6 +39,10 @@ public:
     UPROPERTY(BlueprintReadOnly, meta=(BindWidget))
     UComboBoxString* FactionComboBox;
 
+    /** Spin box determining how many AI opponents to spawn. */
+    UPROPERTY(BlueprintReadOnly, meta=(BindWidget))
+    USpinBox* AICountSpinBox;
+
     /** Button used to lock in the selection. */
     UPROPERTY(BlueprintReadOnly, meta=(BindWidget))
     UButton* LockInButton;
@@ -54,6 +59,10 @@ protected:
     /** Faction combo selection handler. */
     UFUNCTION(BlueprintCallable, Category="Skald|Widgets")
     void HandleFactionSelected(FString SelectedItem, ESelectInfo::Type SelectionType);
+
+    /** AI count change handler. */
+    UFUNCTION(BlueprintCallable, Category="Skald|Widgets")
+    void HandleAICountChanged(float Value);
 
     /** Enable lock in button when prerequisites are met. */
     UFUNCTION(BlueprintCallable, Category="Skald|Widgets")

--- a/Source/Skald/Skald_GameInstance.h
+++ b/Source/Skald/Skald_GameInstance.h
@@ -31,6 +31,10 @@ public:
     UPROPERTY(BlueprintReadWrite, Category="Player")
     bool bIsMultiplayer;
 
+    /** Number of AI opponents requested by the player. */
+    UPROPERTY(BlueprintReadWrite, Category="Player")
+    int32 AIPlayersToSpawn = 1;
+
     /** Factions that have already been selected by players or AI. */
     UPROPERTY(BlueprintReadWrite, Category="Player")
     TArray<ESkaldFaction> TakenFactions;

--- a/Source/Skald/Skald_GameMode.cpp
+++ b/Source/Skald/Skald_GameMode.cpp
@@ -21,7 +21,6 @@
 #include "WorldMap.h"
 
 namespace {
-constexpr int32 ExpectedPlayerCount = 4;
 constexpr float StartGameTimeout = 10.f;
 constexpr int32 StartingResources = 100;
 constexpr int32 DefaultAIMaxCost = 10;
@@ -56,15 +55,6 @@ void ASkaldGameMode::BeginPlay() {
   }
   PlayerDataArray.Empty();
 
-  if (!TurnManager) {
-    TurnManager = GetWorld()->SpawnActor<ATurnManager>();
-  }
-
-  if (!WorldMap) {
-    WorldMap = Cast<AWorldMap>(UGameplayStatics::GetActorOfClass(
-        GetWorld(), AWorldMap::StaticClass()));
-  }
-
   for (FConstPlayerControllerIterator It =
            GetWorld()->GetPlayerControllerIterator();
        It; ++It) {
@@ -81,8 +71,7 @@ void ASkaldGameMode::BeginPlay() {
     }
   }
 
-  // Defer AI population until a human player locks in so the game state is
-  // fully established before spawning bots.
+  // Defer AI population and world initialization until players lock in.
   RefreshHUDs();
 
   TryInitializeWorldAndStart();
@@ -380,9 +369,34 @@ void ASkaldGameMode::HandlePlayerLockedIn(ASkaldPlayerState *PS) {
          TurnManager ? TurnManager->GetControllerCount() : 0,
          GS ? GS->PlayerArray.Num() : 0);
 
+  USkaldGameInstance *GI = GetGameInstance<USkaldGameInstance>();
+  int32 HumanCount = 0;
+  if (GS) {
+    for (APlayerState *ExistingPS : GS->PlayerArray) {
+      ASkaldPlayerState *Existing = Cast<ASkaldPlayerState>(ExistingPS);
+      if (Existing && !Existing->bIsAI) {
+        ++HumanCount;
+      }
+    }
+  }
+  const int32 AICount = GI ? GI->AIPlayersToSpawn : 0;
+  ExpectedPlayerCount = FMath::Max(HumanCount + AICount, MinPlayerCount);
+  PlayerDataArray.SetNum(ExpectedPlayerCount);
+
   // Once a human has locked in their choice, populate remaining slots with AI
   // opponents so they respect the player's faction selection.
   PopulateAIPlayers();
+
+  if (!WorldMap) {
+    WorldMap = Cast<AWorldMap>(UGameplayStatics::GetActorOfClass(
+        GetWorld(), AWorldMap::StaticClass()));
+    if (!WorldMap) {
+      WorldMap = GetWorld()->SpawnActor<AWorldMap>();
+    }
+  }
+  if (!TurnManager) {
+    TurnManager = GetWorld()->SpawnActor<ATurnManager>();
+  }
 
   FS_PlayerData *PlayerData =
       PlayerDataArray.FindByPredicate([PS](const FS_PlayerData &Data) {

--- a/Source/Skald/Skald_GameMode.h
+++ b/Source/Skald/Skald_GameMode.h
@@ -74,6 +74,11 @@ protected:
             meta = (ClampMin = "1"))
   int32 MinPlayerCount = 1;
 
+  /** Total number of players expected in the match (humans + AI). */
+  UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "Players",
+            meta = (ClampMin = "1"))
+  int32 ExpectedPlayerCount = 4;
+
   /** Controller class used when spawning AI players. */
   UPROPERTY(EditDefaultsOnly, Category = "Players")
   TSubclassOf<APlayerController> AIControllerClass;

--- a/Source/Skald/Skald_PlayerController.cpp
+++ b/Source/Skald/Skald_PlayerController.cpp
@@ -203,10 +203,10 @@ void ASkaldPlayerController::OnRep_PlayerState() {
 }
 
 void ASkaldPlayerController::ServerInitPlayerState_Implementation(
-    const FString &Name, ESkaldFaction Faction) {
+    const FString &Name, ESkaldFaction Faction, int32 NumAIPlayers) {
   UE_LOG(LogSkald, Log,
-         TEXT("ServerInitPlayerState_Implementation: Name=%s Faction=%d"),
-         *Name, static_cast<int32>(Faction));
+         TEXT("ServerInitPlayerState_Implementation: Name=%s Faction=%d AI=%d"),
+         *Name, static_cast<int32>(Faction), NumAIPlayers);
 
   if (ASkaldPlayerState *PS = GetPlayerState<ASkaldPlayerState>()) {
     UE_LOG(LogSkald, Log,
@@ -215,6 +215,10 @@ void ASkaldPlayerController::ServerInitPlayerState_Implementation(
     PS->PlayerDisplayName = Name;
     PS->Faction = Faction;
     PS->bHasLockedIn = true;
+
+    if (USkaldGameInstance *GI = GetGameInstance<USkaldGameInstance>()) {
+      GI->AIPlayersToSpawn = NumAIPlayers;
+    }
 
     if (ASkaldGameMode *GM = GetWorld()->GetAuthGameMode<ASkaldGameMode>()) {
       UE_LOG(LogSkald, Log,

--- a/Source/Skald/Skald_PlayerController.h
+++ b/Source/Skald/Skald_PlayerController.h
@@ -65,7 +65,8 @@ public:
 
   /** Send the local player's initial data to the server for replication. */
   UFUNCTION(Server, Reliable)
-  void ServerInitPlayerState(const FString &Name, ESkaldFaction Faction);
+  void ServerInitPlayerState(const FString &Name, ESkaldFaction Faction,
+                             int32 NumAIPlayers);
 
 protected:
   /** Widget class to instantiate for the player's HUD.


### PR DESCRIPTION
## Summary
- Let players choose 1-3 AI opponents with a new spin box during name/faction selection
- Store AI count in the game instance and send it to the server when locking in
- Game mode now spawns the selected number of AI, then creates the world map and turn manager before assigning territories

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ba557a307c83248432f609310b497a