### PR TITLE
Expose CanAfford to public for fighter selection

### DIFF
--- a/Source/Skald/UI/FighterSelectionWidget.h
+++ b/Source/Skald/UI/FighterSelectionWidget.h
@@ -151,6 +151,10 @@ public:
   UFUNCTION(BlueprintCallable, Category = "Skald|Fighter")
   void LockIn();
 
+  /** Check whether a fighter can be afforded with remaining cost. */
+  UFUNCTION(BlueprintCallable, BlueprintPure, Category = "Skald|Fighter")
+  bool CanAfford(const FFighterDefinition& Fighter) const;
+
   // Add a setter that repopulates when data arrives later:
   UFUNCTION(BlueprintCallable, Category="Skald|Fighter")
   void SetAvailableFighters(const TArray<FFighterDefinition>& InFighters);
@@ -159,10 +163,6 @@ protected:
   /** Populate the fighter list scroll box. */
   UFUNCTION(BlueprintCallable, Category = "Skald|Fighter")
   void PopulateFighterList();
-
-  /** Check whether a fighter can be afforded with remaining cost. */
-  UFUNCTION(BlueprintCallable, Category = "Skald|Fighter")
-  bool CanAfford(const FFighterDefinition &Fighter) const;
 
   /** Update cost display text from current/max cost. */
   UFUNCTION(BlueprintCallable, Category = "Skald|Fighter")


### PR DESCRIPTION
## Summary
- Move `CanAfford` to public API on `UFighterSelectionWidget`
- Mark `CanAfford` as `BlueprintPure` so it can be used in UMG logic

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c72467917c8324967efaf84b0a0935