### PR TITLE
Update cached turn info when turn index changes

### DIFF
--- a/Source/Skald/UI/SkaldMainHUDWidget.cpp
+++ b/Source/Skald/UI/SkaldMainHUDWidget.cpp
@@ -583,16 +583,23 @@ void USkaldMainHUDWidget::HandlePlayersUpdated() {
 }
 
 void USkaldMainHUDWidget::HandleTurnIndexChanged(int32 /*NewTurnIndex*/) {
-  // Derive current player ID from GameState.
+  // Derive current player ID and approximate turn number from GameState.
   int32 NewPlayerID = -1;
+  int32 NewTurnNumber = TurnNumber;
   if (GameState) {
     if (ASkaldPlayerState *PS = GameState->GetCurrentPlayer()) {
       NewPlayerID = PS->GetPlayerId();
     }
+
+    const int32 PlayerCount = GameState->Players.Num();
+    if (PlayerCount > 0) {
+      NewTurnNumber = GameState->CurrentTurnIndex / PlayerCount + 1;
+    }
   }
 
-  // Keep existing turn number; only the active player changed.
+  // Update cached turn state before refreshing widgets.
   CurrentPlayerID = NewPlayerID;
+  TurnNumber = NewTurnNumber;
 
   // Update widget text and cached state.
   BP_SetTurnText(TurnNumber, CurrentPlayerID);


### PR DESCRIPTION
## Summary
- Update HUD turn change handler to sync cached player ID and turn number before refreshing widgets

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68be2ba58c2c8324b586b914ed0131df