### PR TITLE
Add NetCore dependency to resolve network failure enum link error

### DIFF
--- a/Source/Skald/Skald.Build.cs
+++ b/Source/Skald/Skald.Build.cs
@@ -16,7 +16,9 @@ public class Skald : ModuleRules
                         "InputCore",
                         "UMG",
                         "Slate",
-                        "SlateCore"
+                        "SlateCore",
+                        // Required for ENetworkFailure enum used in USkaldGameInstance
+                        "NetCore"
                 });
 
                 PrivateDependencyModuleNames.AddRange(new string[]

--- a/Source/Skald/Skald_GameInstance.h
+++ b/Source/Skald/Skald_GameInstance.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include "CoreMinimal.h"
-#include "Engine/EngineBaseTypes.h"
+#include "Net/Core/NetworkResult.h"
 #include "Engine/GameInstance.h"
 #include "SkaldTypes.h"
 #include "Skald_GameInstance.generated.h"


### PR DESCRIPTION
## Summary
- include NetCore module in Skald.Build.cs
- include Net/Core/NetworkResult.h in game instance

## Testing
- `dotnet test` *(fails: MSB1003 - Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_68bb3d7995fc8324bfc1edca59b4ec92