### PR TITLE
Enable collision for territories

### DIFF
--- a/Source/Skald/Territory.cpp
+++ b/Source/Skald/Territory.cpp
@@ -49,6 +49,7 @@ ATerritory::ATerritory() {
   PrimaryActorTick.bCanEverTick = false;
   bReplicates = true;
   MeshComponent = CreateDefaultSubobject<UStaticMeshComponent>(TEXT("Mesh"));
+  MeshComponent->SetCollisionProfileName(TEXT("BlockAll"));
   RootComponent = MeshComponent;
 
   // Provide basic visuals so the world map can function even if assets


### PR DESCRIPTION
## Summary
- Set territory mesh collision profile to BlockAll so mouse line traces hit

## Testing
- `bash Build/validate.sh` *(fails: UnrealBuildTool not found; UnrealEditor not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bbd1c02be083249dafa705f28f501e