### PR TITLE
Simplify territory selection handling

### DIFF
--- a/Source/Skald/Territory.cpp
+++ b/Source/Skald/Territory.cpp
@@ -169,7 +169,6 @@ void ATerritory::Select() {
     DynamicMaterial->SetVectorParameterValue(FName("Color"),
                                              FLinearColor::White);
   }
-  OnTerritorySelected.Broadcast(this);
 }
 
 void ATerritory::Deselect() {

--- a/Source/Skald/Territory.h
+++ b/Source/Skald/Territory.h
@@ -13,8 +13,6 @@ class UPrimitiveComponent;
 class UMaterialInstanceDynamic;
 class UTextRenderComponent;
 
-DECLARE_DYNAMIC_MULTICAST_DELEGATE_OneParam(FTerritorySelectedSignature, ATerritory*, Territory);
-
 /**
  * Actor representing a single territory on the world map.
  */
@@ -74,10 +72,6 @@ public:
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Territory", Replicated)
     bool bHasTreasure = false;
 
-
-    /** Called when the territory is selected. */
-    UPROPERTY(BlueprintAssignable, Category = "Territory")
-    FTerritorySelectedSignature OnTerritorySelected;
 
     /** Mark this territory as selected. */
     UFUNCTION(BlueprintCallable, Category = "Territory")

--- a/Source/Skald/WorldMap.cpp
+++ b/Source/Skald/WorldMap.cpp
@@ -293,8 +293,6 @@ bool AWorldMap::GenerateTerritoriesFromTable() {
 void AWorldMap::RegisterTerritory(ATerritory *Territory) {
   if (Territory && !Territories.Contains(Territory)) {
     Territories.Add(Territory);
-    Territory->OnTerritorySelected.AddDynamic(this,
-                                              &AWorldMap::SelectTerritory);
   }
 }
 


### PR DESCRIPTION
## Summary
- streamline territory selection by removing redundant territory-selected delegate
- world map now solely manages selected territory state

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bd011255dc8324ad58a64435aed3df