### PR TITLE
Clean up player state on seamless travel

### DIFF
--- a/Source/Skald/Skald_GameMode.cpp
+++ b/Source/Skald/Skald_GameMode.cpp
@@ -49,10 +49,7 @@ ASkaldGameMode::ASkaldGameMode() {
 void ASkaldGameMode::BeginPlay() {
   Super::BeginPlay();
 
-  if (ASkaldGameState *GS = GetGameState<ASkaldGameState>()) {
-    GS->Players.Empty();
-    GS->PlayerArray.Empty();
-  }
+  CleanupStalePlayerStates();
   PlayerDataArray.Empty();
 
   for (FConstPlayerControllerIterator It =
@@ -138,6 +135,41 @@ void ASkaldGameMode::BeginPlay() {
         }
       }
     }
+
+    // Verification that player and controller counts match and a human owns
+    // at least one territory after travelling to the battle map.
+    if (ASkaldGameState *GS = GetGameState<ASkaldGameState>()) {
+      int32 ControllerCount = 0;
+      for (FConstPlayerControllerIterator It =
+               GetWorld()->GetPlayerControllerIterator();
+           It; ++It) {
+        ++ControllerCount;
+      }
+      ensureMsgf(GS->PlayerArray.Num() == ControllerCount,
+                 TEXT("PlayerCount %d != ControllerCount %d after travel"),
+                 GS->PlayerArray.Num(), ControllerCount);
+
+      bool bHumanHasTerritory = false;
+      if (WorldMap) {
+        for (APlayerState *BasePS : GS->PlayerArray) {
+          ASkaldPlayerState *PS = Cast<ASkaldPlayerState>(BasePS);
+          if (!PS || PS->bIsAI) {
+            continue;
+          }
+          for (ATerritory *Territory : WorldMap->Territories) {
+            if (WorldMap->IsOwnedBy(Territory, PS)) {
+              bHumanHasTerritory = true;
+              break;
+            }
+          }
+          if (bHumanHasTerritory) {
+            break;
+          }
+        }
+      }
+      ensureMsgf(bHumanHasTerritory,
+                 TEXT("Human player does not own any territory after travel"));
+    }
   }
 }
 
@@ -197,6 +229,16 @@ void ASkaldGameMode::Logout(AController *Exiting) {
 
   RefreshHUDs();
   TryInitializeWorldAndStart();
+}
+
+void ASkaldGameMode::HandleSeamlessTravelPlayer(AController *&C) {
+  Super::HandleSeamlessTravelPlayer(C);
+
+  CleanupStalePlayerStates();
+
+  if (ASkaldPlayerController *PC = Cast<ASkaldPlayerController>(C)) {
+    RegisterPlayer(PC);
+  }
 }
 
 void ASkaldGameMode::RegisterPlayer(ASkaldPlayerController *PC) {
@@ -279,6 +321,30 @@ void ASkaldGameMode::RegisterPlayer(ASkaldPlayerController *PC) {
     FTimerDelegate RefreshDelegate =
         FTimerDelegate::CreateUObject(this, &ASkaldGameMode::RefreshHUDs);
     GetWorldTimerManager().SetTimerForNextTick(RefreshDelegate);
+  }
+}
+
+void ASkaldGameMode::CleanupStalePlayerStates() {
+  ASkaldGameState *GS = GetGameState<ASkaldGameState>();
+  if (!GS) {
+    return;
+  }
+
+  bool bRemovedAny = false;
+  for (int32 i = GS->PlayerArray.Num() - 1; i >= 0; --i) {
+    APlayerState *BasePS = GS->PlayerArray[i];
+    AController *Owner = BasePS ? Cast<AController>(BasePS->GetOwner()) : nullptr;
+    if (!IsValid(Owner)) {
+      GS->PlayerArray.RemoveAt(i);
+      if (ASkaldPlayerState *SkaldPS = Cast<ASkaldPlayerState>(BasePS)) {
+        GS->Players.RemoveSwap(SkaldPS);
+      }
+      bRemovedAny = true;
+    }
+  }
+
+  if (bRemovedAny) {
+    GS->OnPlayersUpdated.Broadcast();
   }
 }
 

--- a/Source/Skald/Skald_GameMode.h
+++ b/Source/Skald/Skald_GameMode.h
@@ -30,6 +30,7 @@ public:
   virtual void BeginPlay() override;
   virtual void PostLogin(APlayerController *NewPlayer) override;
   virtual void Logout(AController *Exiting) override;
+  virtual void HandleSeamlessTravelPlayer(AController *&C) override;
 
   /** Advance army placement to the next controller. */
   void AdvanceArmyPlacement();
@@ -142,4 +143,7 @@ private:
 
   /** Attempt to initialise the world and start the game flow. */
   void TryInitializeWorldAndStart();
+
+  /** Remove invalid player states before re-registering controllers. */
+  void CleanupStalePlayerStates();
 };


### PR DESCRIPTION
## Summary
- remove stale PlayerStates when loading a new map
- re-register controllers via HandleSeamlessTravelPlayer
- ensure BattleMap keeps player/controller counts aligned and a human owns territory

## Testing
- `bash Build/validate.sh` *(fails: UnrealBuildTool not found; UnrealEditor not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bb891e3ec08324855d8ba3ed519256