### PR TITLE
fix: avoid Actor::Owner shadowing in game mode cleanup

### DIFF
--- a/Source/Skald/Skald_GameMode.cpp
+++ b/Source/Skald/Skald_GameMode.cpp
@@ -330,9 +330,9 @@ void ASkaldGameMode::CleanupStalePlayerStates() {
   bool bRemovedAny = false;
   for (int32 i = GS->PlayerArray.Num() - 1; i >= 0; --i) {
     APlayerState *BasePS = GS->PlayerArray[i];
-    AController *Owner =
+    AController *OwnerController =
         BasePS ? Cast<AController>(BasePS->GetOwner()) : nullptr;
-    if (!IsValid(Owner)) {
+    if (!IsValid(OwnerController)) {
       GS->PlayerArray.RemoveAt(i);
       if (ASkaldPlayerState *SkaldPS = Cast<ASkaldPlayerState>(BasePS)) {
         GS->Players.RemoveSwap(SkaldPS);


### PR DESCRIPTION
## Summary
- rename local variable in `ASkaldGameMode::CleanupStalePlayerStates` to prevent shadowing `AActor::Owner`

## Testing
- `g++ -c Source/Skald/Skald_GameMode.cpp -std=c++20` (fails: CoreMinimal.h: No such file or directory)

------
https://chatgpt.com/codex/tasks/task_e_68bb9a0bc8a88324b7fa8223920cc00d