### PR TITLE
Allow game modes to override world initialization

### DIFF
--- a/Source/Skald/Skald_GameMode.h
+++ b/Source/Skald/Skald_GameMode.h
@@ -131,7 +131,7 @@ public:
   void UpdatePlayerResources(ASkaldPlayerState *Player);
 
   /** Attempt to initialise the world and start the game flow. */
-  void TryInitializeWorldAndStart();
+  virtual void TryInitializeWorldAndStart();
 
 protected:
   /** Timer used to retry initialization until readiness checks pass. */


### PR DESCRIPTION
## Summary
- mark `ASkaldGameMode::TryInitializeWorldAndStart` as `virtual` so derived game modes can replace initialization logic

## Testing
- `g++ -std=c++17 -fsyntax-only Source/Skald/Skald_GameMode.cpp` *(fails: CoreMinimal.h missing)*

------
https://chatgpt.com/codex/tasks/task_e_68c77802db388324b418a65ce97c9239