### PR TITLE
Add server-side army selection validation

### DIFF
--- a/Source/Skald/Skald_GameMode.cpp
+++ b/Source/Skald/Skald_GameMode.cpp
@@ -551,26 +551,27 @@ void ASkaldGameMode::HandlePlayerLockedIn(ASkaldPlayerState *PS) {
   TryInitializeWorldAndStart();
 }
 
-void ASkaldGameMode::BeginPreBattleSelection(ASkaldPlayerState* A, ASkaldPlayerState* D,
-                                             int32 ABudget, int32 DBudget)
-{
-    if (!HasAuthority())
-    {
-        return;
-    }
-    if (!A || !D)
-    {
-        return;
-    }
+void ASkaldGameMode::BeginPreBattleSelection(ASkaldPlayerState *A,
+                                             ASkaldPlayerState *D,
+                                             int32 ABudget, int32 DBudget) {
+  if (!HasAuthority()) {
+    return;
+  }
+  if (!A || !D) {
+    return;
+  }
 
-    if (ASkaldPlayerController* APC = Cast<ASkaldPlayerController>(A->GetOwner()))
-    {
-        APC->Client_ShowFighterSelection(ABudget, A->Faction);
-    }
-    if (ASkaldPlayerController* DPC = Cast<ASkaldPlayerController>(D->GetOwner()))
-    {
-        DPC->Client_ShowFighterSelection(DBudget, D->Faction);
-    }
+  A->PendingArmyBudget = ABudget;
+  D->PendingArmyBudget = DBudget;
+
+  if (ASkaldPlayerController *APC =
+          Cast<ASkaldPlayerController>(A->GetOwner())) {
+    APC->Client_ShowFighterSelection(ABudget, A->Faction);
+  }
+  if (ASkaldPlayerController *DPC =
+          Cast<ASkaldPlayerController>(D->GetOwner())) {
+    DPC->Client_ShowFighterSelection(DBudget, D->Faction);
+  }
 }
 
 void ASkaldGameMode::RefreshHUDs() {
@@ -1079,8 +1080,9 @@ void ASkaldGameMode::AdvanceArmyPlacement() {
     if (ASkaldGameState *GSLocal = GetGameState<ASkaldGameState>()) {
       const int32 NewIndex = GSLocal->PlayerArray.IndexOfByKey(PS);
       if (NewIndex != INDEX_NONE) {
-        GSLocal->CurrentTurnIndex = NewIndex;      // RepNotify → OnTurnIndexChanged
-        GSLocal->OnTurnIndexChanged.Broadcast(NewIndex); // optional immediate local broadcast
+        GSLocal->CurrentTurnIndex = NewIndex; // RepNotify → OnTurnIndexChanged
+        GSLocal->OnTurnIndexChanged.Broadcast(
+            NewIndex); // optional immediate local broadcast
       }
     }
 

--- a/Source/Skald/Skald_PlayerController.cpp
+++ b/Source/Skald/Skald_PlayerController.cpp
@@ -5,9 +5,9 @@
 #include "Engine/Engine.h"
 #include "Engine/World.h"
 #include "EngineUtils.h"
+#include "FighterDataLibrary.h"
 #include "FighterPawn.h"
 #include "GridBattleManager.h"
-#include "FighterDataLibrary.h"
 #include "GridOverlayComponent.h"
 #include "InputCoreTypes.h"
 #include "Kismet/GameplayStatics.h"
@@ -277,167 +277,194 @@ void ASkaldPlayerController::SetTurnManager(ATurnManager *Manager) {
 
 void ASkaldPlayerController::InitializeFighterSelectionIfNeeded() {}
 
-void ASkaldPlayerController::Client_ShowFighterSelection_Implementation(int32 MaxBudget, ESkaldFaction Faction)
-{
-    if (!IsLocalController())
-    {
-        return;
-    }
+void ASkaldPlayerController::Client_ShowFighterSelection_Implementation(
+    int32 MaxBudget, ESkaldFaction Faction) {
+  if (!IsLocalController()) {
+    return;
+  }
 
-    if (!CurrentSelectionWidget)
-    {
-        TSubclassOf<UFighterSelectionWidget> WidgetClass = UFighterSelectionWidget::StaticClass();
-        CurrentSelectionWidget = CreateWidget<UFighterSelectionWidget>(this, WidgetClass);
-    }
-    if (!CurrentSelectionWidget)
-    {
-        return;
-    }
+  if (!CurrentSelectionWidget) {
+    TSubclassOf<UFighterSelectionWidget> WidgetClass =
+        UFighterSelectionWidget::StaticClass();
+    CurrentSelectionWidget =
+        CreateWidget<UFighterSelectionWidget>(this, WidgetClass);
+  }
+  if (!CurrentSelectionWidget) {
+    return;
+  }
 
-    CurrentSelectionWidget->PlayerFaction = Faction;
-    CurrentSelectionWidget->MaxCost = MaxBudget;
-    CurrentSelectionWidget->ChosenFighters.Reset();
-    CurrentSelectionWidget->CurrentCost = 0;
-    CurrentSelectionWidget->AvailableFighters = UFighterDataLibrary::GetFightersForFaction(this, Faction);
-    CurrentSelectionWidget->PopulateFighterList();
-    CurrentSelectionWidget->UpdateCostDisplay();
+  CurrentSelectionWidget->PlayerFaction = Faction;
+  CurrentSelectionWidget->MaxCost = MaxBudget;
+  CurrentSelectionWidget->ChosenFighters.Reset();
+  CurrentSelectionWidget->CurrentCost = 0;
+  CurrentSelectionWidget->AvailableFighters =
+      UFighterDataLibrary::GetFightersForFaction(this, Faction);
+  CurrentSelectionWidget->PopulateFighterList();
+  CurrentSelectionWidget->UpdateCostDisplay();
 
-    CurrentSelectionWidget->OnLockedIn.RemoveAll(this);
-    CurrentSelectionWidget->OnLockedIn.AddDynamic(this, &ASkaldPlayerController::HandleLockedIn);
+  CurrentSelectionWidget->OnLockedIn.RemoveAll(this);
+  CurrentSelectionWidget->OnLockedIn.AddDynamic(
+      this, &ASkaldPlayerController::HandleLockedIn);
 
-    CurrentSelectionWidget->AddToViewport();
-    FInputModeUIOnly Mode;
-    SetInputMode(Mode);
-    bShowMouseCursor = true;
+  CurrentSelectionWidget->AddToViewport();
+  FInputModeUIOnly Mode;
+  SetInputMode(Mode);
+  bShowMouseCursor = true;
 }
 
-void ASkaldPlayerController::HandleLockedIn()
-{
-    if (!CurrentSelectionWidget)
-    {
-        return;
-    }
+void ASkaldPlayerController::HandleLockedIn() {
+  if (!CurrentSelectionWidget) {
+    return;
+  }
 
-    Server_CommitArmy(CurrentSelectionWidget->ChosenFighters);
+  Server_CommitArmy(CurrentSelectionWidget->ChosenFighters);
 
-    CurrentSelectionWidget->RemoveFromParent();
-    CurrentSelectionWidget = nullptr;
+  CurrentSelectionWidget->RemoveFromParent();
+  CurrentSelectionWidget = nullptr;
 
-    FInputModeGameOnly Mode;
-    SetInputMode(Mode);
-    bShowMouseCursor = false;
+  FInputModeGameOnly Mode;
+  SetInputMode(Mode);
+  bShowMouseCursor = false;
 }
 
-void ASkaldPlayerController::Server_CommitArmy_Implementation(const TArray<FFighterDefinition>& Chosen)
-{
-    if (ASkaldPlayerState* PS = GetPlayerState<ASkaldPlayerState>())
-    {
-        PS->PendingArmy = Chosen;
-        PS->bArmyLockedIn = true;
+bool ASkaldPlayerController::Server_CommitArmy_Validate(
+    const TArray<FFighterDefinition> &Chosen) {
+  ASkaldPlayerState *PS = GetPlayerState<ASkaldPlayerState>();
+  if (!PS) {
+    return false;
+  }
+
+  int32 TotalCost = 0;
+  for (const FFighterDefinition &Def : Chosen) {
+    if (Def.Faction != PS->Faction) {
+      return false;
+    }
+    TotalCost += FMath::Max(Def.Stats.ArmyCost, 0);
+    if (TotalCost > PS->PendingArmyBudget) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+void ASkaldPlayerController::Server_CommitArmy_Implementation(
+    const TArray<FFighterDefinition> &Chosen) {
+  ASkaldPlayerState *PS = GetPlayerState<ASkaldPlayerState>();
+  if (PS) {
+    TArray<FFighterDefinition> ValidFighters;
+    int32 TotalCost = 0;
+    for (const FFighterDefinition &Def : Chosen) {
+      if (Def.Faction != PS->Faction) {
+        continue;
+      }
+      const int32 Cost = FMath::Max(Def.Stats.ArmyCost, 0);
+      if (TotalCost + Cost > PS->PendingArmyBudget) {
+        break;
+      }
+      ValidFighters.Add(Def);
+      TotalCost += Cost;
     }
 
-    UWorld* W = GetWorld();
-    if (!W)
-    {
-        return;
-    }
+    PS->PendingArmy = ValidFighters;
+    PS->bArmyLockedIn = true;
+  }
 
-    ASkaldGameState* GS = W->GetGameState<ASkaldGameState>();
-    if (!GS)
-    {
-        return;
-    }
+  UWorld *W = GetWorld();
+  if (!W) {
+    return;
+  }
 
-    int32 ReadyCount = 0;
-    ASkaldPlayerState* First = nullptr;
-    ASkaldPlayerState* Second = nullptr;
-    for (APlayerState* Base : GS->PlayerArray)
-    {
-        if (ASkaldPlayerState* S = Cast<ASkaldPlayerState>(Base))
-        {
-            if (S->bArmyLockedIn)
-            {
-                ++ReadyCount;
-                if (!First)
-                {
-                    First = S;
-                }
-                else if (!Second)
-                {
-                    Second = S;
-                }
-            }
+  ASkaldGameState *GS = W->GetGameState<ASkaldGameState>();
+  if (!GS) {
+    return;
+  }
+
+  int32 ReadyCount = 0;
+  ASkaldPlayerState *First = nullptr;
+  ASkaldPlayerState *Second = nullptr;
+  for (APlayerState *Base : GS->PlayerArray) {
+    if (ASkaldPlayerState *S = Cast<ASkaldPlayerState>(Base)) {
+      if (S->bArmyLockedIn) {
+        ++ReadyCount;
+        if (!First) {
+          First = S;
+        } else if (!Second) {
+          Second = S;
         }
+      }
     }
+  }
 
-    if (ReadyCount >= 2 && First && Second)
-    {
-        if (USkaldGameInstance* GI = GetGameInstance<USkaldGameInstance>())
-        {
-            if (GI->GridBattleManager)
-            {
-                TArray<FFighter> Attackers;
-                for (const FFighterDefinition& Def : First->PendingArmy)
-                {
-                    FFighter F;
-                    F.Stats = Def.Stats;
-                    F.Faction = First->Faction;
-                    Attackers.Add(F);
-                }
-
-                TArray<FFighter> Defenders;
-                for (const FFighterDefinition& Def : Second->PendingArmy)
-                {
-                    FFighter F;
-                    F.Stats = Def.Stats;
-                    F.Faction = Second->Faction;
-                    Defenders.Add(F);
-                }
-
-                GI->GridBattleManager->InitBattle(Attackers, Defenders);
-
-                UGridOverlayComponent* Grid = FindGridOverlay();
-                auto* BM = GI->GridBattleManager;
-                FRandomStream& RS = GI->CombatRandomStream;
-                const int32 Edge = 3;
-                const int32 MaxX = UGridBattleManager::GridSize - 1;
-                const int32 MaxY = UGridBattleManager::GridSize - 1;
-
-                auto SpawnAtCell = [&](const FIntPoint& Cell, const FFighterDefinition& Def, bool bAsAttacker)
-                {
-                    const FVector SpawnLoc = Grid ? Grid->GridToWorld(Cell) : FVector::ZeroVector;
-                    FActorSpawnParameters Params;
-                    Params.SpawnCollisionHandlingOverride = ESpawnActorCollisionHandlingMethod::AdjustIfPossibleButAlwaysSpawn;
-                    AFighterPawn* Pawn = W->SpawnActor<AFighterPawn>(AFighterPawn::StaticClass(), SpawnLoc, FRotator::ZeroRotator, Params);
-                    if (Pawn)
-                    {
-                        Pawn->Stats = Def.Stats;
-                        Pawn->bIsAttacker = bAsAttacker;
-                        BM->RegisterFighter(Pawn, bAsAttacker);
-                    }
-                };
-
-                for (const FFighterDefinition& Def : First->PendingArmy)
-                {
-                    FIntPoint Cell(RS.RandRange(0, Edge - 1), RS.RandRange(0, MaxY));
-                    SpawnAtCell(Cell, Def, true);
-                }
-                for (const FFighterDefinition& Def : Second->PendingArmy)
-                {
-                    FIntPoint Cell(RS.RandRange(MaxX - (Edge - 1), MaxX), RS.RandRange(0, MaxY));
-                    SpawnAtCell(Cell, Def, false);
-                }
-
-                BM->RollInitiative();
-                BM->StartRound(RS);
-            }
+  if (ReadyCount >= 2 && First && Second) {
+    if (USkaldGameInstance *GI = GetGameInstance<USkaldGameInstance>()) {
+      if (GI->GridBattleManager) {
+        TArray<FFighter> Attackers;
+        for (const FFighterDefinition &Def : First->PendingArmy) {
+          FFighter F;
+          F.Stats = Def.Stats;
+          F.Faction = First->Faction;
+          Attackers.Add(F);
         }
 
-        First->bArmyLockedIn = false;
-        Second->bArmyLockedIn = false;
-        First->PendingArmy.Reset();
-        Second->PendingArmy.Reset();
+        TArray<FFighter> Defenders;
+        for (const FFighterDefinition &Def : Second->PendingArmy) {
+          FFighter F;
+          F.Stats = Def.Stats;
+          F.Faction = Second->Faction;
+          Defenders.Add(F);
+        }
+
+        GI->GridBattleManager->InitBattle(Attackers, Defenders);
+
+        UGridOverlayComponent *Grid = FindGridOverlay();
+        auto *BM = GI->GridBattleManager;
+        FRandomStream &RS = GI->CombatRandomStream;
+        const int32 Edge = 3;
+        const int32 MaxX = UGridBattleManager::GridSize - 1;
+        const int32 MaxY = UGridBattleManager::GridSize - 1;
+
+        auto SpawnAtCell = [&](const FIntPoint &Cell,
+                               const FFighterDefinition &Def,
+                               bool bAsAttacker) {
+          const FVector SpawnLoc =
+              Grid ? Grid->GridToWorld(Cell) : FVector::ZeroVector;
+          FActorSpawnParameters Params;
+          Params.SpawnCollisionHandlingOverride =
+              ESpawnActorCollisionHandlingMethod::
+                  AdjustIfPossibleButAlwaysSpawn;
+          AFighterPawn *Pawn =
+              W->SpawnActor<AFighterPawn>(AFighterPawn::StaticClass(), SpawnLoc,
+                                          FRotator::ZeroRotator, Params);
+          if (Pawn) {
+            Pawn->Stats = Def.Stats;
+            Pawn->bIsAttacker = bAsAttacker;
+            BM->RegisterFighter(Pawn, bAsAttacker);
+          }
+        };
+
+        for (const FFighterDefinition &Def : First->PendingArmy) {
+          FIntPoint Cell(RS.RandRange(0, Edge - 1), RS.RandRange(0, MaxY));
+          SpawnAtCell(Cell, Def, true);
+        }
+        for (const FFighterDefinition &Def : Second->PendingArmy) {
+          FIntPoint Cell(RS.RandRange(MaxX - (Edge - 1), MaxX),
+                         RS.RandRange(0, MaxY));
+          SpawnAtCell(Cell, Def, false);
+        }
+
+        BM->RollInitiative();
+        BM->StartRound(RS);
+      }
     }
+
+    First->bArmyLockedIn = false;
+    Second->bArmyLockedIn = false;
+    First->PendingArmy.Reset();
+    Second->PendingArmy.Reset();
+    First->PendingArmyBudget = 0;
+    Second->PendingArmyBudget = 0;
+  }
 }
 
 void ASkaldPlayerController::InitializeBattleHUD() {
@@ -1255,14 +1282,16 @@ void ASkaldPlayerController::HandleFighterSelectionLockedIn() {
       const int32 MaxX = UGridBattleManager::GridSize - 1;
       const int32 MaxY = UGridBattleManager::GridSize - 1;
 
-      auto SpawnAtCell = [&](const FIntPoint &Cell, const FFighterDefinition &Def,
-                             bool bAsAttacker) {
-        const FVector SpawnLoc = Grid ? Grid->GridToWorld(Cell) : FVector::ZeroVector;
+      auto SpawnAtCell = [&](const FIntPoint &Cell,
+                             const FFighterDefinition &Def, bool bAsAttacker) {
+        const FVector SpawnLoc =
+            Grid ? Grid->GridToWorld(Cell) : FVector::ZeroVector;
         FActorSpawnParameters Params;
         Params.SpawnCollisionHandlingOverride =
             ESpawnActorCollisionHandlingMethod::AdjustIfPossibleButAlwaysSpawn;
         AFighterPawn *Pawn = World->SpawnActor<AFighterPawn>(
-            AFighterPawn::StaticClass(), SpawnLoc, FRotator::ZeroRotator, Params);
+            AFighterPawn::StaticClass(), SpawnLoc, FRotator::ZeroRotator,
+            Params);
         if (Pawn) {
           Pawn->Stats = Def.Stats;
           Pawn->bIsAttacker = bAsAttacker;
@@ -1284,8 +1313,8 @@ void ASkaldPlayerController::HandleFighterSelectionLockedIn() {
 
       BM->RollInitiative();
       BM->StartRound(RS);
-      BM->OnBattleEnded.AddDynamic(
-          this, &ASkaldPlayerController::HandleBattleEnded);
+      BM->OnBattleEnded.AddDynamic(this,
+                                   &ASkaldPlayerController::HandleBattleEnded);
 
       InitializeBattleHUD();
     }
@@ -1380,8 +1409,7 @@ void ASkaldPlayerController::HandleGridClick() {
     Grid->ClearHighlights();
     if (Active->ActionsRemaining <= 0) {
       CurrentCommandMode = EBattleCommandMode::None;
-      if (USkaldGameInstance *GI =
-              GetGameInstance<USkaldGameInstance>()) {
+      if (USkaldGameInstance *GI = GetGameInstance<USkaldGameInstance>()) {
         if (GI->GridBattleManager) {
           GI->GridBattleManager->AdvanceTurn();
         }
@@ -1402,8 +1430,7 @@ void ASkaldPlayerController::HandleGridClick() {
     Grid->ClearHighlights();
     if (Active->ActionsRemaining <= 0) {
       CurrentCommandMode = EBattleCommandMode::None;
-      if (USkaldGameInstance *GI =
-              GetGameInstance<USkaldGameInstance>()) {
+      if (USkaldGameInstance *GI = GetGameInstance<USkaldGameInstance>()) {
         if (GI->GridBattleManager) {
           GI->GridBattleManager->AdvanceTurn();
         }

--- a/Source/Skald/Skald_PlayerController.h
+++ b/Source/Skald/Skald_PlayerController.h
@@ -3,10 +3,10 @@
 #include "CoreMinimal.h"
 #include "Engine/EngineTypes.h"
 #include "GameFramework/PlayerController.h"
-#include "SkaldTypes.h"
-#include "TimerManager.h"
 #include "GridBattleManager.h"
+#include "SkaldTypes.h"
 #include "Skald_PlayerController.generated.h"
+#include "TimerManager.h"
 
 class ATurnManager;
 class UUserWidget;
@@ -81,8 +81,8 @@ public:
   UFUNCTION(Client, Reliable)
   void Client_ShowFighterSelection(int32 MaxBudget, ESkaldFaction Faction);
 
-  UFUNCTION(Server, Reliable)
-  void Server_CommitArmy(const TArray<FFighterDefinition>& Chosen);
+  UFUNCTION(Server, Reliable, WithValidation)
+  void Server_CommitArmy(const TArray<FFighterDefinition> &Chosen);
 
 protected:
   /** Widget class to instantiate for the player's HUD.
@@ -235,7 +235,7 @@ public:
                          int32 DefenderCasualties);
 
   UFUNCTION()
-  void HandleActiveFighterChanged(AFighterPawn* NewFighter);
+  void HandleActiveFighterChanged(AFighterPawn *NewFighter);
 
   /** Server-side processing of an attack request. */
   UFUNCTION(Server, Reliable)
@@ -298,7 +298,7 @@ protected:
 
 private:
   UPROPERTY()
-  class UFighterSelectionWidget* CurrentSelectionWidget;
+  class UFighterSelectionWidget *CurrentSelectionWidget;
 
   UFUNCTION()
   void HandleLockedIn();
@@ -313,7 +313,7 @@ private:
   void InitializeChoosePlayerWidget();
 
   void InitializeBattleHUD();
-  UGridOverlayComponent* FindGridOverlay() const;
+  UGridOverlayComponent *FindGridOverlay() const;
 
   /** Attempt to locate the world map and bind to its selection event. */
   void TryBindWorldMap();

--- a/Source/Skald/Skald_PlayerState.cpp
+++ b/Source/Skald/Skald_PlayerState.cpp
@@ -1,94 +1,70 @@
 #include "Skald_PlayerState.h"
-#include "Net/UnrealNetwork.h"
 #include "Engine/World.h"
+#include "Net/UnrealNetwork.h"
 #include "Skald_GameState.h"
 #include "Skald_PlayerController.h"
 #include "UI/SkaldMainHUDWidget.h"
 
 ASkaldPlayerState::ASkaldPlayerState()
-    : DeployableUnits(0)
-    , InitiativeRoll(0)
-    , Resources(0)
-    , PlayerDisplayName(TEXT("Player"))
-    , Faction(ESkaldFaction::None)
-    , bIsAI(false)
-    , bHasLockedIn(false)
-    , IsEliminated(false)
-{
-}
+    : DeployableUnits(0), InitiativeRoll(0), Resources(0),
+      PlayerDisplayName(TEXT("Player")), Faction(ESkaldFaction::None),
+      bIsAI(false), bHasLockedIn(false), IsEliminated(false) {}
 
 void ASkaldPlayerState::GetLifetimeReplicatedProps(
-    TArray<FLifetimeProperty>& OutLifetimeProps) const
-{
-    Super::GetLifetimeReplicatedProps(OutLifetimeProps);
+    TArray<FLifetimeProperty> &OutLifetimeProps) const {
+  Super::GetLifetimeReplicatedProps(OutLifetimeProps);
 
-    DOREPLIFETIME(ASkaldPlayerState, PlayerDisplayName);
-    DOREPLIFETIME(ASkaldPlayerState, Faction);
-    DOREPLIFETIME(ASkaldPlayerState, PendingArmy);
-    DOREPLIFETIME(ASkaldPlayerState, bArmyLockedIn);
-    DOREPLIFETIME(ASkaldPlayerState, bIsAI);
-    DOREPLIFETIME(ASkaldPlayerState, DeployableUnits);
-    DOREPLIFETIME(ASkaldPlayerState, InitiativeRoll);
-    DOREPLIFETIME(ASkaldPlayerState, Resources);
-    DOREPLIFETIME(ASkaldPlayerState, bHasLockedIn);
-    DOREPLIFETIME(ASkaldPlayerState, IsEliminated);
+  DOREPLIFETIME(ASkaldPlayerState, PlayerDisplayName);
+  DOREPLIFETIME(ASkaldPlayerState, Faction);
+  DOREPLIFETIME(ASkaldPlayerState, PendingArmy);
+  DOREPLIFETIME(ASkaldPlayerState, PendingArmyBudget);
+  DOREPLIFETIME(ASkaldPlayerState, bArmyLockedIn);
+  DOREPLIFETIME(ASkaldPlayerState, bIsAI);
+  DOREPLIFETIME(ASkaldPlayerState, DeployableUnits);
+  DOREPLIFETIME(ASkaldPlayerState, InitiativeRoll);
+  DOREPLIFETIME(ASkaldPlayerState, Resources);
+  DOREPLIFETIME(ASkaldPlayerState, bHasLockedIn);
+  DOREPLIFETIME(ASkaldPlayerState, IsEliminated);
 }
 
-void ASkaldPlayerState::OnRep_DeployableUnits()
-{
-    if (APlayerController* PC = GetOwner<APlayerController>())
-    {
-        if (ASkaldPlayerController* SkaldPC = Cast<ASkaldPlayerController>(PC))
-        {
-            if (USkaldMainHUDWidget* HUD = SkaldPC->GetHUDWidget())
-            {
-                HUD->UpdateDeployableUnits(DeployableUnits);
-            }
-        }
+void ASkaldPlayerState::OnRep_DeployableUnits() {
+  if (APlayerController *PC = GetOwner<APlayerController>()) {
+    if (ASkaldPlayerController *SkaldPC = Cast<ASkaldPlayerController>(PC)) {
+      if (USkaldMainHUDWidget *HUD = SkaldPC->GetHUDWidget()) {
+        HUD->UpdateDeployableUnits(DeployableUnits);
+      }
     }
+  }
 }
 
-void ASkaldPlayerState::OnRep_HasLockedIn()
-{
-    if (UWorld* World = GetWorld())
-    {
-        if (ASkaldGameState* GS = World->GetGameState<ASkaldGameState>())
-        {
-            GS->OnPlayersUpdated.Broadcast();
-        }
+void ASkaldPlayerState::OnRep_HasLockedIn() {
+  if (UWorld *World = GetWorld()) {
+    if (ASkaldGameState *GS = World->GetGameState<ASkaldGameState>()) {
+      GS->OnPlayersUpdated.Broadcast();
     }
+  }
 }
 
-void ASkaldPlayerState::OnRep_IsEliminated()
-{
-    if (UWorld* World = GetWorld())
-    {
-        if (ASkaldGameState* GS = World->GetGameState<ASkaldGameState>())
-        {
-            GS->OnPlayersUpdated.Broadcast();
-        }
+void ASkaldPlayerState::OnRep_IsEliminated() {
+  if (UWorld *World = GetWorld()) {
+    if (ASkaldGameState *GS = World->GetGameState<ASkaldGameState>()) {
+      GS->OnPlayersUpdated.Broadcast();
     }
+  }
 }
 
-void ASkaldPlayerState::OnRep_PlayerDisplayName()
-{
-    if (UWorld* World = GetWorld())
-    {
-        if (ASkaldGameState* GS = World->GetGameState<ASkaldGameState>())
-        {
-            GS->OnPlayersUpdated.Broadcast();
-        }
+void ASkaldPlayerState::OnRep_PlayerDisplayName() {
+  if (UWorld *World = GetWorld()) {
+    if (ASkaldGameState *GS = World->GetGameState<ASkaldGameState>()) {
+      GS->OnPlayersUpdated.Broadcast();
     }
+  }
 }
 
-void ASkaldPlayerState::OnRep_IsAI()
-{
-    if (UWorld* World = GetWorld())
-    {
-        if (ASkaldGameState* GS = World->GetGameState<ASkaldGameState>())
-        {
-            GS->OnPlayersUpdated.Broadcast();
-        }
+void ASkaldPlayerState::OnRep_IsAI() {
+  if (UWorld *World = GetWorld()) {
+    if (ASkaldGameState *GS = World->GetGameState<ASkaldGameState>()) {
+      GS->OnPlayersUpdated.Broadcast();
     }
+  }
 }
-

--- a/Source/Skald/Skald_PlayerState.h
+++ b/Source/Skald/Skald_PlayerState.h
@@ -2,76 +2,84 @@
 
 #include "CoreMinimal.h"
 #include "GameFramework/PlayerState.h"
-#include "SkaldTypes.h"
 #include "GridBattleManager.h"
+#include "SkaldTypes.h"
 #include "Skald_PlayerState.generated.h"
 
 /**
  * Player state containing basic information for turn management.
  */
 UCLASS(Blueprintable, BlueprintType)
-class SKALD_API ASkaldPlayerState : public APlayerState
-{
-    GENERATED_BODY()
+class SKALD_API ASkaldPlayerState : public APlayerState {
+  GENERATED_BODY()
 
 public:
-    ASkaldPlayerState();
+  ASkaldPlayerState();
 
-    /** Deployable units available for placement. */
-    UPROPERTY(BlueprintReadWrite, ReplicatedUsing = OnRep_DeployableUnits, Category="PlayerState")
-    int32 DeployableUnits;
+  /** Deployable units available for placement. */
+  UPROPERTY(BlueprintReadWrite, ReplicatedUsing = OnRep_DeployableUnits,
+            Category = "PlayerState")
+  int32 DeployableUnits;
 
-    /** Initiative roll determining turn order. */
-    UPROPERTY(BlueprintReadWrite, Replicated, Category="PlayerState")
-    int32 InitiativeRoll;
+  /** Initiative roll determining turn order. */
+  UPROPERTY(BlueprintReadWrite, Replicated, Category = "PlayerState")
+  int32 InitiativeRoll;
 
-    /** Resource points available to the player. */
-    UPROPERTY(BlueprintReadWrite, Replicated, Category="PlayerState")
-    int32 Resources;
+  /** Resource points available to the player. */
+  UPROPERTY(BlueprintReadWrite, Replicated, Category = "PlayerState")
+  int32 Resources;
 
-    /** Player chosen display name. */
-    UPROPERTY(BlueprintReadWrite, ReplicatedUsing = OnRep_PlayerDisplayName, Category="PlayerState")
-    FString PlayerDisplayName;
+  /** Player chosen display name. */
+  UPROPERTY(BlueprintReadWrite, ReplicatedUsing = OnRep_PlayerDisplayName,
+            Category = "PlayerState")
+  FString PlayerDisplayName;
 
-    /** Selected faction for this player. */
-    UPROPERTY(Replicated, BlueprintReadOnly, Category="Skald|Player")
-    ESkaldFaction Faction = ESkaldFaction::None;
+  /** Selected faction for this player. */
+  UPROPERTY(Replicated, BlueprintReadOnly, Category = "Skald|Player")
+  ESkaldFaction Faction = ESkaldFaction::None;
 
-    /** Fighters chosen during pre-battle selection. */
-    UPROPERTY(Replicated, BlueprintReadOnly, Category="Skald|Player")
-    TArray<FFighterDefinition> PendingArmy;
+  /** Fighters chosen during pre-battle selection. */
+  UPROPERTY(Replicated, BlueprintReadOnly, Category = "Skald|Player")
+  TArray<FFighterDefinition> PendingArmy;
 
-    /** Whether the player has finalised their army selection. */
-    UPROPERTY(Replicated, BlueprintReadOnly, Category="Skald|Player")
-    bool bArmyLockedIn = false;
+  /** Maximum budget allowed for the pending army selection. */
+  UPROPERTY(Replicated, BlueprintReadOnly, Category = "Skald|Player")
+  int32 PendingArmyBudget = 0;
 
-    /** Whether this player is controlled by AI. */
-    UPROPERTY(BlueprintReadWrite, ReplicatedUsing = OnRep_IsAI, Category="PlayerState")
-    bool bIsAI;
+  /** Whether the player has finalised their army selection. */
+  UPROPERTY(Replicated, BlueprintReadOnly, Category = "Skald|Player")
+  bool bArmyLockedIn = false;
 
-    /** Whether the player has locked in their actions for the current turn. */
-    UPROPERTY(BlueprintReadWrite, ReplicatedUsing = OnRep_HasLockedIn, Category="PlayerState")
-    bool bHasLockedIn;
+  /** Whether this player is controlled by AI. */
+  UPROPERTY(BlueprintReadWrite, ReplicatedUsing = OnRep_IsAI,
+            Category = "PlayerState")
+  bool bIsAI;
 
-    /** Whether this player has been eliminated from the match. */
-    UPROPERTY(BlueprintReadWrite, ReplicatedUsing = OnRep_IsEliminated, Category="PlayerState")
-    bool IsEliminated;
+  /** Whether the player has locked in their actions for the current turn. */
+  UPROPERTY(BlueprintReadWrite, ReplicatedUsing = OnRep_HasLockedIn,
+            Category = "PlayerState")
+  bool bHasLockedIn;
 
-    UFUNCTION()
-    void OnRep_DeployableUnits();
+  /** Whether this player has been eliminated from the match. */
+  UPROPERTY(BlueprintReadWrite, ReplicatedUsing = OnRep_IsEliminated,
+            Category = "PlayerState")
+  bool IsEliminated;
 
-    UFUNCTION()
-    void OnRep_HasLockedIn();
+  UFUNCTION()
+  void OnRep_DeployableUnits();
 
-    UFUNCTION()
-    void OnRep_IsEliminated();
+  UFUNCTION()
+  void OnRep_HasLockedIn();
 
-    UFUNCTION()
-    void OnRep_PlayerDisplayName();
+  UFUNCTION()
+  void OnRep_IsEliminated();
 
-    UFUNCTION()
-    void OnRep_IsAI();
+  UFUNCTION()
+  void OnRep_PlayerDisplayName();
 
-    virtual void GetLifetimeReplicatedProps(TArray<FLifetimeProperty>& OutLifetimeProps) const override;
+  UFUNCTION()
+  void OnRep_IsAI();
+
+  virtual void GetLifetimeReplicatedProps(
+      TArray<FLifetimeProperty> &OutLifetimeProps) const override;
 };
-


### PR DESCRIPTION
## Summary
- Track an army budget per player state and replicate it to clients
- Persist battle budgets when prompting clients to choose fighters
- Add validation for Server_CommitArmy to enforce faction and cost limits, and reset budgets after battle

## Testing
- `clang++ -std=c++17 -I../Engine/Source -ISource -c Source/Skald/Skald_PlayerController.cpp` *(fails: 'CoreMinimal.h' file not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c733f455d08324b11d2cae475d111c