### PR TITLE
Avoid AI resource loss during army placement

### DIFF
--- a/Source/Skald/Skald_AIController.cpp
+++ b/Source/Skald/Skald_AIController.cpp
@@ -55,12 +55,10 @@ void ASkaldAIController::MakeAIDecision() {
         ++TargetTerritory->ArmyUnits;
         TargetTerritory->RefreshAppearance();
         --PS->DeployableUnits;
-        --PS->Resources;
         ++SpreadIndex;
       }
 
       TurnManager->BroadcastDeployableUnits(PS);
-      TurnManager->BroadcastResources(PS);
       if (ASkaldGameMode *GM =
               GetWorld()->GetAuthGameMode<ASkaldGameMode>()) {
         GM->AdvanceArmyPlacement();


### PR DESCRIPTION
## Summary
- Prevent AI from spending resources during initial army placement so resources match human players

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bedd3bef3483248defd87d14971c80