### PR TITLE
Allow game mode to bind world map

### DIFF
--- a/Source/Skald/Skald_GameMode.cpp
+++ b/Source/Skald/Skald_GameMode.cpp
@@ -670,6 +670,18 @@ void ASkaldGameMode::TryInitializeWorldAndStart() {
     return;
   }
 
+  // Player IDs can grow without bound across repeated sessions. Reassign
+  // them to match the compact `PlayerDataArray` so blueprints that index by
+  // ID never read past the array length.
+  for (int32 i = 0; i < GS->PlayerArray.Num(); ++i) {
+    if (ASkaldPlayerState *PS = Cast<ASkaldPlayerState>(GS->PlayerArray[i])) {
+      PS->SetPlayerId(i);
+      if (PlayerDataArray.IsValidIndex(i)) {
+        PlayerDataArray[i].PlayerID = i;
+      }
+    }
+  }
+
   UE_LOG(LogSkald, Log,
          TEXT("TryInitializeWorldAndStart: Listing player lock states"));
   for (APlayerState *PSBase : GS->PlayerArray) {

--- a/Source/Skald/Skald_PlayerController.h
+++ b/Source/Skald/Skald_PlayerController.h
@@ -29,6 +29,9 @@ UCLASS(Blueprintable, BlueprintType)
 class SKALD_API ASkaldPlayerController : public APlayerController {
   GENERATED_BODY()
 
+  /** Allow the game mode to trigger binding once the world map exists. */
+  friend class ASkaldGameMode;
+
 public:
   ASkaldPlayerController();
 


### PR DESCRIPTION
## Summary
- allow `ASkaldGameMode` to access `ASkaldPlayerController::TryBindWorldMap`
- normalize player IDs so client blueprints never index beyond the player list

## Testing
- `./Build/validate.sh` *(fails: UnrealBuildTool not found; tests skipped)*

------
https://chatgpt.com/codex/tasks/task_e_68bb9d41e468832483f4211ce2c71b34