### PR TITLE
Avoid duplicate controller registration

### DIFF
--- a/Source/Skald/Skald_GameMode.cpp
+++ b/Source/Skald/Skald_GameMode.cpp
@@ -208,9 +208,11 @@ void ASkaldGameMode::RegisterPlayer(ASkaldPlayerController *PC) {
     }
 
     if (TurnManager) {
-      TurnManager->RegisterController(PC);
-      UE_LOG(LogSkald, Log, TEXT("RegisterPlayer: ControllerCount=%d"),
-             TurnManager->GetControllerCount());
+      if (!TurnManager->GetControllers().Contains(PC)) {
+        TurnManager->RegisterController(PC);
+        UE_LOG(LogSkald, Log, TEXT("RegisterPlayer: ControllerCount=%d"),
+               TurnManager->GetControllerCount());
+      }
     } else {
       // Defer final registration until the turn manager is available. Only
       // queue retries when running in multiplayer.


### PR DESCRIPTION
## Summary
- Skip registering controllers already tracked by TurnManager
- Log controller counts only when a new controller is added

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68bb5ab1a4c483248bb4e3b5aad4e4c0