### PR TITLE
feat: improve turn messaging and button gating

### DIFF
--- a/Source/Skald/Skald_PlayerController.cpp
+++ b/Source/Skald/Skald_PlayerController.cpp
@@ -347,6 +347,12 @@ void ASkaldPlayerController::ShowTurnAnnouncement(const FString &PlayerName,
   }
 }
 
+void ASkaldPlayerController::NotifyTurnEnded(const FString &PlayerName) {
+  if (MainHudWidget) {
+    MainHudWidget->ShowTurnEnded(PlayerName);
+  }
+}
+
 void ASkaldPlayerController::StartTurn() {
   FInputModeGameAndUI Mode;
   Mode.SetWidgetToFocus(nullptr);

--- a/Source/Skald/Skald_PlayerController.h
+++ b/Source/Skald/Skald_PlayerController.h
@@ -56,6 +56,9 @@ public:
   UFUNCTION(BlueprintCallable, Category = "Turn")
   void ShowTurnAnnouncement(const FString &PlayerName, bool bIsMyTurn);
 
+  UFUNCTION(BlueprintCallable, Category = "Turn")
+  void NotifyTurnEnded(const FString &PlayerName);
+
   UFUNCTION(BlueprintCallable, Category = "UI")
   void HandleTerritorySelected(ATerritory *Terr);
 

--- a/Source/Skald/Skald_TurnManager.cpp
+++ b/Source/Skald/Skald_TurnManager.cpp
@@ -204,6 +204,13 @@ void ATurnManager::AdvanceTurn() {
   ASkaldPlayerController *PreviousController =
       Controllers.IsValidIndex(CurrentIndex) ? Controllers[CurrentIndex].Get()
                                              : nullptr;
+  FString PreviousPlayerName;
+  if (PreviousController) {
+    if (ASkaldPlayerState *PrevPS =
+            PreviousController->GetPlayerState<ASkaldPlayerState>()) {
+      PreviousPlayerName = PrevPS->PlayerDisplayName;
+    }
+  }
 
   Controllers.RemoveAll([](const TWeakObjectPtr<ASkaldPlayerController> &Ptr) {
     if (!Ptr.IsValid()) {
@@ -246,13 +253,14 @@ void ATurnManager::AdvanceTurn() {
          Controllers) {
       if (ASkaldPlayerController *Controller = ControllerPtr.Get()) {
         const bool bIsActive = Controller == CurrentController;
+        Controller->NotifyTurnEnded(PreviousPlayerName);
         Controller->ShowTurnAnnouncement(PlayerName, bIsActive);
-      if (USkaldMainHUDWidget *HUD = Controller->GetHUDWidget()) {
-        HUD->UpdateTurnBanner(PS ? PS->GetPlayerId() : -1, 1);
-        HUD->UpdatePhaseBanner(CurrentPhase);
+        if (USkaldMainHUDWidget *HUD = Controller->GetHUDWidget()) {
+          HUD->UpdateTurnBanner(PS ? PS->GetPlayerId() : -1, 1);
+          HUD->UpdatePhaseBanner(CurrentPhase);
+        }
       }
     }
-  }
 
     CurrentController->StartTurn();
     SyncGameStateTurnIndex();

--- a/Source/Skald/UI/SkaldMainHUDWidget.cpp
+++ b/Source/Skald/UI/SkaldMainHUDWidget.cpp
@@ -19,6 +19,7 @@
 #include "UI/DeployWidget.h"
 #include "UObject/ConstructorHelpers.h"
 #include "WorldMap.h"
+#include "TimerManager.h"
 
 USkaldMainHUDWidget::USkaldMainHUDWidget(
     const FObjectInitializer &ObjectInitializer)
@@ -98,7 +99,7 @@ void USkaldMainHUDWidget::NativeConstruct() {
     DeployButton->SetVisibility(ESlateVisibility::Collapsed);
   }
 
-  SyncPhaseButtons(CurrentPlayerID == LocalPlayerID);
+  SyncPhaseButtons(false);
   RebuildPlayerList(CachedPlayers);
 }
 
@@ -284,6 +285,12 @@ void USkaldMainHUDWidget::ShowEndingTurn() {
   if (EndingTurnText) {
     EndingTurnText->SetText(FText::FromString(TEXT("Ending turn.")));
     EndingTurnText->SetVisibility(ESlateVisibility::Visible);
+    if (UWorld *World = GetWorld()) {
+      World->GetTimerManager().ClearTimer(TurnMessageTimerHandle);
+      World->GetTimerManager().SetTimer(TurnMessageTimerHandle, this,
+                                       &USkaldMainHUDWidget::HideEndingTurn,
+                                       3.f, false);
+    }
   }
 }
 
@@ -300,12 +307,36 @@ void USkaldMainHUDWidget::ShowTurnMessage(bool bIsMyTurn) {
     EndingTurnText->SetVisibility(ESlateVisibility::Visible);
   }
   SyncPhaseButtons(bIsMyTurn);
+  if (UWorld *World = GetWorld()) {
+    World->GetTimerManager().ClearTimer(TurnMessageTimerHandle);
+    World->GetTimerManager().SetTimer(TurnMessageTimerHandle, this,
+                                     &USkaldMainHUDWidget::HideEndingTurn, 3.f,
+                                     false);
+  }
 }
 
 void USkaldMainHUDWidget::UpdateInitiativeText(const FString &Message) {
   if (InitiativeText) {
     InitiativeText->SetText(FText::FromString(Message));
     InitiativeText->SetVisibility(ESlateVisibility::Visible);
+    if (UWorld *World = GetWorld()) {
+      World->GetTimerManager().ClearTimer(InitiativeTimerHandle);
+      World->GetTimerManager().SetTimer(InitiativeTimerHandle, this,
+                                       &USkaldMainHUDWidget::HideInitiativeText,
+                                       3.f, false);
+    }
+  }
+}
+
+void USkaldMainHUDWidget::ShowTurnEnded(const FString &PlayerName) {
+  const FString Text =
+      FString::Printf(TEXT("%s ended their turn"), *PlayerName);
+  UpdateInitiativeText(Text);
+}
+
+void USkaldMainHUDWidget::HideInitiativeText() {
+  if (InitiativeText) {
+    InitiativeText->SetVisibility(ESlateVisibility::Collapsed);
   }
 }
 

--- a/Source/Skald/UI/SkaldMainHUDWidget.h
+++ b/Source/Skald/UI/SkaldMainHUDWidget.h
@@ -3,6 +3,7 @@
 #include "Blueprint/UserWidget.h"
 #include "CoreMinimal.h"
 #include "SkaldTypes.h"
+#include "TimerManager.h"
 #include "SkaldMainHUDWidget.generated.h"
 
 class UButton;
@@ -159,6 +160,10 @@ public:
   UFUNCTION(BlueprintCallable, Category = "Skald|HUD")
   void ShowTurnMessage(bool bIsMyTurn);
 
+  /** Display a message that a player has ended their turn. */
+  UFUNCTION(BlueprintCallable, Category = "Skald|HUD")
+  void ShowTurnEnded(const FString &PlayerName);
+
   /** Update and display the initiative announcement. */
   UFUNCTION(BlueprintCallable, Category = "Skald|HUD")
   void UpdateInitiativeText(const FString &Message);
@@ -292,6 +297,12 @@ public:
   TSubclassOf<UDeployWidget> DeployWidgetClass;
 
 protected:
+  UFUNCTION()
+  void HideInitiativeText();
+
+  FTimerHandle InitiativeTimerHandle;
+  FTimerHandle TurnMessageTimerHandle;
+
   // Internal handlers for widget actions
   UFUNCTION()
   void HandleEndTurnClicked();


### PR DESCRIPTION
## Summary
- disable phase buttons until the local player's turn begins
- add timers so initiative and turn messages auto-hide
- announce when a player ends their turn

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c62713c0bc8324bfacc2f9949a9d89