### PR TITLE
Guard game start initialization after lock-in

### DIFF
--- a/Source/Skald/Skald_GameMode.cpp
+++ b/Source/Skald/Skald_GameMode.cpp
@@ -212,7 +212,9 @@ void ASkaldGameMode::Logout(AController *Exiting) {
   }
 
   RefreshHUDs();
-  TryInitializeWorldAndStart();
+  if (!bWorldInitialized) {
+    TryInitializeWorldAndStart();
+  }
 }
 
 void ASkaldGameMode::HandleSeamlessTravelPlayer(AController *&C) {
@@ -325,7 +327,9 @@ void ASkaldGameMode::RegisterPlayer(ASkaldPlayerController *PC) {
         FTimerDelegate::CreateUObject(this, &ASkaldGameMode::RefreshHUDs);
     GetWorldTimerManager().SetTimerForNextTick(RefreshDelegate);
 
-    TryInitializeWorldAndStart();
+    if (!bWorldInitialized) {
+      TryInitializeWorldAndStart();
+    }
   }
 }
 
@@ -476,15 +480,9 @@ void ASkaldGameMode::PopulateAIPlayers() {
       break;
     }
 
-    AIState->bHasLockedIn = true;
-
     RegisterPlayer(AIController);
 
     NewlySpawnedAI.Add(AIState);
-
-    // RegisterPlayer may reset lock-in state; ensure AI players remain locked
-    // so TryInitializeWorldAndStart sees them as ready.
-    AIState->bHasLockedIn = true;
     ++ExistingAI;
 
     if (!AIController->GetPawn() && DefaultPawnClass) {
@@ -512,9 +510,11 @@ void ASkaldGameMode::PopulateAIPlayers() {
 }
 
 void ASkaldGameMode::HandlePlayerLockedIn(ASkaldPlayerState *PS) {
-  if (!PS) {
+  if (!PS || bWorldInitialized || PS->bHasLockedIn) {
     return;
   }
+
+  PS->bHasLockedIn = true;
 
   UE_LOG(LogSkald, Log, TEXT("HandlePlayerLockedIn: Player=%s bIsAI=%d"),
          *PS->PlayerDisplayName, PS->bIsAI ? 1 : 0);
@@ -633,7 +633,6 @@ void ASkaldGameMode::TryInitializeWorldAndStart() {
     }
 
     for (ASkaldPlayerState *PS : AutoLockPlayers) {
-      PS->bHasLockedIn = true;
       HandlePlayerLockedIn(PS);
     }
   }

--- a/Source/Skald/Skald_GameMode.h
+++ b/Source/Skald/Skald_GameMode.h
@@ -54,6 +54,9 @@ public:
   UFUNCTION(BlueprintCallable, BlueprintPure, Category = "GameMode")
   ATurnManager *GetTurnManager() const { return TurnManager; }
 
+  /** Whether the world has already been initialised. */
+  bool IsWorldInitialized() const { return bWorldInitialized; }
+
   /** Handle a player confirming their name and faction selection. */
   void HandlePlayerLockedIn(ASkaldPlayerState *PS);
 

--- a/Source/Skald/Skald_PlayerController.cpp
+++ b/Source/Skald/Skald_PlayerController.cpp
@@ -214,7 +214,6 @@ void ASkaldPlayerController::ServerInitPlayerState_Implementation(
     PS->PlayerDisplayName = Name;
     PS->SetPlayerName(Name);
     PS->Faction = Faction;
-    PS->bHasLockedIn = true;
 
     if (USkaldGameInstance *GI = GetGameInstance<USkaldGameInstance>()) {
       GI->AIPlayersToSpawn = NumAIPlayers;

--- a/Source/Skald/Skald_TurnManager.cpp
+++ b/Source/Skald/Skald_TurnManager.cpp
@@ -56,7 +56,9 @@ void ATurnManager::BeginPlay() {
 
   if (ASkaldGameMode *GM =
           GetWorld()->GetAuthGameMode<ASkaldGameMode>()) {
-    GM->TryInitializeWorldAndStart();
+    if (!GM->IsWorldInitialized()) {
+      GM->TryInitializeWorldAndStart();
+    }
   }
 }
 


### PR DESCRIPTION
## Summary
- Avoid redundant world initialization by exiting `HandlePlayerLockedIn` when the world is already initialized or the player was locked in
- Only start the world from player registration, logout, or turn manager when no game has begun
- Move player lock-in flag setting to `HandlePlayerLockedIn` and defer from controllers

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bc575721188324808fb837d65f5840