### PR TITLE
Fix timer scheduling for retries

### DIFF
--- a/Source/Skald/Skald_GameMode.cpp
+++ b/Source/Skald/Skald_GameMode.cpp
@@ -24,6 +24,7 @@ namespace {
 constexpr float StartGameTimeout = 10.f;
 constexpr int32 StartingResources = 100;
 constexpr int32 DefaultAIMaxCost = 10;
+constexpr float RetryInitDelay = 0.01f;
 // Instance variables moved into ASkaldGameMode to avoid cross-instance
 // interference; see header for declarations.
 } // namespace
@@ -659,8 +660,9 @@ void ASkaldGameMode::TryInitializeWorldAndStart() {
       if (!bIsAI && PC->IsLocalController() && !PC->GetHUDWidget()) {
         FTimerDelegate RetryInit = FTimerDelegate::CreateUObject(
             this, &ASkaldGameMode::TryInitializeWorldAndStart);
-        RetryInitTimerHandle =
-            GetWorldTimerManager().SetTimerForNextTick(RetryInit);
+        GetWorldTimerManager().ClearTimer(RetryInitTimerHandle);
+        GetWorldTimerManager().SetTimer(RetryInitTimerHandle, RetryInit,
+                                        RetryInitDelay, false);
         return;
       }
     }
@@ -725,8 +727,9 @@ void ASkaldGameMode::TryInitializeWorldAndStart() {
     GetWorldTimerManager().SetTimerForNextTick(RefreshDelegate);
     FTimerDelegate RetryInit = FTimerDelegate::CreateUObject(
         this, &ASkaldGameMode::TryInitializeWorldAndStart);
-    RetryInitTimerHandle =
-        GetWorldTimerManager().SetTimerForNextTick(RetryInit);
+    GetWorldTimerManager().ClearTimer(RetryInitTimerHandle);
+    GetWorldTimerManager().SetTimer(RetryInitTimerHandle, RetryInit,
+                                    RetryInitDelay, false);
     return;
   }
 

--- a/Source/Skald/Skald_GameMode.h
+++ b/Source/Skald/Skald_GameMode.h
@@ -3,9 +3,8 @@
 #include "CoreMinimal.h"
 #include "GameFramework/GameModeBase.h"
 #include "SkaldTypes.h"
+#include "TimerManager.h"
 #include "Skald_GameMode.generated.h"
-
-struct FTimerHandle;
 class ATurnManager;
 class ASkaldGameState;
 class ASkaldPlayerController;

--- a/Source/Skald/Skald_PlayerController.h
+++ b/Source/Skald/Skald_PlayerController.h
@@ -3,6 +3,7 @@
 #include "CoreMinimal.h"
 #include "GameFramework/PlayerController.h"
 #include "SkaldTypes.h"
+#include "TimerManager.h"
 #include "Skald_PlayerController.generated.h"
 
 class ATurnManager;
@@ -16,7 +17,6 @@ class ASkaldGameState;
 class USkaldGameInstance;
 class UFighterSelectionWidget;
 class AWorldMap;
-struct FTimerHandle;
 
 /** Command issued by the player during a battle. */
 UENUM()


### PR DESCRIPTION
## Summary
- ensure retry init timers clear previous handle and use a short delay to avoid synchronous recursion
- include TimerManager in headers to define `FTimerHandle`

## Testing
- `make test` *(fails: No rule to make target 'test')*


------
https://chatgpt.com/codex/tasks/task_e_68bc8ea406108324b8fe14827503a3b1