### PR TITLE
Allow starting singleplayer sessions without AI opponents

### DIFF
--- a/Source/Skald/ChoosePlayerWidget.cpp
+++ b/Source/Skald/ChoosePlayerWidget.cpp
@@ -90,10 +90,10 @@ void UChoosePlayerWidget::OnLockIn()
         }
     }
 
-    int32 AICount = 1;
+    int32 AICount = 0;
     if (AICountSpinBox)
     {
-        AICount = FMath::Clamp(FMath::RoundToInt(AICountSpinBox->GetValue()), 1, 3);
+        AICount = FMath::Clamp(FMath::RoundToInt(AICountSpinBox->GetValue()), 0, 3);
     }
 
     if (UWorld* World = GetWorld())
@@ -137,7 +137,20 @@ void UChoosePlayerWidget::UpdateLockInEnabled()
 {
     const bool bHasName = DisplayNameBox && !DisplayNameBox->GetText().IsEmpty();
     const bool bHasFaction = FactionComboBox && !FactionComboBox->GetSelectedOption().IsEmpty();
-    const bool bHasAI = AICountSpinBox && AICountSpinBox->GetValue() >= 1.f;
+    bool bHasAI = true;
+    if (AICountSpinBox)
+    {
+        const float Value = AICountSpinBox->GetValue();
+        bool bRequireAI = false;
+        if (UWorld* World = GetWorld())
+        {
+            if (USkaldGameInstance* GI = World->GetGameInstance<USkaldGameInstance>())
+            {
+                bRequireAI = GI->bIsMultiplayer;
+            }
+        }
+        bHasAI = bRequireAI ? Value >= 1.f : Value >= 0.f;
+    }
     if (LockInButton)
     {
         LockInButton->SetIsEnabled(bHasName && bHasFaction && bHasAI);

--- a/Source/Skald/Skald_GameInstance.cpp
+++ b/Source/Skald/Skald_GameInstance.cpp
@@ -11,3 +11,10 @@ void USkaldGameInstance::SeedCombatRandomStream(int32 Seed)
     CombatRandomStream.Initialize(Seed);
 }
 
+void USkaldGameInstance::ResetSession()
+{
+    TakenFactions.Empty();
+    AIPlayersToSpawn = 0;
+    bIsMultiplayer = false;
+}
+

--- a/Source/Skald/Skald_GameInstance.h
+++ b/Source/Skald/Skald_GameInstance.h
@@ -74,5 +74,9 @@ public:
     /** Save game loaded when transitioning from the main menu. */
     UPROPERTY(BlueprintReadWrite, Category="SaveGame")
     USkaldSaveGame* LoadedSaveGame = nullptr;
+
+    /** Reset transient session state before starting a new game. */
+    UFUNCTION(BlueprintCallable, Category="Player")
+    void ResetSession();
 };
 

