### PR TITLE
Fix missing SetMouseCaptureMode call for UE5.5

### DIFF
--- a/Source/Skald/Skald_PlayerController.cpp
+++ b/Source/Skald/Skald_PlayerController.cpp
@@ -339,7 +339,11 @@ void ASkaldPlayerController::StartTurn() {
   FInputModeGameAndUI Mode;
   Mode.SetWidgetToFocus(nullptr);
   Mode.SetLockMouseToViewportBehavior(EMouseLockMode::DoNotLock);
+#if ENGINE_MAJOR_VERSION > 5 || (ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION >= 5)
+  Mode.SetCaptureMouseOnClick(EMouseCaptureMode::NoCapture);
+#else
   Mode.SetMouseCaptureMode(EMouseCaptureMode::NoCapture);
+#endif
   SetInputMode(Mode);
 }
 
@@ -966,7 +970,11 @@ void ASkaldPlayerController::HandleFactionLockedIn() {
   FInputModeGameAndUI Mode;
   Mode.SetWidgetToFocus(nullptr);
   Mode.SetLockMouseToViewportBehavior(EMouseLockMode::DoNotLock);
+#if ENGINE_MAJOR_VERSION > 5 || (ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION >= 5)
+  Mode.SetCaptureMouseOnClick(EMouseCaptureMode::NoCapture);
+#else
   Mode.SetMouseCaptureMode(EMouseCaptureMode::NoCapture);
+#endif
   SetInputMode(Mode);
   bShowMouseCursor = true;
   bEnableClickEvents = true;
@@ -1032,7 +1040,11 @@ void ASkaldPlayerController::HandleFighterSelectionLockedIn() {
   FInputModeGameAndUI Mode;
   Mode.SetWidgetToFocus(nullptr);
   Mode.SetLockMouseToViewportBehavior(EMouseLockMode::DoNotLock);
+#if ENGINE_MAJOR_VERSION > 5 || (ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION >= 5)
+  Mode.SetCaptureMouseOnClick(EMouseCaptureMode::NoCapture);
+#else
   Mode.SetMouseCaptureMode(EMouseCaptureMode::NoCapture);
+#endif
   SetInputMode(Mode);
   SetIgnoreMoveInput(false);
   SetIgnoreLookInput(false);


### PR DESCRIPTION
## Summary
- update mouse capture handling to use `SetCaptureMouseOnClick` when building with UE5.5+

## Testing
- `clang++ -std=c++17 -I../Engine/Source -ISource -c Source/Skald/Skald_PlayerController.cpp` *(fails: 'CoreMinimal.h' file not found)*

------
https://chatgpt.com/codex/tasks/task_e_68be120c44408324b2f1540267956bb0