### PR TITLE
Ensure world start after seamless travel re-registration

### DIFF
--- a/Source/Skald/Skald_GameMode.cpp
+++ b/Source/Skald/Skald_GameMode.cpp
@@ -238,6 +238,8 @@ void ASkaldGameMode::HandleSeamlessTravelPlayer(AController *&C) {
 
   if (ASkaldPlayerController *PC = Cast<ASkaldPlayerController>(C)) {
     RegisterPlayer(PC);
+    RefreshHUDs();
+    TryInitializeWorldAndStart();
   }
 }
 
@@ -333,7 +335,8 @@ void ASkaldGameMode::CleanupStalePlayerStates() {
   bool bRemovedAny = false;
   for (int32 i = GS->PlayerArray.Num() - 1; i >= 0; --i) {
     APlayerState *BasePS = GS->PlayerArray[i];
-    AController *Owner = BasePS ? Cast<AController>(BasePS->GetOwner()) : nullptr;
+    AController *Owner =
+        BasePS ? Cast<AController>(BasePS->GetOwner()) : nullptr;
     if (!IsValid(Owner)) {
       GS->PlayerArray.RemoveAt(i);
       if (ASkaldPlayerState *SkaldPS = Cast<ASkaldPlayerState>(BasePS)) {


### PR DESCRIPTION
## Summary
- Call RefreshHUDs and TryInitializeWorldAndStart when handling seamless travel players
- Guarantees world initialization and turn startup after seamless travel

## Testing
- `clang-format -i Source/Skald/Skald_GameMode.cpp`
- `g++ -fsyntax-only Source/Skald/Skald_GameMode.cpp` *(fails: CoreMinimal.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68bb8ee164e48324a2f87e6590ceb7aa