### PR TITLE
Guard AI population on human lock-in

### DIFF
--- a/Source/Skald/Skald_GameMode.cpp
+++ b/Source/Skald/Skald_GameMode.cpp
@@ -497,7 +497,9 @@ void ASkaldGameMode::HandlePlayerLockedIn(ASkaldPlayerState *PS) {
 
   // Once a human has locked in their choice, populate remaining slots with AI
   // opponents so they respect the player's faction selection.
-  PopulateAIPlayers();
+  if (!PS->bIsAI) {
+    PopulateAIPlayers();
+  }
 
   if (!WorldMap) {
     WorldMap = Cast<AWorldMap>(UGameplayStatics::GetActorOfClass(


### PR DESCRIPTION
## Summary
- Only populate AI players when a human locks in

## Testing
- `./Build/validate.sh` *(fails: UnrealBuildTool not found; skipping compile check. UnrealEditor not found; cannot run tests.)*


------
https://chatgpt.com/codex/tasks/task_e_68bbb8f65d0c8324b6d8dd1d2330b45d