### PR TITLE
Expose server-side battle summary broadcast helper

### DIFF
--- a/Source/Skald/Skald_GameMode.cpp
+++ b/Source/Skald/Skald_GameMode.cpp
@@ -592,7 +592,7 @@ void ASkaldGameMode::HandleBattleEnded(ESkaldFaction Winner, int32 AttackerCasua
     GS->LastBattleWinner = Winner;
     GS->LastAttackerCasualties = AttackerCasualties;
     GS->LastDefenderCasualties = DefenderCasualties;
-    GS->OnRep_BattleSummary();
+    GS->NotifyBattleSummaryChanged();
   }
 }
 

--- a/Source/Skald/Skald_GameState.cpp
+++ b/Source/Skald/Skald_GameState.cpp
@@ -90,6 +90,11 @@ void ASkaldGameState::OnRep_FighterRoster()
     OnFighterRosterUpdated.Broadcast();
 }
 
+void ASkaldGameState::NotifyBattleSummaryChanged()
+{
+    OnRep_BattleSummary();
+}
+
 void ASkaldGameState::OnRep_BattleSummary()
 {
     OnBattleSummaryUpdated.Broadcast();

--- a/Source/Skald/Skald_GameState.h
+++ b/Source/Skald/Skald_GameState.h
@@ -83,6 +83,12 @@ public:
     UFUNCTION(BlueprintCallable, BlueprintPure, Category="GameState|Fighters")
     const TArray<FFighterDefinition>& GetFighterRoster() const { return FighterRoster; }
 
+    /**
+     * Manual trigger for broadcasting battle summary updates on the server.
+     * Calls the OnRep handler so server-side UI can refresh immediately.
+     */
+    void NotifyBattleSummaryChanged();
+
 protected:
     UFUNCTION()
     void OnRep_Players();


### PR DESCRIPTION
## Summary
- Add `NotifyBattleSummaryChanged` helper to `ASkaldGameState` so the server can broadcast battle summary updates
- Use the new helper from `ASkaldGameMode` instead of calling the protected `OnRep_BattleSummary`

## Testing
- `g++ -std=c++17 -I../Engine/Source -ISource -c Source/Skald/Skald_GameMode.cpp` *(fails: CoreMinimal.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68c76a93b6348324aa0687a83ab80c07