### PR TITLE
Guard player controller initialization

### DIFF
--- a/Source/Skald/ChoosePlayerWidget.cpp
+++ b/Source/Skald/ChoosePlayerWidget.cpp
@@ -5,6 +5,7 @@
 #include "Components/EditableTextBox.h"
 #include "Components/SpinBox.h"
 #include "Skald_GameInstance.h"
+#include "Skald_GameMode.h"
 #include "Skald_PlayerController.h"
 
 void UChoosePlayerWidget::NativeConstruct()
@@ -112,7 +113,19 @@ void UChoosePlayerWidget::OnLockIn()
 
     if (ASkaldPlayerController* PC = Cast<ASkaldPlayerController>(GetOwningPlayer()))
     {
-        PC->ServerInitPlayerState(Name, Faction, AICount);
+        bool bShouldInit = true;
+        if (UWorld* World = PC->GetWorld())
+        {
+            if (ASkaldGameMode* GM = World->GetAuthGameMode<ASkaldGameMode>())
+            {
+                bShouldInit = !GM->IsWorldInitialized();
+            }
+        }
+
+        if (bShouldInit)
+        {
+            PC->ServerInitPlayerState(Name, Faction, AICount);
+        }
     }
 
     OnPlayerLockedIn.Broadcast();

--- a/Source/Skald/Skald_PlayerController.cpp
+++ b/Source/Skald/Skald_PlayerController.cpp
@@ -32,6 +32,7 @@ ASkaldPlayerController::ASkaldPlayerController() {
   MainHudWidget = nullptr;
   BattleHudWidget = nullptr;
   CurrentCommandMode = EBattleCommandMode::None;
+  bHasInitialized = false;
 
   bShowMouseCursor = true;
   bEnableClickEvents = true;
@@ -161,7 +162,8 @@ void ASkaldPlayerController::BeginPlay() {
     }
     if (CachedGameInstance && CachedGameInstance->bIsMultiplayer) {
       InitializeChoosePlayerWidget();
-    } else if (CachedGameInstance) {
+    } else if (CachedGameInstance && !bHasInitialized &&
+               (!CachedGameMode || !CachedGameMode->IsWorldInitialized())) {
       ServerInitPlayerState(CachedGameInstance->DisplayName,
                             CachedGameInstance->Faction,
                             CachedGameInstance->AIPlayersToSpawn);
@@ -226,10 +228,15 @@ void ASkaldPlayerController::ServerInitPlayerState_Implementation(
     }
 
     if (ASkaldGameMode *GM = GetWorld()->GetAuthGameMode<ASkaldGameMode>()) {
-      UE_LOG(LogSkald, Log,
-             TEXT("ServerInitPlayerState_Implementation: Notify GameMode %s"),
-             *GM->GetName());
-      GM->HandlePlayerLockedIn(PS);
+      if (!GM->IsWorldInitialized()) {
+        UE_LOG(LogSkald, Log,
+               TEXT("ServerInitPlayerState_Implementation: Notify GameMode %s"),
+               *GM->GetName());
+        GM->HandlePlayerLockedIn(PS);
+      } else {
+        UE_LOG(LogSkald, Log,
+               TEXT("ServerInitPlayerState_Implementation: World already initialized"));
+      }
     } else {
       UE_LOG(LogSkald, Warning,
              TEXT("ServerInitPlayerState_Implementation: GameMode is null"));
@@ -903,6 +910,11 @@ void ASkaldPlayerController::HandleWorldStateChanged() {
 void ASkaldPlayerController::HandlePlayerLockedIn() { HandleFactionLockedIn(); }
 
 void ASkaldPlayerController::HandleFactionLockedIn() {
+  if (bHasInitialized) {
+    return;
+  }
+  bHasInitialized = true;
+
   if (ChoosePlayerWidget) {
     ChoosePlayerWidget->OnPlayerLockedIn.RemoveDynamic(
         this, &ASkaldPlayerController::HandleFactionLockedIn);

--- a/Source/Skald/Skald_PlayerController.h
+++ b/Source/Skald/Skald_PlayerController.h
@@ -130,6 +130,9 @@ protected:
   /** Current command selection when issuing grid battle orders. */
   EBattleCommandMode CurrentCommandMode;
 
+  /** Ensures ServerInitPlayerState and lock-in handling run only once. */
+  bool bHasInitialized;
+
   virtual void SetupInputComponent() override;
 
   /** Begin selecting a move destination. */


### PR DESCRIPTION
## Summary
- add bHasInitialized to ASkaldPlayerController to avoid duplicate setup
- gate player state initialization on GameMode's world state
- avoid redundant ServerInitPlayerState calls from ChoosePlayerWidget

## Testing
- `npm test` *(fails: no package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bc827a664c832480acfbf02d9994ba