### PR TITLE
Track battle map state and reinit fighter selection after travel

### DIFF
--- a/Source/Skald/Skald_GameInstance.h
+++ b/Source/Skald/Skald_GameInstance.h
@@ -13,82 +13,85 @@ class UNetDriver;
 DECLARE_DYNAMIC_MULTICAST_DELEGATE(FSkaldFactionsUpdated);
 /** Game instance storing player selections from the lobby. */
 UCLASS()
-class SKALD_API USkaldGameInstance : public UGameInstance
-{
-    GENERATED_BODY()
+class SKALD_API USkaldGameInstance : public UGameInstance {
+  GENERATED_BODY()
 
 public:
-    /** Initialize the game instance. */
-    virtual void Init() override;
+  /** Initialize the game instance. */
+  virtual void Init() override;
 
-    /** Player chosen display name. */
-    UPROPERTY(BlueprintReadWrite, Category="Player")
-    FString DisplayName = TEXT("Player");
+  /** Player chosen display name. */
+  UPROPERTY(BlueprintReadWrite, Category = "Player")
+  FString DisplayName = TEXT("Player");
 
-    /** Selected faction for this player. */
-    UPROPERTY(BlueprintReadWrite, Category="Player")
-    ESkaldFaction Faction = ESkaldFaction::Human;
+  /** Selected faction for this player. */
+  UPROPERTY(BlueprintReadWrite, Category = "Player")
+  ESkaldFaction Faction = ESkaldFaction::Human;
 
-    /** Whether the game was started in multiplayer mode. */
-    UPROPERTY(BlueprintReadWrite, Category="Player")
-    bool bIsMultiplayer = false;
+  /** Whether the game was started in multiplayer mode. */
+  UPROPERTY(BlueprintReadWrite, Category = "Player")
+  bool bIsMultiplayer = false;
 
-    /** True if this instance is hosting a multiplayer session. */
-    UPROPERTY(BlueprintReadWrite, Category="Network")
-    bool bIsHost = false;
+  /** True if this instance is hosting a multiplayer session. */
+  UPROPERTY(BlueprintReadWrite, Category = "Network")
+  bool bIsHost = false;
 
-    /** Address to join when acting as a client. */
-    UPROPERTY(BlueprintReadWrite, Category="Network")
-    FString JoinAddress;
+  /** Address to join when acting as a client. */
+  UPROPERTY(BlueprintReadWrite, Category = "Network")
+  FString JoinAddress;
 
-    /** Number of AI opponents requested by the player. */
-    UPROPERTY(BlueprintReadWrite, Category="Player")
-    int32 AIPlayersToSpawn = 1;
+  /** Number of AI opponents requested by the player. */
+  UPROPERTY(BlueprintReadWrite, Category = "Player")
+  int32 AIPlayersToSpawn = 1;
 
-    /** Factions that have already been selected by players or AI. */
-    UPROPERTY(BlueprintReadWrite, Category="Player")
-    TArray<ESkaldFaction> TakenFactions;
+  /** Factions that have already been selected by players or AI. */
+  UPROPERTY(BlueprintReadWrite, Category = "Player")
+  TArray<ESkaldFaction> TakenFactions;
 
-    /** Event fired when the taken faction list changes. */
-    UPROPERTY(BlueprintAssignable, Category="Player|Events")
-    FSkaldFactionsUpdated OnFactionsUpdated;
+  /** Event fired when the taken faction list changes. */
+  UPROPERTY(BlueprintAssignable, Category = "Player|Events")
+  FSkaldFactionsUpdated OnFactionsUpdated;
 
-    /** Payload describing the battle to resolve when returning from the battle map. */
-    UPROPERTY(BlueprintReadWrite, Category="Battle")
-    FS_BattlePayload PendingBattle;
+  /** Payload describing the battle to resolve when returning from the battle
+   * map. */
+  UPROPERTY(BlueprintReadWrite, Category = "Battle")
+  FS_BattlePayload PendingBattle;
 
-    /** Runtime manager used to execute grid based battles. */
-    UPROPERTY(BlueprintReadWrite, Category="Battle")
-    class UGridBattleManager* GridBattleManager = nullptr;
+  /** Runtime manager used to execute grid based battles. */
+  UPROPERTY(BlueprintReadWrite, Category = "Battle")
+  class UGridBattleManager *GridBattleManager = nullptr;
 
-    /** Random stream used for deterministic combat rolls. */
-    UPROPERTY()
-    FRandomStream CombatRandomStream;
+  /** True when the game has travelled to a dedicated battle map. */
+  UPROPERTY(BlueprintReadWrite, Category = "Battle")
+  bool bIsInBattleMap = false;
 
-    /** Index of the current player turn when travelling between maps. */
-    UPROPERTY(BlueprintReadWrite, Category="Turn")
-    int32 SavedTurnIndex = 0;
+  /** Random stream used for deterministic combat rolls. */
+  UPROPERTY()
+  FRandomStream CombatRandomStream;
 
-    /** Phase of the turn cycle that was active before travelling. */
-    UPROPERTY(BlueprintReadWrite, Category="Turn")
-    ETurnPhase SavedTurnPhase = ETurnPhase::Reinforcement;
+  /** Index of the current player turn when travelling between maps. */
+  UPROPERTY(BlueprintReadWrite, Category = "Turn")
+  int32 SavedTurnIndex = 0;
 
-    /** Flag indicating whether the turn manager should resume after travel. */
-    UPROPERTY(BlueprintReadWrite, Category="Turn")
-    bool bResumeTurns = false;
+  /** Phase of the turn cycle that was active before travelling. */
+  UPROPERTY(BlueprintReadWrite, Category = "Turn")
+  ETurnPhase SavedTurnPhase = ETurnPhase::Reinforcement;
 
-    /** Seed the combat random stream so all clients use the same sequence. */
-    UFUNCTION(BlueprintCallable, Category="Battle")
-    void SeedCombatRandomStream(int32 Seed);
+  /** Flag indicating whether the turn manager should resume after travel. */
+  UPROPERTY(BlueprintReadWrite, Category = "Turn")
+  bool bResumeTurns = false;
 
-    /** Handle network failures and return to the lobby. */
-    UFUNCTION()
-    void HandleNetworkFailure(UWorld* World, UNetDriver* Driver,
-                              ENetworkFailure::Type FailureType,
-                              const FString& ErrorString);
+  /** Seed the combat random stream so all clients use the same sequence. */
+  UFUNCTION(BlueprintCallable, Category = "Battle")
+  void SeedCombatRandomStream(int32 Seed);
 
-    /** Save game loaded when transitioning from the main menu. */
-    UPROPERTY(BlueprintReadWrite, Category="SaveGame")
-    USkaldSaveGame* LoadedSaveGame = nullptr;
+  /** Handle network failures and return to the lobby. */
+  UFUNCTION()
+  void HandleNetworkFailure(UWorld *World, UNetDriver *Driver,
+                            ENetworkFailure::Type FailureType,
+                            const FString &ErrorString);
+
+  /** Save game loaded when transitioning from the main menu. */
+  UPROPERTY(BlueprintReadWrite, Category = "SaveGame")
+  USkaldSaveGame *LoadedSaveGame = nullptr;
 };
-

--- a/Source/Skald/Skald_PlayerController.cpp
+++ b/Source/Skald/Skald_PlayerController.cpp
@@ -3,6 +3,7 @@
 #include "ChoosePlayerWidget.h"
 #include "Components/InputComponent.h"
 #include "Engine/Engine.h"
+#include "Engine/World.h"
 #include "EngineUtils.h"
 #include "FighterPawn.h"
 #include "GridBattleManager.h"
@@ -153,6 +154,9 @@ void ASkaldPlayerController::BeginPlay() {
   Super::BeginPlay();
   CacheGameReferences();
 
+  FWorldDelegates::OnPostLoadMapWithWorld.AddUObject(
+      this, &ASkaldPlayerController::HandlePostLoadMap);
+
   if (IsLocalPlayerController() && GetLocalPlayer() != nullptr) {
     InitializeHUDWidget();
     if (CachedGameInstance && CachedGameInstance->bIsMultiplayer &&
@@ -177,6 +181,11 @@ void ASkaldPlayerController::BeginPlay() {
   }
 
   TryBindWorldMap();
+}
+
+void ASkaldPlayerController::EndPlay(const EEndPlayReason::Type EndPlayReason) {
+  FWorldDelegates::OnPostLoadMapWithWorld.RemoveAll(this);
+  Super::EndPlay(EndPlayReason);
 }
 
 void ASkaldPlayerController::TryBindWorldMap() {
@@ -308,6 +317,14 @@ void ASkaldPlayerController::InitializeFighterSelectionIfNeeded() {
 void ASkaldPlayerController::DetectBattleMap() {
   bIsBattleMap = false;
 
+  if (!CachedGameInstance) {
+    CachedGameInstance = GetGameInstance<USkaldGameInstance>();
+  }
+  if (CachedGameInstance && CachedGameInstance->bIsInBattleMap) {
+    bIsBattleMap = true;
+    return;
+  }
+
   const FString CurrentMap = UGameplayStatics::GetCurrentLevelName(this, true);
   if (CurrentMap.Equals(TEXT("BattleMap"), ESearchCase::IgnoreCase)) {
     bIsBattleMap = true;
@@ -334,6 +351,10 @@ void ASkaldPlayerController::DetectBattleMap() {
       break;
     }
   }
+}
+
+void ASkaldPlayerController::HandlePostLoadMap(UWorld * /*LoadedWorld*/) {
+  InitializeFighterSelectionIfNeeded();
 }
 
 void ASkaldPlayerController::ShowTurnAnnouncement(const FString &PlayerName,

--- a/Source/Skald/Skald_PlayerController.h
+++ b/Source/Skald/Skald_PlayerController.h
@@ -1,11 +1,11 @@
 #pragma once
 
 #include "CoreMinimal.h"
+#include "Engine/EngineTypes.h"
 #include "GameFramework/PlayerController.h"
 #include "SkaldTypes.h"
-#include "TimerManager.h"
-#include "Engine/EngineTypes.h"
 #include "Skald_PlayerController.generated.h"
+#include "TimerManager.h"
 
 class ATurnManager;
 class UUserWidget;
@@ -139,6 +139,8 @@ protected:
   EMouseCaptureMode DefaultMouseCaptureMode;
 
   virtual void SetupInputComponent() override;
+
+  virtual void EndPlay(const EEndPlayReason::Type EndPlayReason) override;
 
   /** Begin selecting a move destination. */
   UFUNCTION()
@@ -302,6 +304,9 @@ private:
 
   /** Detect if the current level is a battle map and update bIsBattleMap. */
   void DetectBattleMap();
+
+  /** Re-run fighter selection setup after level transitions. */
+  void HandlePostLoadMap(UWorld *LoadedWorld);
 
   void BuildPlayerDataArray(TArray<FS_PlayerData> &OutPlayers) const;
 

--- a/Source/Skald/Skald_TurnManager.cpp
+++ b/Source/Skald/Skald_TurnManager.cpp
@@ -54,8 +54,7 @@ void ATurnManager::BeginPlay() {
     }
   }
 
-  if (ASkaldGameMode *GM =
-          GetWorld()->GetAuthGameMode<ASkaldGameMode>()) {
+  if (ASkaldGameMode *GM = GetWorld()->GetAuthGameMode<ASkaldGameMode>()) {
     if (!GM->IsWorldInitialized()) {
       GM->TryInitializeWorldAndStart();
     }
@@ -115,7 +114,8 @@ void ATurnManager::ApplyReinforcementsAndResources(ASkaldPlayerState *PS,
   BroadcastResources(PS);
 }
 
-/** Internal: set GameState.CurrentTurnIndex (and broadcast) to match CurrentIndex. */
+/** Internal: set GameState.CurrentTurnIndex (and broadcast) to match
+ * CurrentIndex. */
 void ATurnManager::SyncGameStateTurnIndex() {
   if (ASkaldGameState *GS = GetWorld()->GetGameState<ASkaldGameState>()) {
     int32 NewIndex = -1;
@@ -247,12 +247,12 @@ void ATurnManager::AdvanceTurn() {
       if (ASkaldPlayerController *Controller = ControllerPtr.Get()) {
         const bool bIsActive = Controller == CurrentController;
         Controller->ShowTurnAnnouncement(PlayerName, bIsActive);
-      if (USkaldMainHUDWidget *HUD = Controller->GetHUDWidget()) {
-        HUD->UpdateTurnBanner(PS ? PS->GetPlayerId() : -1, 1);
-        HUD->UpdatePhaseBanner(CurrentPhase);
+        if (USkaldMainHUDWidget *HUD = Controller->GetHUDWidget()) {
+          HUD->UpdateTurnBanner(PS ? PS->GetPlayerId() : -1, 1);
+          HUD->UpdatePhaseBanner(CurrentPhase);
+        }
       }
     }
-  }
 
     CurrentController->StartTurn();
     SyncGameStateTurnIndex();
@@ -321,12 +321,18 @@ void ATurnManager::TriggerGridBattle(const FS_BattlePayload &Battle) {
         MapToLoad = Selected;
       }
     }
+    if (USkaldGameInstance *GI = GetGameInstance<USkaldGameInstance>()) {
+      GI->bIsInBattleMap = true;
+    }
     World->ServerTravel(MapToLoad);
   }
 }
 
 void ATurnManager::ResolveGridBattleResult_Implementation() {
   USkaldGameInstance *GI = GetGameInstance<USkaldGameInstance>();
+  if (GI) {
+    GI->bIsInBattleMap = false;
+  }
   if (!GI || !GI->GridBattleManager) {
     return;
   }


### PR DESCRIPTION
## Summary
- Track whether the game has travelled to a battle map via a new `bIsInBattleMap` flag and update it when entering or exiting grid battles.
- Have the player controller consult this flag before probing the turn manager and re-run fighter selection after level travel.

## Testing
- `./Build/validate.sh` *(fails: UnrealBuildTool and UnrealEditor not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c627a15ec883249fe89abac3801f2d