### PR TITLE
Forward declare UUserWidget in LobbyPlayerController header

### DIFF
--- a/Source/Skald/Public/LobbyPlayerController.h
+++ b/Source/Skald/Public/LobbyPlayerController.h
@@ -4,6 +4,7 @@
 #include "LobbyPlayerController.generated.h"
 
 class ULobbyMenuWidget;
+class UUserWidget;
 
 UCLASS()
 class SKALD_API ALobbyPlayerController : public APlayerController


### PR DESCRIPTION
## Summary
- forward declare `UUserWidget` in `LobbyPlayerController` so `TSubclassOf` property compiles

## Testing
- `./Build/validate.sh` *(fails: UnrealBuildTool not found; skipping compile check. UnrealEditor not found; cannot run tests.)*

------
https://chatgpt.com/codex/tasks/task_e_68c71f8b64b083249594c6a78e823ad1