### PR TITLE
Ensure AI players remain locked after registration

### DIFF
--- a/Source/Skald/Skald_GameMode.cpp
+++ b/Source/Skald/Skald_GameMode.cpp
@@ -376,6 +376,10 @@ void ASkaldGameMode::PopulateAIPlayers() {
     }
 
     RegisterPlayer(AIController);
+
+    // RegisterPlayer may reset lock-in state; ensure AI players remain locked
+    // so TryInitializeWorldAndStart sees them as ready.
+    AIState->bHasLockedIn = true;
     ++ExistingAI;
 
     if (!AIController->GetPawn() && DefaultPawnClass) {


### PR DESCRIPTION
## Summary
- Preserve AI player lock-in state after registering the controller so initialization sees them as ready

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bb6fe5547083249e19ad6c38448673