### PR TITLE
Fix DataTable row name retrieval

### DIFF
--- a/Source/Skald/FighterDataLibrary.cpp
+++ b/Source/Skald/FighterDataLibrary.cpp
@@ -30,8 +30,7 @@ TArray<FFighterDefinition> UFighterDataLibrary::GetFightersForFaction(UObject* W
     TArray<FFighterDefinition> Out;
     if (UDataTable* DT = ResolveFighterDataTable(WorldContext))
     {
-        TArray<FName> Rows;
-        DT->GetRowNames(Rows);
+        const TArray<FName> Rows = DT->GetRowNames();
         for (const FName& N : Rows)
         {
             if (const FFighterDefinition* Row = DT->FindRow<FFighterDefinition>(N, TEXT("FighterFilter")))


### PR DESCRIPTION
## Summary
- adapt FighterDataLibrary to new UDataTable::GetRowNames API

## Testing
- `g++ -c Source/Skald/FighterDataLibrary.cpp` *(fails: Kismet/BlueprintFunctionLibrary.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68c753d5de4c83249465acb1c6904668