### PR TITLE
Add territory selection debug logs and test

### DIFF
--- a/Source/Skald/Skald_PlayerController.cpp
+++ b/Source/Skald/Skald_PlayerController.cpp
@@ -662,6 +662,8 @@ void ASkaldPlayerController::ServerDeployUnits_Implementation(int32 TerritoryID,
 
 void ASkaldPlayerController::ServerSelectTerritory_Implementation(
     int32 TerritoryID) {
+  UE_LOG(LogSkald, Log, TEXT("ServerSelectTerritory called with %d"),
+         TerritoryID);
   AWorldMap *WorldMap = Cast<AWorldMap>(
       UGameplayStatics::GetActorOfClass(GetWorld(), AWorldMap::StaticClass()));
   if (!WorldMap) {

--- a/Source/Skald/Territory.cpp
+++ b/Source/Skald/Territory.cpp
@@ -231,6 +231,10 @@ void ATerritory::HandleMouseLeave(UPrimitiveComponent *TouchedComponent) {
 
 void ATerritory::HandleClicked(UPrimitiveComponent *TouchedComponent,
                                FKey ButtonPressed) {
+  UE_LOG(LogSkald, Log,
+         TEXT("Territory %d clicked; currently %s"), TerritoryID,
+         bIsSelected ? TEXT("selected") : TEXT("not selected"));
+
   if (ASkaldPlayerController *PC = Cast<ASkaldPlayerController>(
           UGameplayStatics::GetPlayerController(this, 0))) {
     const bool bDeselected = bIsSelected;

--- a/Source/Skald/Tests/TerritorySelectionTest.cpp
+++ b/Source/Skald/Tests/TerritorySelectionTest.cpp
@@ -1,0 +1,52 @@
+#include "TerritorySelectionTest.h"
+
+#include "Misc/AutomationTest.h"
+#include "Tests/AutomationEditorCommon.h"
+#include "WorldMap.h"
+#include "Territory.h"
+#include "InputCoreTypes.h"
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FTerritorySelectionFlowTest,
+                                 "Skald.World.TerritorySelection",
+                                 EAutomationTestFlags::EditorContext |
+                                     EAutomationTestFlags::EngineFilter)
+
+bool FTerritorySelectionFlowTest::RunTest(const FString& Parameters)
+{
+    UWorld* World = FAutomationEditorCommonUtils::CreateNewMap();
+    TestNotNull(TEXT("World created"), World);
+    if (!World)
+    {
+        return false;
+    }
+
+    AWorldMap* Map = World->SpawnActor<AWorldMap>();
+    ATerritory* Terr = World->SpawnActor<ATerritory>();
+    ATerritorySelectionTestPC* PC = World->SpawnActor<ATerritorySelectionTestPC>();
+
+    TestNotNull(TEXT("WorldMap"), Map);
+    TestNotNull(TEXT("Territory"), Terr);
+    TestNotNull(TEXT("PlayerController"), PC);
+    if (!Map || !Terr || !PC)
+    {
+        return false;
+    }
+
+    Terr->TerritoryID = 99;
+    Map->RegisterTerritory(Terr);
+
+    UPrimitiveComponent* Mesh = Terr->FindComponentByClass<UPrimitiveComponent>();
+    TestNotNull(TEXT("Mesh component"), Mesh);
+    if (!Mesh)
+    {
+        return false;
+    }
+
+    Terr->HandleClicked(Mesh, EKeys::LeftMouseButton);
+
+    TestTrue(TEXT("ServerSelectTerritory called"), PC->bServerSelectCalled);
+    TestEqual(TEXT("SelectedTerritory updated"), Map->SelectedTerritory, Terr);
+
+    return true;
+}
+

--- a/Source/Skald/Tests/TerritorySelectionTest.h
+++ b/Source/Skald/Tests/TerritorySelectionTest.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Skald_PlayerController.h"
+#include "TerritorySelectionTest.generated.h"
+
+/** Player controller capturing server selection calls for tests. */
+UCLASS()
+class ATerritorySelectionTestPC : public ASkaldPlayerController {
+    GENERATED_BODY()
+public:
+    bool bServerSelectCalled = false;
+    virtual void ServerSelectTerritory_Implementation(int32 TerritoryID) override {
+        bServerSelectCalled = true;
+        Super::ServerSelectTerritory_Implementation(TerritoryID);
+    }
+};
+

--- a/Source/Skald/WorldMap.cpp
+++ b/Source/Skald/WorldMap.cpp
@@ -292,6 +292,7 @@ bool AWorldMap::GenerateTerritoriesFromTable() {
 
 void AWorldMap::RegisterTerritory(ATerritory *Territory) {
   if (Territory && !Territories.Contains(Territory)) {
+    Territory->SetOwner(this);
     Territories.Add(Territory);
   }
 }
@@ -308,6 +309,11 @@ void AWorldMap::SelectTerritory(ATerritory *Territory) {
   if (Territory == SelectedTerritory) {
     return;
   }
+
+  UE_LOG(LogSkald, Log,
+         TEXT("WorldMap %s selecting territory %s (previous %s)"),
+         *GetName(), Territory ? *Territory->GetName() : TEXT("None"),
+         SelectedTerritory ? *SelectedTerritory->GetName() : TEXT("None"));
 
   if (SelectedTerritory) {
     SelectedTerritory->Deselect();


### PR DESCRIPTION
## Summary
- Set the world map as the owner for registered territories so manual placement works
- Add debug logs for territory clicks, server selection RPCs, and world map selection
- Introduce automation test covering territory selection flow

## Testing
- `clang++ -std=c++20 -I Source -c Source/Skald/Tests/TerritorySelectionTest.cpp` *(fails: 'CoreMinimal.h' file not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bd11a39e348324993edb68f4e6aede