### PR TITLE
Update mouse capture API usage for UE5.5

### DIFF
--- a/Source/Skald/Skald_PlayerController.cpp
+++ b/Source/Skald/Skald_PlayerController.cpp
@@ -339,7 +339,7 @@ void ASkaldPlayerController::StartTurn() {
   FInputModeGameAndUI Mode;
   Mode.SetWidgetToFocus(nullptr);
   Mode.SetLockMouseToViewportBehavior(EMouseLockMode::DoNotLock);
-  Mode.SetCaptureMouseOnClick(EMouseCaptureMode::NoCapture);
+  Mode.SetMouseCaptureMode(EMouseCaptureMode::NoCapture);
   SetInputMode(Mode);
 }
 
@@ -966,7 +966,7 @@ void ASkaldPlayerController::HandleFactionLockedIn() {
   FInputModeGameAndUI Mode;
   Mode.SetWidgetToFocus(nullptr);
   Mode.SetLockMouseToViewportBehavior(EMouseLockMode::DoNotLock);
-  Mode.SetCaptureMouseOnClick(EMouseCaptureMode::NoCapture);
+  Mode.SetMouseCaptureMode(EMouseCaptureMode::NoCapture);
   SetInputMode(Mode);
   bShowMouseCursor = true;
   bEnableClickEvents = true;
@@ -1032,7 +1032,7 @@ void ASkaldPlayerController::HandleFighterSelectionLockedIn() {
   FInputModeGameAndUI Mode;
   Mode.SetWidgetToFocus(nullptr);
   Mode.SetLockMouseToViewportBehavior(EMouseLockMode::DoNotLock);
-  Mode.SetCaptureMouseOnClick(EMouseCaptureMode::NoCapture);
+  Mode.SetMouseCaptureMode(EMouseCaptureMode::NoCapture);
   SetInputMode(Mode);
   SetIgnoreMoveInput(false);
   SetIgnoreLookInput(false);


### PR DESCRIPTION
## Summary
- replace deprecated `SetCaptureMouseOnClick` with `SetMouseCaptureMode`

## Testing
- `g++ -c Source/Skald/Skald_PlayerController.cpp` *(fails: CoreMinimal.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68bdaa920cfc83248b11c19fb2af2c29