### PR TITLE
Fix pending controller retry when TurnManager spawns

### DIFF
--- a/Source/Skald/Skald_TurnManager.cpp
+++ b/Source/Skald/Skald_TurnManager.cpp
@@ -53,6 +53,11 @@ void ATurnManager::BeginPlay() {
       }
     }
   }
+
+  if (ASkaldGameMode *GM =
+          GetWorld()->GetAuthGameMode<ASkaldGameMode>()) {
+    GM->TryInitializeWorldAndStart();
+  }
 }
 
 void ATurnManager::RegisterController(ASkaldPlayerController *Controller) {


### PR DESCRIPTION
## Summary
- call `TryInitializeWorldAndStart` from `ATurnManager::BeginPlay` so early players queued before the TurnManager spawns finish registration

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bb91fb4228832483471aa44086a8c6