### PR TITLE
Fix delegate wrapper generation in grid battle manager

### DIFF
--- a/Source/Skald/GridBattleManager.h
+++ b/Source/Skald/GridBattleManager.h
@@ -8,14 +8,14 @@
 
 class AFighterPawn;
 
-#include "GridBattleManager.generated.h"
-
 // Event fired when a grid battle concludes.
 DECLARE_DYNAMIC_MULTICAST_DELEGATE_ThreeParams(
     FOnBattleEnded, ESkaldFaction, WinningFaction, int32, AttackerCasualties, int32, DefenderCasualties);
 
 // Event fired whenever the active fighter changes (including nullptr)
 DECLARE_DYNAMIC_MULTICAST_DELEGATE_OneParam(FOnActiveFighterChanged, AFighterPawn*, NewFighter);
+
+#include "GridBattleManager.generated.h"
 
 /** Statistics for a fighter in grid battle mode. */
 USTRUCT(BlueprintType)


### PR DESCRIPTION
## Summary
- Declare grid battle delegates before `GridBattleManager.generated.h` so UHT emits wrappers
- Ensure forward declaration precedes delegates and keep active fighter change event exposed

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c70882ba988324ab427b2e0bffa1d6