### PR TITLE
Log player readiness before world initialization

### DIFF
--- a/Source/Skald/Skald_GameMode.cpp
+++ b/Source/Skald/Skald_GameMode.cpp
@@ -589,6 +589,21 @@ void ASkaldGameMode::TryInitializeWorldAndStart() {
     return;
   }
 
+  UE_LOG(LogSkald, Log,
+         TEXT("TryInitializeWorldAndStart: Listing player lock states"));
+  for (APlayerState *PSBase : GS->PlayerArray) {
+    ASkaldPlayerState *PS = Cast<ASkaldPlayerState>(PSBase);
+    ASkaldPlayerController *OwningController =
+        PS ? Cast<ASkaldPlayerController>(PS->GetOwner()) : nullptr;
+    UE_LOG(
+        LogSkald, Log,
+        TEXT("TryInitializeWorldAndStart: Player=%s IsAI=%s LockedIn=%s Controller=%s"),
+        PS ? *PS->GetPlayerName() : TEXT("null"),
+        PS && PS->bIsAI ? TEXT("true") : TEXT("false"),
+        PS && PS->bHasLockedIn ? TEXT("true") : TEXT("false"),
+        *GetNameSafe(OwningController));
+  }
+
   bool bAllLockedIn = true;
   bool bAllHaveControllers = true;
   for (APlayerState *PSBase : GS->PlayerArray) {


### PR DESCRIPTION
## Summary
- log each player's AI status, lock-in flag, and owning controller in `TryInitializeWorldAndStart`

## Testing
- `./Build/validate.sh` *(fails: UnrealBuildTool and UnrealEditor not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bb6e44c05c832491192753dcbd81ff