### PR TITLE
Implement pre-battle fighter selection flow

### DIFF
--- a/Source/Skald/FighterDataLibrary.cpp
+++ b/Source/Skald/FighterDataLibrary.cpp
@@ -1,0 +1,48 @@
+#include "FighterDataLibrary.h"
+
+#include "Engine/DataTable.h"
+#include "Skald_GameInstance.h"
+
+/** Resolve the fighter data table from game singletons or a fallback path. */
+static UDataTable* ResolveFighterDataTable(UObject* WorldContext)
+{
+    static const TCHAR* FallbackPath = TEXT("/Game/DataTables/FighterTable.FighterTable");
+
+    if (WorldContext)
+    {
+        if (UWorld* World = WorldContext->GetWorld())
+        {
+            if (USkaldGameInstance* GI = World->GetGameInstance<USkaldGameInstance>())
+            {
+                if (GI->GridBattleManager && GI->GridBattleManager->FighterDefinitions)
+                {
+                    return GI->GridBattleManager->FighterDefinitions;
+                }
+            }
+        }
+    }
+
+    return LoadObject<UDataTable>(nullptr, FallbackPath);
+}
+
+TArray<FFighterDefinition> UFighterDataLibrary::GetFightersForFaction(UObject* WorldContext, ESkaldFaction Faction)
+{
+    TArray<FFighterDefinition> Out;
+    if (UDataTable* DT = ResolveFighterDataTable(WorldContext))
+    {
+        TArray<FName> Rows;
+        DT->GetRowNames(Rows);
+        for (const FName& N : Rows)
+        {
+            if (const FFighterDefinition* Row = DT->FindRow<FFighterDefinition>(N, TEXT("FighterFilter")))
+            {
+                if (Row->Faction == Faction)
+                {
+                    Out.Add(*Row);
+                }
+            }
+        }
+    }
+    return Out;
+}
+

--- a/Source/Skald/FighterDataLibrary.h
+++ b/Source/Skald/FighterDataLibrary.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include "Kismet/BlueprintFunctionLibrary.h"
+#include "GridBattleManager.h" // for FFighterDefinition
+#include "SkaldTypes.h"
+#include "FighterDataLibrary.generated.h"
+
+/** Utility functions for accessing fighter data tables. */
+UCLASS()
+class SKALD_API UFighterDataLibrary : public UBlueprintFunctionLibrary
+{
+    GENERATED_BODY()
+public:
+    /** Return fighter definitions belonging to the specified faction. */
+    UFUNCTION(BlueprintCallable, Category="Skald|Fighters", meta=(WorldContext="WorldContext"))
+    static TArray<FFighterDefinition> GetFightersForFaction(UObject* WorldContext, ESkaldFaction Faction);
+};
+

--- a/Source/Skald/Skald_GameMode.cpp
+++ b/Source/Skald/Skald_GameMode.cpp
@@ -551,6 +551,28 @@ void ASkaldGameMode::HandlePlayerLockedIn(ASkaldPlayerState *PS) {
   TryInitializeWorldAndStart();
 }
 
