### PR TITLE
Ensure HUD initialization precedes world start

### DIFF
--- a/Source/Skald/Skald_GameMode.cpp
+++ b/Source/Skald/Skald_GameMode.cpp
@@ -642,6 +642,24 @@ void ASkaldGameMode::TryInitializeWorldAndStart() {
     PopulateAIPlayers();
   }
 
+  // Ensure local human controllers have their HUD widgets initialized before
+  // proceeding with world initialization. Retry on the next tick if any are
+  // still pending.
+  for (FConstPlayerControllerIterator It =
+           GetWorld()->GetPlayerControllerIterator();
+       It; ++It) {
+    if (ASkaldPlayerController *PC = Cast<ASkaldPlayerController>(*It)) {
+      ASkaldPlayerState *PS = PC->GetPlayerState<ASkaldPlayerState>();
+      const bool bIsAI = PS && PS->bIsAI;
+      if (!bIsAI && PC->IsLocalController() && !PC->GetHUDWidget()) {
+        FTimerDelegate RetryInit = FTimerDelegate::CreateUObject(
+            this, &ASkaldGameMode::TryInitializeWorldAndStart);
+        GetWorldTimerManager().SetTimerForNextTick(RetryInit);
+        return;
+      }
+    }
+  }
+
   UE_LOG(LogSkald, Log,
          TEXT("TryInitializeWorldAndStart: TurnManager=%s PlayerCount=%d"),
          TurnManager ? *TurnManager->GetName() : TEXT("null"),
@@ -1291,9 +1309,11 @@ bool ASkaldGameMode::InitializeWorld() {
              GetWorld()->GetPlayerControllerIterator();
          It; ++It) {
       if (ASkaldPlayerController *PC = Cast<ASkaldPlayerController>(*It)) {
+        ASkaldPlayerState *PS = PC->GetPlayerState<ASkaldPlayerState>();
+        const bool bIsAI = PS && PS->bIsAI;
         if (USkaldMainHUDWidget *HUD = PC->GetHUDWidget()) {
           HUD->UpdateInitiativeText(Message);
-        } else {
+        } else if (!bIsAI && PC->IsLocalController()) {
           UE_LOG(LogSkald, Warning,
                  TEXT("InitializeWorld: Controller %s missing HUD widget"),
                  *PC->GetName());

--- a/Source/Skald/Skald_PlayerController.cpp
+++ b/Source/Skald/Skald_PlayerController.cpp
@@ -117,6 +117,12 @@ void ASkaldPlayerController::InitializeHUDWidget() {
       this, &ASkaldPlayerController::HandleBuildSiegeRequested);
   MainHudWidget->OnDigTreasureRequested.AddDynamic(
       this, &ASkaldPlayerController::HandleDigTreasureRequested);
+
+  // Notify the game mode that the HUD is now ready so world start checks can
+  // proceed only after widgets are initialized.
+  if (CachedGameMode) {
+    CachedGameMode->TryInitializeWorldAndStart();
+  }
 }
 
 void ASkaldPlayerController::InitializeChoosePlayerWidget() {

--- a/Source/Skald/Skald_TurnManager.cpp
+++ b/Source/Skald/Skald_TurnManager.cpp
@@ -153,10 +153,13 @@ void ATurnManager::StartTurns() {
     if (ASkaldPlayerController *Controller = ControllerPtr.Get()) {
       const bool bIsActive = Controller == CurrentController;
       Controller->ShowTurnAnnouncement(PlayerName, bIsActive);
+      ASkaldPlayerState *ControllerPS =
+          Controller->GetPlayerState<ASkaldPlayerState>();
+      const bool bIsAI = ControllerPS && ControllerPS->bIsAI;
       if (USkaldMainHUDWidget *HUD = Controller->GetHUDWidget()) {
         HUD->UpdateTurnBanner(PS ? PS->GetPlayerId() : -1, 1);
         HUD->UpdatePhaseBanner(CurrentPhase);
-      } else {
+      } else if (!bIsAI && Controller->IsLocalController()) {
         UE_LOG(LogSkald, Warning,
                TEXT("StartTurns: Controller %s missing HUD widget"),
                *Controller->GetName());


### PR DESCRIPTION
## Summary
- Re-trigger world start after player HUD initialization and defer startup until all local HUDs exist
- Warn about missing HUDs only for local human controllers in game mode initialization and turn start

## Testing
- `pytest >/tmp/pytest.log && tail -n 20 /tmp/pytest.log`


------
https://chatgpt.com/codex/tasks/task_e_68bc58a8506c8324b2df300361a65fff