### PR TITLE
Ensure WorldMap reference is cached for selection

### DIFF
--- a/Source/Skald/Skald_PlayerCharacter.cpp
+++ b/Source/Skald/Skald_PlayerCharacter.cpp
@@ -11,6 +11,7 @@
 #include "Skald_GameInstance.h"
 #include "Camera/CameraComponent.h"
 #include "GameFramework/SpringArmComponent.h"
+#include "TimerManager.h"
 
 // Sets default values
 ASkald_PlayerCharacter::ASkald_PlayerCharacter()
@@ -37,12 +38,27 @@ void ASkald_PlayerCharacter::BeginPlay()
 {
         Super::BeginPlay();
 
-        // Cache reference to the world map if one exists in the level
-        WorldMap = Cast<AWorldMap>(UGameplayStatics::GetActorOfClass(GetWorld(), AWorldMap::StaticClass()));
+        TryCacheWorldMap();
 
         CachedGameMode = GetWorld()->GetAuthGameMode<ASkaldGameMode>();
         CachedGameState = GetWorld()->GetGameState<ASkaldGameState>();
         CachedGameInstance = GetGameInstance<USkaldGameInstance>();
+}
+
+void ASkald_PlayerCharacter::TryCacheWorldMap()
+{
+        if (!WorldMap)
+        {
+                if (AWorldMap* Found = Cast<AWorldMap>(UGameplayStatics::GetActorOfClass(GetWorld(), AWorldMap::StaticClass())))
+                {
+                        WorldMap = Found;
+                        GetWorldTimerManager().ClearTimer(WorldMapSearchHandle);
+                }
+                else
+                {
+                        GetWorldTimerManager().SetTimer(WorldMapSearchHandle, this, &ASkald_PlayerCharacter::TryCacheWorldMap, 0.5f, false);
+                }
+        }
 }
 
 // Called every frame
@@ -124,6 +140,11 @@ void ASkald_PlayerCharacter::Select()
         if (!PlayerController)
         {
                 return;
+        }
+
+        if (!IsValid(WorldMap))
+        {
+                TryCacheWorldMap();
         }
 
         FHitResult Hit;

--- a/Source/Skald/Skald_PlayerCharacter.h
+++ b/Source/Skald/Skald_PlayerCharacter.h
@@ -2,6 +2,7 @@
 
 #include "CoreMinimal.h"
 #include "GameFramework/Character.h"
+#include "TimerManager.h"
 
 class AWorldMap;
 class ATerritory;
@@ -43,6 +44,12 @@ protected:
 
         UPROPERTY(BlueprintReadOnly, Category="Game")
         USkaldGameInstance* CachedGameInstance;
+
+        /** Timer handle used to repeatedly search for the world map */
+        FTimerHandle WorldMapSearchHandle;
+
+        /** Attempt to cache a reference to the world map */
+        void TryCacheWorldMap();
 
 public:
         /** Called every frame */


### PR DESCRIPTION
## Summary
- Cache and retry finding the WorldMap in Skald_PlayerCharacter using a timer
- Reattempt to find WorldMap during selection if not yet cached

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bcd9a4b1bc8324aab67cee5ff14e06