### PR TITLE
Enable interactive mode during army placement

### DIFF
--- a/Source/Skald/Skald_GameMode.cpp
+++ b/Source/Skald/Skald_GameMode.cpp
@@ -1086,6 +1086,10 @@ void ASkaldGameMode::AdvanceArmyPlacement() {
     }
 
     // Human player: wait for manual deployment with current pool visible.
+    // Ensure the active controller is in interactive mode so they can deploy.
+    if (PC) {
+      PC->StartTurn();
+    }
     return;
   }
 


### PR DESCRIPTION
## Summary
- Ensure human players are placed in interactive mode during army placement by calling `StartTurn` on the active controller.

## Testing
- `./Build/validate.sh` *(fails: UnrealBuildTool not found; UnrealEditor not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bc9c8999d483249d7270456b12c947