### PR TITLE
Advance turn when fighter uses all actions

### DIFF
--- a/Source/Skald/FighterPawn.cpp
+++ b/Source/Skald/FighterPawn.cpp
@@ -4,6 +4,7 @@
 #include "Components/TextBlock.h"
 #include "EngineUtils.h"
 #include "GridOverlayComponent.h"
+#include "GridBattleManager.h"
 #include "Skald_GameInstance.h"
 #include "TimerManager.h"
 
@@ -95,6 +96,17 @@ void AFighterPawn::MoveToCell(FIntPoint TargetCell) {
   SetActorLocation(NewLocation);
   ActionsRemaining -= Distance;
 
+  if (ActionsRemaining <= 0) {
+    if (UWorld *World = GetWorld()) {
+      if (USkaldGameInstance *GI =
+              Cast<USkaldGameInstance>(World->GetGameInstance())) {
+        if (GI->GridBattleManager) {
+          GI->GridBattleManager->AdvanceTurn();
+        }
+      }
+    }
+  }
+
   if (Grid) {
     Grid->SetOccupied(TargetCell, true);
     Grid->ClearHighlights();
@@ -171,6 +183,17 @@ void AFighterPawn::PerformAttack(AFighterPawn *Target) {
     Target->Destroy();
   }
   --ActionsRemaining;
+
+  if (ActionsRemaining <= 0) {
+    if (UWorld *World = GetWorld()) {
+      if (USkaldGameInstance *GI =
+              Cast<USkaldGameInstance>(World->GetGameInstance())) {
+        if (GI->GridBattleManager) {
+          GI->GridBattleManager->AdvanceTurn();
+        }
+      }
+    }
+  }
 
   if (Grid) {
     Grid->ClearHighlights();


### PR DESCRIPTION
## Summary
- End fighter turn automatically when all actions are spent after moving or attacking
- Include GridBattleManager header for turn control

## Testing
- `./Build/validate.sh` *(fails: UnrealBuildTool not found; cannot run tests)*

------
https://chatgpt.com/codex/tasks/task_e_68c6d838cd2c8324b715765147c04a23