### PR TITLE
Use battle payload to cap fighter selection

### DIFF
--- a/Source/Skald/Skald_PlayerController.cpp
+++ b/Source/Skald/Skald_PlayerController.cpp
@@ -306,20 +306,29 @@ void ASkaldPlayerController::InitializeFighterSelectionIfNeeded() {
       Selection->AvailableFighters =
           CachedGameInstance->GridBattleManager->GetFightersForFaction(
               PlayerFaction);
+      // Set selection budget from pending battle; attacker uses ArmyCountSent,
+      // defender uses DefenderArmyCount.
+      const FS_BattlePayload &Battle =
+          CachedGameInstance->PendingBattle;
+
+      int32 MyId = -1;
+      if (ASkaldPlayerState *PS_Local =
+              GetPlayerState<ASkaldPlayerState>()) {
+        MyId = PS_Local->GetPlayerId();
+      }
+      const bool bImAttacker = (Battle.AttackerPlayerID == MyId);
+
+      // Fallback: if DefenderArmyCount isn’t populated, mirror the
+      // attacker’s budget.
+      const int32 DefenderBudget =
+          (Battle.DefenderArmyCount > 0) ? Battle.DefenderArmyCount
+                                         : Battle.ArmyCountSent;
+
+      Selection->MaxCost =
+          bImAttacker ? Battle.ArmyCountSent : DefenderBudget;
     }
     Selection->OnLockedIn.AddDynamic(
         this, &ASkaldPlayerController::HandleFighterSelectionLockedIn);
-
-    // Set MaxCost from the pending battle payload
-    if (CachedGameInstance)
-    {
-      const FS_BattlePayload& Battle = CachedGameInstance->PendingBattle;
-      int32 MyId = -1;
-      if (ASkaldPlayerState* PS = GetPlayerState<ASkaldPlayerState>()) { MyId = PS->GetPlayerId(); }
-      const bool bImAttacker = (Battle.AttackerPlayerID == MyId);
-
-      Selection->MaxCost = bImAttacker ? Battle.ArmyCountSent : Battle.DefenderArmyCount;
-    }
     Selection->AddToViewport();
     SetIgnoreMoveInput(true);
   }

--- a/Source/Skald/UI/FighterSelectionWidget.cpp
+++ b/Source/Skald/UI/FighterSelectionWidget.cpp
@@ -91,6 +91,7 @@ bool UFighterSelectionWidget::ChooseFighter(const FFighterDefinition &Fighter) {
 }
 
 void UFighterSelectionWidget::LockIn() {
+  // Prevent empty or over-budget lock-ins.
   if (ChosenFighters.Num() == 0 || CurrentCost > MaxCost) {
     return;
   }


### PR DESCRIPTION
## Summary
- Derive fighter selection budget from the pending battle payload, respecting attacker/defender roles and providing a fallback when defender data is missing
- Document guard against empty or over-budget fighter selections

## Testing
- `./Build/validate.sh` *(fails: UnrealBuildTool not found; UnrealEditor not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c6f896f42c8324a1931acd5e4c9591