### PR TITLE
Fix undeclared OwningController variable in AI cleanup

### DIFF
--- a/Source/Skald/Skald_GameMode.cpp
+++ b/Source/Skald/Skald_GameMode.cpp
@@ -368,7 +368,6 @@ void ASkaldGameMode::PopulateAIPlayers() {
       ASkaldPlayerState *ExcessPS = AIStates[Index];
       if (AController *ControllerOwner =
               Cast<AController>(ExcessPS->GetOwner())) {
-        OwningController->Destroy();
         ControllerOwner->Destroy();
       }
       GS->RemovePlayerState(ExcessPS);


### PR DESCRIPTION
## Summary
- Remove reference to undeclared `OwningController` in `PopulateAIPlayers`

## Testing
- `g++ Source/Skald/Skald_GameMode.cpp -c` *(fails: CoreMinimal.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68bc4c628ba0832481150843e1fa5b07