### PR TITLE
Handle battle victory in AdvanceTurn

### DIFF
--- a/Source/Skald/GridBattleManager.cpp
+++ b/Source/Skald/GridBattleManager.cpp
@@ -466,14 +466,30 @@ void UGridBattleManager::AdvanceTurn()
         return;
     }
 
-    InitiativeOrder.RemoveAll([](AFighterPawn* Fighter)
-    {
+    // Remove dead or null fighters
+    InitiativeOrder.RemoveAll([](AFighterPawn* Fighter) {
         return !Fighter || !Fighter->IsAlive();
     });
 
+    // If no fighters remain, end immediately
     if (InitiativeOrder.Num() == 0)
     {
         ActiveFighter = nullptr;
+        EndBattle();
+        return;
+    }
+
+    // Victory check: ensure both sides still exist
+    bool bAnyAttackers = false, bAnyDefenders = false;
+    for (AFighterPawn* F : InitiativeOrder)
+    {
+        if (!F) continue;
+        if (F->bIsAttacker) bAnyAttackers = true; else bAnyDefenders = true;
+        if (bAnyAttackers && bAnyDefenders) break;
+    }
+    if (!bAnyAttackers || !bAnyDefenders)
+    {
+        EndBattle();
         return;
     }
 


### PR DESCRIPTION
## Summary
- ensure AdvanceTurn ends battle when one side has no living fighters
- skip activation when no fighters remain

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c6d706ee988324949a1c3f2819173c