### PR TITLE
Handle AI army placement and revolt phase

### DIFF
--- a/Source/Skald/Skald_AIController.cpp
+++ b/Source/Skald/Skald_AIController.cpp
@@ -2,6 +2,7 @@
 #include "Engine/World.h"
 #include "Kismet/GameplayStatics.h"
 #include "Skald.h"
+#include "Skald_GameMode.h"
 #include "Skald_PlayerState.h"
 #include "Skald_TurnManager.h"
 #include "SkaldTypes.h"
@@ -36,10 +37,36 @@ void ASkaldAIController::MakeAIDecision() {
 
   ETurnPhase Phase = TurnManager->GetCurrentPhase();
   int32 IterationCount = 0;
-  while (Phase != ETurnPhase::EndTurn && IterationCount++ < MaxAIIterations) {
+  while (Phase != ETurnPhase::Revolt && IterationCount++ < MaxAIIterations) {
     const ETurnPhase PrevPhase = Phase;
 
-    if (Phase == ETurnPhase::Reinforcement) {
+    if (Phase == ETurnPhase::ArmyPlacement) {
+      TArray<ATerritory *> OwnedTerritories;
+      for (ATerritory *Territory : WorldMap->Territories) {
+        if (Territory && Territory->OwningPlayer == PS) {
+          OwnedTerritories.Add(Territory);
+        }
+      }
+
+      int32 SpreadIndex = 0;
+      while (PS->DeployableUnits > 0 && OwnedTerritories.Num() > 0) {
+        ATerritory *TargetTerritory =
+            OwnedTerritories[SpreadIndex % OwnedTerritories.Num()];
+        ++TargetTerritory->ArmyUnits;
+        TargetTerritory->RefreshAppearance();
+        --PS->DeployableUnits;
+        --PS->Resources;
+        ++SpreadIndex;
+      }
+
+      TurnManager->BroadcastDeployableUnits(PS);
+      TurnManager->BroadcastResources(PS);
+      if (ASkaldGameMode *GM =
+              GetWorld()->GetAuthGameMode<ASkaldGameMode>()) {
+        GM->AdvanceArmyPlacement();
+      }
+      return;
+    } else if (Phase == ETurnPhase::Reinforcement) {
       TArray<ATerritory *> OwnedTerritories;
       for (ATerritory *Territory : WorldMap->Territories) {
         if (Territory && Territory->OwningPlayer == PS) {
@@ -124,6 +151,8 @@ void ASkaldAIController::MakeAIDecision() {
                             TroopsToMove);
       }
 
+      TurnManager->AdvancePhase();
+    } else if (Phase == ETurnPhase::EndTurn) {
       TurnManager->AdvancePhase();
     } else {
       UE_LOG(LogSkald, Warning,

--- a/Source/Skald/Skald_GameMode.cpp
+++ b/Source/Skald/Skald_GameMode.cpp
@@ -1072,30 +1072,7 @@ void ASkaldGameMode::AdvanceArmyPlacement() {
       }
     }
 
-    // AI players automatically distribute their armies evenly.
-    if (PS->bIsAI) {
-      TArray<ATerritory *> OwnedTerritories;
-      for (ATerritory *Territory : WorldMap->Territories) {
-        if (Territory && Territory->OwningPlayer == PS) {
-          OwnedTerritories.Add(Territory);
-        }
-      }
-      int32 SpreadIndex = 0;
-      while (PS->DeployableUnits > 0 && OwnedTerritories.Num() > 0) {
-        ATerritory *TargetTerritory =
-            OwnedTerritories[SpreadIndex % OwnedTerritories.Num()];
-        ++TargetTerritory->ArmyUnits;
-        TargetTerritory->RefreshAppearance();
-        --PS->DeployableUnits;
-        ++SpreadIndex;
-      }
-      TurnManager->BroadcastDeployableUnits(PS);
-      ++PlacementIndex;
-      continue;
-    }
-
-    // Human player: wait for manual deployment with current pool visible.
-    // Ensure the active controller is in interactive mode so they can deploy.
+    // Hand control to the active player (AI or human) to deploy units.
     if (PC) {
       PC->StartTurn();
     }


### PR DESCRIPTION
## Summary
- Let AI distribute units during the army placement phase using the same logic as reinforcements and advance placement automatically
- Remove game mode's special-case placement for AI so all controllers handle their own deployment
- Advance AI turns through EndTurn into Revolt so outcomes are auto-settled

## Testing
- `./Build/validate.sh` *(UnrealBuildTool not found; compile and tests skipped)*

------
https://chatgpt.com/codex/tasks/task_e_68be488dbbc48324847a5272f46c5d6e