### PR TITLE
feat: introduce battle-specific game mode

### DIFF
--- a/Config/DefaultGame.ini
+++ b/Config/DefaultGame.ini
@@ -6,3 +6,6 @@ ProjectID=4D4CC8134ED301908A6AE78FF6365DE9
 [/Script/UnrealEd.ProjectPackagingSettings]
 bMakeBinaryConfig=False
 
+[/Script/EngineSettings.GameMapsSettings]
++GameModeMapOverrides=(Map="/Game/Blueprints/Maps/BattleMap",GameMode="/Script/Skald.Skald_BattleGameMode")
+

--- a/Source/Skald/Skald_BattleGameMode.cpp
+++ b/Source/Skald/Skald_BattleGameMode.cpp
@@ -1,0 +1,122 @@
+#include "Skald_BattleGameMode.h"
+
+#include "Algo/RandomShuffle.h"
+#include "GridBattleManager.h"
+#include "Skald_GameInstance.h"
+#include "Skald_GameState.h"
+#include "Skald_PlayerState.h"
+#include "Engine/World.h"
+#include "Territory.h"
+#include "TimerManager.h"
+#include "WorldMap.h"
+
+namespace {
+constexpr int32 DefaultAIMaxCost = 10;
+}
+
+void ASkald_BattleGameMode::BeginPlay() {
+  Super::BeginPlay();
+
+  if (!BattleManager) {
+    UClass *ClassToUse = BattleManagerClass ? *BattleManagerClass
+                                            : UGridBattleManager::StaticClass();
+    BattleManager = NewObject<UGridBattleManager>(this, ClassToUse);
+    const int32 Seed =
+        static_cast<int32>(FDateTime::Now().GetTicks() & 0x7FFFFFFF);
+    BattleManager->SetRandomSeed(Seed);
+    BattleManager->OnBattleEnded.AddDynamic(this,
+                                           &ASkaldGameMode::HandleBattleEnded);
+    if (USkaldGameInstance *GI = GetGameInstance<USkaldGameInstance>()) {
+      GI->GridBattleManager = BattleManager;
+    }
+  }
+
+  if (USkaldGameInstance *GI = GetGameInstance<USkaldGameInstance>()) {
+    if (GI->GridBattleManager) {
+      ASkaldGameState *GS = GetGameState<ASkaldGameState>();
+      if (GS) {
+        for (APlayerState *BasePS : GS->PlayerArray) {
+          ASkaldPlayerState *PS = Cast<ASkaldPlayerState>(BasePS);
+          if (!PS || !PS->bIsAI) {
+            continue;
+          }
+
+          TArray<FFighterDefinition> Definitions =
+              GI->GridBattleManager->GetFightersForFaction(PS->Faction);
+          if (Definitions.Num() <= 0) {
+            PS->bHasLockedIn = true;
+            continue;
+          }
+
+          const int32 MaxCost = GI->PendingBattle.ArmyCountSent > 0
+                                    ? GI->PendingBattle.ArmyCountSent
+                                    : DefaultAIMaxCost;
+          int32 CurrentCost = 0;
+
+          Algo::RandomShuffle(Definitions);
+
+          TArray<FFighter> Fighters;
+          for (const FFighterDefinition &Def : Definitions) {
+            if (CurrentCost + Def.Stats.ArmyCost > MaxCost) {
+              continue;
+            }
+            FFighter Fighter;
+            Fighter.Stats = Def.Stats;
+            Fighter.Faction = PS->Faction;
+            Fighters.Add(Fighter);
+            CurrentCost += Def.Stats.ArmyCost;
+          }
+
+          if (Fighters.Num() > 0) {
+            GI->GridBattleManager->InitBattle(Fighters, Fighters);
+            GI->GridBattleManager->RollInitiative();
+            GI->GridBattleManager->StartRound();
+          }
+
+          PS->bHasLockedIn = true;
+        }
+      }
+    }
+  }
+
+  if (ASkaldGameState *GS = GetGameState<ASkaldGameState>()) {
+    int32 ControllerCount = 0;
+    for (FConstPlayerControllerIterator It =
+             GetWorld()->GetPlayerControllerIterator();
+         It; ++It) {
+      ++ControllerCount;
+    }
+    ensureMsgf(GS->PlayerArray.Num() == ControllerCount,
+               TEXT("PlayerCount %d != ControllerCount %d after travel"),
+               GS->PlayerArray.Num(), ControllerCount);
+
+    bool bHumanHasTerritory = false;
+    if (WorldMap) {
+      for (APlayerState *BasePS : GS->PlayerArray) {
+        ASkaldPlayerState *PS = Cast<ASkaldPlayerState>(BasePS);
+        if (!PS || PS->bIsAI) {
+          continue;
+        }
+        for (ATerritory *Territory : WorldMap->Territories) {
+          if (WorldMap->IsOwnedBy(Territory, PS)) {
+            bHumanHasTerritory = true;
+            break;
+          }
+        }
+        if (bHumanHasTerritory) {
+          break;
+        }
+      }
+    }
+    ensureMsgf(
+        bHumanHasTerritory,
+        TEXT("Human player does not own any territory after travel"));
+  }
+}
+
+void ASkald_BattleGameMode::TryInitializeWorldAndStart() {
+  bWorldInitialized = true;
+  bTurnsStarted = true;
+  GetWorldTimerManager().ClearTimer(RetryInitTimerHandle);
+}
+

