### PR TITLE
Re-enable mouse-over events after UI-only mode

### DIFF
--- a/Source/Skald/Skald_PlayerController.cpp
+++ b/Source/Skald/Skald_PlayerController.cpp
@@ -961,6 +961,7 @@ void ASkaldPlayerController::HandleFactionLockedIn() {
   SetInputMode(FInputModeGameAndUI());
   bShowMouseCursor = true;
   bEnableClickEvents = true;
+  bEnableMouseOverEvents = true;
   SetIgnoreMoveInput(false);
   SetIgnoreLookInput(false);
   TryBindWorldMap();


### PR DESCRIPTION
## Summary
- Restore mouse-over events when the player controller exits UI-only mode

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pytest` *(no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_68bd0b1613908324a4b34a665e26923e