### PR TITLE
Refactor lobby UI ownership and fighter roster replication

### DIFF
--- a/Source/Skald/LobbyGameMode.cpp
+++ b/Source/Skald/LobbyGameMode.cpp
@@ -11,22 +11,6 @@ ALobbyGameMode::ALobbyGameMode()
 void ALobbyGameMode::BeginPlay()
 {
     Super::BeginPlay();
-
-    if (LobbyWidgetClass)
-    {
-        UUserWidget* Widget = CreateWidget<UUserWidget>(GetWorld(), LobbyWidgetClass);
-        if (Widget)
-        {
-            Widget->AddToViewport();
-
-            if (APlayerController* PC = GetWorld()->GetFirstPlayerController())
-            {
-                PC->SetInputMode(FInputModeUIOnly());
-                PC->bShowMouseCursor = true;
-                PC->bEnableClickEvents = true;
-                PC->bEnableMouseOverEvents = true;
-            }
-        }
-    }
+    // REMOVE UI creation here; UI is now created in ALobbyPlayerController::BeginPlay() on the local client.
 }
 

--- a/Source/Skald/LobbyMenuWidget.cpp
+++ b/Source/Skald/LobbyMenuWidget.cpp
@@ -6,6 +6,8 @@
 #include "Kismet/GameplayStatics.h"
 #include "Kismet/KismetSystemLibrary.h"
 #include "UObject/ConstructorHelpers.h"
+#include "Skald_GameState.h"
+#include "UI/FighterSelectionWidget.h"
 
 ULobbyMenuWidget::ULobbyMenuWidget(const FObjectInitializer& ObjectInitializer)
     : Super(ObjectInitializer) {
@@ -39,6 +41,17 @@ void ULobbyMenuWidget::NativeConstruct()
     if (ExitButton)
     {
         ExitButton->OnClicked.AddDynamic(this, &ULobbyMenuWidget::OnExit);
+    }
+
+    if (ASkaldGameState* GS = GetWorld() ? GetWorld()->GetGameState<ASkaldGameState>() : nullptr)
+    {
+        if (FighterSelection)
+        {
+            // Initial fill
+            FighterSelection->SetAvailableFighters(GS->GetFighterRoster());
+            // Live updates
+            GS->OnFighterRosterUpdated.AddDynamic(this, &ULobbyMenuWidget::HandleFighterRosterUpdated);
+        }
     }
 }
 
@@ -104,6 +117,17 @@ void ULobbyMenuWidget::OnExit()
     if (APlayerController* PC = GetOwningPlayer())
     {
         UKismetSystemLibrary::QuitGame(this, PC, EQuitPreference::Quit, false);
+    }
+}
+
+void ULobbyMenuWidget::HandleFighterRosterUpdated()
+{
+    if (ASkaldGameState* GS = GetWorld() ? GetWorld()->GetGameState<ASkaldGameState>() : nullptr)
+    {
+        if (FighterSelection)
+        {
+            FighterSelection->SetAvailableFighters(GS->GetFighterRoster());
+        }
     }
 }
 

--- a/Source/Skald/LobbyMenuWidget.h
+++ b/Source/Skald/LobbyMenuWidget.h
@@ -9,6 +9,7 @@ class UVerticalBox;
 class ULoadGameWidget;
 class USettingsWidget;
 class UStartGameWidget;
