### PR TITLE
Configure AI player state before registration

### DIFF
--- a/Source/Skald/Skald_GameMode.cpp
+++ b/Source/Skald/Skald_GameMode.cpp
@@ -386,8 +386,6 @@ void ASkaldGameMode::PopulateAIPlayers() {
     AIController->FinishSpawning(SpawnTransform);
     AIController->InitPlayerState();
 
-    RegisterPlayer(AIController);
-
     ASkaldPlayerState *AIState =
         AIController->GetPlayerState<ASkaldPlayerState>();
     if (!AIState) {
@@ -396,7 +394,6 @@ void ASkaldGameMode::PopulateAIPlayers() {
     }
 
     AIState->bIsAI = true;
-    AIState->bHasLockedIn = true;
     AIState->PlayerDisplayName =
         FString::Printf(TEXT("AI_%d"), GS->PlayerArray.Num());
 
@@ -434,8 +431,10 @@ void ASkaldGameMode::PopulateAIPlayers() {
       break;
     }
 
-    NewlySpawnedAI.Add(AIState);
+    AIState->bHasLockedIn = true;
+
     RegisterPlayer(AIController);
+
     NewlySpawnedAI.Add(AIState);
 
     // RegisterPlayer may reset lock-in state; ensure AI players remain locked


### PR DESCRIPTION
## Summary
- configure spawned AI player state before registration
- ensure each AI controller registers once and stays locked in

## Testing
- `./Build/validate.sh` *(fails: UnrealBuildTool not found; UnrealEditor not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bb9e555c7483249f154579c9e9a31e