### PR TITLE
Fix territory click handling duplicates

### DIFF
--- a/Source/Skald/Territory.cpp
+++ b/Source/Skald/Territory.cpp
@@ -227,8 +227,6 @@ void ATerritory::HandleClicked(UPrimitiveComponent *TouchedComponent,
           UGameplayStatics::GetPlayerController(this, 0))) {
     const bool bDeselected = bIsSelected;
     PC->ServerSelectTerritory(bDeselected ? -1 : TerritoryID);
-    PC->HandleTerritorySelected(bDeselected ? nullptr : this);
-    PC->ServerSelectTerritory(bIsSelected ? -1 : TerritoryID);
   }
 }
 


### PR DESCRIPTION
## Summary
- remove redundant server calls and manual UI updates when clicking a territory

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bcf3dcf7fc8324aaa67b95cc15cdee