### PR TITLE
Align player registration with chosen display name and AI count

### DIFF
--- a/Source/Skald/Skald_GameMode.cpp
+++ b/Source/Skald/Skald_GameMode.cpp
@@ -40,9 +40,6 @@ ASkaldGameMode::ASkaldGameMode() {
   bWorldInitialized = false;
   AIControllerClass = ASkaldAIController::StaticClass();
 
-  // Preallocate slots so blueprint scripts can safely write
-  // player data to indices without hitting "invalid index" warnings.
-  PlayerDataArray.SetNum(ExpectedPlayerCount);
   NextSiegeID = 1;
 }
 
@@ -183,15 +180,6 @@ void ASkaldGameMode::PostLogin(APlayerController *NewPlayer) {
     PC->ClientMessage(TEXT("Game already in progress."));
     PC->Destroy();
     return;
-  }
-
-  if (ASkaldGameState *GS = GetGameState<ASkaldGameState>()) {
-    if (GS->PlayerArray.Num() >= ExpectedPlayerCount) {
-      PC->ClientMessage(FString::Printf(TEXT("Game is full (%d players max)."),
-                                        ExpectedPlayerCount));
-      PC->Destroy();
-      return;
-    }
   }
 
   RegisterPlayer(PC);
@@ -480,20 +468,6 @@ void ASkaldGameMode::HandlePlayerLockedIn(ASkaldPlayerState *PS) {
          TurnManager ? *TurnManager->GetName() : TEXT("null"),
          TurnManager ? TurnManager->GetControllerCount() : 0,
          GS ? GS->PlayerArray.Num() : 0);
-
-  USkaldGameInstance *GI = GetGameInstance<USkaldGameInstance>();
-  int32 HumanCount = 0;
-  if (GS) {
-    for (APlayerState *ExistingPS : GS->PlayerArray) {
-      ASkaldPlayerState *Existing = Cast<ASkaldPlayerState>(ExistingPS);
-      if (Existing && !Existing->bIsAI) {
-        ++HumanCount;
-      }
-    }
-  }
-  const int32 AICount = GI ? GI->AIPlayersToSpawn : 0;
-  ExpectedPlayerCount = FMath::Max(HumanCount + AICount, MinPlayerCount);
-  PlayerDataArray.SetNum(ExpectedPlayerCount);
 
   // Once a human has locked in their choice, populate remaining slots with AI
   // opponents so they respect the player's faction selection.
@@ -1068,22 +1042,7 @@ bool ASkaldGameMode::InitializeWorld() {
     return false;
   }
 
-  int32 TotalPlayerCount = GS->PlayerArray.Num();
-  if (TotalPlayerCount > ExpectedPlayerCount) {
-    UE_LOG(LogSkald, Warning,
-           TEXT("InitializeWorld: maximum %d players supported but found %d; "
-                "proceeding "
-                "with first %d players"),
-           ExpectedPlayerCount, TotalPlayerCount, ExpectedPlayerCount);
-    while (GS->PlayerArray.Num() > ExpectedPlayerCount) {
-      if (APlayerState *Extra = GS->PlayerArray[ExpectedPlayerCount]) {
-        GS->RemovePlayerState(Extra);
-      } else {
-        GS->PlayerArray.RemoveAt(ExpectedPlayerCount);
-      }
-    }
-    TotalPlayerCount = ExpectedPlayerCount;
-  }
+  const int32 TotalPlayerCount = GS->PlayerArray.Num();
   if (TotalPlayerCount < MinPlayerCount) {
     UE_LOG(
         LogSkald, Warning,

--- a/Source/Skald/Skald_GameMode.h
+++ b/Source/Skald/Skald_GameMode.h
@@ -66,8 +66,7 @@ protected:
   UPROPERTY(BlueprintReadOnly, Category = "GameMode")
   AWorldMap *WorldMap;
 
-  /** Data describing each player in the match. Pre-sized so blueprints can
-   * safely write to indices without hitting invalid array warnings. */
+  /** Data describing each player in the match. */
   UPROPERTY(BlueprintReadOnly, Category = "Players")
   TArray<FS_PlayerData> PlayerDataArray;
 
@@ -76,10 +75,6 @@ protected:
             meta = (ClampMin = "1"))
   int32 MinPlayerCount = 1;
 
-  /** Total number of players expected in the match (humans + AI). */
-  UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "Players",
-            meta = (ClampMin = "1"))
-  int32 ExpectedPlayerCount = 4;
 
   /** Controller class used when spawning AI players. */
   UPROPERTY(EditDefaultsOnly, Category = "Players")

--- a/Source/Skald/Skald_PlayerController.cpp
+++ b/Source/Skald/Skald_PlayerController.cpp
@@ -212,6 +212,7 @@ void ASkaldPlayerController::ServerInitPlayerState_Implementation(
            TEXT("ServerInitPlayerState_Implementation: PlayerState=%s"),
            *PS->GetName());
     PS->PlayerDisplayName = Name;
+    PS->SetPlayerName(Name);
     PS->Faction = Faction;
     PS->bHasLockedIn = true;
 


### PR DESCRIPTION
## Summary
- synchronize PlayerState's internal name with the chosen display name to avoid machine names appearing in logs
- remove fixed expected player cap so AI opponents spawn only according to the AiCountSpinBox selection

## Testing
- `bash Build/validate.sh` *(fails: UnrealBuildTool not found; UnrealEditor not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bbbfebdac08324b33b2a6990371ad6