### PR TITLE
Use battle payload defender info for fighter selection cost

### DIFF
--- a/Source/Skald/SkaldTypes.h
+++ b/Source/Skald/SkaldTypes.h
@@ -117,6 +117,9 @@ struct SKALD_API FS_BattlePayload
     int32 ArmyCountSent = 0;
 
     UPROPERTY(BlueprintReadWrite, EditAnywhere)
+    int32 DefenderArmyCount = 0;
+
+    UPROPERTY(BlueprintReadWrite, EditAnywhere)
     bool IsCapitalAttack = false;
 
     UPROPERTY(BlueprintReadWrite, EditAnywhere)

--- a/Source/Skald/Skald_PlayerController.cpp
+++ b/Source/Skald/Skald_PlayerController.cpp
@@ -309,6 +309,17 @@ void ASkaldPlayerController::InitializeFighterSelectionIfNeeded() {
     }
     Selection->OnLockedIn.AddDynamic(
         this, &ASkaldPlayerController::HandleFighterSelectionLockedIn);
+
+    // Set MaxCost from the pending battle payload
+    if (CachedGameInstance)
+    {
+      const FS_BattlePayload& Battle = CachedGameInstance->PendingBattle;
+      int32 MyId = -1;
+      if (ASkaldPlayerState* PS = GetPlayerState<ASkaldPlayerState>()) { MyId = PS->GetPlayerId(); }
+      const bool bImAttacker = (Battle.AttackerPlayerID == MyId);
+
+      Selection->MaxCost = bImAttacker ? Battle.ArmyCountSent : Battle.DefenderArmyCount;
+    }
     Selection->AddToViewport();
     SetIgnoreMoveInput(true);
   }
@@ -579,6 +590,7 @@ void ASkaldPlayerController::ServerHandleAttack_Implementation(int32 FromID,
     Battle.FromTerritoryID = FromID;
     Battle.TargetTerritoryID = ToID;
     Battle.ArmyCountSent = ArmySent;
+    Battle.DefenderArmyCount = Target->ArmyUnits;
     Battle.IsCapitalAttack = Target->bIsCapital;
     if (bUseSiege && CachedGameMode) {
       const int32 SiegeID = CachedGameMode->ConsumeSiege(FromID);


### PR DESCRIPTION
## Summary
- allow fighter selection widget to set max cost from pending battle payload
- track defender army count in `FS_BattlePayload` and populate it when an attack is initiated

## Testing
- `g++ -std=c++17 -c Source/Skald/Skald_PlayerController.cpp` *(fails: CoreMinimal.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68c6efece4288324b43f480364cfca90