### PR TITLE
Skip PlayerData removal when player ID is unknown

### DIFF
--- a/Source/Skald/Skald_GameMode.cpp
+++ b/Source/Skald/Skald_GameMode.cpp
@@ -173,17 +173,21 @@ void ASkaldGameMode::PostLogin(APlayerController *NewPlayer) {
 void ASkaldGameMode::Logout(AController *Exiting) {
   ASkaldPlayerController *PC = Cast<ASkaldPlayerController>(Exiting);
   int32 PlayerID = 0;
+  bool bHasValidPlayerState = false;
   if (PC) {
     PendingControllers.Remove(PC);
     if (ASkaldPlayerState *PS = PC->GetPlayerState<ASkaldPlayerState>()) {
       PlayerID = PS->GetPlayerId();
+      bHasValidPlayerState = true;
     }
   }
 
   Super::Logout(Exiting);
 
-  PlayerDataArray.RemoveAll([
-      PlayerID](const FS_PlayerData &Data) { return Data.PlayerID == PlayerID; });
+  if (bHasValidPlayerState) {
+    PlayerDataArray.RemoveAll([
+        PlayerID](const FS_PlayerData &Data) { return Data.PlayerID == PlayerID; });
+  }
 
   if (TurnManager) {
     // Remove the exiting controller from the turn manager's list.


### PR DESCRIPTION
## Summary
- Guard Logout player data removal with a valid player state to avoid wiping unrelated entries when the exiting controller lacks a replicated player state.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bb6119a9b08324ae021914d5929870