### PR TITLE
Ensure PlayerState name matches display name

### DIFF
--- a/Source/Skald/Skald_PlayerController.cpp
+++ b/Source/Skald/Skald_PlayerController.cpp
@@ -212,6 +212,7 @@ void ASkaldPlayerController::ServerInitPlayerState_Implementation(
            TEXT("ServerInitPlayerState_Implementation: PlayerState=%s"),
            *PS->GetName());
     PS->PlayerDisplayName = Name;
+    PS->SetPlayerName(Name);
     PS->Faction = Faction;
     PS->bHasLockedIn = true;
 


### PR DESCRIPTION
## Summary
- synchronize PlayerState's internal name with the chosen display name to avoid machine names appearing in logs

## Testing
- `bash Build/validate.sh` *(fails: UnrealBuildTool not found; UnrealEditor not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bbbfebdac08324b33b2a6990371ad6