### PR TITLE
Add defender army count field to battle payload

### DIFF
--- a/Source/Skald/SkaldTypes.h
+++ b/Source/Skald/SkaldTypes.h
@@ -116,7 +116,8 @@ struct SKALD_API FS_BattlePayload
     UPROPERTY(BlueprintReadWrite, EditAnywhere)
     int32 ArmyCountSent = 0;
 
-    UPROPERTY(BlueprintReadWrite, EditAnywhere)
+    // Budget for the defending side (e.g., target army units). Optional; 0 = unknown.
+    UPROPERTY(EditAnywhere, BlueprintReadWrite)
     int32 DefenderArmyCount = 0;
 
     UPROPERTY(BlueprintReadWrite, EditAnywhere)


### PR DESCRIPTION
## Summary
- clarify defender army budget in battle payload

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c6f42fefcc8324be1f5d2ae58d77bd