### PR TITLE
feat: broadcast turn index updates via game state

### DIFF
--- a/Source/Skald/Skald_GameState.h
+++ b/Source/Skald/Skald_GameState.h
@@ -7,7 +7,7 @@
 class ASkaldPlayerState;
 
 DECLARE_DYNAMIC_MULTICAST_DELEGATE(FSkaldPlayersUpdated);
-DECLARE_DYNAMIC_MULTICAST_DELEGATE_OneParam(FSkaldTurnChanged, int32, NewTurnIndex);
+DECLARE_DYNAMIC_MULTICAST_DELEGATE_OneParam(FSkaldTurnIndexChanged, int32, NewTurnIndex);
 
 /**
  * Stores information about players and the current turn.
@@ -30,7 +30,7 @@ public:
 
     /** Broadcast when the active turn index changes (client & server). */
     UPROPERTY(BlueprintAssignable, Category="GameState|Events")
-    FSkaldTurnChanged OnTurnIndexChanged;
+    FSkaldTurnIndexChanged OnTurnIndexChanged;
 
     /** Index of the player whose turn is active. */
     UPROPERTY(BlueprintReadOnly, ReplicatedUsing=OnRep_CurrentTurnIndex, Category="GameState")

--- a/Source/Skald/Skald_TurnManager.cpp
+++ b/Source/Skald/Skald_TurnManager.cpp
@@ -115,6 +115,22 @@ void ATurnManager::ApplyReinforcementsAndResources(ASkaldPlayerState *PS,
   BroadcastResources(PS);
 }
 
+/** Internal: set GameState.CurrentTurnIndex (and broadcast) to match CurrentIndex. */
+void ATurnManager::SyncGameStateTurnIndex() {
+  if (ASkaldGameState *GS = GetWorld()->GetGameState<ASkaldGameState>()) {
+    int32 NewIndex = -1;
+    if (Controllers.IsValidIndex(CurrentIndex) &&
+        Controllers[CurrentIndex].IsValid()) {
+      if (ASkaldPlayerState *PS =
+              Controllers[CurrentIndex]->GetPlayerState<ASkaldPlayerState>()) {
+        NewIndex = GS->PlayerArray.IndexOfByKey(PS);
+      }
+    }
+    GS->CurrentTurnIndex = NewIndex;
+    GS->OnTurnIndexChanged.Broadcast(NewIndex);
+  }
+}
+
 void ATurnManager::StartTurns() {
   SortControllersByInitiative();
   CurrentIndex = 0;
@@ -174,6 +190,7 @@ void ATurnManager::StartTurns() {
   }
 
   if (CurrentController) {
+    SyncGameStateTurnIndex();
     CurrentController->StartTurn();
     if (ASkaldGameMode *GM = GetWorld()->GetAuthGameMode<ASkaldGameMode>()) {
       GM->CheckVictoryConditions();
@@ -230,14 +247,15 @@ void ATurnManager::AdvanceTurn() {
       if (ASkaldPlayerController *Controller = ControllerPtr.Get()) {
         const bool bIsActive = Controller == CurrentController;
         Controller->ShowTurnAnnouncement(PlayerName, bIsActive);
-        if (USkaldMainHUDWidget *HUD = Controller->GetHUDWidget()) {
-          HUD->UpdateTurnBanner(PS ? PS->GetPlayerId() : -1, 1);
-          HUD->UpdatePhaseBanner(CurrentPhase);
-        }
+      if (USkaldMainHUDWidget *HUD = Controller->GetHUDWidget()) {
+        HUD->UpdateTurnBanner(PS ? PS->GetPlayerId() : -1, 1);
+        HUD->UpdatePhaseBanner(CurrentPhase);
       }
     }
+  }
 
     CurrentController->StartTurn();
+    SyncGameStateTurnIndex();
     if (ASkaldGameMode *GM = GetWorld()->GetAuthGameMode<ASkaldGameMode>()) {
       GM->CheckVictoryConditions();
     }
@@ -376,6 +394,7 @@ void ATurnManager::ResolveGridBattleResult_Implementation() {
     if (Controllers.IsValidIndex(CurrentIndex)) {
       if (ASkaldPlayerController *Controller =
               Controllers[CurrentIndex].Get()) {
+        SyncGameStateTurnIndex();
         Controller->StartTurn();
         BroadcastCurrentPhase();
       }

--- a/Source/Skald/Skald_TurnManager.h
+++ b/Source/Skald/Skald_TurnManager.h
@@ -121,4 +121,7 @@ protected:
    */
   void ApplyReinforcementsAndResources(ASkaldPlayerState *PS,
                                        const TCHAR *Caller);
+
+  /** Internal: set GameState.CurrentTurnIndex (and broadcast) to match CurrentIndex. */
+  void SyncGameStateTurnIndex();
 };


### PR DESCRIPTION
## Summary
- expose a FSkaldTurnIndexChanged delegate and event on ASkaldGameState
- add a SyncGameStateTurnIndex helper in ATurnManager
- update TurnManager to drive CurrentTurnIndex at each turn boundary

## Testing
- `npm test` *(fails: Could not read package.json)*
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68be272be27083249bfb526dc315bde9