### PR TITLE
Configure player before level travel

### DIFF
--- a/Source/Skald/Skald_GameInstance.h
+++ b/Source/Skald/Skald_GameInstance.h
@@ -25,11 +25,11 @@ public:
 
     /** Selected faction for this player. */
     UPROPERTY(BlueprintReadWrite, Category="Player")
-    ESkaldFaction Faction;
+    ESkaldFaction Faction = ESkaldFaction::None;
 
     /** Whether the game was started in multiplayer mode. */
     UPROPERTY(BlueprintReadWrite, Category="Player")
-    bool bIsMultiplayer;
+    bool bIsMultiplayer = false;
 
     /** Number of AI opponents requested by the player. */
     UPROPERTY(BlueprintReadWrite, Category="Player")

--- a/Source/Skald/Skald_PlayerController.cpp
+++ b/Source/Skald/Skald_PlayerController.cpp
@@ -151,7 +151,14 @@ void ASkaldPlayerController::BeginPlay() {
 
   if (IsLocalPlayerController() && GetLocalPlayer() != nullptr) {
     InitializeHUDWidget();
-    InitializeChoosePlayerWidget();
+    if (CachedGameInstance && CachedGameInstance->bIsMultiplayer) {
+      InitializeChoosePlayerWidget();
+    } else if (CachedGameInstance) {
+      ServerInitPlayerState(CachedGameInstance->DisplayName,
+                            CachedGameInstance->Faction,
+                            CachedGameInstance->AIPlayersToSpawn);
+      HandleFactionLockedIn();
+    }
     InitializeFighterSelectionIfNeeded();
   }
 

--- a/Source/Skald/StartGameWidget.cpp
+++ b/Source/Skald/StartGameWidget.cpp
@@ -1,6 +1,9 @@
 #include "StartGameWidget.h"
 
 #include "Components/Button.h"
+#include "Components/ComboBoxString.h"
+#include "Components/EditableTextBox.h"
+#include "Components/SpinBox.h"
 #include "GameFramework/PlayerController.h"
 #include "Kismet/GameplayStatics.h"
 #include "LobbyMenuWidget.h"
@@ -48,6 +51,31 @@ void UStartGameWidget::StartGame(bool bMultiplayer) {
   if (UWorld *World = GetWorld()) {
     if (USkaldGameInstance *GI = World->GetGameInstance<USkaldGameInstance>()) {
       GI->bIsMultiplayer = bMultiplayer;
+      if (!bMultiplayer) {
+        if (DisplayNameBox) {
+          GI->DisplayName = DisplayNameBox->GetText().ToString();
+        }
+
+        if (FactionComboBox) {
+          const FString Option = FactionComboBox->GetSelectedOption();
+          if (UEnum *Enum = StaticEnum<ESkaldFaction>()) {
+            const int64 Value = Enum->GetValueByNameString(Option);
+            if (Value != INDEX_NONE) {
+              GI->Faction = static_cast<ESkaldFaction>(Value);
+            }
+          }
+        }
+
+        if (AICountSpinBox) {
+          GI->AIPlayersToSpawn =
+              FMath::Clamp(FMath::RoundToInt(AICountSpinBox->GetValue()), 1, 3);
+        }
+
+        GI->TakenFactions.Empty();
+        if (GI->Faction != ESkaldFaction::None) {
+          GI->TakenFactions.AddUnique(GI->Faction);
+        }
+      }
     }
 
     if (APlayerController *PC = GetOwningPlayer()) {

--- a/Source/Skald/StartGameWidget.h
+++ b/Source/Skald/StartGameWidget.h
@@ -7,6 +7,9 @@
 class ULobbyMenuWidget;
 class UButton;
 class APlayerController;
+class UEditableTextBox;
+class UComboBoxString;
+class USpinBox;
 
 /**
  * Menu shown after pressing Start Game, to choose single or multiplayer.
@@ -30,6 +33,21 @@ public:
   UPROPERTY(BlueprintReadOnly, Category = "Skald|Widgets",
             meta = (BindWidgetOptional))
   UButton *MainMenuButton;
+
+  /** Entry box for the player's display name. */
+  UPROPERTY(BlueprintReadOnly, Category = "Skald|Widgets",
+            meta = (BindWidgetOptional))
+  UEditableTextBox *DisplayNameBox;
+
+  /** Combo box used to choose the player's faction. */
+  UPROPERTY(BlueprintReadOnly, Category = "Skald|Widgets",
+            meta = (BindWidgetOptional))
+  UComboBoxString *FactionComboBox;
+
+  /** Spin box determining how many AI opponents to spawn. */
+  UPROPERTY(BlueprintReadOnly, Category = "Skald|Widgets",
+            meta = (BindWidgetOptional))
+  USpinBox *AICountSpinBox;
 
   /** Record the lobby menu that spawned this widget so we can unhide it later. */
   UFUNCTION(BlueprintCallable, Category = "Skald|Widgets")


### PR DESCRIPTION
## Summary
- Configure `USkaldGameInstance` with name, faction, and AI count from the start-game screen
- Skip choose-player UI when launching a solo game by initializing the local player state in `BeginPlay`
- Provide default values for `Faction` and `bIsMultiplayer` in the game instance

## Testing
- `clang++ -std=c++17 -I../Engine/Source -ISource -c Source/Skald/StartGameWidget.cpp` *(fails: 'Blueprint/UserWidget.h' file not found)*
- `clang++ -std=c++17 -I../Engine/Source -ISource -c Source/Skald/Skald_PlayerController.cpp` *(fails: 'CoreMinimal.h' file not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bb306491608324852e48595708108f