### PR TITLE
Clamp defender army count before grid battle

### DIFF
--- a/Source/Skald/Skald_PlayerController.cpp
+++ b/Source/Skald/Skald_PlayerController.cpp
@@ -590,7 +590,6 @@ void ASkaldPlayerController::ServerHandleAttack_Implementation(int32 FromID,
     Battle.FromTerritoryID = FromID;
     Battle.TargetTerritoryID = ToID;
     Battle.ArmyCountSent = ArmySent;
-    Battle.DefenderArmyCount = Target->ArmyUnits;
     Battle.IsCapitalAttack = Target->bIsCapital;
     if (bUseSiege && CachedGameMode) {
       const int32 SiegeID = CachedGameMode->ConsumeSiege(FromID);
@@ -598,6 +597,7 @@ void ASkaldPlayerController::ServerHandleAttack_Implementation(int32 FromID,
         Battle.AssignedSiegeIDs.Add(SiegeID);
       }
     }
+    Battle.DefenderArmyCount = Target ? FMath::Max(0, Target->ArmyUnits) : 0;
     TurnManager->TriggerGridBattle(Battle);
     return;
   }


### PR DESCRIPTION
## Summary
- Prevent negative defender units by clamping army count when sending battle payload

## Testing
- ⚠️ `bash Build/validate.sh` *(UnrealBuildTool/UnrealEditor not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68c6f7b01bdc8324a2b46f05582b0080