--- a/Source/Skald/Skald_GameMode.cpp
+++ b/Source/Skald/Skald_GameMode.cpp
@@ -243,7 +243,12 @@ void ASkaldGameMode::RegisterPlayer(ASkaldPlayerController *PC) {
 void ASkaldGameMode::PopulateAIPlayers() {
   ASkaldGameState *GS = GetGameState<ASkaldGameState>();
   USkaldGameInstance *GI = GetGameInstance<USkaldGameInstance>();
-  if (!GS || !GI || GI->bIsMultiplayer || !AIControllerClass) {
+  if (!GS || !GI) {
+    UE_LOG(LogSkald, Error,
+           TEXT("PopulateAIPlayers: missing GameState or GameInstance"));
+    return;
+  }
+  if (GI->bIsMultiplayer || !AIControllerClass) {
     return;
   }
 
@@ -257,6 +262,8 @@ void ASkaldGameMode::PopulateAIPlayers() {
     }
   }
   if (!bHasHuman) {
+    UE_LOG(LogSkald, Error,
+           TEXT("PopulateAIPlayers: no human players present"));
     return;
   }
 
@@ -268,6 +275,8 @@ void ASkaldGameMode::PopulateAIPlayers() {
     ASkaldPlayerState *AIState =
         GetWorld()->SpawnActor<ASkaldPlayerState>(PlayerStateClass);
     if (!AIState) {
+      UE_LOG(LogSkald, Error,
+             TEXT("PopulateAIPlayers: failed to spawn AI player state"));
       break;
     }
 
@@ -280,6 +289,8 @@ void ASkaldGameMode::PopulateAIPlayers() {
             AIControllerClass, SpawnTransform, nullptr, nullptr,
             ESpawnActorCollisionHandlingMethod::AlwaysSpawn);
     if (!NewController) {
+      UE_LOG(LogSkald, Error,
+             TEXT("PopulateAIPlayers: failed to spawn AI controller"));
       AIState->Destroy();
       break;
     }
@@ -294,6 +305,8 @@ void ASkaldGameMode::PopulateAIPlayers() {
     ASkaldPlayerController *AIController =
         Cast<ASkaldPlayerController>(NewController);
     if (!AIController) {
+      UE_LOG(LogSkald, Error,
+             TEXT("PopulateAIPlayers: controller cast failed"));
       NewController->Destroy();
       AIState->Destroy();
       break;
@@ -354,6 +367,29 @@ void ASkaldGameMode::PopulateAIPlayers() {
   }
 }
 
+void ASkaldGameMode::StartSingleplayerGame()
+{
+  if (USkaldGameInstance *GI = GetGameInstance<USkaldGameInstance>()) {
+    GI->bIsMultiplayer = false;
+  }
+
+  PopulateAIPlayers();
+
+  if (!WorldMap) {
+    WorldMap = Cast<AWorldMap>(UGameplayStatics::GetActorOfClass(
+        GetWorld(), AWorldMap::StaticClass()));
+    if (!WorldMap) {
+      WorldMap = GetWorld()->SpawnActor<AWorldMap>();
+    }
+  }
+  if (!TurnManager) {
+    TurnManager = GetWorld()->SpawnActor<ATurnManager>();
+  }
+
+  RefreshHUDs();
+  TryInitializeWorldAndStart();
+}
+
 void ASkaldGameMode::HandlePlayerLockedIn(ASkaldPlayerState *PS) {
   if (!PS) {
     return;
@@ -383,8 +419,22 @@ void ASkaldGameMode::HandlePlayerLockedIn(ASkaldPlayerState *PS) {
   ExpectedPlayerCount = FMath::Max(HumanCount + AICount, MinPlayerCount);
   PlayerDataArray.SetNum(ExpectedPlayerCount);
 
-  // Once a human has locked in their choice, populate remaining slots with AI
-  // opponents so they respect the player's faction selection.
+  FS_PlayerData *PlayerData =
+      PlayerDataArray.FindByPredicate([PS](const FS_PlayerData &Data) {
+        return Data.PlayerID == PS->GetPlayerId();
+      });
+  if (PlayerData) {
+    PlayerData->PlayerName = PS->PlayerDisplayName;
+    PlayerData->Faction = PS->Faction;
+  }
+
+  if (GI && !GI->bIsMultiplayer) {
+    StartSingleplayerGame();
+    return;
+  }
+
+  // Once a human has locked in their choice in multiplayer, populate AI
+  // opponents and proceed with normal initialization.
   PopulateAIPlayers();
 
   if (!WorldMap) {
@@ -396,15 +446,6 @@ void ASkaldGameMode::HandlePlayerLockedIn(ASkaldPlayerState *PS) {
   }
   if (!TurnManager) {
     TurnManager = GetWorld()->SpawnActor<ATurnManager>();
-  }
-
-  FS_PlayerData *PlayerData =
-      PlayerDataArray.FindByPredicate([PS](const FS_PlayerData &Data) {
-        return Data.PlayerID == PS->GetPlayerId();
-      });
-  if (PlayerData) {
-    PlayerData->PlayerName = PS->PlayerDisplayName;
-    PlayerData->Faction = PS->Faction;
   }
 
   RefreshHUDs();
@@ -489,20 +530,40 @@ void ASkaldGameMode::TryInitializeWorldAndStart() {
   TArray<ASkaldPlayerController *> RegisteredControllers =
       TurnManager ? TurnManager->GetControllers()
                   : TArray<ASkaldPlayerController *>();
+  bool bIsMultiplayer = true;
+  if (USkaldGameInstance *GI = GetGameInstance<USkaldGameInstance>()) {
+    bIsMultiplayer = GI->bIsMultiplayer;
+  }
   for (APlayerState *PSBase : GS->PlayerArray) {
     ASkaldPlayerState *PS = Cast<ASkaldPlayerState>(PSBase);
-    if (!PS || !PS->bHasLockedIn) {
+    if (!PS) {
       bAllLockedIn = false;
+      UE_LOG(LogSkald, Error,
+             TEXT("TryInitializeWorldAndStart: null PlayerState in array"));
+      continue;
+    }
+    if (PS->bIsAI && !bIsMultiplayer) {
+      continue;
+    }
+    if (PS->Faction == ESkaldFaction::None) {
+      UE_LOG(LogSkald, Error,
+             TEXT("TryInitializeWorldAndStart: PlayerState %s has no faction"),
+             *GetNameSafe(PS));
+    }
+    if (!PS->bHasLockedIn) {
+      bAllLockedIn = false;
+      UE_LOG(LogSkald, Error,
+             TEXT("TryInitializeWorldAndStart: %s not locked in"),
+             *GetNameSafe(PS));
     }
     ASkaldPlayerController *OwningController =
-        PS ? Cast<ASkaldPlayerController>(PS->GetOwner()) : nullptr;
+        Cast<ASkaldPlayerController>(PS->GetOwner());
     if (!OwningController ||
         !RegisteredControllers.Contains(OwningController)) {
       bAllHaveControllers = false;
-      UE_LOG(
-          LogSkald, Warning,
-          TEXT("TryInitializeWorldAndStart: PlayerState %s missing controller"),
-          *GetNameSafe(PS));
+      UE_LOG(LogSkald, Error,
+             TEXT("TryInitializeWorldAndStart: PlayerState %s missing controller"),
+             *GetNameSafe(PS));
     }
     if (!bAllLockedIn || !bAllHaveControllers) {
       break;
@@ -537,6 +598,9 @@ void ASkaldGameMode::TryInitializeWorldAndStart() {
     if (InitializeWorld()) {
       bWorldInitialized = true;
       BeginArmyPlacementPhase();
+    } else {
+      UE_LOG(LogSkald, Error,
+             TEXT("TryInitializeWorldAndStart: InitializeWorld failed"));
     }
   }
 

--- a/Source/Skald/Skald_GameMode.h
+++ b/Source/Skald/Skald_GameMode.h
@@ -55,6 +55,9 @@ public:
   /** Handle a player confirming their name and faction selection. */
   void HandlePlayerLockedIn(ASkaldPlayerState *PS);
 
+  /** Start a singleplayer match once local setup is complete. */
+  void StartSingleplayerGame();
+
 protected:
   /** Handles turn sequencing for the match. */
   UPROPERTY(BlueprintReadOnly, Category = "GameMode")

--- a/Source/Skald/StartGameWidget.cpp
+++ b/Source/Skald/StartGameWidget.cpp
@@ -33,11 +33,23 @@ void UStartGameWidget::NativeConstruct() {
   }
 }
 
-void UStartGameWidget::OnSingleplayer() { StartGame(false); }
+void UStartGameWidget::OnSingleplayer() {
+  if (UWorld *World = GetWorld()) {
+    if (USkaldGameInstance *GI = World->GetGameInstance<USkaldGameInstance>()) {
+      GI->ResetSession();
+    }
+  }
+  StartGame(false);
+}
 
 void UStartGameWidget::OnMultiplayer() { StartGame(true); }
 
 void UStartGameWidget::OnMainMenu() {
+  if (UWorld *World = GetWorld()) {
+    if (USkaldGameInstance *GI = World->GetGameInstance<USkaldGameInstance>()) {
+      GI->ResetSession();
+    }
+  }
   RemoveFromParent();
   if (OwningLobbyMenu.IsValid()) {
     OwningLobbyMenu->SetVisibility(ESlateVisibility::Visible);


### PR DESCRIPTION
## Summary
- Permit zero AI opponents in player setup and enable locking in without AI for singleplayer
- Add session reset helper and call it when starting singleplayer or returning to menu
- Introduce StartSingleplayerGame routine, skip AI controller/lock checks offline, and improve error logging for start-up failures

## Testing
- `bash Build/validate.sh` *(fails: UnrealBuildTool not found; skipping compile check. UnrealEditor not found; cannot run tests.)*

------
https://chatgpt.com/codex/tasks/task_e_68ba66fbc8508324a75345092bba6f0d