### PR TITLE
feat: detect battle maps

### DIFF
--- a/Source/Skald/Skald_PlayerController.cpp
+++ b/Source/Skald/Skald_PlayerController.cpp
@@ -172,6 +172,7 @@ void ASkaldPlayerController::BeginPlay() {
       HandleFactionLockedIn();
     }
     InitializeFighterSelectionIfNeeded();
+    DetectBattleMap();
   }
 
   TryBindWorldMap();
@@ -280,32 +281,7 @@ void ASkaldPlayerController::InitializeFighterSelectionIfNeeded() {
     return;
   }
 
-  ATurnManager *TM = TurnManager;
-  if (!TM) {
-    if (!CachedGameMode) {
-      CachedGameMode = GetWorld()->GetAuthGameMode<ASkaldGameMode>();
-    }
-    if (CachedGameMode) {
-      TM = CachedGameMode->GetTurnManager();
-    }
-  }
-  if (!TM) {
-    return;
-  }
-
-  const FString CurrentMap = UGameplayStatics::GetCurrentLevelName(this, true);
-  bool bIsBattleMap = false;
-  for (const TSoftObjectPtr<UWorld> &Map : TM->BattleMaps) {
-    if (CurrentMap.Equals(Map.ToSoftObjectPath().GetAssetName(),
-                          ESearchCase::IgnoreCase)) {
-      bIsBattleMap = true;
-      break;
-    }
-  }
-
-  // Persist map type for LMB handling
-  this->bIsBattleMap = bIsBattleMap;
-
+  DetectBattleMap();
   if (!bIsBattleMap) {
     return;
   }
@@ -325,6 +301,37 @@ void ASkaldPlayerController::InitializeFighterSelectionIfNeeded() {
         this, &ASkaldPlayerController::HandleFighterSelectionLockedIn);
     Selection->AddToViewport();
     SetIgnoreMoveInput(true);
+  }
+}
+
+void ASkaldPlayerController::DetectBattleMap() {
+  bIsBattleMap = false;
+
+  const FString CurrentMap = UGameplayStatics::GetCurrentLevelName(this, true);
+  if (CurrentMap.Equals(TEXT("BattleMap"), ESearchCase::IgnoreCase)) {
+    bIsBattleMap = true;
+    return;
+  }
+
+  ATurnManager *TM = TurnManager;
+  if (!TM) {
+    if (!CachedGameMode) {
+      CachedGameMode = GetWorld()->GetAuthGameMode<ASkaldGameMode>();
+    }
+    if (CachedGameMode) {
+      TM = CachedGameMode->GetTurnManager();
+    }
+  }
+  if (!TM) {
+    return;
+  }
+
+  for (const TSoftObjectPtr<UWorld> &Map : TM->BattleMaps) {
+    if (CurrentMap.Equals(Map.ToSoftObjectPath().GetAssetName(),
+                          ESearchCase::IgnoreCase)) {
+      bIsBattleMap = true;
+      break;
+    }
   }
 }
 
@@ -356,8 +363,10 @@ void ASkaldPlayerController::StartTurn() {
     if (ASkaldPlayerState *MyPS = GetPlayerState<ASkaldPlayerState>()) {
       const int32 NewIndex = GS->PlayerArray.IndexOfByKey(MyPS);
       if (NewIndex != INDEX_NONE) {
-        GS->CurrentTurnIndex = NewIndex; // RepNotify will fire OnTurnIndexChanged
-        // If you haven't applied RepNotifies yet, you can optionally direct-broadcast:
+        GS->CurrentTurnIndex =
+            NewIndex; // RepNotify will fire OnTurnIndexChanged
+        // If you haven't applied RepNotifies yet, you can optionally
+        // direct-broadcast:
         GS->OnTurnIndexChanged.Broadcast(NewIndex);
       }
     }
@@ -1089,29 +1098,18 @@ void ASkaldPlayerController::BeginAttackMode() {
 
 void ASkaldPlayerController::HandleGridClick() {
   FHitResult Hit;
-#if 1 // Use Visibility by default
-  GetHitResultUnderCursor(ECC_Visibility, /*bTraceComplex*/ true, Hit);
-#else // Switch to this block if using custom channel (see step 6)
-  static constexpr ECollisionChannel TerritoryClickChannel =
-      ECC_GameTraceChannel1;
-  GetHitResultUnderCursorByChannel(TerritoryClickChannel,
-                                   /*bTraceComplex*/ true, Hit);
-#endif
-
-  // WORLD MAP mode: select/deselect territories on LMB
   if (!bIsBattleMap) {
+    GetHitResultUnderCursor(ECC_Visibility, /*bTraceComplex*/ true, Hit);
     if (ATerritory *Terr = Cast<ATerritory>(Hit.GetActor())) {
-      ServerSelectTerritory(Terr->GetTerritoryId());
-      UE_LOG(LogSkald, Log, TEXT("PC click -> Select Territory %d"),
-             Terr->GetTerritoryId());
+      ServerSelectTerritory(Terr->TerritoryID);
     } else {
       ServerSelectTerritory(-1);
-      UE_LOG(LogSkald, Log, TEXT("PC click -> Deselect (empty space)"));
     }
-    return; // do not fall through to battle code
+    return;
   }
 
-  // BATTLE MAP mode (existing behavior)
+  GetHitResultUnderCursor(ECC_Visibility, /*bTraceComplex*/ true, Hit);
+
   if (!CachedGameInstance || !CachedGameInstance->GridBattleManager) {
     return;
   }

--- a/Source/Skald/Skald_PlayerController.h
+++ b/Source/Skald/Skald_PlayerController.h
@@ -3,8 +3,8 @@
 #include "CoreMinimal.h"
 #include "GameFramework/PlayerController.h"
 #include "SkaldTypes.h"
-#include "TimerManager.h"
 #include "Skald_PlayerController.generated.h"
+#include "TimerManager.h"
 
 class ATurnManager;
 class UUserWidget;
@@ -291,7 +291,12 @@ private:
   FTimerHandle WorldMapSearchHandle;
 
   /** Whether the current map is a battle map. */
+  UPROPERTY(BlueprintReadOnly, Category = "Turn",
+            meta = (AllowPrivateAccess = "true"))
   bool bIsBattleMap = false;
+
+  /** Detect if the current level is a battle map and update bIsBattleMap. */
+  void DetectBattleMap();
 
   void BuildPlayerDataArray(TArray<FS_PlayerData> &OutPlayers) const;
 


### PR DESCRIPTION
## Summary
- expose bIsBattleMap and detect current map type
- handle world map clicks to select/deselect territories
- determine battle maps in BeginPlay and fighter selection setup

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68be29efae2c8324a74d89e47c309691