+class UFighterSelectionWidget;
 
 /**
  * Main menu widget shown on the lobby map.
@@ -45,9 +46,12 @@ public:
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="Lobby")
     TSubclassOf<UStartGameWidget> StartGameWidgetClass;
 
-protected:
     virtual void NativeConstruct() override;
 
+    UFUNCTION(BlueprintCallable, BlueprintPure, Category="UI")
+    UFighterSelectionWidget* GetFighterSelectionWidget() const { return FighterSelection; }
+
+protected:
     UFUNCTION(BlueprintCallable)
     void OnStartGame();
 
@@ -59,5 +63,12 @@ protected:
 
     UFUNCTION(BlueprintCallable)
     void OnExit();
+
+    // Must match the child widget name in the BP and be IsVariable=true
+    UPROPERTY(BlueprintReadOnly, meta=(BindWidgetOptional))
+    UFighterSelectionWidget* FighterSelection;
+
+    UFUNCTION()
+    void HandleFighterRosterUpdated();
 };
 

--- a/Source/Skald/Private/LobbyPlayerController.cpp
+++ b/Source/Skald/Private/LobbyPlayerController.cpp
@@ -1,0 +1,33 @@
+#include "LobbyPlayerController.h"
+#include "Blueprint/UserWidget.h"
+#include "LobbyMenuWidget.h"
+
+void ALobbyPlayerController::BeginPlay()
+{
+    Super::BeginPlay();
+    if (IsLocalController())
+    {
+        InitLobbyUI();
+    }
+}
+
+void ALobbyPlayerController::InitLobbyUI()
+{
+    if (LobbyWidgetInstance || !LobbyWidgetClass) { return; }
+
+    LobbyWidgetInstance = CreateWidget<ULobbyMenuWidget>(this, LobbyWidgetClass);
+    if (!LobbyWidgetInstance) { return; }
+
+    LobbyWidgetInstance->AddToViewport();
+
+    FInputModeUIOnly Mode;
+    Mode.SetWidgetToFocus(LobbyWidgetInstance->TakeWidget());
+    Mode.SetLockMouseToViewportBehavior(EMouseLockMode::DoNotLock);
+    SetInputMode(Mode);
+
+    bShowMouseCursor = true;
+    bEnableClickEvents = true;
+    bEnableMouseOverEvents = true;
+
+    // Wiring fighter selection happens inside the lobby widget init (see Change 4).
+}

--- a/Source/Skald/Public/LobbyPlayerController.h
+++ b/Source/Skald/Public/LobbyPlayerController.h
@@ -1,0 +1,23 @@
+#pragma once
+#include "CoreMinimal.h"
+#include "GameFramework/PlayerController.h"
+#include "LobbyPlayerController.generated.h"
+
+class ULobbyMenuWidget;
+
+UCLASS()
+class SKALD_API ALobbyPlayerController : public APlayerController
+{
+    GENERATED_BODY()
+public:
+    virtual void BeginPlay() override;
+
+protected:
+    UPROPERTY(EditDefaultsOnly, Category="UI")
+    TSubclassOf<UUserWidget> LobbyWidgetClass;
+
+    UPROPERTY()
+    ULobbyMenuWidget* LobbyWidgetInstance = nullptr;
+
+    void InitLobbyUI();
+};

--- a/Source/Skald/Skald_GameState.cpp
+++ b/Source/Skald/Skald_GameState.cpp
@@ -14,6 +14,7 @@ void ASkaldGameState::GetLifetimeReplicatedProps(
 
     DOREPLIFETIME(ASkaldGameState, Players);
     DOREPLIFETIME(ASkaldGameState, CurrentTurnIndex);
+    DOREPLIFETIME(ASkaldGameState, FighterRoster); // NEW
 }
 
 void ASkaldGameState::AddPlayerState(APlayerState* PlayerState)
@@ -81,6 +82,11 @@ void ASkaldGameState::OnRep_CurrentTurnIndex()
     OnTurnIndexChanged.Broadcast(CurrentTurnIndex);
 }
 
+void ASkaldGameState::OnRep_FighterRoster()
+{
+    OnFighterRosterUpdated.Broadcast();
+}
+
 void ASkaldGameState::ClampTurnIndex()
 {
     if (Players.Num() == 0)
@@ -109,5 +115,12 @@ void ASkaldGameState::SortAndDedupPlayers()
             Players.RemoveAt(i);
         }
     }
+}
+
+void ASkaldGameState::ServerSetFighterRoster_Implementation(const TArray<FFighterDefinition>& InRoster)
+{
+    FighterRoster = InRoster;
+    // Fire local notify so server-side UI (if any) also refreshes immediately
+    OnRep_FighterRoster();
 }
 

--- a/Source/Skald/Skald_GameState.h
+++ b/Source/Skald/Skald_GameState.h
@@ -2,12 +2,14 @@
 
 #include "CoreMinimal.h"
 #include "GameFramework/GameStateBase.h"
+#include "GridBattleManager.h" // for FFighterDefinition (ensure it’s a USTRUCT)
 #include "Skald_GameState.generated.h"
 
 class ASkaldPlayerState;
 
 DECLARE_DYNAMIC_MULTICAST_DELEGATE(FSkaldPlayersUpdated);
 DECLARE_DYNAMIC_MULTICAST_DELEGATE_OneParam(FSkaldTurnIndexChanged, int32, NewTurnIndex);
+DECLARE_DYNAMIC_MULTICAST_DELEGATE(FFighterRosterUpdated);
 
 /**
  * Stores information about players and the current turn.
@@ -32,6 +34,14 @@ public:
     UPROPERTY(BlueprintAssignable, Category="GameState|Events")
     FSkaldTurnIndexChanged OnTurnIndexChanged;
 
+    /** Replicated roster of all fighters available in the lobby. */
+    UPROPERTY(BlueprintReadOnly, ReplicatedUsing=OnRep_FighterRoster, Category="GameState|Fighters")
+    TArray<FFighterDefinition> FighterRoster;
+
+    /** Broadcast whenever FighterRoster replicates/changes. */
+    UPROPERTY(BlueprintAssignable, Category="GameState|Events")
+    FFighterRosterUpdated OnFighterRosterUpdated;
+
     /** Index of the player whose turn is active. */
     UPROPERTY(BlueprintReadOnly, ReplicatedUsing=OnRep_CurrentTurnIndex, Category="GameState")
     int32 CurrentTurnIndex;
