### PR TITLE
Add RefreshStats function to battle HUD

### DIFF
--- a/Source/Skald/UI/BattleHUDWidget.cpp
+++ b/Source/Skald/UI/BattleHUDWidget.cpp
@@ -19,6 +19,8 @@ void UBattleHUDWidget::NativeConstruct() {
   }
 }
 
+void UBattleHUDWidget::RefreshStats() { UpdateStatPanel(); }
+
 void UBattleHUDWidget::BindToFighter(AFighterPawn *Fighter) {
   if (BoundFighter) {
     BoundFighter->OnHealthChanged.RemoveDynamic(
@@ -29,6 +31,28 @@ void UBattleHUDWidget::BindToFighter(AFighterPawn *Fighter) {
     BoundFighter->OnHealthChanged.AddDynamic(
         this, &UBattleHUDWidget::HandleHealthChanged);
     UpdateStatPanel();
+  } else {
+    if (HealthText) {
+      HealthText->SetText(FText::GetEmpty());
+    }
+    if (AttackText) {
+      AttackText->SetText(FText::GetEmpty());
+    }
+    if (MoveText) {
+      MoveText->SetText(FText::GetEmpty());
+    }
+    if (StrengthText) {
+      StrengthText->SetText(FText::GetEmpty());
+    }
+    if (DefenceText) {
+      DefenceText->SetText(FText::GetEmpty());
+    }
+    if (AttackRangeText) {
+      AttackRangeText->SetText(FText::GetEmpty());
+    }
+    if (AttackDiceText) {
+      AttackDiceText->SetText(FText::GetEmpty());
+    }
   }
 }
 

--- a/Source/Skald/UI/BattleHUDWidget.h
+++ b/Source/Skald/UI/BattleHUDWidget.h
@@ -18,6 +18,10 @@ class SKALD_API UBattleHUDWidget : public UUserWidget {
 public:
   virtual void NativeConstruct() override;
 
+  /** Refresh all stat text from the currently bound fighter. */
+  UFUNCTION(BlueprintCallable, Category = "Skald|Battle")
+  void RefreshStats();
+
   /** Bind this HUD to a fighter so its stats are displayed. */
   UFUNCTION(BlueprintCallable, Category = "Skald|Battle")
   void BindToFighter(AFighterPawn *Fighter);


### PR DESCRIPTION
## Summary
- expose RefreshStats blueprint callable function for BattleHUDWidget
- refresh stats when binding to fighter and clear text when unbound

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c6e147a0c88324b8d9ef3e5cd7dc61