### PR TITLE
Include PrimitiveComponent header in territory selection test

### DIFF
--- a/Source/Skald/Tests/TerritorySelectionTest.cpp
+++ b/Source/Skald/Tests/TerritorySelectionTest.cpp
@@ -6,6 +6,7 @@
 #include "InputCoreTypes.h"
 #include "Misc/AutomationTest.h"
 #include "Territory.h"
+#include "Components/PrimitiveComponent.h"
 #include "Tests/AutomationEditorCommon.h"
 #include "WorldMap.h"
 


### PR DESCRIPTION
## Summary
- include PrimitiveComponent header to resolve undefined UPrimitiveComponent in TerritorySelectionTest

## Testing
- `clang++-20 -fsyntax-only Source/Skald/Tests/TerritorySelectionTest.cpp` *(fails: 'CoreMinimal.h' file not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bd9def4130832495d833eef8f76a42