### PR TITLE
Initialize HUD when world already initialized

### DIFF
--- a/Source/Skald/Skald_PlayerController.cpp
+++ b/Source/Skald/Skald_PlayerController.cpp
@@ -162,11 +162,12 @@ void ASkaldPlayerController::BeginPlay() {
     }
     if (CachedGameInstance && CachedGameInstance->bIsMultiplayer) {
       InitializeChoosePlayerWidget();
-    } else if (CachedGameInstance && !bHasInitialized &&
-               (!CachedGameMode || !CachedGameMode->IsWorldInitialized())) {
-      ServerInitPlayerState(CachedGameInstance->DisplayName,
-                            CachedGameInstance->Faction,
-                            CachedGameInstance->AIPlayersToSpawn);
+    } else if (CachedGameInstance && !bHasInitialized) {
+      if (!CachedGameMode || !CachedGameMode->IsWorldInitialized()) {
+        ServerInitPlayerState(CachedGameInstance->DisplayName,
+                              CachedGameInstance->Faction,
+                              CachedGameInstance->AIPlayersToSpawn);
+      }
       HandleFactionLockedIn();
     }
     InitializeFighterSelectionIfNeeded();
@@ -235,7 +236,8 @@ void ASkaldPlayerController::ServerInitPlayerState_Implementation(
         GM->HandlePlayerLockedIn(PS);
       } else {
         UE_LOG(LogSkald, Log,
-               TEXT("ServerInitPlayerState_Implementation: World already initialized"));
+               TEXT("ServerInitPlayerState_Implementation: World already "
+                    "initialized"));
       }
     } else {
       UE_LOG(LogSkald, Warning,


### PR DESCRIPTION
## Summary
- Always call HandleFactionLockedIn in single-player BeginPlay even if world is already initialized
- Only run ServerInitPlayerState when world is not yet initialized

## Testing
- `clang++ -c Source/Skald/Skald_PlayerController.cpp` *(fails: 'CoreMinimal.h' file not found)*


------
https://chatgpt.com/codex/tasks/task_e_68bc8eb3ff108324bd8c90a1e1507775