### PR TITLE
Retry world map binding until available

### DIFF
--- a/Source/Skald/Skald_PlayerController.cpp
+++ b/Source/Skald/Skald_PlayerController.cpp
@@ -180,9 +180,11 @@ void ASkaldPlayerController::TryBindWorldMap() {
     }
     GetWorldTimerManager().ClearTimer(WorldMapSearchHandle);
   } else {
-    GetWorldTimerManager().SetTimer(WorldMapSearchHandle, this,
-                                    &ASkaldPlayerController::TryBindWorldMap,
-                                    0.5f, false);
+    if (!GetWorldTimerManager().IsTimerActive(WorldMapSearchHandle)) {
+      GetWorldTimerManager().SetTimer(
+          WorldMapSearchHandle, this,
+          &ASkaldPlayerController::TryBindWorldMap, 0.5f, true);
+    }
   }
 }
 


### PR DESCRIPTION
## Summary
- Ensure player controller keeps retrying to bind to the World Map until it exists

## Testing
- `bash Build/validate.sh` *(fails: UnrealBuildTool not found; UnrealEditor not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bbdb4314a08324928f2c8717378433