### PR TITLE
fix: include engine version header for player controller

### DIFF
--- a/Source/Skald/Skald_PlayerController.cpp
+++ b/Source/Skald/Skald_PlayerController.cpp
@@ -25,6 +25,7 @@
 #include "UI/SkaldMainHUDWidget.h"
 #include "UObject/ConstructorHelpers.h"
 #include "WorldMap.h"
+#include "Runtime/Launch/Resources/Version.h"
 
 ASkaldPlayerController::ASkaldPlayerController() {
   TurnManager = nullptr;


### PR DESCRIPTION
## Summary
- include engine version header to enable ENGINE_MAJOR_VERSION macro

## Testing
- `dotnet test` *(fails: MSBUILD : error MSB1003: Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_68be19e2719c832499d78ef1f0093c61