### PR TITLE
Add multiplayer host/join lobby and session management

### DIFF
--- a/Source/Skald/Skald_GameInstance.cpp
+++ b/Source/Skald/Skald_GameInstance.cpp
@@ -1,5 +1,8 @@
 #include "Skald_GameInstance.h"
 
+#include "Engine/Engine.h"
+#include "Kismet/GameplayStatics.h"
+
 void USkaldGameInstance::Init()
 {
     Super::Init();
@@ -9,10 +12,32 @@ void USkaldGameInstance::Init()
     {
         TakenFactions.Add(Faction);
     }
+
+    if (GEngine)
+    {
+        GEngine->OnNetworkFailure().AddUObject(this, &USkaldGameInstance::HandleNetworkFailure);
+    }
 }
 
 void USkaldGameInstance::SeedCombatRandomStream(int32 Seed)
 {
     CombatRandomStream.Initialize(Seed);
+}
+
+void USkaldGameInstance::HandleNetworkFailure(UWorld* World, UNetDriver* /*Driver*/,
+                                              ENetworkFailure::Type /*FailureType*/,
+                                              const FString& ErrorString)
+{
+    if (GEngine)
+    {
+        GEngine->AddOnScreenDebugMessage(-1, 5.f, FColor::Red,
+                                         FString::Printf(TEXT("Network failure: %s"), *ErrorString));
+    }
+
+    bIsMultiplayer = false;
+    bIsHost = false;
+
+    const FName LobbyMap(TEXT("/Game/Blueprints/Maps/Skald_Lobby"));
+    UGameplayStatics::OpenLevel(World, LobbyMap);
 }
 

--- a/Source/Skald/Skald_GameInstance.h
+++ b/Source/Skald/Skald_GameInstance.h
@@ -1,12 +1,14 @@
 #pragma once
 
 #include "CoreMinimal.h"
+#include "Engine/EngineBaseTypes.h"
 #include "Engine/GameInstance.h"
 #include "SkaldTypes.h"
 #include "Skald_GameInstance.generated.h"
 
 class UGridBattleManager;
 class USkaldSaveGame;
+class UNetDriver;
 
 DECLARE_DYNAMIC_MULTICAST_DELEGATE(FSkaldFactionsUpdated);
 /** Game instance storing player selections from the lobby. */
@@ -30,6 +32,14 @@ public:
     /** Whether the game was started in multiplayer mode. */
     UPROPERTY(BlueprintReadWrite, Category="Player")
     bool bIsMultiplayer = false;
+
+    /** True if this instance is hosting a multiplayer session. */
+    UPROPERTY(BlueprintReadWrite, Category="Network")
+    bool bIsHost = false;
+
+    /** Address to join when acting as a client. */
+    UPROPERTY(BlueprintReadWrite, Category="Network")
+    FString JoinAddress;
 
     /** Number of AI opponents requested by the player. */
     UPROPERTY(BlueprintReadWrite, Category="Player")
@@ -70,6 +80,12 @@ public:
     /** Seed the combat random stream so all clients use the same sequence. */
     UFUNCTION(BlueprintCallable, Category="Battle")
     void SeedCombatRandomStream(int32 Seed);
+
+    /** Handle network failures and return to the lobby. */
+    UFUNCTION()
+    void HandleNetworkFailure(UWorld* World, UNetDriver* Driver,
+                              ENetworkFailure::Type FailureType,
+                              const FString& ErrorString);
 
     /** Save game loaded when transitioning from the main menu. */
     UPROPERTY(BlueprintReadWrite, Category="SaveGame")

