### PR TITLE
Fix mouse capture version guard for UE 5.5+

### DIFF
--- a/Source/Skald/Skald_PlayerController.cpp
+++ b/Source/Skald/Skald_PlayerController.cpp
@@ -340,9 +340,9 @@ void ASkaldPlayerController::StartTurn() {
   Mode.SetWidgetToFocus(nullptr);
   Mode.SetLockMouseToViewportBehavior(EMouseLockMode::DoNotLock);
 #if ENGINE_MAJOR_VERSION > 5 || (ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION >= 5)
-  Mode.SetCaptureMouseOnClick(EMouseCaptureMode::NoCapture);
-#else
   Mode.SetMouseCaptureMode(EMouseCaptureMode::NoCapture);
+#else
+  Mode.SetCaptureMouseOnClick(EMouseCaptureMode::NoCapture);
 #endif
   SetInputMode(Mode);
 }
@@ -971,9 +971,9 @@ void ASkaldPlayerController::HandleFactionLockedIn() {
   Mode.SetWidgetToFocus(nullptr);
   Mode.SetLockMouseToViewportBehavior(EMouseLockMode::DoNotLock);
 #if ENGINE_MAJOR_VERSION > 5 || (ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION >= 5)
-  Mode.SetCaptureMouseOnClick(EMouseCaptureMode::NoCapture);
-#else
   Mode.SetMouseCaptureMode(EMouseCaptureMode::NoCapture);
+#else
+  Mode.SetCaptureMouseOnClick(EMouseCaptureMode::NoCapture);
 #endif
   SetInputMode(Mode);
   bShowMouseCursor = true;
@@ -1041,9 +1041,9 @@ void ASkaldPlayerController::HandleFighterSelectionLockedIn() {
   Mode.SetWidgetToFocus(nullptr);
   Mode.SetLockMouseToViewportBehavior(EMouseLockMode::DoNotLock);
 #if ENGINE_MAJOR_VERSION > 5 || (ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION >= 5)
-  Mode.SetCaptureMouseOnClick(EMouseCaptureMode::NoCapture);
-#else
   Mode.SetMouseCaptureMode(EMouseCaptureMode::NoCapture);
+#else
+  Mode.SetCaptureMouseOnClick(EMouseCaptureMode::NoCapture);
 #endif
   SetInputMode(Mode);
   SetIgnoreMoveInput(false);


### PR DESCRIPTION
## Summary
- call `SetMouseCaptureMode` for UE 5.5+ and `SetCaptureMouseOnClick` for older engines

## Testing
- `./Build/validate.sh` *(fails: UnrealBuildTool and UnrealEditor not found)*

------
https://chatgpt.com/codex/tasks/task_e_68be14323cd08324be27053a2a756b49