### PR TITLE
Initialize battle HUD and active fighter handler

### DIFF
--- a/Source/Skald/Skald_PlayerController.cpp
+++ b/Source/Skald/Skald_PlayerController.cpp
@@ -314,6 +314,54 @@ void ASkaldPlayerController::InitializeFighterSelectionIfNeeded() {
   }
 }
 
+void ASkaldPlayerController::InitializeBattleHUD() {
+  if (!IsLocalController()) return;
+  if (!BattleHUDWidgetClass) return;
+  if (!BattleHudWidget) {
+    BattleHudWidget = CreateWidget<UBattleHUDWidget>(this, BattleHUDWidgetClass);
+    if (BattleHudWidget) {
+      BattleHudWidget->AddToViewport(20);
+
+      // Hook HUD buttons to controller modes
+      BattleHudWidget->OnMovePressed.AddDynamic(this, &ASkaldPlayerController::BeginMoveMode);
+      BattleHudWidget->OnAttackPressed.AddDynamic(this, &ASkaldPlayerController::BeginAttackMode);
+    }
+  }
+
+  // Bind to active-fighter changes
+  if (USkaldGameInstance* GI = GetGameInstance<USkaldGameInstance>()) {
+    if (GI->GridBattleManager) {
+      GI->GridBattleManager->OnActiveFighterChanged.RemoveAll(this);
+      GI->GridBattleManager->OnActiveFighterChanged.AddDynamic(
+        this, &ASkaldPlayerController::HandleActiveFighterChanged);
+      // Initial bind
+      HandleActiveFighterChanged(GI->GridBattleManager->GetActiveFighter());
+    }
+  }
+}
+
+UGridOverlayComponent* ASkaldPlayerController::FindGridOverlay() const {
+  if (UWorld* World = GetWorld()) {
+    for (TActorIterator<AActor> It(World); It; ++It) {
+      if (UGridOverlayComponent* Comp = It->FindComponentByClass<UGridOverlayComponent>()) {
+        return Comp;
+      }
+    }
+  }
+  return nullptr;
+}
+
+void ASkaldPlayerController::HandleActiveFighterChanged(AFighterPawn* NewFighter) {
+  if (BattleHudWidget) {
+    BattleHudWidget->BindToFighter(NewFighter);
+  }
+  // Clear previous highlights when the turn swaps
+  if (UGridOverlayComponent* Grid = FindGridOverlay()) {
+    Grid->ClearHighlights();
+  }
+  CurrentCommandMode = EBattleCommandMode::None;
+}
+
 void ASkaldPlayerController::DetectBattleMap() {
   bIsBattleMap = false;
 
@@ -322,12 +370,14 @@ void ASkaldPlayerController::DetectBattleMap() {
   }
   if (CachedGameInstance && CachedGameInstance->bIsInBattleMap) {
     bIsBattleMap = true;
+    InitializeBattleHUD();
     return;
   }
 
   const FString CurrentMap = UGameplayStatics::GetCurrentLevelName(this, true);
   if (CurrentMap.Equals(TEXT("BattleMap"), ESearchCase::IgnoreCase)) {
     bIsBattleMap = true;
+    InitializeBattleHUD();
     return;
   }
 
@@ -348,6 +398,7 @@ void ASkaldPlayerController::DetectBattleMap() {
     if (CurrentMap.Equals(Map.ToSoftObjectPath().GetAssetName(),
                           ESearchCase::IgnoreCase)) {
       bIsBattleMap = true;
+      InitializeBattleHUD();
       break;
     }
   }
@@ -1138,16 +1189,7 @@ void ASkaldPlayerController::HandleGridClick() {
     return;
   }
 
-  UGridOverlayComponent *GridOverlay = nullptr;
-  if (UWorld *World = GetWorld()) {
-    for (TActorIterator<AActor> It(World); It; ++It) {
-      if (UGridOverlayComponent *Comp =
-              It->FindComponentByClass<UGridOverlayComponent>()) {
-        GridOverlay = Comp;
-        break;
-      }
-    }
-  }
+  UGridOverlayComponent *GridOverlay = FindGridOverlay();
 
   if (CurrentCommandMode == EBattleCommandMode::Move && GridOverlay) {
     const FIntPoint Cell = GridOverlay->WorldToGrid(Hit.Location);
@@ -1159,14 +1201,6 @@ void ASkaldPlayerController::HandleGridClick() {
   }
 
   GridBattleManager->AdvanceTurn();
-  if (BattleHudWidget) {
-    BattleHudWidget->BindToFighter(GridBattleManager->GetActiveFighter());
-  }
-
-  if (GridOverlay) {
-    GridOverlay->ClearHighlights();
-  }
-  CurrentCommandMode = EBattleCommandMode::None;
 }
 
 void ASkaldPlayerController::HandleBattleEnded(ESkaldFaction WinningFaction,

--- a/Source/Skald/Skald_PlayerController.h
+++ b/Source/Skald/Skald_PlayerController.h
@@ -18,6 +18,8 @@ class ASkaldGameState;
 class USkaldGameInstance;
 class UFighterSelectionWidget;
 class AWorldMap;
+class AFighterPawn;
+class UGridOverlayComponent;
 
 /** Command issued by the player during a battle. */
 UENUM()
@@ -225,6 +227,9 @@ public:
   void HandleBattleEnded(ESkaldFaction WinningFaction, int32 AttackerCasualties,
                          int32 DefenderCasualties);
 
+  UFUNCTION()
+  void HandleActiveFighterChanged(AFighterPawn* NewFighter);
+
   /** Server-side processing of an attack request. */
   UFUNCTION(Server, Reliable)
   void ServerHandleAttack(int32 FromID, int32 ToID, int32 ArmySent,
@@ -293,6 +298,9 @@ private:
 
   /** Create the faction selection widget for the local player. */
   void InitializeChoosePlayerWidget();
+
+  void InitializeBattleHUD();
+  UGridOverlayComponent* FindGridOverlay() const;
 
   /** Attempt to locate the world map and bind to its selection event. */
   void TryBindWorldMap();


### PR DESCRIPTION
## Summary
- Add `HandleActiveFighterChanged` and helpers to manage battle HUD lifecycle
- Initialize battle HUD and bind to active fighter when entering battle maps
- Use new grid overlay helper in click handling

## Testing
- `npm test` *(fails: package.json not found)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c6dd0a13808324a27545a6d28f0e79