### PR TITLE
Fix duplicate territory selection RPCs

### DIFF
--- a/Source/Skald/Skald_PlayerCharacter.cpp
+++ b/Source/Skald/Skald_PlayerCharacter.cpp
@@ -53,6 +53,7 @@ void ASkald_PlayerCharacter::TryCacheWorldMap()
                 if (AWorldMap* Found = Cast<AWorldMap>(UGameplayStatics::GetActorOfClass(GetWorld(), AWorldMap::StaticClass())))
                 {
                         WorldMap = Found;
+                        WorldMap->OnTerritorySelected.AddUniqueDynamic(this, &ASkald_PlayerCharacter::HandleTerritorySelected);
                         GetWorldTimerManager().ClearTimer(WorldMapSearchHandle);
                 }
                 else
@@ -146,15 +147,23 @@ void ASkald_PlayerCharacter::Select()
         FHitResult Hit;
         if (PlayerController->GetHitResultUnderCursor(ECC_Visibility, false, Hit))
         {
-                if (ATerritory* Territory = Cast<ATerritory>(Hit.GetActor()))
+                if (Cast<ATerritory>(Hit.GetActor()))
                 {
-                        if (ASkaldPlayerController* PC = Cast<ASkaldPlayerController>(PlayerController))
-                        {
-                                PC->ServerSelectTerritory(Territory->TerritoryID);
-                                CurrentSelection = Territory;
-                        }
+                        // ATerritory::HandleClicked already issues the RPC with toggle state
+                        return;
                 }
         }
+
+        // Clicked empty space; request deselection
+        if (ASkaldPlayerController* PC = Cast<ASkaldPlayerController>(PlayerController))
+        {
+                PC->ServerSelectTerritory(-1);
+        }
+}
+
+void ASkald_PlayerCharacter::HandleTerritorySelected(ATerritory* Territory)
+{
+        CurrentSelection = Territory;
 }
 
 void ASkald_PlayerCharacter::AbilityOne()

--- a/Source/Skald/Skald_PlayerCharacter.h
+++ b/Source/Skald/Skald_PlayerCharacter.h
@@ -51,6 +51,10 @@ protected:
         /** Attempt to cache a reference to the world map */
         void TryCacheWorldMap();
 
+        /** Update current selection when the world map changes */
+        UFUNCTION()
+        void HandleTerritorySelected(ATerritory* Territory);
+
 public:
         /** Called every frame */
         virtual void Tick(float DeltaTime) override;


### PR DESCRIPTION
## Summary
- Avoid dispatching multiple ServerSelectTerritory RPCs on territory click
- Track world map territory selection via player character binding

## Testing
- `clang++ -std=c++17 -I../Engine/Source -ISource -c Source/Skald/Skald_PlayerCharacter.cpp` *(fails: command not found)*
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bcff8b72948324ae37c4ef434297ca