### PR TITLE
Add active fighter event and registration hooks

### DIFF
--- a/Source/Skald/GridBattleManager.cpp
+++ b/Source/Skald/GridBattleManager.cpp
@@ -352,9 +352,24 @@ AFighterPawn* UGridBattleManager::GetActiveFighter() const
     return ActiveFighter;
 }
 
-void UGridBattleManager::BroadcastActiveFighter()
+void UGridBattleManager::RegisterFighter(AFighterPawn* Fighter, bool bAsAttacker)
 {
-    OnActiveFighterChanged.Broadcast(ActiveFighter);
+    if (!Fighter) return;
+    if (!InitiativeOrder.Contains(Fighter))
+    {
+        InitiativeOrder.Add(Fighter);
+    }
+    Fighter->bIsAttacker = bAsAttacker;
+}
+
+void UGridBattleManager::UnregisterFighter(AFighterPawn* Fighter)
+{
+    InitiativeOrder.Remove(Fighter);
+    if (ActiveFighter == Fighter)
+    {
+        ActiveFighter = nullptr;
+        OnActiveFighterChanged.Broadcast(nullptr);
+    }
 }
 
 TArray<FFighterDefinition> UGridBattleManager::GetFightersForFaction(ESkaldFaction Faction) const
@@ -414,7 +429,7 @@ void UGridBattleManager::RollInitiative()
     {
         ActiveFighter->BeginActivation();
     }
-    BroadcastActiveFighter();
+    OnActiveFighterChanged.Broadcast(ActiveFighter);
 }
 
 void UGridBattleManager::StartRound(FRandomStream& RandomStream)
@@ -464,7 +479,7 @@ void UGridBattleManager::StartRound(FRandomStream& RandomStream)
     if (ActiveFighter) {
         ActiveFighter->BeginActivation();
     }
-    BroadcastActiveFighter();
+    OnActiveFighterChanged.Broadcast(ActiveFighter);
 }
 
 void UGridBattleManager::AdvanceTurn()
@@ -479,13 +494,15 @@ void UGridBattleManager::AdvanceTurn()
         return !Fighter || !Fighter->IsAlive();
     });
 
-    // If no fighters remain, end immediately
     if (InitiativeOrder.Num() == 0)
     {
         ActiveFighter = nullptr;
-        BroadcastActiveFighter();
-        EndBattle();
+        OnActiveFighterChanged.Broadcast(nullptr);
         return;
+    }
+    if (CurrentTurn >= InitiativeOrder.Num())
+    {
+        CurrentTurn = 0;
     }
 
     // Victory check: ensure both sides still exist
@@ -508,7 +525,7 @@ void UGridBattleManager::AdvanceTurn()
     {
         ActiveFighter->BeginActivation();
     }
-    BroadcastActiveFighter();
+    OnActiveFighterChanged.Broadcast(ActiveFighter);
 }
 
 void UGridBattleManager::EndBattle()
@@ -542,7 +559,8 @@ void UGridBattleManager::EndBattle()
 
     int32 AttackerCasualties = AttackerInitialArmyCost - AttackerSurvivorCount;
     int32 DefenderCasualties = DefenderInitialArmyCost - DefenderSurvivorCount;
-
+    ActiveFighter = nullptr;
+    OnActiveFighterChanged.Broadcast(nullptr);
     OnBattleEnded.Broadcast(Winner, AttackerCasualties, DefenderCasualties);
 }
 

--- a/Source/Skald/GridBattleManager.h
+++ b/Source/Skald/GridBattleManager.h
@@ -8,6 +8,8 @@
 
 class AFighterPawn;
 
+DECLARE_DYNAMIC_MULTICAST_DELEGATE_OneParam(FOnActiveFighterChanged, AFighterPawn*, NewFighter);
+
 #include "GridBattleManager.generated.h"
 
 /** Statistics for a fighter in grid battle mode. */
@@ -173,10 +175,14 @@ public:
     FOnBattleEnded OnBattleEnded;
 
     /** Event fired when the active fighter changes. */
-    DECLARE_DYNAMIC_MULTICAST_DELEGATE_OneParam(FOnActiveFighterChanged, AFighterPawn*, NewFighter);
-
     UPROPERTY(BlueprintAssignable, Category="Battle|Events")
     FOnActiveFighterChanged OnActiveFighterChanged;
+
+    UFUNCTION(BlueprintCallable, Category="Battle")
+    void RegisterFighter(AFighterPawn* Fighter, bool bAsAttacker);
+
+    UFUNCTION(BlueprintCallable, Category="Battle")
+    void UnregisterFighter(AFighterPawn* Fighter);
 
     /** Table containing fighter definitions. */
     UPROPERTY(BlueprintReadOnly, Category="Battle")
@@ -227,8 +233,5 @@ protected:
 
     /** Whether fighters have been assigned to attacker or defender sides. */
     bool bTeamsAssigned = false;
-
-private:
-    void BroadcastActiveFighter();
 };
 


### PR DESCRIPTION
## Summary
- expose OnActiveFighterChanged event and fighter registration functions
- broadcast active fighter changes during initiative, round start, turn advance, and battle end

## Testing
- `./Build/validate.sh` *(fails: UnrealBuildTool not found; UnrealEditor not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c6eb7cc4e48324b6b22b250741f04a