### PR TITLE
Fix territory selection to replicate through server

### DIFF
--- a/Source/Skald/Skald_PlayerController.cpp
+++ b/Source/Skald/Skald_PlayerController.cpp
@@ -668,6 +668,11 @@ void ASkaldPlayerController::ServerSelectTerritory_Implementation(
     return;
   }
 
+  if (TerritoryID < 0) {
+    WorldMap->MulticastSelectTerritory(nullptr);
+    return;
+  }
+
   ATerritory *Terr = WorldMap->GetTerritoryById(TerritoryID);
   if (!Terr || WorldMap->SelectedTerritory == Terr) {
     return;

--- a/Source/Skald/Skald_PlayerController.h
+++ b/Source/Skald/Skald_PlayerController.h
@@ -3,8 +3,8 @@
 #include "CoreMinimal.h"
 #include "GameFramework/PlayerController.h"
 #include "SkaldTypes.h"
-#include "TimerManager.h"
 #include "Skald_PlayerController.generated.h"
+#include "TimerManager.h"
 
 class ATurnManager;
 class UUserWidget;
@@ -240,7 +240,7 @@ public:
   UFUNCTION(Server, Reliable)
   void ServerDeployUnits(int32 TerritoryID, int32 Amount);
 
-  /** Server-side processing of a territory selection. */
+  /** Server-side processing of a territory selection. Pass -1 to deselect. */
   UFUNCTION(Server, Reliable)
   void ServerSelectTerritory(int32 TerritoryID);
 
@@ -265,29 +265,28 @@ public:
    *  turn events without keeping an external pointer that might be
    *  uninitialised.
    */
-  protected:
-    UPROPERTY(EditInstanceOnly, BlueprintReadOnly, Category = "Turn",
-              meta = (ExposeOnSpawn = true))
-    TObjectPtr<ATurnManager> TurnManager;
+protected:
+  UPROPERTY(EditInstanceOnly, BlueprintReadOnly, Category = "Turn",
+            meta = (ExposeOnSpawn = true))
+  TObjectPtr<ATurnManager> TurnManager;
 
-  private:
-    /** Cache references to key game singletons and bind delegates. */
-    void CacheGameReferences();
+private:
+  /** Cache references to key game singletons and bind delegates. */
+  void CacheGameReferences();
 
-    /** Set up the main HUD widget for the local player. */
-    void InitializeHUDWidget();
+  /** Set up the main HUD widget for the local player. */
+  void InitializeHUDWidget();
 
-    /** Create the faction selection widget for the local player. */
-    void InitializeChoosePlayerWidget();
+  /** Create the faction selection widget for the local player. */
+  void InitializeChoosePlayerWidget();
 
-    /** Attempt to locate the world map and bind to its selection event. */
-    void TryBindWorldMap();
+  /** Attempt to locate the world map and bind to its selection event. */
+  void TryBindWorldMap();
 
-    /** Timer used to poll for the world map actor until it exists. */
-    FTimerHandle WorldMapSearchHandle;
+  /** Timer used to poll for the world map actor until it exists. */
+  FTimerHandle WorldMapSearchHandle;
 
-
-    void BuildPlayerDataArray(TArray<FS_PlayerData> &OutPlayers) const;
+  void BuildPlayerDataArray(TArray<FS_PlayerData> &OutPlayers) const;
 
   bool ValidateAttack(int32 FromID, int32 ToID, int32 ArmySent, bool bUseSiege,
                       FString *OutError);

--- a/Source/Skald/Territory.cpp
+++ b/Source/Skald/Territory.cpp
@@ -2,9 +2,9 @@
 #include "Components/PrimitiveComponent.h"
 #include "Components/StaticMeshComponent.h"
 #include "Components/TextRenderComponent.h"
+#include "Engine/StaticMesh.h"
 #include "Kismet/GameplayStatics.h"
 #include "Materials/MaterialInstanceDynamic.h"
-#include "Engine/StaticMesh.h"
 #include "Materials/MaterialInterface.h"
 #include "Net/UnrealNetwork.h"
 #include "Skald.h"
@@ -130,9 +130,8 @@ void ATerritory::BeginPlay() {
   // Ensure this territory is registered with the world map. When territories
   // are placed manually in a level they may not have been added during map
   // initialization, so register here if needed.
-  if (AWorldMap *WorldMap =
-          Cast<AWorldMap>(UGameplayStatics::GetActorOfClass(
-              this, AWorldMap::StaticClass()))) {
+  if (AWorldMap *WorldMap = Cast<AWorldMap>(
+          UGameplayStatics::GetActorOfClass(this, AWorldMap::StaticClass()))) {
     if (!WorldMap->Territories.Contains(this)) {
       WorldMap->RegisterTerritory(this);
     }
@@ -224,14 +223,9 @@ void ATerritory::HandleMouseLeave(UPrimitiveComponent *TouchedComponent) {
 
 void ATerritory::HandleClicked(UPrimitiveComponent *TouchedComponent,
                                FKey ButtonPressed) {
-  if (AWorldMap *WorldMap =
-          Cast<AWorldMap>(UGameplayStatics::GetActorOfClass(
-              this, AWorldMap::StaticClass()))) {
-    if (!bIsSelected) {
-      WorldMap->MulticastSelectTerritory(this);
-    } else {
-      WorldMap->MulticastSelectTerritory(nullptr);
-    }
+  if (ASkaldPlayerController *PC = Cast<ASkaldPlayerController>(
+          UGameplayStatics::GetPlayerController(this, 0))) {
+    PC->ServerSelectTerritory(bIsSelected ? -1 : TerritoryID);
   }
 }
 
@@ -269,8 +263,7 @@ void ATerritory::UpdateLabel() {
 
   const FString OwnerName =
       OwningPlayer ? OwningPlayer->PlayerDisplayName : TEXT("Neutral");
-  const FString Text =
-      FString::Printf(TEXT("%s\nOwner: %s\nUnits: %d"), *TerritoryName,
-                      *OwnerName, ArmyUnits);
+  const FString Text = FString::Printf(TEXT("%s\nOwner: %s\nUnits: %d"),
+                                       *TerritoryName, *OwnerName, ArmyUnits);
   LabelComponent->SetText(FText::FromString(Text));
 }


### PR DESCRIPTION
## Summary
- Send territory clicks to `ServerSelectTerritory` instead of directly calling `MulticastSelectTerritory`
- Allow `ServerSelectTerritory` to clear selection with `-1`
- Document deselection sentinel in player controller header

## Testing
- `bash Build/validate.sh` *(fails: UnrealBuildTool not found; UnrealEditor not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bce7a7fa948324be2fa6edf155fdaa