### PR TITLE
Fix missing include for network failure

### DIFF
--- a/Source/Skald/Skald_GameInstance.h
+++ b/Source/Skald/Skald_GameInstance.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include "CoreMinimal.h"
-#include "Net/Core/NetworkResult.h"
+#include "Engine/EngineBaseTypes.h"
 #include "Engine/GameInstance.h"
 #include "SkaldTypes.h"
 #include "Skald_GameInstance.generated.h"


### PR DESCRIPTION
## Summary
- replace nonexistent Net/Core/NetworkResult include with EngineBaseTypes

## Testing
- `g++ -std=c++17 -fsyntax-only Source/Skald/Skald_GameInstance.cpp` *(fails: CoreMinimal.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68bb4bad25208324a085f45ffbd4644e