### PR TITLE
Ensure HUD reacts to turn changes

### DIFF
--- a/Source/Skald/Skald_GameMode.cpp
+++ b/Source/Skald/Skald_GameMode.cpp
@@ -1053,6 +1053,15 @@ void ASkaldGameMode::AdvanceArmyPlacement() {
 
     TurnManager->BroadcastDeployableUnits(PS);
 
+    // Mark whose placement turn it is so HUDs sync on all clients.
+    if (ASkaldGameState *GSLocal = GetGameState<ASkaldGameState>()) {
+      const int32 NewIndex = GSLocal->PlayerArray.IndexOfByKey(PS);
+      if (NewIndex != INDEX_NONE) {
+        GSLocal->CurrentTurnIndex = NewIndex;      // RepNotify → OnTurnIndexChanged
+        GSLocal->OnTurnIndexChanged.Broadcast(NewIndex); // optional immediate local broadcast
+      }
+    }
+
     // Announce whose placement turn it is.
     const FString PlayerName = PS->PlayerDisplayName;
     for (ASkaldPlayerController *Controller : Controllers) {

--- a/Source/Skald/Skald_PlayerController.cpp
+++ b/Source/Skald/Skald_PlayerController.cpp
@@ -350,6 +350,18 @@ void ASkaldPlayerController::StartTurn() {
   Mode.SetCaptureMouseOnClick(EMouseCaptureMode::NoCapture);
 #endif
   SetInputMode(Mode);
+
+  // Drive GameState turn index so HUDs can react on all clients.
+  if (ASkaldGameState *GS = GetWorld()->GetGameState<ASkaldGameState>()) {
+    if (ASkaldPlayerState *MyPS = GetPlayerState<ASkaldPlayerState>()) {
+      const int32 NewIndex = GS->PlayerArray.IndexOfByKey(MyPS);
+      if (NewIndex != INDEX_NONE) {
+        GS->CurrentTurnIndex = NewIndex; // RepNotify will fire OnTurnIndexChanged
+        // If you haven't applied RepNotifies yet, you can optionally direct-broadcast:
+        GS->OnTurnIndexChanged.Broadcast(NewIndex);
+      }
+    }
+  }
 }
 
 void ASkaldPlayerController::EndTurn() {


### PR DESCRIPTION
## Summary
- Update GameState's CurrentTurnIndex whenever a controller's StartTurn runs
- Sync CurrentTurnIndex during army placement rotation for all clients

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68be26b491dc8324a00c4f2ba405a8e2