### PR TITLE
Initialize local HUD after faction lock-in

### DIFF
--- a/Source/Skald/Skald_PlayerController.cpp
+++ b/Source/Skald/Skald_PlayerController.cpp
@@ -932,8 +932,11 @@ void ASkaldPlayerController::HandleFactionLockedIn() {
       MainHudWidget->RefreshPlayerList(Players);
     }
     if (ASkaldPlayerState *PS = GetPlayerState<ASkaldPlayerState>()) {
+      MainHudWidget->LocalPlayerID = PS->GetPlayerId();
       MainHudWidget->UpdateDeployableUnits(PS->DeployableUnits);
       MainHudWidget->UpdateResources(PS->Resources);
+      MainHudWidget->SyncPhaseButtons(MainHudWidget->CurrentPlayerID ==
+                                      MainHudWidget->LocalPlayerID);
     }
     if (TurnManager) {
       MainHudWidget->UpdatePhaseBanner(TurnManager->GetCurrentPhase());


### PR DESCRIPTION
## Summary
- register the local player's ID during faction lock-in so the HUD knows whose turn it is
- refresh phase buttons based on the now-known player ID

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bce2229dd88324aa044ad8e7f26bd9