### PR TITLE
Prevent empty lock-in and improve cost display formatting

### DIFF
--- a/Source/Skald/UI/FighterSelectionWidget.cpp
+++ b/Source/Skald/UI/FighterSelectionWidget.cpp
@@ -90,12 +90,19 @@ bool UFighterSelectionWidget::ChooseFighter(const FFighterDefinition &Fighter) {
   return true;
 }
 
-void UFighterSelectionWidget::LockIn() { OnLockedIn.Broadcast(); }
+void UFighterSelectionWidget::LockIn() {
+  if (ChosenFighters.Num() == 0 || CurrentCost > MaxCost) {
+    return;
+  }
+  OnLockedIn.Broadcast();
+}
 
 void UFighterSelectionWidget::UpdateCostDisplay() {
   if (CostDisplayText) {
-    CostDisplayText->SetText(FText::Format(FText::FromString("{0} / {1}"),
-                                          FText::AsNumber(CurrentCost),
-                                          FText::AsNumber(MaxCost)));
+    FFormatNamedArguments Args;
+    Args.Add(TEXT("Cur"), CurrentCost);
+    Args.Add(TEXT("Max"), MaxCost);
+    CostDisplayText->SetText(
+        FText::Format(FText::FromString("{Cur} / {Max}"), Args));
   }
 }


### PR DESCRIPTION
## Summary
- avoid locking in when no fighters chosen or cost exceeds budget
- format cost display using named arguments for safety

## Testing
- `./Build/validate.sh` *(fails: UnrealBuildTool not found; UnrealEditor not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c6f213e9b48324bcba8e7dc83fc400