### PR TITLE
Centralize territory selection in PlayerController

### DIFF
--- a/Source/Skald/Skald_PlayerCharacter.cpp
+++ b/Source/Skald/Skald_PlayerCharacter.cpp
@@ -88,7 +88,6 @@ void ASkald_PlayerCharacter::SetupPlayerInputComponent(UInputComponent* PlayerIn
         PlayerInputComponent->BindAxis("Turn", this, &ASkald_PlayerCharacter::Turn);
         PlayerInputComponent->BindAxis("LookUp", this, &ASkald_PlayerCharacter::LookUp);
 
-        PlayerInputComponent->BindAction("Select", IE_Pressed, this, &ASkald_PlayerCharacter::Select);
         PlayerInputComponent->BindAction("Ability1", IE_Pressed, this, &ASkald_PlayerCharacter::AbilityOne);
         PlayerInputComponent->BindAction("Ability2", IE_Pressed, this, &ASkald_PlayerCharacter::AbilityTwo);
         PlayerInputComponent->BindAction("Ability3", IE_Pressed, this, &ASkald_PlayerCharacter::AbilityThree);

--- a/Source/Skald/Skald_PlayerController.cpp
+++ b/Source/Skald/Skald_PlayerController.cpp
@@ -303,6 +303,9 @@ void ASkaldPlayerController::InitializeFighterSelectionIfNeeded() {
     }
   }
 
+  // Persist map type for LMB handling
+  this->bIsBattleMap = bIsBattleMap;
+
   if (!bIsBattleMap) {
     return;
   }
@@ -704,6 +707,7 @@ void ASkaldPlayerController::ClientSelectTerritory_Implementation(
   ATerritory *Terr = TerritoryID >= 0 ? WorldMap->GetTerritoryById(TerritoryID)
                                      : nullptr;
   WorldMap->SelectTerritory(Terr);
+  UE_LOG(LogSkald, Log, TEXT("ClientSelectTerritory <- %d"), TerritoryID);
 }
 
 void ASkaldPlayerController::HandleEndAttackRequested(bool bConfirmed) {
@@ -1069,18 +1073,36 @@ void ASkaldPlayerController::BeginAttackMode() {
 }
 
 void ASkaldPlayerController::HandleGridClick() {
+  FHitResult Hit;
+#if 1 // Use Visibility by default
+  GetHitResultUnderCursor(ECC_Visibility, /*bTraceComplex*/ true, Hit);
+#else // Switch to this block if using custom channel (see step 6)
+  static constexpr ECollisionChannel TerritoryClickChannel = ECC_GameTraceChannel1;
+  GetHitResultUnderCursorByChannel(TerritoryClickChannel, /*bTraceComplex*/ true, Hit);
+#endif
+
+  // WORLD MAP mode: select/deselect territories on LMB
+  if (!bIsBattleMap) {
+    if (ATerritory* Terr = Cast<ATerritory>(Hit.GetActor())) {
+      ServerSelectTerritory(Terr->GetTerritoryId());
+      UE_LOG(LogSkald, Log, TEXT("PC click -> Select Territory %d"),
+             Terr->GetTerritoryId());
+    } else {
+      ServerSelectTerritory(-1);
+      UE_LOG(LogSkald, Log, TEXT("PC click -> Deselect (empty space)"));
+    }
+    return; // do not fall through to battle code
+  }
+
+  // BATTLE MAP mode (existing behavior)
   if (!CachedGameInstance || !CachedGameInstance->GridBattleManager) {
     return;
   }
-
   UGridBattleManager *GridBattleManager = CachedGameInstance->GridBattleManager;
   AFighterPawn *ActiveFighter = GridBattleManager->GetActiveFighter();
   if (!ActiveFighter) {
     return;
   }
-
-  FHitResult Hit;
-  GetHitResultUnderCursor(ECC_Visibility, false, Hit);
 
   UGridOverlayComponent *GridOverlay = nullptr;
   if (UWorld *World = GetWorld()) {

--- a/Source/Skald/Skald_PlayerController.h
+++ b/Source/Skald/Skald_PlayerController.h
@@ -290,6 +290,9 @@ private:
   /** Timer used to poll for the world map actor until it exists. */
   FTimerHandle WorldMapSearchHandle;
 
+  /** Whether the current map is a battle map. */
+  bool bIsBattleMap = false;
+
   void BuildPlayerDataArray(TArray<FS_PlayerData> &OutPlayers) const;
 
   bool ValidateAttack(int32 FromID, int32 ToID, int32 ArmySent, bool bUseSiege,

--- a/Source/Skald/Territory.cpp
+++ b/Source/Skald/Territory.cpp
@@ -49,7 +49,10 @@ ATerritory::ATerritory() {
   PrimaryActorTick.bCanEverTick = false;
   bReplicates = true;
   MeshComponent = CreateDefaultSubobject<UStaticMeshComponent>(TEXT("Mesh"));
-  MeshComponent->SetCollisionProfileName(TEXT("BlockAll"));
+  MeshComponent->SetCollisionEnabled(ECollisionEnabled::QueryOnly);
+  MeshComponent->SetCollisionResponseToAllChannels(ECR_Ignore);
+  // Use visibility channel by default for clicks
+  MeshComponent->SetCollisionResponseToChannel(ECC_Visibility, ECR_Block);
   RootComponent = MeshComponent;
 
   // Provide basic visuals so the world map can function even if assets

--- a/Source/Skald/Territory.h
+++ b/Source/Skald/Territory.h
@@ -81,6 +81,8 @@ public:
     UFUNCTION(BlueprintCallable, Category = "Territory")
     void Deselect();
 
+    int32 GetTerritoryId() const { return TerritoryID; }
+
     /** Check if another territory is adjacent to this one. */
     UFUNCTION(BlueprintCallable, BlueprintPure, Category = "Territory")
     bool IsAdjacentTo(const ATerritory* Other) const;


### PR DESCRIPTION
## Summary
- Track battle map state in `ASkaldPlayerController` and persist it when initializing fighter selection
- Route all left mouse clicks through `HandleGridClick` to support world map territory selection with logging
- Remove conflicting character input binding and expose a safe territory ID accessor while tightening territory mesh collision

## Testing
- `make` *(fails: No targets specified and no makefile found)*

------
https://chatgpt.com/codex/tasks/task_e_68be1e6650488324a8337313f5bccbe0