### PR TITLE
Fix territory click handling duplicates

### DIFF
--- a/Source/Skald/Skald_PlayerCharacter.cpp
+++ b/Source/Skald/Skald_PlayerCharacter.cpp
@@ -2,6 +2,7 @@
 #include "Skald.h"
 #include "WorldMap.h"
 #include "Territory.h"
+#include "Skald_PlayerController.h"
 #include "Kismet/GameplayStatics.h"
 #include "Engine/World.h"
 #include "Components/InputComponent.h"
@@ -142,20 +143,15 @@ void ASkald_PlayerCharacter::Select()
                 return;
         }
 
-        if (!IsValid(WorldMap))
-        {
-                TryCacheWorldMap();
-        }
-
         FHitResult Hit;
         if (PlayerController->GetHitResultUnderCursor(ECC_Visibility, false, Hit))
         {
                 if (ATerritory* Territory = Cast<ATerritory>(Hit.GetActor()))
                 {
-                        if (IsValid(WorldMap))
+                        if (ASkaldPlayerController* PC = Cast<ASkaldPlayerController>(PlayerController))
                         {
-                                WorldMap->SelectTerritory(Territory);
-                                CurrentSelection = WorldMap->SelectedTerritory;
+                                PC->ServerSelectTerritory(Territory->TerritoryID);
+                                CurrentSelection = Territory;
                         }
                 }
         }

--- a/Source/Skald/Skald_PlayerController.cpp
+++ b/Source/Skald/Skald_PlayerController.cpp
@@ -669,16 +669,31 @@ void ASkaldPlayerController::ServerSelectTerritory_Implementation(
   }
 
   if (TerritoryID < 0) {
-    WorldMap->MulticastSelectTerritory(nullptr);
+    WorldMap->SelectTerritory(nullptr);
+    ClientSelectTerritory(-1);
     return;
   }
 
   ATerritory *Terr = WorldMap->GetTerritoryById(TerritoryID);
-  if (!Terr || WorldMap->SelectedTerritory == Terr) {
+  if (!Terr) {
     return;
   }
 
-  WorldMap->MulticastSelectTerritory(Terr);
+  WorldMap->SelectTerritory(Terr);
+  ClientSelectTerritory(TerritoryID);
+}
+
+void ASkaldPlayerController::ClientSelectTerritory_Implementation(
+    int32 TerritoryID) {
+  AWorldMap *WorldMap = Cast<AWorldMap>(
+      UGameplayStatics::GetActorOfClass(GetWorld(), AWorldMap::StaticClass()));
+  if (!WorldMap) {
+    return;
+  }
+
+  ATerritory *Terr = TerritoryID >= 0 ? WorldMap->GetTerritoryById(TerritoryID)
+                                     : nullptr;
+  WorldMap->SelectTerritory(Terr);
 }
 
 void ASkaldPlayerController::HandleEndAttackRequested(bool bConfirmed) {

--- a/Source/Skald/Skald_PlayerController.h
+++ b/Source/Skald/Skald_PlayerController.h
@@ -244,6 +244,10 @@ public:
   UFUNCTION(Server, Reliable)
   void ServerSelectTerritory(int32 TerritoryID);
 
+  /** Client-side update for a territory selection. Pass -1 to clear. */
+  UFUNCTION(Client, Reliable)
+  void ClientSelectTerritory(int32 TerritoryID);
+
   /** Phase change handlers. */
   UFUNCTION(BlueprintCallable, Category = "Turn")
   void HandleEngineeringPhase();

--- a/Source/Skald/Territory.cpp
+++ b/Source/Skald/Territory.cpp
@@ -227,8 +227,6 @@ void ATerritory::HandleClicked(UPrimitiveComponent *TouchedComponent,
           UGameplayStatics::GetPlayerController(this, 0))) {
     const bool bDeselected = bIsSelected;
     PC->ServerSelectTerritory(bDeselected ? -1 : TerritoryID);
-    PC->HandleTerritorySelected(bDeselected ? nullptr : this);
-    PC->ServerSelectTerritory(bIsSelected ? -1 : TerritoryID);
   }
 }
 

--- a/Source/Skald/WorldMap.cpp
+++ b/Source/Skald/WorldMap.cpp
@@ -430,6 +430,3 @@ bool AWorldMap::IsOwnedBy(const ATerritory *Territory,
   return Territory->OwningPlayer->GetPlayerId() == Player->GetPlayerId();
 }
 
-void AWorldMap::MulticastSelectTerritory_Implementation(ATerritory *Territory) {
-  SelectTerritory(Territory);
-}

--- a/Source/Skald/WorldMap.h
+++ b/Source/Skald/WorldMap.h
@@ -87,9 +87,6 @@ public:
   UFUNCTION(BlueprintCallable, Category = "WorldMap")
   void SelectTerritory(ATerritory *Territory);
 
-  /** Multicast selection so all clients highlight the same territory. */
-  UFUNCTION(NetMulticast, Reliable)
-  void MulticastSelectTerritory(ATerritory *Territory);
 
   /** Generate territories from the assigned data table. */
   UFUNCTION(BlueprintCallable, Category = "WorldMap")


### PR DESCRIPTION
## Summary
- remove redundant server calls and manual UI updates when clicking a territory
- limit territory selection updates to the selecting player's HUD only

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bcf3dcf7fc8324aaa67b95cc15cdee