### PR TITLE
Collect players to auto-lock before processing

### DIFF
--- a/Source/Skald/Skald_GameMode.cpp
+++ b/Source/Skald/Skald_GameMode.cpp
@@ -529,15 +529,19 @@ void ASkaldGameMode::TryInitializeWorldAndStart() {
 
   USkaldGameInstance *GI = GetGameInstance<USkaldGameInstance>();
   if (GI && !GI->bIsMultiplayer) {
+    TArray<ASkaldPlayerState *> AutoLockPlayers;
     for (APlayerState *PSBase : GS->PlayerArray) {
       ASkaldPlayerState *PS = Cast<ASkaldPlayerState>(PSBase);
-      if (PS && !PS->bIsAI && !PS->bHasLockedIn) {
-        PS->bHasLockedIn = true;
-        HandlePlayerLockedIn(PS);
+      if (PS && !PS->bIsAI && !PS->bHasLockedIn &&
+          PS->Faction != ESkaldFaction::None) {
+        AutoLockPlayers.Add(PS);
       }
     }
 
-    PopulateAIPlayers();
+    for (ASkaldPlayerState *PS : AutoLockPlayers) {
+      PS->bHasLockedIn = true;
+      HandlePlayerLockedIn(PS);
+    }
   }
 
   UE_LOG(LogSkald, Log,


### PR DESCRIPTION
## Summary
- Avoid modifying `PlayerArray` during ranged-for by gathering players needing auto-lock into a temp array
- Lock in collected players and trigger AI population after iteration
- Skip auto-lock for factionless players so AI waits until human selection

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bb66bb3be88324b2065a8487665ccd