### PR TITLE
Fix player controller mouse capture for UE 5.5

### DIFF
--- a/Source/Skald/Skald_PlayerController.cpp
+++ b/Source/Skald/Skald_PlayerController.cpp
@@ -340,11 +340,7 @@ void ASkaldPlayerController::StartTurn() {
   FInputModeGameAndUI Mode;
   Mode.SetWidgetToFocus(nullptr);
   Mode.SetLockMouseToViewportBehavior(EMouseLockMode::DoNotLock);
-#if ENGINE_MAJOR_VERSION > 5 || (ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION >= 5)
-  Mode.SetMouseCaptureMode(EMouseCaptureMode::NoCapture);
-#else
   Mode.SetCaptureMouseOnClick(EMouseCaptureMode::NoCapture);
-#endif
   SetInputMode(Mode);
 }
 
@@ -971,11 +967,7 @@ void ASkaldPlayerController::HandleFactionLockedIn() {
   FInputModeGameAndUI Mode;
   Mode.SetWidgetToFocus(nullptr);
   Mode.SetLockMouseToViewportBehavior(EMouseLockMode::DoNotLock);
-#if ENGINE_MAJOR_VERSION > 5 || (ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION >= 5)
-  Mode.SetMouseCaptureMode(EMouseCaptureMode::NoCapture);
-#else
   Mode.SetCaptureMouseOnClick(EMouseCaptureMode::NoCapture);
-#endif
   SetInputMode(Mode);
   bShowMouseCursor = true;
   bEnableClickEvents = true;
@@ -1041,11 +1033,7 @@ void ASkaldPlayerController::HandleFighterSelectionLockedIn() {
   FInputModeGameAndUI Mode;
   Mode.SetWidgetToFocus(nullptr);
   Mode.SetLockMouseToViewportBehavior(EMouseLockMode::DoNotLock);
-#if ENGINE_MAJOR_VERSION > 5 || (ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION >= 5)
-  Mode.SetMouseCaptureMode(EMouseCaptureMode::NoCapture);
-#else
   Mode.SetCaptureMouseOnClick(EMouseCaptureMode::NoCapture);
-#endif
   SetInputMode(Mode);
   SetIgnoreMoveInput(false);
   SetIgnoreLookInput(false);


### PR DESCRIPTION
## Summary
- replace FInputModeGameAndUI::SetMouseCaptureMode with SetCaptureMouseOnClick

## Testing
- `bash Build/validate.sh`

------
https://chatgpt.com/codex/tasks/task_e_68be1ca9b11483249444e81d0bc737aa