@@ -48,12 +58,23 @@ public:
     UFUNCTION(BlueprintCallable, BlueprintPure, Category="GameState")
     ASkaldPlayerState* GetPlayerById(int32 PlayerID) const;
 
+    /** Server API to set/update roster. */
+    UFUNCTION(Server, Reliable)
+    void ServerSetFighterRoster(const TArray<FFighterDefinition>& InRoster);
+
+    /** Getter for BP/UI */
+    UFUNCTION(BlueprintCallable, BlueprintPure, Category="GameState|Fighters")
+    const TArray<FFighterDefinition>& GetFighterRoster() const { return FighterRoster; }
+
 protected:
     UFUNCTION()
     void OnRep_Players();
 
     UFUNCTION()
     void OnRep_CurrentTurnIndex();
+
+    UFUNCTION()
+    void OnRep_FighterRoster();
 
     /** Keep CurrentTurnIndex in bounds after roster changes. */
     void ClampTurnIndex();

--- a/Source/Skald/UI/FighterSelectionWidget.cpp
+++ b/Source/Skald/UI/FighterSelectionWidget.cpp
@@ -4,6 +4,8 @@
 #include "Components/ScrollBox.h"
 #include "Components/TextBlock.h"
 
+DEFINE_LOG_CATEGORY_STATIC(LogSkaldUI, Log, All);
+
 void UFighterEntryWidget::NativeConstruct() {
   Super::NativeConstruct();
   if (SelectButton) {
@@ -43,12 +45,37 @@ void UFighterEntryWidget::Init(const FFighterDefinition &InFighter,
   if (CostText) {
     CostText->SetText(FText::AsNumber(Fighter.Stats.ArmyCost));
   }
+
+  // Disable selection if fighter cannot be afforded.
+  if (SelectButton && Owner)
+  {
+      const bool bCan = Owner->CanAfford(Fighter);
+      SelectButton->SetIsEnabled(bCan);
+  }
 }
 
 void UFighterEntryWidget::HandleClicked() {
   if (Owner) {
     Owner->ChooseFighter(Fighter);
   }
+}
+
+void UFighterSelectionWidget::SetAvailableFighters(const TArray<FFighterDefinition>& InFighters)
+{
+    AvailableFighters = InFighters;
+    PopulateFighterList();
+}
+
+void UFighterSelectionWidget::NativePreConstruct()
+{
+    Super::NativePreConstruct();
+    UpdateCostDisplay();
+#if WITH_EDITOR
+    if (IsDesignTime())
+    {
+        PopulateFighterList();
+    }
+#endif
 }
 
 void UFighterSelectionWidget::NativeConstruct() {
@@ -61,17 +88,37 @@ void UFighterSelectionWidget::NativeConstruct() {
 }
 
 void UFighterSelectionWidget::PopulateFighterList() {
-  if (!FighterList || !FighterEntryClass) {
+  if (!FighterList)
+  {
+    UE_LOG(LogSkaldUI, Warning, TEXT("[FighterSelection] FighterList is null. "
+           "UMG variable must be named 'FighterList' and IsVariable=true."));
     return;
   }
+  if (!FighterEntryClass)
+  {
+    UE_LOG(LogSkaldUI, Warning, TEXT("[FighterSelection] FighterEntryClass is null. "
+           "Set it in the widget defaults."));
+    return;
+  }
+
   FighterList->ClearChildren();
+
+  if (AvailableFighters.Num() == 0)
+  {
+    UE_LOG(LogSkaldUI, Warning, TEXT("[FighterSelection] AvailableFighters is EMPTY."));
+  }
+
+  int32 Added = 0;
   for (const FFighterDefinition &Fighter : AvailableFighters) {
     if (UFighterEntryWidget *Entry =
             CreateWidget<UFighterEntryWidget>(this, FighterEntryClass)) {
       Entry->Init(Fighter, this);
       FighterList->AddChild(Entry);
+      ++Added;
     }
   }
+
+  UE_LOG(LogSkaldUI, Log, TEXT("[FighterSelection] Populated %d fighter entries."), Added);
 }
 
 bool UFighterSelectionWidget::CanAfford(

--- a/Source/Skald/UI/FighterSelectionWidget.h
+++ b/Source/Skald/UI/FighterSelectionWidget.h
@@ -96,13 +96,15 @@ class SKALD_API UFighterSelectionWidget : public UUserWidget {
 
 public:
   virtual void NativeConstruct() override;
+  virtual void NativePreConstruct() override;
 
   /** Faction of the player owning this selection widget. */
   UPROPERTY(BlueprintReadOnly, Category = "Skald|Fighter")
   ESkaldFaction PlayerFaction = ESkaldFaction::None;
 
   /** Fighters that can be chosen. */
-  UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Skald|Fighter")
+  // Make these spawn-exposed so they can be passed at CreateWidget time:
+  UPROPERTY(EditAnywhere, BlueprintReadWrite, meta=(ExposeOnSpawn=true), Category = "Skald|Fighter")
   TArray<FFighterDefinition> AvailableFighters;
 
   /** Fighters chosen by the player. */
@@ -110,7 +112,7 @@ public:
   TArray<FFighterDefinition> ChosenFighters;
 
   /** Maximum total army cost allowed. */
-  UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Skald|Fighter")
+  UPROPERTY(EditAnywhere, BlueprintReadWrite, meta=(ExposeOnSpawn=true), Category = "Skald|Fighter")
   int32 MaxCost = 0;
 
   /** Current cost of chosen fighters. */
@@ -148,6 +150,10 @@ public:
   /** Lock in the current selection. */
   UFUNCTION(BlueprintCallable, Category = "Skald|Fighter")
   void LockIn();
+
+  // Add a setter that repopulates when data arrives later:
+  UFUNCTION(BlueprintCallable, Category="Skald|Fighter")
+  void SetAvailableFighters(const TArray<FFighterDefinition>& InFighters);
 
 protected:
   /** Populate the fighter list scroll box. */


### PR DESCRIPTION
## Summary
- Move lobby menu creation to a new `ALobbyPlayerController` and remove GameMode UI spawning
- Replicate fighter roster through `ASkaldGameState` with update events
- Make fighter selection widget data-driven with logging and dynamic population
- Wire lobby menu to update fighter selection from replicated roster

## Testing
- `Build/validate.sh` *(fails: UnrealBuildTool not found; UnrealEditor not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c71cfa69d8832495b03b0e506f78da