### PR TITLE
Broadcast active fighter changes

### DIFF
--- a/Source/Skald/GridBattleManager.cpp
+++ b/Source/Skald/GridBattleManager.cpp
@@ -352,6 +352,11 @@ AFighterPawn* UGridBattleManager::GetActiveFighter() const
     return ActiveFighter;
 }
 
+void UGridBattleManager::BroadcastActiveFighter()
+{
+    OnActiveFighterChanged.Broadcast(ActiveFighter);
+}
+
 TArray<FFighterDefinition> UGridBattleManager::GetFightersForFaction(ESkaldFaction Faction) const
 {
     TArray<FFighterDefinition> Fighters;
@@ -409,6 +414,7 @@ void UGridBattleManager::RollInitiative()
     {
         ActiveFighter->BeginActivation();
     }
+    BroadcastActiveFighter();
 }
 
 void UGridBattleManager::StartRound(FRandomStream& RandomStream)
@@ -458,6 +464,7 @@ void UGridBattleManager::StartRound(FRandomStream& RandomStream)
     if (ActiveFighter) {
         ActiveFighter->BeginActivation();
     }
+    BroadcastActiveFighter();
 }
 
 void UGridBattleManager::AdvanceTurn()
@@ -476,6 +483,7 @@ void UGridBattleManager::AdvanceTurn()
     if (InitiativeOrder.Num() == 0)
     {
         ActiveFighter = nullptr;
+        BroadcastActiveFighter();
         EndBattle();
         return;
     }
@@ -500,6 +508,7 @@ void UGridBattleManager::AdvanceTurn()
     {
         ActiveFighter->BeginActivation();
     }
+    BroadcastActiveFighter();
 }
 
 void UGridBattleManager::EndBattle()

--- a/Source/Skald/GridBattleManager.h
+++ b/Source/Skald/GridBattleManager.h
@@ -172,6 +172,12 @@ public:
     UPROPERTY(BlueprintAssignable, Category="Battle|Events")
     FOnBattleEnded OnBattleEnded;
 
+    /** Event fired when the active fighter changes. */
+    DECLARE_DYNAMIC_MULTICAST_DELEGATE_OneParam(FOnActiveFighterChanged, AFighterPawn*, NewFighter);
+
+    UPROPERTY(BlueprintAssignable, Category="Battle|Events")
+    FOnActiveFighterChanged OnActiveFighterChanged;
+
     /** Table containing fighter definitions. */
     UPROPERTY(BlueprintReadOnly, Category="Battle")
     UDataTable* FighterDefinitions;
@@ -221,5 +227,8 @@ protected:
 
     /** Whether fighters have been assigned to attacker or defender sides. */
     bool bTeamsAssigned = false;
+
+private:
+    void BroadcastActiveFighter();
 };
 


### PR DESCRIPTION
## Summary
- expose `OnActiveFighterChanged` event from `UGridBattleManager`
- broadcast when the active fighter changes during initiative, round start, and turn advance

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c6dc17dbe08324953cc557610f6f14