### PR TITLE
Fix DefaultAIMaxCost redefinition in Skald_GameMode

### DIFF
--- a/Source/Skald/Skald_GameMode.cpp
+++ b/Source/Skald/Skald_GameMode.cpp
@@ -23,7 +23,6 @@
 namespace {
 constexpr float StartGameTimeout = 10.f;
 constexpr int32 StartingResources = 100;
-constexpr int32 DefaultAIMaxCost = 10;
 constexpr float RetryInitDelay = 0.01f;
 // Instance variables moved into ASkaldGameMode to avoid cross-instance
 // interference; see header for declarations.


### PR DESCRIPTION
## Summary
- remove unused DefaultAIMaxCost constant from Skald_GameMode to prevent duplicate definition

## Testing
- `rg DefaultAIMaxCost -n`


------
https://chatgpt.com/codex/tasks/task_e_68c77fdab4d0832486960c1ffa6026d7