### PR TITLE
Ensure HUD updates active player on turn change

### DIFF
--- a/Source/Skald/UI/SkaldMainHUDWidget.cpp
+++ b/Source/Skald/UI/SkaldMainHUDWidget.cpp
@@ -576,12 +576,15 @@ void USkaldMainHUDWidget::HandleTurnIndexChanged(int32 /*NewTurnIndex*/) {
   }
 
   // Keep existing turn number; only the active player changed.
-  UpdateTurnBanner(NewPlayerID, TurnNumber);
+  CurrentPlayerID = NewPlayerID;
 
-  // Optional: show a brief turn message and re-sync buttons.
-  const bool bIsMyTurn = (NewPlayerID == LocalPlayerID);
+  // Update widget text and cached state.
+  BP_SetTurnText(TurnNumber, CurrentPlayerID);
+
+  // Update buttons for the new player and show a brief turn message.
+  const bool bIsMyTurn = (CurrentPlayerID == LocalPlayerID);
+  SyncPhaseButtons(bIsMyTurn);
   ShowTurnMessage(bIsMyTurn);
-  // (UpdateTurnBanner already calls SyncPhaseButtons, so this is just UX sugar.)
 }
 
 void USkaldMainHUDWidget::SyncPhaseButtons(bool bIsMyTurn) {


### PR DESCRIPTION
## Summary
- Update stored player ID when the active turn changes
- Refresh turn text and phase button state for the new player

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68be2a1da20c832496a69f7bfc644521