### PR TITLE
Bind grid battle end event and resolve results conditionally

### DIFF
--- a/Source/Skald/Skald_TurnManager.cpp
+++ b/Source/Skald/Skald_TurnManager.cpp
@@ -34,9 +34,18 @@ void ATurnManager::BeginPlay() {
   CachedWorldMap = Cast<AWorldMap>(
       UGameplayStatics::GetActorOfClass(GetWorld(), AWorldMap::StaticClass()));
 
+  const bool bOnWorldMap = (CachedWorldMap != nullptr);
+
   if (USkaldGameInstance *GI = GetGameInstance<USkaldGameInstance>()) {
-    if (GI->GridBattleManager) {
+    // Only resolve results when we are back on the world map
+    if (GI->GridBattleManager && bOnWorldMap) {
       ResolveGridBattleResult();
+    }
+
+    // On the battle map, listen for battle end and travel back on event
+    if (GI->GridBattleManager && !bOnWorldMap) {
+      GI->GridBattleManager->OnBattleEnded.AddDynamic(
+          this, &ATurnManager::HandleGridBattleEnded);
     }
 
     if (GI->bResumeTurns) {
@@ -58,6 +67,13 @@ void ATurnManager::BeginPlay() {
     if (!GM->IsWorldInitialized()) {
       GM->TryInitializeWorldAndStart();
     }
+  }
+}
+
+void ATurnManager::HandleGridBattleEnded(ESkaldFaction /*WinningFaction*/, int32 /*AttackerCasualties*/, int32 /*DefenderCasualties*/) {
+  if (UWorld *World = GetWorld()) {
+    // Travel back to the overworld after the tactical battle ends
+    World->ServerTravel(TEXT("WorldMap"));
   }
 }
 

--- a/Source/Skald/Skald_TurnManager.h
+++ b/Source/Skald/Skald_TurnManager.h
@@ -112,6 +112,9 @@ protected:
   UPROPERTY()
   AWorldMap *CachedWorldMap;
 
+  UFUNCTION()
+  void HandleGridBattleEnded(ESkaldFaction WinningFaction, int32 AttackerCasualties, int32 DefenderCasualties);
+
   /** Notify controllers and HUDs of a phase change. */
   void BroadcastCurrentPhase();
 


### PR DESCRIPTION
## Summary
- add handler for grid battle completion
- resolve grid battle results only when returning to world map
- travel back to overworld when battle manager signals battle end

## Testing
- `./Build/validate.sh` *(fails: UnrealBuildTool not found; UnrealEditor not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c6d569b4e88324b47c1665e00b3498