### PR TITLE
Fix SetTimerForNextTick usage in game mode

### DIFF
--- a/Source/Skald/Skald_GameMode.cpp
+++ b/Source/Skald/Skald_GameMode.cpp
@@ -659,8 +659,8 @@ void ASkaldGameMode::TryInitializeWorldAndStart() {
       if (!bIsAI && PC->IsLocalController() && !PC->GetHUDWidget()) {
         FTimerDelegate RetryInit = FTimerDelegate::CreateUObject(
             this, &ASkaldGameMode::TryInitializeWorldAndStart);
-        GetWorldTimerManager().SetTimerForNextTick(RetryInitTimerHandle,
-                                                   RetryInit);
+        RetryInitTimerHandle =
+            GetWorldTimerManager().SetTimerForNextTick(RetryInit);
         return;
       }
     }
@@ -725,7 +725,8 @@ void ASkaldGameMode::TryInitializeWorldAndStart() {
     GetWorldTimerManager().SetTimerForNextTick(RefreshDelegate);
     FTimerDelegate RetryInit = FTimerDelegate::CreateUObject(
         this, &ASkaldGameMode::TryInitializeWorldAndStart);
-    GetWorldTimerManager().SetTimerForNextTick(RetryInitTimerHandle, RetryInit);
+    RetryInitTimerHandle =
+        GetWorldTimerManager().SetTimerForNextTick(RetryInit);
     return;
   }
 


### PR DESCRIPTION
## Summary
- Update `ASkaldGameMode` to assign returned handle from `SetTimerForNextTick` instead of passing it as an argument, matching UE 5.5 API.

## Testing
- `g++ -std=c++17 -I../Engine/Source -ISource -c Source/Skald/Skald_GameMode.cpp` *(fails: CoreMinimal.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68bc76c2d26c83248fae20a6f742c7b4