### PR TITLE
Prevent duplicate AI spawning and enforce configured AI count

### DIFF
--- a/Source/Skald/Skald_GameMode.cpp
+++ b/Source/Skald/Skald_GameMode.cpp
@@ -38,6 +38,7 @@ ASkaldGameMode::ASkaldGameMode() {
   WorldMap = nullptr;
   bTurnsStarted = false;
   bWorldInitialized = false;
+  bAIPlayersSpawned = false;
   AIControllerClass = ASkaldAIController::StaticClass();
 
   NextSiegeID = 1;
@@ -343,10 +344,12 @@ void ASkaldGameMode::PopulateAIPlayers() {
 
   bool bHasHuman = false;
   int32 ExistingAI = 0;
+  TArray<ASkaldPlayerState *> AIStates;
   for (APlayerState *ExistingPS : GS->PlayerArray) {
     if (ASkaldPlayerState *EPS = Cast<ASkaldPlayerState>(ExistingPS)) {
       if (EPS->bIsAI) {
         ++ExistingAI;
+        AIStates.Add(EPS);
       } else {
         bHasHuman = true;
       }
@@ -357,6 +360,25 @@ void ASkaldGameMode::PopulateAIPlayers() {
   }
 
   const int32 TargetAI = FMath::Max(GI->AIPlayersToSpawn, 0);
+
+  // Trim any excess AI players to respect the configured total.
+  if (ExistingAI > TargetAI) {
+    for (int32 Index = AIStates.Num() - 1; Index >= 0 && ExistingAI > TargetAI;
+         --Index) {
+      ASkaldPlayerState *ExcessPS = AIStates[Index];
+      if (AController *Owner = Cast<AController>(ExcessPS->GetOwner())) {
+        Owner->Destroy();
+      }
+      GS->RemovePlayerState(ExcessPS);
+      PlayerDataArray.RemoveAll([ExcessPS](const FS_PlayerData &Data) {
+        return Data.PlayerID == ExcessPS->GetPlayerId();
+      });
+      GI->TakenFactions.Remove(ExcessPS->Faction);
+      --ExistingAI;
+    }
+    GS->OnPlayersUpdated.Broadcast();
+  }
+
   const int32 MaxSpawnAttempts = TargetAI * 2;
   int32 SpawnAttempts = 0;
   TArray<ASkaldPlayerState *> NewlySpawnedAI;
@@ -469,12 +491,6 @@ void ASkaldGameMode::HandlePlayerLockedIn(ASkaldPlayerState *PS) {
          TurnManager ? TurnManager->GetControllerCount() : 0,
          GS ? GS->PlayerArray.Num() : 0);
 
-  // Once a human has locked in their choice, populate remaining slots with AI
-  // opponents so they respect the player's faction selection.
-  if (!PS->bIsAI) {
-    PopulateAIPlayers();
-  }
-
   if (!WorldMap) {
     WorldMap = Cast<AWorldMap>(UGameplayStatics::GetActorOfClass(
         GetWorld(), AWorldMap::StaticClass()));
@@ -585,6 +601,11 @@ void ASkaldGameMode::TryInitializeWorldAndStart() {
       PS->bHasLockedIn = true;
       HandlePlayerLockedIn(PS);
     }
+  }
+
+  if (!bAIPlayersSpawned) {
+    bAIPlayersSpawned = true;
+    PopulateAIPlayers();
   }
 
   UE_LOG(LogSkald, Log,

--- a/Source/Skald/Skald_GameMode.h
+++ b/Source/Skald/Skald_GameMode.h
@@ -124,6 +124,9 @@ private:
   /** Whether the world has been initialized and territories assigned. */
   bool bWorldInitialized;
 
+  /** Flag to avoid spawning AI players multiple times. */
+  bool bAIPlayersSpawned;
+
   /** Controllers whose PlayerState is not yet valid, queued for retry. */
   TArray<ASkaldPlayerController *> PendingControllers;
 


### PR DESCRIPTION
## Summary
- stop AI from respawning on every lock-in
- spawn AI once during world start and track with `bAIPlayersSpawned`
- clamp or remove existing AI players so the total matches `AIPlayersToSpawn`

## Testing
- `g++ -std=c++17 -c Source/Skald/Skald_GameMode.cpp` *(fails: CoreMinimal.h: No such file or directory)*
- `./Binaries/Linux/Skald` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68bbd9f2124c8324ae7abf9d70718213