### PR TITLE
Fix delegate wrapper errors by moving generated include

### DIFF
--- a/Source/Skald/GridBattleManager.h
+++ b/Source/Skald/GridBattleManager.h
@@ -5,6 +5,7 @@
 #include "Engine/DataTable.h"
 #include "GameFramework/Actor.h"
 #include "SkaldTypes.h"
+#include "GridBattleManager.generated.h"
 
 class AFighterPawn; // MUST be before the delegates
 
@@ -12,8 +13,6 @@ DECLARE_DYNAMIC_MULTICAST_DELEGATE_ThreeParams(
     FOnBattleEnded, ESkaldFaction, WinningFaction, int32, AttackerCasualties, int32, DefenderCasualties);
 
 DECLARE_DYNAMIC_MULTICAST_DELEGATE_OneParam(FOnActiveFighterChanged, AFighterPawn*, NewFighter);
-
-#include "GridBattleManager.generated.h"
 
 /** Statistics for a fighter in grid battle mode. */
 USTRUCT(BlueprintType)


### PR DESCRIPTION
## Summary
- ensure GridBattleManager includes its generated header before declaring delegates

## Testing
- `g++ -c Source/Skald/GridBattleManager.cpp -I./Source -std=c++17` *(fails: CoreMinimal.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68c70dbfbae88324946fc9ff6a0a4ddd