### PR TITLE
Allow game mode to bind world map

### DIFF
--- a/Source/Skald/Skald_PlayerController.h
+++ b/Source/Skald/Skald_PlayerController.h
@@ -29,6 +29,9 @@ UCLASS(Blueprintable, BlueprintType)
 class SKALD_API ASkaldPlayerController : public APlayerController {
   GENERATED_BODY()
 
+  /** Allow the game mode to trigger binding once the world map exists. */
+  friend class ASkaldGameMode;
+
 public:
   ASkaldPlayerController();
 


### PR DESCRIPTION
## Summary
- allow `ASkaldGameMode` to access `ASkaldPlayerController::TryBindWorldMap`

## Testing
- `./Build/validate.sh` *(fails: UnrealBuildTool not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bb9d41e468832483f4211ce2c71b34