### PR TITLE
Fix click event disabling after load

### DIFF
--- a/Source/Skald/LoadGameWidget.cpp
+++ b/Source/Skald/LoadGameWidget.cpp
@@ -93,8 +93,6 @@ void ULoadGameWidget::HandleLoadSlot(int32 SlotIndex)
         {
             PC->SetInputMode(FInputModeGameOnly());
             PC->bShowMouseCursor = false;
-            PC->bEnableClickEvents = false;
-            PC->bEnableMouseOverEvents = false;
         }
 
         // After loading, transition to the main gameplay map


### PR DESCRIPTION
## Summary
- Avoid disabling click and mouse-over events when loading a save to keep input functional in the next level

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bbcd7922c08324851c85715878ffa3