### PR TITLE
Fix compile errors in FighterDataLibrary and battle game mode

### DIFF
--- a/Source/Skald/FighterDataLibrary.cpp
+++ b/Source/Skald/FighterDataLibrary.cpp
@@ -1,6 +1,7 @@
 #include "FighterDataLibrary.h"
 
 #include "Engine/DataTable.h"
+#include "Engine/World.h"
 #include "Skald_GameInstance.h"
 
 /** Resolve the fighter data table from game singletons or a fallback path. */

--- a/Source/Skald/Skald_BattleGameMode.cpp
+++ b/Source/Skald/Skald_BattleGameMode.cpp
@@ -25,7 +25,7 @@ void ASkald_BattleGameMode::BeginPlay() {
         static_cast<int32>(FDateTime::Now().GetTicks() & 0x7FFFFFFF);
     BattleManager->SetRandomSeed(Seed);
     BattleManager->OnBattleEnded.AddDynamic(this,
-                                           &ASkaldGameMode::HandleBattleEnded);
+                                           &ASkald_BattleGameMode::HandleBattleEnded);
     if (USkaldGameInstance *GI = GetGameInstance<USkaldGameInstance>()) {
       GI->GridBattleManager = BattleManager;
     }


### PR DESCRIPTION
## Summary
- include Engine/World header for fighter data lookup
- bind battle-end delegate to accessible handler

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c77b6b85a483248bfbb4f557844db0