### PR TITLE
Keep world map selection in sync after troop moves

### DIFF
--- a/Source/Skald/Territory.cpp
+++ b/Source/Skald/Territory.cpp
@@ -180,6 +180,11 @@ void ATerritory::Deselect() {
     // Restore the color that was in use prior to selection
     DynamicMaterial->SetVectorParameterValue(FName("Color"), DefaultColor);
   }
+  if (AWorldMap *Map = Cast<AWorldMap>(GetOwner())) {
+    if (Map->SelectedTerritory == this) {
+      Map->SelectedTerritory = nullptr;
+    }
+  }
 }
 
 bool ATerritory::IsAdjacentTo(const ATerritory *Other) const {
@@ -202,8 +207,12 @@ bool ATerritory::MoveTo(ATerritory *TargetTerritory, int32 Troops) {
   RefreshAppearance();
   TargetTerritory->RefreshAppearance();
 
-  Deselect();
-  TargetTerritory->Select();
+  if (AWorldMap *Map = Cast<AWorldMap>(GetOwner())) {
+    Map->SelectTerritory(TargetTerritory);
+  } else {
+    Deselect();
+    TargetTerritory->Select();
+  }
 
   return true;
 }


### PR DESCRIPTION
## Summary
- Clear world map's selected pointer when a territory deselects
- Route troop move selection updates through AWorldMap::SelectTerritory

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bd050652108324b932f414aee7a960