### PR TITLE
Reset session state after network failure

### DIFF
--- a/Source/Skald/Skald_GameInstance.cpp
+++ b/Source/Skald/Skald_GameInstance.cpp
@@ -3,41 +3,52 @@
 #include "Engine/Engine.h"
 #include "Kismet/GameplayStatics.h"
 
-void USkaldGameInstance::Init()
-{
-    Super::Init();
-    SeedCombatRandomStream(FMath::Rand());
-    TakenFactions.Empty();
-    if (Faction != ESkaldFaction::None)
-    {
-        TakenFactions.Add(Faction);
-    }
+void USkaldGameInstance::Init() {
+  Super::Init();
+  SeedCombatRandomStream(FMath::Rand());
+  TakenFactions.Empty();
+  if (Faction != ESkaldFaction::None) {
+    TakenFactions.Add(Faction);
+  }
 
-    if (GEngine)
-    {
-        GEngine->OnNetworkFailure().AddUObject(this, &USkaldGameInstance::HandleNetworkFailure);
-    }
+  if (GEngine) {
+    GEngine->OnNetworkFailure().AddUObject(
+        this, &USkaldGameInstance::HandleNetworkFailure);
+  }
 }
 
-void USkaldGameInstance::SeedCombatRandomStream(int32 Seed)
-{
-    CombatRandomStream.Initialize(Seed);
+void USkaldGameInstance::SeedCombatRandomStream(int32 Seed) {
+  CombatRandomStream.Initialize(Seed);
 }
 
-void USkaldGameInstance::HandleNetworkFailure(UWorld* World, UNetDriver* /*Driver*/,
-                                              ENetworkFailure::Type /*FailureType*/,
-                                              const FString& ErrorString)
-{
-    if (GEngine)
-    {
-        GEngine->AddOnScreenDebugMessage(-1, 5.f, FColor::Red,
-                                         FString::Printf(TEXT("Network failure: %s"), *ErrorString));
-    }
+void USkaldGameInstance::HandleNetworkFailure(
+    UWorld *World, UNetDriver * /*Driver*/,
+    ENetworkFailure::Type /*FailureType*/, const FString &ErrorString) {
+  if (GEngine) {
+    GEngine->AddOnScreenDebugMessage(
+        -1, 5.f, FColor::Red,
+        FString::Printf(TEXT("Network failure: %s"), *ErrorString));
+  }
 
-    bIsMultiplayer = false;
-    bIsHost = false;
+  bIsMultiplayer = false;
+  bIsHost = false;
 
-    const FName LobbyMap(TEXT("/Game/Blueprints/Maps/Skald_Lobby"));
-    UGameplayStatics::OpenLevel(World, LobbyMap);
+  // Clear any per-session state so a fresh lobby is created after reconnecting.
+  JoinAddress.Empty();
+  AIPlayersToSpawn = 1;
+  TakenFactions.Empty();
+  if (Faction != ESkaldFaction::None) {
+    TakenFactions.Add(Faction);
+  }
+  OnFactionsUpdated.Broadcast();
+  PendingBattle = FS_BattlePayload();
+  GridBattleManager = nullptr;
+  SeedCombatRandomStream(FMath::Rand());
+  SavedTurnIndex = 0;
+  SavedTurnPhase = ETurnPhase::Reinforcement;
+  bResumeTurns = false;
+  LoadedSaveGame = nullptr;
+
+  const FName LobbyMap(TEXT("/Game/Blueprints/Maps/Skald_Lobby"));
+  UGameplayStatics::OpenLevel(World, LobbyMap);
 }
-


### PR DESCRIPTION
## Summary
- Reset per-session state in `HandleNetworkFailure` to ensure a fresh lobby after disconnects
- Clear lingering battle manager and turn data and re-seed random stream

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bb3893948083248a657b264296b82e