### PR TITLE
Use survivor cost when resolving battle results

### DIFF
--- a/Source/Skald/Skald_TurnManager.cpp
+++ b/Source/Skald/Skald_TurnManager.cpp
@@ -382,8 +382,10 @@ void ATurnManager::ResolveGridBattleResult_Implementation() {
   const int32 InitialSourceArmy = Source->ArmyUnits;
   const int32 InitialTargetArmy = Target->ArmyUnits;
 
-  const int32 AttackerSurvivors = GI->GridBattleManager->GetAttackerSurvivors();
-  const int32 DefenderSurvivors = GI->GridBattleManager->GetDefenderSurvivors();
+  const int32 AttackerSurvivors =
+      GI->GridBattleManager->GetAttackerSurvivorCost();
+  const int32 DefenderSurvivors =
+      GI->GridBattleManager->GetDefenderSurvivorCost();
 
   // Army-cost totals for potential downstream use
   const int32 AttackerSurvivorCost =


### PR DESCRIPTION
## Summary
- use survivor cost accessors when determining grid battle survivors

## Testing
- `make test` *(fails: No rule to make target 'test')*

------
https://chatgpt.com/codex/tasks/task_e_68c6d60bddc883248c50b45ce634fb5e