### PR TITLE
Add default player settings for singleplayer

### DIFF
--- a/Source/Skald/Skald_GameInstance.cpp
+++ b/Source/Skald/Skald_GameInstance.cpp
@@ -4,6 +4,11 @@ void USkaldGameInstance::Init()
 {
     Super::Init();
     SeedCombatRandomStream(FMath::Rand());
+    TakenFactions.Empty();
+    if (Faction != ESkaldFaction::None)
+    {
+        TakenFactions.Add(Faction);
+    }
 }
 
 void USkaldGameInstance::SeedCombatRandomStream(int32 Seed)

--- a/Source/Skald/Skald_GameInstance.h
+++ b/Source/Skald/Skald_GameInstance.h
@@ -21,11 +21,11 @@ public:
 
     /** Player chosen display name. */
     UPROPERTY(BlueprintReadWrite, Category="Player")
-    FString DisplayName;
+    FString DisplayName = TEXT("Player");
 
     /** Selected faction for this player. */
     UPROPERTY(BlueprintReadWrite, Category="Player")
-    ESkaldFaction Faction = ESkaldFaction::None;
+    ESkaldFaction Faction = ESkaldFaction::Human;
 
     /** Whether the game was started in multiplayer mode. */
     UPROPERTY(BlueprintReadWrite, Category="Player")

--- a/Source/Skald/StartGameWidget.cpp
+++ b/Source/Skald/StartGameWidget.cpp
@@ -53,15 +53,20 @@ void UStartGameWidget::StartGame(bool bMultiplayer) {
       GI->bIsMultiplayer = bMultiplayer;
       if (!bMultiplayer) {
         if (DisplayNameBox) {
-          GI->DisplayName = DisplayNameBox->GetText().ToString();
+          const FString Name = DisplayNameBox->GetText().ToString();
+          if (!Name.IsEmpty()) {
+            GI->DisplayName = Name;
+          }
         }
 
         if (FactionComboBox) {
           const FString Option = FactionComboBox->GetSelectedOption();
-          if (UEnum *Enum = StaticEnum<ESkaldFaction>()) {
-            const int64 Value = Enum->GetValueByNameString(Option);
-            if (Value != INDEX_NONE) {
-              GI->Faction = static_cast<ESkaldFaction>(Value);
+          if (!Option.IsEmpty() && Option != TEXT("None")) {
+            if (UEnum *Enum = StaticEnum<ESkaldFaction>()) {
+              const int64 Value = Enum->GetValueByNameString(Option);
+              if (Value != INDEX_NONE) {
+                GI->Faction = static_cast<ESkaldFaction>(Value);
+              }
             }
           }
         }


### PR DESCRIPTION
## Summary
- Add default display name and faction in `USkaldGameInstance` for zero-input singleplayer
- Track default faction in `USkaldGameInstance::Init` to reserve that faction
- Avoid overriding defaults in `StartGameWidget` when fields are left blank

## Testing
- `make` *(fails: No targets specified and no makefile found)*

------
https://chatgpt.com/codex/tasks/task_e_68bb3492a9d083248d19cbf2c3a185cb