### PR TITLE
Make grid overlay dimensions configurable

### DIFF
--- a/Source/Skald/GridOverlayComponent.cpp
+++ b/Source/Skald/GridOverlayComponent.cpp
@@ -15,8 +15,6 @@ UGridOverlayComponent::UGridOverlayComponent() {
 void UGridOverlayComponent::BeginPlay() {
   Super::BeginPlay();
 
-  Width = 50;
-  Height = 50;
   Cells.Init(false, Width * Height);
   ObscuredCells.Init(false, Width * Height);
 

--- a/Source/Skald/GridOverlayComponent.h
+++ b/Source/Skald/GridOverlayComponent.h
@@ -2,6 +2,7 @@
 
 #include "Components/ActorComponent.h"
 #include "CoreMinimal.h"
+#include "GridBattleManager.h"
 #include "GridOverlayComponent.generated.h"
 
 class AFighterPawn;
@@ -85,12 +86,15 @@ public:
 
 protected:
   /** Width of the grid in cells. */
-  int32 Width = 0;
+  UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Grid")
+  int32 Width = UGridBattleManager::GridSize;
 
   /** Height of the grid in cells. */
-  int32 Height = 0;
+  UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Grid")
+  int32 Height = UGridBattleManager::GridSize;
 
   /** Size of one cell in world units. */
+  UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Grid")
   float CellSize = 100.f;
 
   /** World origin of the grid (cell 0,0). */


### PR DESCRIPTION
## Summary
- expose grid width, height, and cell size as editable properties defaulting to `UGridBattleManager::GridSize`
- rely on these properties in `BeginPlay` instead of hard-coded grid values

## Testing
- `./Build/validate.sh` (UnrealBuildTool not found; skipping compile check. UnrealEditor not found; cannot run tests.)

------
https://chatgpt.com/codex/tasks/task_e_68c6edb814e48324bce416dbbfb2f44c