### PR TITLE
Prevent repeated world start attempts

### DIFF
--- a/Source/Skald/Skald_GameMode.cpp
+++ b/Source/Skald/Skald_GameMode.cpp
@@ -611,6 +611,11 @@ void ASkaldGameMode::TryInitializeWorldAndStart() {
     return;
   }
 
+  if (bWorldInitialized && bTurnsStarted) {
+    GetWorldTimerManager().ClearTimer(RetryInitTimerHandle);
+    return;
+  }
+
   // Purge any stale controller references before we evaluate player counts. A
   // player may have disconnected leaving behind a PlayerState with an owning
   // controller that is pending kill. Ensuring the turn manager drops these
@@ -654,7 +659,8 @@ void ASkaldGameMode::TryInitializeWorldAndStart() {
       if (!bIsAI && PC->IsLocalController() && !PC->GetHUDWidget()) {
         FTimerDelegate RetryInit = FTimerDelegate::CreateUObject(
             this, &ASkaldGameMode::TryInitializeWorldAndStart);
-        GetWorldTimerManager().SetTimerForNextTick(RetryInit);
+        GetWorldTimerManager().SetTimerForNextTick(RetryInitTimerHandle,
+                                                   RetryInit);
         return;
       }
     }
@@ -719,7 +725,7 @@ void ASkaldGameMode::TryInitializeWorldAndStart() {
     GetWorldTimerManager().SetTimerForNextTick(RefreshDelegate);
     FTimerDelegate RetryInit = FTimerDelegate::CreateUObject(
         this, &ASkaldGameMode::TryInitializeWorldAndStart);
-    GetWorldTimerManager().SetTimerForNextTick(RetryInit);
+    GetWorldTimerManager().SetTimerForNextTick(RetryInitTimerHandle, RetryInit);
     return;
   }
 
@@ -815,6 +821,10 @@ void ASkaldGameMode::TryInitializeWorldAndStart() {
       GEngine->AddOnScreenDebugMessage(-1, 4.f, FColor::Green,
                                        TEXT("Game started"));
     }
+  }
+
+  if (bWorldInitialized && bTurnsStarted) {
+    GetWorldTimerManager().ClearTimer(RetryInitTimerHandle);
   }
 }
 

--- a/Source/Skald/Skald_GameMode.h
+++ b/Source/Skald/Skald_GameMode.h
@@ -78,7 +78,6 @@ protected:
             meta = (ClampMin = "1"))
   int32 MinPlayerCount = 1;
 
-
   /** Controller class used when spawning AI players. */
   UPROPERTY(EditDefaultsOnly, Category = "Players")
   TSubclassOf<APlayerController> AIControllerClass;
@@ -120,6 +119,9 @@ public:
 private:
   /** Timer that triggers auto-start of the turn sequence. */
   FTimerHandle StartGameTimerHandle;
+
+  /** Timer used to retry initialization until readiness checks pass. */
+  FTimerHandle RetryInitTimerHandle;
 
   /** Tracks whether turns have already begun to avoid duplicates. */
   bool bTurnsStarted;


### PR DESCRIPTION
## Summary
- return early from `TryInitializeWorldAndStart` once the world is initialized and turns have begun
- manage a retry timer handle so it can be cleared when setup completes

## Testing
- `./Build/validate.sh` *(fails: UnrealBuildTool not found; UnrealEditor not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bc83aa1d9883248baf4805974029f1