### PR TITLE
Ensure world map binding for controllers

### DIFF
--- a/Source/Skald/Skald_GameMode.cpp
+++ b/Source/Skald/Skald_GameMode.cpp
@@ -1134,6 +1134,16 @@ bool ASkaldGameMode::InitializeWorld() {
     }
     return false;
   }
+
+  // The world map now exists with generated territories; ensure all player
+  // controllers bind to its selection event.
+  for (FConstPlayerControllerIterator It = GetWorld()->GetPlayerControllerIterator();
+       It; ++It) {
+    if (ASkaldPlayerController *PC = Cast<ASkaldPlayerController>(*It)) {
+      PC->TryBindWorldMap();
+    }
+  }
+
   // Shuffle territories before assignment
   Algo::RandomShuffle(WorldMap->Territories);
 

--- a/Source/Skald/Skald_PlayerController.cpp
+++ b/Source/Skald/Skald_PlayerController.cpp
@@ -26,8 +26,6 @@
 #include "UObject/ConstructorHelpers.h"
 #include "WorldMap.h"
 
-constexpr int32 MaxWorldMapSearchAttempts = 5;
-
 ASkaldPlayerController::ASkaldPlayerController() {
   TurnManager = nullptr;
   HUDRef = nullptr;
@@ -43,8 +41,6 @@ ASkaldPlayerController::ASkaldPlayerController() {
   // blueprint-derived widget that may not exist or may be corrupt.
   HUDWidgetClass = USkaldMainHUDWidget::StaticClass();
   BattleHUDWidgetClass = UBattleHUDWidget::StaticClass();
-
-  WorldMapSearchAttempts = 0;
 
   static ConstructorHelpers::FClassFinder<UChoosePlayerWidget> ChooseBP(
       TEXT("/Game/Blueprints/UI/Skald_ChoosePlayerWidget"));
@@ -183,21 +179,11 @@ void ASkaldPlayerController::TryBindWorldMap() {
                      this, &ASkaldPlayerController::HandleTerritorySelected),
                  TEXT("Failed to bind HandleTerritorySelected to WorldMap."));
     }
-    WorldMapSearchAttempts = 0;
     GetWorldTimerManager().ClearTimer(WorldMapSearchHandle);
   } else {
-    ++WorldMapSearchAttempts;
-    if (WorldMapSearchAttempts >= MaxWorldMapSearchAttempts) {
-      UE_LOG(LogSkald, Warning,
-             TEXT("ASkaldPlayerController could not find AWorldMap after %d "
-                  "attempts."),
-             WorldMapSearchAttempts);
-      GetWorldTimerManager().ClearTimer(WorldMapSearchHandle);
-    } else {
-      GetWorldTimerManager().SetTimer(WorldMapSearchHandle, this,
-                                      &ASkaldPlayerController::TryBindWorldMap,
-                                      0.5f, false);
-    }
+    GetWorldTimerManager().SetTimer(WorldMapSearchHandle, this,
+                                    &ASkaldPlayerController::TryBindWorldMap,
+                                    0.5f, false);
   }
 }
 

--- a/Source/Skald/Skald_PlayerController.h
+++ b/Source/Skald/Skald_PlayerController.h
@@ -280,8 +280,6 @@ public:
     /** Timer used to poll for the world map actor until it exists. */
     FTimerHandle WorldMapSearchHandle;
 
-    /** Number of times we've attempted to locate the world map. */
-    int32 WorldMapSearchAttempts;
 
     void BuildPlayerDataArray(TArray<FS_PlayerData> &OutPlayers) const;
 


### PR DESCRIPTION
## Summary
- bind world map selection for all controllers once territories are generated
- retry binding indefinitely in `TryBindWorldMap`

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bba70710488324a833b7deca72a389