### PR TITLE
Remove trimmed AI from replicated Players list

### DIFF
--- a/Source/Skald/Skald_GameMode.cpp
+++ b/Source/Skald/Skald_GameMode.cpp
@@ -369,13 +369,9 @@ void ASkaldGameMode::PopulateAIPlayers() {
       if (AController *OwningController =
               Cast<AController>(ExcessPS->GetOwner())) {
         OwningController->Destroy();
-      if (AController *OwnerController =
-              Cast<AController>(ExcessPS->GetOwner())) {
-        OwnerController->Destroy();
-      if (AController *Owner = Cast<AController>(ExcessPS->GetOwner())) {
-        Owner->Destroy();
       }
       GS->RemovePlayerState(ExcessPS);
+      GS->Players.RemoveSwap(ExcessPS);
       PlayerDataArray.RemoveAll([ExcessPS](const FS_PlayerData &Data) {
         return Data.PlayerID == ExcessPS->GetPlayerId();
       });


### PR DESCRIPTION
## Summary
- Remove trimmed AI player states from `ASkaldGameState::Players` to avoid stale replication

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bbe49da6048324962283954d2a1f56