### PR TITLE
Toggle move and attack previews in battle HUD

### DIFF
--- a/Source/Skald/UI/BattleHUDWidget.cpp
+++ b/Source/Skald/UI/BattleHUDWidget.cpp
@@ -34,21 +34,35 @@ void UBattleHUDWidget::BindToFighter(AFighterPawn *Fighter) {
 
 void UBattleHUDWidget::HandleMovePressed() {
   OnMovePressed.Broadcast();
+  bAttackSelected = false;
   if (!BoundFighter) {
     return;
   }
   if (UGridOverlayComponent *Grid = FindGridOverlay()) {
-    Grid->HighlightMovement(BoundFighter);
+    if (bMoveSelected) {
+      Grid->ClearHighlights();
+      bMoveSelected = false;
+    } else {
+      Grid->HighlightMovement(BoundFighter);
+      bMoveSelected = true;
+    }
   }
 }
 
 void UBattleHUDWidget::HandleAttackPressed() {
   OnAttackPressed.Broadcast();
+  bMoveSelected = false;
   if (!BoundFighter) {
     return;
   }
   if (UGridOverlayComponent *Grid = FindGridOverlay()) {
-    Grid->HighlightAttack(BoundFighter);
+    if (bAttackSelected) {
+      Grid->ClearHighlights();
+      bAttackSelected = false;
+    } else {
+      Grid->HighlightAttack(BoundFighter);
+      bAttackSelected = true;
+    }
   }
 }
 

--- a/Source/Skald/UI/BattleHUDWidget.h
+++ b/Source/Skald/UI/BattleHUDWidget.h
@@ -87,6 +87,12 @@ private:
   /** Find the grid overlay component in the world. */
   UGridOverlayComponent *FindGridOverlay() const;
 
+  /** Whether movement preview is currently shown. */
+  bool bMoveSelected = false;
+
+  /** Whether attack preview is currently shown. */
+  bool bAttackSelected = false;
+
   /** Fighter currently bound to the HUD. */
   UPROPERTY()
   AFighterPawn *BoundFighter;


### PR DESCRIPTION
## Summary
- Track attack and move selection in BattleHUDWidget
- Allow re-pressing move or attack buttons to clear grid highlights

## Testing
- `make test` *(fails: No rule to make target 'test')*

------
https://chatgpt.com/codex/tasks/task_e_68c6df115a60832491fd3168b28d8a84