+void ASkaldGameMode::BeginPreBattleSelection(ASkaldPlayerState* A, ASkaldPlayerState* D,
+                                             int32 ABudget, int32 DBudget)
+{
+    if (!HasAuthority())
+    {
+        return;
+    }
+    if (!A || !D)
+    {
+        return;
+    }
+
+    if (ASkaldPlayerController* APC = Cast<ASkaldPlayerController>(A->GetOwner()))
+    {
+        APC->Client_ShowFighterSelection(ABudget, A->Faction);
+    }
+    if (ASkaldPlayerController* DPC = Cast<ASkaldPlayerController>(D->GetOwner()))
+    {
+        DPC->Client_ShowFighterSelection(DBudget, D->Faction);
+    }
+}
+
 void ASkaldGameMode::RefreshHUDs() {
   ASkaldGameState *GS = GetGameState<ASkaldGameState>();
   if (!GS) {

--- a/Source/Skald/Skald_GameMode.h
+++ b/Source/Skald/Skald_GameMode.h
@@ -59,6 +59,11 @@ public:
   /** Handle a player confirming their name and faction selection. */
   void HandlePlayerLockedIn(ASkaldPlayerState *PS);
 
+  /** Initiate pre-battle fighter selection for both sides. */
+  UFUNCTION(BlueprintCallable, Category="Skald|Battle")
+  void BeginPreBattleSelection(ASkaldPlayerState* AttackerPS, ASkaldPlayerState* DefenderPS,
+                               int32 AttackerBudget, int32 DefenderBudget);
+
 protected:
   /** Handles turn sequencing for the match. */
   UPROPERTY(BlueprintReadOnly, Category = "GameMode")

--- a/Source/Skald/Skald_PlayerController.cpp
+++ b/Source/Skald/Skald_PlayerController.cpp
@@ -7,6 +7,7 @@
 #include "EngineUtils.h"
 #include "FighterPawn.h"
 #include "GridBattleManager.h"
+#include "FighterDataLibrary.h"
 #include "GridOverlayComponent.h"
 #include "InputCoreTypes.h"
 #include "Kismet/GameplayStatics.h"
@@ -274,60 +275,169 @@ void ASkaldPlayerController::SetTurnManager(ATurnManager *Manager) {
   }
 }
 
-void ASkaldPlayerController::InitializeFighterSelectionIfNeeded() {
-  if (FighterSelectionWidget || GetLocalPlayer() == nullptr ||
-      !IsLocalPlayerController()) {
-    return;
-  }
+void ASkaldPlayerController::InitializeFighterSelectionIfNeeded() {}
 
-  if (!CachedGameInstance) {
-    CachedGameInstance = GetGameInstance<USkaldGameInstance>();
-  }
-  if (!CachedGameInstance || !CachedGameInstance->GridBattleManager) {
-    return;
-  }
-
-  DetectBattleMap();
-  if (!bIsBattleMap) {
-    return;
-  }
-
-  if (UFighterSelectionWidget *Selection =
-          CreateWidget<UFighterSelectionWidget>(
-              this, UFighterSelectionWidget::StaticClass())) {
-    FighterSelectionWidget = Selection;
-    if (ASkaldPlayerState *PS = GetPlayerState<ASkaldPlayerState>()) {
-      const ESkaldFaction PlayerFaction = PS->Faction;
-      Selection->PlayerFaction = PlayerFaction;
-      Selection->AvailableFighters =
-          CachedGameInstance->GridBattleManager->GetFightersForFaction(
-              PlayerFaction);
-      // Set selection budget from pending battle; attacker uses ArmyCountSent,
-      // defender uses DefenderArmyCount.
-      const FS_BattlePayload &Battle =
-          CachedGameInstance->PendingBattle;
-
-      int32 MyId = -1;
-      if (ASkaldPlayerState *PS_Local =
-              GetPlayerState<ASkaldPlayerState>()) {
-        MyId = PS_Local->GetPlayerId();
-      }
-      const bool bImAttacker = (Battle.AttackerPlayerID == MyId);
-
-      // Fallback: if DefenderArmyCount isn’t populated, mirror the
-      // attacker’s budget.
-      const int32 DefenderBudget =
-          (Battle.DefenderArmyCount > 0) ? Battle.DefenderArmyCount
-                                         : Battle.ArmyCountSent;
-
-      Selection->MaxCost =
-          bImAttacker ? Battle.ArmyCountSent : DefenderBudget;
+void ASkaldPlayerController::Client_ShowFighterSelection_Implementation(int32 MaxBudget, ESkaldFaction Faction)
+{
+    if (!IsLocalController())
+    {
+        return;
     }
-    Selection->OnLockedIn.AddDynamic(
-        this, &ASkaldPlayerController::HandleFighterSelectionLockedIn);
-    Selection->AddToViewport();
-    SetIgnoreMoveInput(true);
-  }
+
+    if (!CurrentSelectionWidget)
+    {
+        TSubclassOf<UFighterSelectionWidget> WidgetClass = UFighterSelectionWidget::StaticClass();
+        CurrentSelectionWidget = CreateWidget<UFighterSelectionWidget>(this, WidgetClass);
+    }
+    if (!CurrentSelectionWidget)
+    {
+        return;
+    }
+
+    CurrentSelectionWidget->PlayerFaction = Faction;
+    CurrentSelectionWidget->MaxCost = MaxBudget;
+    CurrentSelectionWidget->ChosenFighters.Reset();
+    CurrentSelectionWidget->CurrentCost = 0;
+    CurrentSelectionWidget->AvailableFighters = UFighterDataLibrary::GetFightersForFaction(this, Faction);
+    CurrentSelectionWidget->PopulateFighterList();
+    CurrentSelectionWidget->UpdateCostDisplay();
+
+    CurrentSelectionWidget->OnLockedIn.RemoveAll(this);
+    CurrentSelectionWidget->OnLockedIn.AddDynamic(this, &ASkaldPlayerController::HandleLockedIn);
+
+    CurrentSelectionWidget->AddToViewport();
+    FInputModeUIOnly Mode;
+    SetInputMode(Mode);
+    bShowMouseCursor = true;
+}
+
+void ASkaldPlayerController::HandleLockedIn()
+{
+    if (!CurrentSelectionWidget)
+    {
+        return;
+    }
+
+    Server_CommitArmy(CurrentSelectionWidget->ChosenFighters);
+
+    CurrentSelectionWidget->RemoveFromParent();
+    CurrentSelectionWidget = nullptr;
+
+    FInputModeGameOnly Mode;
+    SetInputMode(Mode);
+    bShowMouseCursor = false;
+}
+
+void ASkaldPlayerController::Server_CommitArmy_Implementation(const TArray<FFighterDefinition>& Chosen)
+{
+    if (ASkaldPlayerState* PS = GetPlayerState<ASkaldPlayerState>())
+    {
+        PS->PendingArmy = Chosen;
+        PS->bArmyLockedIn = true;
+    }
+
+    UWorld* W = GetWorld();
+    if (!W)
+    {
+        return;
+    }
+
+    ASkaldGameState* GS = W->GetGameState<ASkaldGameState>();
+    if (!GS)
+    {
+        return;
+    }
+
+    int32 ReadyCount = 0;
+    ASkaldPlayerState* First = nullptr;
+    ASkaldPlayerState* Second = nullptr;
+    for (APlayerState* Base : GS->PlayerArray)
+    {
+        if (ASkaldPlayerState* S = Cast<ASkaldPlayerState>(Base))
+        {
+            if (S->bArmyLockedIn)
+            {
+                ++ReadyCount;
+                if (!First)
+                {
+                    First = S;
+                }
+                else if (!Second)
+                {
+                    Second = S;
+                }
+            }
+        }
+    }
+
+    if (ReadyCount >= 2 && First && Second)
+    {
+        if (USkaldGameInstance* GI = GetGameInstance<USkaldGameInstance>())
+        {
+            if (GI->GridBattleManager)
+            {
+                TArray<FFighter> Attackers;
+                for (const FFighterDefinition& Def : First->PendingArmy)
+                {
+                    FFighter F;
+                    F.Stats = Def.Stats;
+                    F.Faction = First->Faction;
+                    Attackers.Add(F);
+                }
+
+                TArray<FFighter> Defenders;
+                for (const FFighterDefinition& Def : Second->PendingArmy)
+                {
+                    FFighter F;
+                    F.Stats = Def.Stats;
+                    F.Faction = Second->Faction;
+                    Defenders.Add(F);
+                }
+
+                GI->GridBattleManager->InitBattle(Attackers, Defenders);
+
+                UGridOverlayComponent* Grid = FindGridOverlay();
+                auto* BM = GI->GridBattleManager;
+                FRandomStream& RS = GI->CombatRandomStream;
+                const int32 Edge = 3;
+                const int32 MaxX = UGridBattleManager::GridSize - 1;
+                const int32 MaxY = UGridBattleManager::GridSize - 1;
+
+                auto SpawnAtCell = [&](const FIntPoint& Cell, const FFighterDefinition& Def, bool bAsAttacker)
+                {
+                    const FVector SpawnLoc = Grid ? Grid->GridToWorld(Cell) : FVector::ZeroVector;
+                    FActorSpawnParameters Params;
+                    Params.SpawnCollisionHandlingOverride = ESpawnActorCollisionHandlingMethod::AdjustIfPossibleButAlwaysSpawn;
+                    AFighterPawn* Pawn = W->SpawnActor<AFighterPawn>(AFighterPawn::StaticClass(), SpawnLoc, FRotator::ZeroRotator, Params);
+                    if (Pawn)
+                    {
+                        Pawn->Stats = Def.Stats;
+                        Pawn->bIsAttacker = bAsAttacker;
+                        BM->RegisterFighter(Pawn, bAsAttacker);
+                    }
+                };
+
+                for (const FFighterDefinition& Def : First->PendingArmy)
+                {
+                    FIntPoint Cell(RS.RandRange(0, Edge - 1), RS.RandRange(0, MaxY));
+                    SpawnAtCell(Cell, Def, true);
+                }
+                for (const FFighterDefinition& Def : Second->PendingArmy)
+                {
+                    FIntPoint Cell(RS.RandRange(MaxX - (Edge - 1), MaxX), RS.RandRange(0, MaxY));
+                    SpawnAtCell(Cell, Def, false);
+                }
+
+                BM->RollInitiative();
+                BM->StartRound(RS);
+            }
+        }
+
+        First->bArmyLockedIn = false;
+        Second->bArmyLockedIn = false;
+        First->PendingArmy.Reset();
+        Second->PendingArmy.Reset();
+    }
 }
 
 void ASkaldPlayerController::InitializeBattleHUD() {

--- a/Source/Skald/Skald_PlayerController.h
+++ b/Source/Skald/Skald_PlayerController.h
@@ -5,6 +5,7 @@
 #include "GameFramework/PlayerController.h"
 #include "SkaldTypes.h"
 #include "TimerManager.h"
+#include "GridBattleManager.h"
 #include "Skald_PlayerController.generated.h"
 
 class ATurnManager;
@@ -76,6 +77,12 @@ public:
   UFUNCTION(Server, Reliable)
   void ServerInitPlayerState(const FString &Name, ESkaldFaction Faction,
                              int32 NumAIPlayers);
+
+  UFUNCTION(Client, Reliable)
+  void Client_ShowFighterSelection(int32 MaxBudget, ESkaldFaction Faction);
+
+  UFUNCTION(Server, Reliable)
+  void Server_CommitArmy(const TArray<FFighterDefinition>& Chosen);
 
 protected:
   /** Widget class to instantiate for the player's HUD.
@@ -290,6 +297,12 @@ protected:
   TObjectPtr<ATurnManager> TurnManager;
 
 private:
+  UPROPERTY()
+  class UFighterSelectionWidget* CurrentSelectionWidget;
+
+  UFUNCTION()
+  void HandleLockedIn();
+
   /** Cache references to key game singletons and bind delegates. */
   void CacheGameReferences();
 

--- a/Source/Skald/Skald_PlayerState.cpp
+++ b/Source/Skald/Skald_PlayerState.cpp
@@ -24,6 +24,8 @@ void ASkaldPlayerState::GetLifetimeReplicatedProps(
 
     DOREPLIFETIME(ASkaldPlayerState, PlayerDisplayName);
     DOREPLIFETIME(ASkaldPlayerState, Faction);
+    DOREPLIFETIME(ASkaldPlayerState, PendingArmy);
+    DOREPLIFETIME(ASkaldPlayerState, bArmyLockedIn);
     DOREPLIFETIME(ASkaldPlayerState, bIsAI);
     DOREPLIFETIME(ASkaldPlayerState, DeployableUnits);
     DOREPLIFETIME(ASkaldPlayerState, InitiativeRoll);

--- a/Source/Skald/Skald_PlayerState.h
+++ b/Source/Skald/Skald_PlayerState.h
@@ -3,6 +3,7 @@
 #include "CoreMinimal.h"
 #include "GameFramework/PlayerState.h"
 #include "SkaldTypes.h"
+#include "GridBattleManager.h"
 #include "Skald_PlayerState.generated.h"
 
 /**
@@ -33,8 +34,16 @@ public:
     FString PlayerDisplayName;
 
     /** Selected faction for this player. */
-    UPROPERTY(BlueprintReadWrite, Replicated, Category="PlayerState")
-    ESkaldFaction Faction;
+    UPROPERTY(Replicated, BlueprintReadOnly, Category="Skald|Player")
+    ESkaldFaction Faction = ESkaldFaction::None;
+
+    /** Fighters chosen during pre-battle selection. */
+    UPROPERTY(Replicated, BlueprintReadOnly, Category="Skald|Player")
+    TArray<FFighterDefinition> PendingArmy;
+
+    /** Whether the player has finalised their army selection. */
+    UPROPERTY(Replicated, BlueprintReadOnly, Category="Skald|Player")
+    bool bArmyLockedIn = false;
 
     /** Whether this player is controlled by AI. */
     UPROPERTY(BlueprintReadWrite, ReplicatedUsing = OnRep_IsAI, Category="PlayerState")


### PR DESCRIPTION
## Summary
- replicate player faction, pending army, and ready flag on `ASkaldPlayerState`
- add `UFighterDataLibrary` to pull fighters by faction from the existing DataTable
- allow game mode and controllers to drive a pre-battle fighter selection UI and commit armies to the server

## Testing
- `g++ -std=c++17 -c Source/Skald/Skald_PlayerState.cpp` *(fails: CoreMinimal.h: No such file or directory)*


------
https://chatgpt.com/codex/tasks/task_e_68c72b532c508324b62a99a788e4c49f