### PR TITLE
Harden GameState replication & events

### DIFF
--- a/Source/Skald/Skald_GameState.cpp
+++ b/Source/Skald/Skald_GameState.cpp
@@ -22,8 +22,32 @@ void ASkaldGameState::AddPlayerState(APlayerState* PlayerState)
 
     if (ASkaldPlayerState* SkaldPlayer = Cast<ASkaldPlayerState>(PlayerState))
     {
-        Players.Add(SkaldPlayer);
-        OnPlayersUpdated.Broadcast();
+        // Avoid duplicates
+        if (!Players.Contains(SkaldPlayer))
+        {
+            Players.Add(SkaldPlayer);
+            SortAndDedupPlayers();
+            ClampTurnIndex();
+            OnPlayersUpdated.Broadcast();
+        }
+    }
+}
+
+void ASkaldGameState::RemovePlayerState(APlayerState* PlayerState)
+{
+    Super::RemovePlayerState(PlayerState);
+
+    if (ASkaldPlayerState* SkaldPlayer = Cast<ASkaldPlayerState>(PlayerState))
+    {
+        const int32 RemovedIndex = Players.IndexOfByKey(SkaldPlayer);
+        if (RemovedIndex != INDEX_NONE)
+        {
+            Players.RemoveAt(RemovedIndex);
+            ClampTurnIndex();
+            OnPlayersUpdated.Broadcast();
+            // Also notify turn change if index moved
+            OnTurnIndexChanged.Broadcast(CurrentTurnIndex);
+        }
     }
 }
 
@@ -42,5 +66,48 @@ ASkaldPlayerState* ASkaldGameState::GetPlayerById(int32 PlayerID) const
         }
     }
     return nullptr;
+}
+
+void ASkaldGameState::OnRep_Players()
+{
+    SortAndDedupPlayers();
+    ClampTurnIndex();
+    OnPlayersUpdated.Broadcast();
+}
+
+void ASkaldGameState::OnRep_CurrentTurnIndex()
+{
+    ClampTurnIndex();
+    OnTurnIndexChanged.Broadcast(CurrentTurnIndex);
+}
+
+void ASkaldGameState::ClampTurnIndex()
+{
+    if (Players.Num() == 0)
+    {
+        CurrentTurnIndex = 0;
+        return;
+    }
+    if (CurrentTurnIndex < 0 || CurrentTurnIndex >= Players.Num())
+    {
+        CurrentTurnIndex = FMath::Clamp(CurrentTurnIndex, 0, FMath::Max(0, Players.Num() - 1));
+    }
+}
+
+void ASkaldGameState::SortAndDedupPlayers()
+{
+    // Stable order by PlayerId for deterministic turns/HUD lists
+    Players.Sort([](const ASkaldPlayerState* A, const ASkaldPlayerState* B)
+    {
+        return A->GetPlayerId() < B->GetPlayerId();
+    });
+    // Dedup in case engine calls AddPlayerState twice for same actor (defensive)
+    for (int32 i = Players.Num() - 1; i > 0; --i)
+    {
+        if (Players[i] == Players[i - 1])
+        {
+            Players.RemoveAt(i);
+        }
+    }
 }
 

--- a/Source/Skald/Skald_GameState.h
+++ b/Source/Skald/Skald_GameState.h
@@ -7,6 +7,7 @@
 class ASkaldPlayerState;
 
 DECLARE_DYNAMIC_MULTICAST_DELEGATE(FSkaldPlayersUpdated);
+DECLARE_DYNAMIC_MULTICAST_DELEGATE_OneParam(FSkaldTurnChanged, int32, NewTurnIndex);
 
 /**
  * Stores information about players and the current turn.
@@ -20,20 +21,25 @@ public:
     ASkaldGameState();
 
     /** List of players participating in the match. */
-    UPROPERTY(BlueprintReadOnly, Replicated, Category="GameState")
+    UPROPERTY(BlueprintReadOnly, ReplicatedUsing=OnRep_Players, Category="GameState")
     TArray<ASkaldPlayerState*> Players;
 
     /** Broadcast whenever the player list changes. */
     UPROPERTY(BlueprintAssignable, Category="GameState|Events")
     FSkaldPlayersUpdated OnPlayersUpdated;
 
+    /** Broadcast when the active turn index changes (client & server). */
+    UPROPERTY(BlueprintAssignable, Category="GameState|Events")
+    FSkaldTurnChanged OnTurnIndexChanged;
+
     /** Index of the player whose turn is active. */
-    UPROPERTY(BlueprintReadOnly, Replicated, Category="GameState")
+    UPROPERTY(BlueprintReadOnly, ReplicatedUsing=OnRep_CurrentTurnIndex, Category="GameState")
     int32 CurrentTurnIndex;
 
     virtual void GetLifetimeReplicatedProps(TArray<FLifetimeProperty>& OutLifetimeProps) const override;
 
     virtual void AddPlayerState(APlayerState* PlayerState) override;
+    virtual void RemovePlayerState(APlayerState* PlayerState) override;
 
     UFUNCTION(BlueprintCallable, BlueprintPure, Category="GameState")
     ASkaldPlayerState* GetCurrentPlayer() const;
@@ -41,5 +47,18 @@ public:
     /** Retrieve a player state by its PlayerID. */
     UFUNCTION(BlueprintCallable, BlueprintPure, Category="GameState")
     ASkaldPlayerState* GetPlayerById(int32 PlayerID) const;
+
+protected:
+    UFUNCTION()
+    void OnRep_Players();
+
+    UFUNCTION()
+    void OnRep_CurrentTurnIndex();
+
+    /** Keep CurrentTurnIndex in bounds after roster changes. */
+    void ClampTurnIndex();
+
+    /** Keep Players unique & stably ordered by PlayerId. */
+    void SortAndDedupPlayers();
 };
 


### PR DESCRIPTION
## Summary
- replicate Players and CurrentTurnIndex with RepNotifies
- broadcast a turn-change event and remove players safely
- sort and deduplicate the player list while clamping the turn index

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open 'package.json')*


------
https://chatgpt.com/codex/tasks/task_e_68be24f86ce08324a2dab9f80af567fd