### PR TITLE
Add debug flush toggle and remove persistent grid highlights

### DIFF
--- a/Source/Skald/GridOverlayComponent.cpp
+++ b/Source/Skald/GridOverlayComponent.cpp
@@ -145,7 +145,7 @@ void UGridOverlayComponent::HighlightCell(const FIntPoint &GridCoord,
 }
 
 void UGridOverlayComponent::ClearHighlights() const {
-  if (GetWorld()) {
+  if (GetWorld() && bFlushAllPersistentOnClear) {
     FlushPersistentDebugLines(GetWorld());
   }
 }
@@ -220,7 +220,7 @@ void UGridOverlayComponent::HighlightMovement(AFighterPawn *Fighter) {
     const int32 Distance = Node.Value;
 
     if (Distance > 0) {
-      HighlightCell(Cell, FColor::Green, 0.f, true);
+      HighlightCell(Cell, FColor::Green, 0.f, false);
     }
 
     if (Distance >= Range) {
@@ -263,7 +263,7 @@ void UGridOverlayComponent::HighlightAttack(AFighterPawn *Fighter) {
       }
 
       if (HasLineOfSight(StartCell, Target)) {
-        HighlightCell(Target, FColor::Red, 0.f, true);
+        HighlightCell(Target, FColor::Red, 0.f, false);
       }
     }
   }

--- a/Source/Skald/GridOverlayComponent.h
+++ b/Source/Skald/GridOverlayComponent.h
@@ -70,6 +70,10 @@ public:
     UFUNCTION(BlueprintCallable, Category = "Grid")
     void RegisterObstacle(UGridObstacleComponent *Obstacle);
 
+  /** If true, ClearHighlights() will FlushPersistentDebugLines for the entire world. */
+  UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="Grid|Debug")
+  bool bFlushAllPersistentOnClear = true;
+
   /** Whether landscape should be treated as an obstacle based on slope. */
   UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Grid|Landscape")
   bool bTreatLandscapeAsObstacle = true;


### PR DESCRIPTION
## Summary
- add option to flush all persistent debug lines when clearing highlights
- avoid persistent debug boxes in movement and attack previews

## Testing
- `clang-format -n Source/Skald/GridOverlayComponent.h Source/Skald/GridOverlayComponent.cpp`

------
https://chatgpt.com/codex/tasks/task_e_68c6da9d92c48324829f581ee7e3cd82