### PR TITLE
Route territory selection through WorldMap

### DIFF
--- a/Source/Skald/Skald_PlayerCharacter.cpp
+++ b/Source/Skald/Skald_PlayerCharacter.cpp
@@ -131,8 +131,11 @@ void ASkald_PlayerCharacter::Select()
         {
                 if (ATerritory* Territory = Cast<ATerritory>(Hit.GetActor()))
                 {
-                        Territory->Select();
-                        CurrentSelection = Territory;
+                        if (IsValid(WorldMap))
+                        {
+                                WorldMap->SelectTerritory(Territory);
+                                CurrentSelection = WorldMap->SelectedTerritory;
+                        }
                 }
         }
 }


### PR DESCRIPTION
## Summary
- Use WorldMap::SelectTerritory to handle territory selection instead of calling Select directly on the territory
- Keep CurrentSelection in sync with the world map's selected territory

## Testing
- `g++ -std=c++17 -I../Engine/Source -ISource -c Source/Skald/Skald_PlayerCharacter.cpp` *(fails: Source/Skald/Skald_PlayerCharacter.h:3:10: fatal error: CoreMinimal.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68bb821e269083248e1635fe3edb16cb