### PR TITLE
Make fighter selection helpers accessible to player controller

### DIFF
--- a/Source/Skald/UI/FighterSelectionWidget.h
+++ b/Source/Skald/UI/FighterSelectionWidget.h
@@ -158,8 +158,8 @@ public:
   // Add a setter that repopulates when data arrives later:
   UFUNCTION(BlueprintCallable, Category="Skald|Fighter")
   void SetAvailableFighters(const TArray<FFighterDefinition>& InFighters);
-
-protected:
+  
+public:
   /** Populate the fighter list scroll box. */
   UFUNCTION(BlueprintCallable, Category = "Skald|Fighter")
   void PopulateFighterList();


### PR DESCRIPTION
## Summary
- Expose `PopulateFighterList` and `UpdateCostDisplay` in `UFighterSelectionWidget` so they can be called from `ASkaldPlayerController`

## Testing
- `clang++ -std=c++17 -I../Engine/Source -ISource -c Source/Skald/Skald_PlayerController.cpp` *(fails: 'CoreMinimal.h' file not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c73976cf04832486eff57605293f22