### PR TITLE
Make TryInitializeWorldAndStart accessible for turn initialization

### DIFF
--- a/Source/Skald/Skald_GameMode.h
+++ b/Source/Skald/Skald_GameMode.h
@@ -116,6 +116,9 @@ public:
   /** Update cached player resource values. */
   void UpdatePlayerResources(ASkaldPlayerState *Player);
 
+  /** Attempt to initialise the world and start the game flow. */
+  void TryInitializeWorldAndStart();
+
 private:
   /** Timer that triggers auto-start of the turn sequence. */
   FTimerHandle StartGameTimerHandle;
@@ -140,9 +143,6 @@ private:
 
   /** Notify HUDs of the current player roster. */
   void RefreshHUDs();
-
-  /** Attempt to initialise the world and start the game flow. */
-  void TryInitializeWorldAndStart();
 
   /** Remove invalid player states before re-registering controllers. */
   void CleanupStalePlayerStates();


### PR DESCRIPTION
## Summary
- Expose `TryInitializeWorldAndStart` so `ATurnManager` can trigger world initialization

## Testing
- `python -m pytest`
- `g++ -std=c++17 -I../Engine/Source -ISource -c Source/Skald/Skald_TurnManager.cpp` *(fails: CoreMinimal.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68bb96add3d48324837cdf6f58e58cd8