--- a/Source/Skald/Skald_PlayerController.cpp
+++ b/Source/Skald/Skald_PlayerController.cpp
@@ -151,6 +151,13 @@ void ASkaldPlayerController::BeginPlay() {
 
   if (IsLocalPlayerController() && GetLocalPlayer() != nullptr) {
     InitializeHUDWidget();
+    if (CachedGameInstance && CachedGameInstance->bIsMultiplayer &&
+        !CachedGameInstance->bIsHost) {
+      if (GEngine) {
+        GEngine->AddOnScreenDebugMessage(-1, 4.f, FColor::Green,
+                                         TEXT("Connected to host"));
+      }
+    }
     if (CachedGameInstance && CachedGameInstance->bIsMultiplayer) {
       InitializeChoosePlayerWidget();
     } else if (CachedGameInstance) {

--- a/Source/Skald/StartGameWidget.cpp
+++ b/Source/Skald/StartGameWidget.cpp
@@ -4,6 +4,7 @@
 #include "Components/ComboBoxString.h"
 #include "Components/EditableTextBox.h"
 #include "Components/SpinBox.h"
+#include "Engine/Engine.h"
 #include "GameFramework/PlayerController.h"
 #include "Kismet/GameplayStatics.h"
 #include "LobbyMenuWidget.h"
@@ -24,11 +25,16 @@ void UStartGameWidget::NativeConstruct() {
     SingleplayerButton->SetVisibility(ESlateVisibility::Visible);
   }
 
-  if (MultiplayerButton) {
-    MultiplayerButton->OnClicked.AddDynamic(this,
-                                            &UStartGameWidget::OnMultiplayer);
-    MultiplayerButton->SetIsEnabled(true);
-    MultiplayerButton->SetVisibility(ESlateVisibility::Visible);
+  if (HostButton) {
+    HostButton->OnClicked.AddDynamic(this, &UStartGameWidget::OnHost);
+    HostButton->SetIsEnabled(true);
+    HostButton->SetVisibility(ESlateVisibility::Visible);
+  }
+
+  if (JoinButton) {
+    JoinButton->OnClicked.AddDynamic(this, &UStartGameWidget::OnJoin);
+    JoinButton->SetIsEnabled(true);
+    JoinButton->SetVisibility(ESlateVisibility::Visible);
   }
 
   if (MainMenuButton) {
@@ -36,9 +42,11 @@ void UStartGameWidget::NativeConstruct() {
   }
 }
 
-void UStartGameWidget::OnSingleplayer() { StartGame(false); }
+void UStartGameWidget::OnSingleplayer() { StartGame(false, true); }
 
-void UStartGameWidget::OnMultiplayer() { StartGame(true); }
+void UStartGameWidget::OnHost() { StartGame(true, true); }
+
+void UStartGameWidget::OnJoin() { StartGame(true, false); }
 
 void UStartGameWidget::OnMainMenu() {
   RemoveFromParent();
@@ -47,10 +55,11 @@ void UStartGameWidget::OnMainMenu() {
   }
 }
 
-void UStartGameWidget::StartGame(bool bMultiplayer) {
+void UStartGameWidget::StartGame(bool bMultiplayer, bool bHost) {
   if (UWorld *World = GetWorld()) {
     if (USkaldGameInstance *GI = World->GetGameInstance<USkaldGameInstance>()) {
       GI->bIsMultiplayer = bMultiplayer;
+      GI->bIsHost = bHost;
       if (!bMultiplayer) {
         if (DisplayNameBox) {
           const FString Name = DisplayNameBox->GetText().ToString();
@@ -80,11 +89,30 @@ void UStartGameWidget::StartGame(bool bMultiplayer) {
         if (GI->Faction != ESkaldFaction::None) {
           GI->TakenFactions.AddUnique(GI->Faction);
         }
+      } else if (!bHost) {
+        if (JoinAddressBox) {
+          GI->JoinAddress = JoinAddressBox->GetText().ToString();
+        }
       }
     }
 
     if (APlayerController *PC = GetOwningPlayer()) {
-      TravelToGameplayMap(PC, bMultiplayer);
+      if (!bMultiplayer || bHost) {
+        TravelToGameplayMap(PC, bMultiplayer);
+      } else {
+        FString Address;
+        if (USkaldGameInstance *GI = World->GetGameInstance<USkaldGameInstance>()) {
+          Address = GI->JoinAddress;
+        }
+        if (!Address.IsEmpty()) {
+          if (GEngine) {
+            GEngine->AddOnScreenDebugMessage(
+                -1, 4.f, FColor::Green,
+                FString::Printf(TEXT("Joining %s"), *Address));
+          }
+          PC->ClientTravel(Address, ETravelType::TRAVEL_Absolute);
+        }
+      }
     }
   }
 }

--- a/Source/Skald/StartGameWidget.h
+++ b/Source/Skald/StartGameWidget.h
@@ -24,10 +24,20 @@ public:
             meta = (BindWidgetOptional))
   UButton *SingleplayerButton;
 
-  /** Button to start multiplayer. */
+  /** Button to host a multiplayer session. */
   UPROPERTY(BlueprintReadOnly, Category = "Skald|Widgets",
             meta = (BindWidgetOptional))
-  UButton *MultiplayerButton;
+  UButton *HostButton;
+
+  /** Button to join an existing multiplayer session. */
+  UPROPERTY(BlueprintReadOnly, Category = "Skald|Widgets",
+            meta = (BindWidgetOptional))
+  UButton *JoinButton;
+
+  /** Entry box for the server address when joining. */
+  UPROPERTY(BlueprintReadOnly, Category = "Skald|Widgets",
+            meta = (BindWidgetOptional))
+  UEditableTextBox *JoinAddressBox;
 
   /** Button to return to the lobby menu. */
   UPROPERTY(BlueprintReadOnly, Category = "Skald|Widgets",
@@ -64,12 +74,15 @@ protected:
   void OnSingleplayer();
 
   UFUNCTION(BlueprintCallable, Category = "Skald|Widgets")
-  void OnMultiplayer();
+  void OnHost();
+
+  UFUNCTION(BlueprintCallable, Category = "Skald|Widgets")
+  void OnJoin();
 
   UFUNCTION(BlueprintCallable, Category = "Skald|Widgets")
   void OnMainMenu();
 
-  void StartGame(bool bMultiplayer);
+  void StartGame(bool bMultiplayer, bool bHost);
 
 private:
   /** Reference back to the owning lobby menu so it can be restored. */


### PR DESCRIPTION
## Summary
- add host and join flows to StartGameWidget, including address entry and client travel
- track host/client state and join address in SkaldGameInstance with network failure handling
- show connection success message for joining players

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bb359681b48324ac88fa5a7dec9e2e