### PR TITLE
Configure game/UI input mode to avoid focus capture

### DIFF
--- a/Source/Skald/Skald_PlayerController.cpp
+++ b/Source/Skald/Skald_PlayerController.cpp
@@ -336,8 +336,11 @@ void ASkaldPlayerController::ShowTurnAnnouncement(const FString &PlayerName,
 }
 
 void ASkaldPlayerController::StartTurn() {
-  FInputModeGameAndUI InputMode;
-  SetInputMode(InputMode);
+  FInputModeGameAndUI Mode;
+  Mode.SetWidgetToFocus(nullptr);
+  Mode.SetLockMouseToViewportBehavior(EMouseLockMode::DoNotLock);
+  Mode.SetCaptureMouseOnClick(EMouseCaptureMode::NoCapture);
+  SetInputMode(Mode);
 }
 
 void ASkaldPlayerController::EndTurn() {
@@ -960,7 +963,11 @@ void ASkaldPlayerController::HandleFactionLockedIn() {
     }
   }
 
-  SetInputMode(FInputModeGameAndUI());
+  FInputModeGameAndUI Mode;
+  Mode.SetWidgetToFocus(nullptr);
+  Mode.SetLockMouseToViewportBehavior(EMouseLockMode::DoNotLock);
+  Mode.SetCaptureMouseOnClick(EMouseCaptureMode::NoCapture);
+  SetInputMode(Mode);
   bShowMouseCursor = true;
   bEnableClickEvents = true;
   bEnableMouseOverEvents = true;
@@ -1022,7 +1029,11 @@ void ASkaldPlayerController::HandleFighterSelectionLockedIn() {
     }
   }
 
-  SetInputMode(FInputModeGameAndUI());
+  FInputModeGameAndUI Mode;
+  Mode.SetWidgetToFocus(nullptr);
+  Mode.SetLockMouseToViewportBehavior(EMouseLockMode::DoNotLock);
+  Mode.SetCaptureMouseOnClick(EMouseCaptureMode::NoCapture);
+  SetInputMode(Mode);
   SetIgnoreMoveInput(false);
   SetIgnoreLookInput(false);
 }

--- a/Source/Skald/Tests/TerritorySelectionTest.cpp
+++ b/Source/Skald/Tests/TerritorySelectionTest.cpp
@@ -6,6 +6,7 @@
 #include "InputCoreTypes.h"
 #include "Misc/AutomationTest.h"
 #include "Territory.h"
+#include "Components/PrimitiveComponent.h"
 #include "Tests/AutomationEditorCommon.h"
 #include "WorldMap.h"
 


### PR DESCRIPTION
## Summary
- configure `FInputModeGameAndUI` to avoid capturing focus so HUD doesn't block world clicks
- include `PrimitiveComponent` header to resolve undefined `UPrimitiveComponent` in territory selection test

## Testing
- `clang++-20 -fsyntax-only Source/Skald/Skald_PlayerController.cpp` *(fails: 'CoreMinimal.h' file not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bd9def4130832495d833eef8f76a42