--- a/Source/Skald/Skald_BattleGameMode.h
+++ b/Source/Skald/Skald_BattleGameMode.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Skald_GameMode.h"
+#include "Skald_BattleGameMode.generated.h"
+
+/** GameMode dedicated to resolving grid-based battles. */
+UCLASS()
+class SKALD_API ASkald_BattleGameMode : public ASkaldGameMode {
+  GENERATED_BODY()
+
+protected:
+  virtual void BeginPlay() override;
+  virtual void TryInitializeWorldAndStart() override;
+};
+

--- a/Source/Skald/Skald_GameMode.cpp
+++ b/Source/Skald/Skald_GameMode.cpp
@@ -48,17 +48,6 @@ ASkaldGameMode::ASkaldGameMode() {
 void ASkaldGameMode::BeginPlay() {
   Super::BeginPlay();
 
-  if (!BattleManager) {
-    UClass* ClassToUse = BattleManagerClass ? *BattleManagerClass : UGridBattleManager::StaticClass();
-    BattleManager = NewObject<UGridBattleManager>(this, ClassToUse);
-    const int32 Seed = static_cast<int32>(FDateTime::Now().GetTicks() & 0x7FFFFFFF);
-    BattleManager->SetRandomSeed(Seed);
-    BattleManager->OnBattleEnded.AddDynamic(this, &ASkaldGameMode::HandleBattleEnded);
-    if (USkaldGameInstance* GI = GetGameInstance<USkaldGameInstance>()) {
-      GI->GridBattleManager = BattleManager;
-    }
-  }
-
   CleanupStalePlayerStates();
   PlayerDataArray.Empty();
 
@@ -80,105 +69,6 @@ void ASkaldGameMode::BeginPlay() {
 
   // Defer AI population and world initialization until players lock in.
   RefreshHUDs();
-
-  // Auto-select fighters for AI players on the battle map
-  const FString CurrentLevel =
-      UGameplayStatics::GetCurrentLevelName(this, true);
-  bool bIsBattleMap =
-      CurrentLevel.Equals(TEXT("BattleMap"), ESearchCase::IgnoreCase);
-  if (!bIsBattleMap && TurnManager) {
-    for (const TSoftObjectPtr<UWorld> &Map : TurnManager->BattleMaps) {
-      if (CurrentLevel.Equals(Map.ToSoftObjectPath().GetAssetName(),
-                              ESearchCase::IgnoreCase)) {
-        bIsBattleMap = true;
-        break;
-      }
-    }
-  }
-  if (bIsBattleMap) {
-    if (USkaldGameInstance *GI = GetGameInstance<USkaldGameInstance>()) {
-      if (GI->GridBattleManager) {
-        ASkaldGameState *GS = GetGameState<ASkaldGameState>();
-        if (GS) {
-          for (APlayerState *BasePS : GS->PlayerArray) {
-            ASkaldPlayerState *PS = Cast<ASkaldPlayerState>(BasePS);
-            if (!PS || !PS->bIsAI) {
-              continue;
-            }
-
-            TArray<FFighterDefinition> Definitions =
-                GI->GridBattleManager->GetFightersForFaction(PS->Faction);
-            if (Definitions.Num() <= 0) {
-              PS->bHasLockedIn = true;
-              continue;
-            }
-
-            const int32 MaxCost = GI->PendingBattle.ArmyCountSent > 0
-                                      ? GI->PendingBattle.ArmyCountSent
-                                      : DefaultAIMaxCost;
-            int32 CurrentCost = 0;
-
-            Algo::RandomShuffle(Definitions);
-
-            TArray<FFighter> Fighters;
-            for (const FFighterDefinition &Def : Definitions) {
-              if (CurrentCost + Def.Stats.ArmyCost > MaxCost) {
-                continue;
-              }
-              FFighter Fighter;
-              Fighter.Stats = Def.Stats;
-              Fighter.Faction = PS->Faction;
-              Fighters.Add(Fighter);
-              CurrentCost += Def.Stats.ArmyCost;
-            }
-
-            if (Fighters.Num() > 0) {
-              GI->GridBattleManager->InitBattle(Fighters, Fighters);
-              GI->GridBattleManager->RollInitiative();
-              GI->GridBattleManager->StartRound();
-            }
-
-            PS->bHasLockedIn = true;
-          }
-        }
-      }
-    }
-
-    // Verification that player and controller counts match and a human owns
-    // at least one territory after travelling to the battle map.
-    if (ASkaldGameState *GS = GetGameState<ASkaldGameState>()) {
-      int32 ControllerCount = 0;
-      for (FConstPlayerControllerIterator It =
-               GetWorld()->GetPlayerControllerIterator();
-           It; ++It) {
-        ++ControllerCount;
-      }
-      ensureMsgf(GS->PlayerArray.Num() == ControllerCount,
-                 TEXT("PlayerCount %d != ControllerCount %d after travel"),
-                 GS->PlayerArray.Num(), ControllerCount);
-
-      bool bHumanHasTerritory = false;
-      if (WorldMap) {
-        for (APlayerState *BasePS : GS->PlayerArray) {
-          ASkaldPlayerState *PS = Cast<ASkaldPlayerState>(BasePS);
-          if (!PS || PS->bIsAI) {
-            continue;
-          }
-          for (ATerritory *Territory : WorldMap->Territories) {
-            if (WorldMap->IsOwnedBy(Territory, PS)) {
-              bHumanHasTerritory = true;
-              break;
-            }
-          }
-          if (bHumanHasTerritory) {
-            break;
-          }
-        }
-      }
-      ensureMsgf(bHumanHasTerritory,
-                 TEXT("Human player does not own any territory after travel"));
-    }
-  }
 }
 
 void ASkaldGameMode::PostLogin(APlayerController *NewPlayer) {

--- a/Source/Skald/Skald_GameMode.h
+++ b/Source/Skald/Skald_GameMode.h
@@ -133,10 +133,7 @@ public:
   /** Attempt to initialise the world and start the game flow. */
   void TryInitializeWorldAndStart();
 
-private:
-  /** Timer that triggers auto-start of the turn sequence. */
-  FTimerHandle StartGameTimerHandle;
-
+protected:
   /** Timer used to retry initialization until readiness checks pass. */
   FTimerHandle RetryInitTimerHandle;
 
@@ -145,6 +142,10 @@ private:
 
   /** Whether the world has been initialized and territories assigned. */
   bool bWorldInitialized;
+
+private:
+  /** Timer that triggers auto-start of the turn sequence. */
+  FTimerHandle StartGameTimerHandle;
 
   /** Flag to avoid spawning AI players multiple times. */
   bool bAIPlayersSpawned;


### PR DESCRIPTION
## Summary
- introduce `Skald_BattleGameMode` for battle maps with AI fighter auto-selection
- simplify `ASkaldGameMode` begin play by removing battle-specific setup
- route BattleMap to use the new battle game mode

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c77605b7fc8324a6286dbf744e2127