### PR TITLE
Implement grid battle victory flow and pending-battle spawning

### DIFF
--- a/Source/Skald/GridBattleManager.cpp
+++ b/Source/Skald/GridBattleManager.cpp
@@ -3,62 +3,6 @@
 #include "FighterPawn.h"
 #include "GridOverlayComponent.h"
 
-namespace
-{
-    /** Compute Manhattan distance between two positions. */
-    int32 Distance(const FIntPoint& A, const FIntPoint& B)
-    {
-        return FMath::Abs(A.X - B.X) + FMath::Abs(A.Y - B.Y);
-    }
-
-    /** Move a fighter towards a target up to their movement allowance. */
-    void MoveTowards(FFighter& Mover, const FFighter& Target)
-    {
-        int32 Required = Distance(Mover.Position, Target.Position) - Mover.Stats.AttackRange;
-        if (Required <= 0)
-        {
-            return;
-        }
-
-        int32 Steps = FMath::Min(Mover.Stats.Movement, Required);
-
-        if (Mover.Position.X < Target.Position.X)
-        {
-            int32 StepX = FMath::Min(Steps, Target.Position.X - Mover.Position.X);
-            Mover.Position.X += StepX;
-            Steps -= StepX;
-        }
-        else if (Mover.Position.X > Target.Position.X)
-        {
-            int32 StepX = FMath::Min(Steps, Mover.Position.X - Target.Position.X);
-            Mover.Position.X -= StepX;
-            Steps -= StepX;
-        }
-
-        if (Steps > 0)
-        {
-            if (Mover.Position.Y < Target.Position.Y)
-            {
-                int32 StepY = FMath::Min(Steps, Target.Position.Y - Mover.Position.Y);
-                Mover.Position.Y += StepY;
-            }
-            else if (Mover.Position.Y > Target.Position.Y)
-            {
-                int32 StepY = FMath::Min(Steps, Mover.Position.Y - Target.Position.Y);
-                Mover.Position.Y -= StepY;
-            }
-        }
-
-        Mover.Position.X = FMath::Clamp(Mover.Position.X, 0, UGridBattleManager::GridSize - 1);
-        Mover.Position.Y = FMath::Clamp(Mover.Position.Y, 0, UGridBattleManager::GridSize - 1);
-    }
-
-    bool IsInRange(const FFighter& Attacker, const FFighter& Defender)
-    {
-        return Distance(Attacker.Position, Defender.Position) <= Attacker.Stats.AttackRange;
-    }
-}
-
 UGridBattleManager::UGridBattleManager()
 {
     // FighterDefinitions is provided via editor (EditDefaultsOnly)
@@ -97,173 +41,7 @@ void UGridBattleManager::InitBattle(const TArray<FFighter>& Attackers, const TAr
     AttackerSurvivorArmyCost = 0;
     DefenderSurvivorArmyCost = 0;
     bTeamsAssigned = false;
-}
-
-void UGridBattleManager::StartBattle()
-{
-    bool bAttackerTurn = Rng.RandRange(1, 6) >= Rng.RandRange(1, 6);
-
-    int32 AttackerSurvivors = 0;
-    int32 AttackerSurvivorCost = 0;
-    for (const FFighter& Fighter : AttackerTeam)
-    {
-        if (Fighter.Stats.Health > 0)
-        {
-            ++AttackerSurvivors;
-            AttackerSurvivorCost += Fighter.Stats.ArmyCost;
-        }
-    }
-
-    int32 DefenderSurvivors = 0;
-    int32 DefenderSurvivorCost = 0;
-    for (const FFighter& Fighter : DefenderTeam)
-    {
-        if (Fighter.Stats.Health > 0)
-        {
-            ++DefenderSurvivors;
-            DefenderSurvivorCost += Fighter.Stats.ArmyCost;
-        }
-    }
-
-    TArray<FIntPoint> PreviousAttackerPositions;
-    PreviousAttackerPositions.Reserve(AttackerTeam.Num());
-    for (const FFighter& Fighter : AttackerTeam)
-    {
-        PreviousAttackerPositions.Add(Fighter.Position);
-    }
-    TArray<FIntPoint> PreviousDefenderPositions;
-    PreviousDefenderPositions.Reserve(DefenderTeam.Num());
-    for (const FFighter& Fighter : DefenderTeam)
-    {
-        PreviousDefenderPositions.Add(Fighter.Position);
-    }
-
-    int32 StalemateTurns = 0;
-
-    while (AttackerSurvivors > 0 && DefenderSurvivors > 0 && CurrentRound <= MaxRounds)
-    {
-        bool bDamageDealt = false;
-        TArray<FFighter>& ActingTeam = bAttackerTurn ? AttackerTeam : DefenderTeam;
-        TArray<FFighter>& TargetTeam = bAttackerTurn ? DefenderTeam : AttackerTeam;
-
-        for (FFighter& Fighter : ActingTeam)
-        {
-            if (Fighter.Stats.Health <= 0)
-            {
-                continue;
-            }
-
-            FFighter* Target = nullptr;
-            for (FFighter& Candidate : TargetTeam)
-            {
-                if (Candidate.Stats.Health > 0)
-                {
-                    Target = &Candidate;
-                    break;
-                }
-            }
-            if (!Target)
-            {
-                break;
-            }
-
-            MoveTowards(Fighter, *Target);
-            if (IsInRange(Fighter, *Target))
-            {
-                int32 Damage = 0;
-                bool bDefeated = ResolveAttack(Fighter, *Target, Damage, Rng);
-                if (Damage > 0)
-                {
-                    bDamageDealt = true;
-                }
-                if (bDefeated)
-                {
-                    if (bAttackerTurn)
-                    {
-                        --DefenderSurvivors;
-                        DefenderSurvivorCost -= Target->Stats.ArmyCost;
-                    }
-                    else
-                    {
-                        --AttackerSurvivors;
-                        AttackerSurvivorCost -= Target->Stats.ArmyCost;
-                    }
-                }
-            }
-
-            if (AttackerSurvivors <= 0 || DefenderSurvivors <= 0)
-            {
-                break;
-            }
-        }
-
-        bool bPositionsChanged = false;
-        for (int32 Index = 0; Index < AttackerTeam.Num(); ++Index)
-        {
-            if (AttackerTeam[Index].Position != PreviousAttackerPositions[Index])
-            {
-                bPositionsChanged = true;
-                break;
-            }
-        }
-        if (!bPositionsChanged)
-        {
-            for (int32 Index = 0; Index < DefenderTeam.Num(); ++Index)
-            {
-                if (DefenderTeam[Index].Position != PreviousDefenderPositions[Index])
-                {
-                    bPositionsChanged = true;
-                    break;
-                }
-            }
-        }
-
-        if (!bDamageDealt && !bPositionsChanged)
-        {
-            ++StalemateTurns;
-        }
-        else
-        {
-            StalemateTurns = 0;
-        }
-
-        for (int32 Index = 0; Index < AttackerTeam.Num(); ++Index)
-        {
-            PreviousAttackerPositions[Index] = AttackerTeam[Index].Position;
-        }
-        for (int32 Index = 0; Index < DefenderTeam.Num(); ++Index)
-        {
-            PreviousDefenderPositions[Index] = DefenderTeam[Index].Position;
-        }
-
-        if (StalemateTurns >= 2)
-        {
-            break;
-        }
-
-        bAttackerTurn = !bAttackerTurn;
-        ++CurrentRound;
-    }
-
-    AttackerSurvivorUnitCount = AttackerSurvivors;
-    DefenderSurvivorUnitCount = DefenderSurvivors;
-    AttackerSurvivorArmyCost = AttackerSurvivorCost;
-    DefenderSurvivorArmyCost = DefenderSurvivorCost;
-
-    ESkaldFaction Winner = ESkaldFaction::None;
-    if (AttackerSurvivors > 0 && DefenderSurvivors <= 0)
-    {
-        Winner = AttackerTeam.Num() > 0 ? AttackerTeam[0].Faction : ESkaldFaction::None;
-    }
-    else if (DefenderSurvivors > 0 && AttackerSurvivors <= 0)
-    {
-        Winner = DefenderTeam.Num() > 0 ? DefenderTeam[0].Faction : ESkaldFaction::None;
-    }
-
-    const int32 AttackerCasualties = AttackerInitialArmyCost - AttackerSurvivorArmyCost;
-    const int32 DefenderCasualties = DefenderInitialArmyCost - DefenderSurvivorArmyCost;
-
-    OnBattleEnded.Broadcast(Winner, AttackerCasualties, DefenderCasualties);
+    bBattleConcluded = false;
 }
 
 bool UGridBattleManager::ResolveAttack(FFighter& Attacker, FFighter& Defender, int32& OutDamage, FRandomStream& RandomStream)
@@ -458,6 +236,11 @@ void UGridBattleManager::StartRound()
 
 void UGridBattleManager::AdvanceTurn()
 {
+    if (bBattleConcluded)
+    {
+        return;
+    }
+
     if (ActiveFighter && ActiveFighter->IsAlive() && ActiveFighter->ActionsRemaining > 0)
     {
         return;
@@ -467,6 +250,35 @@ void UGridBattleManager::AdvanceTurn()
     {
         return !Fighter || !Fighter->IsAlive();
     });
+
+    bool bAttackerAlive = false;
+    bool bDefenderAlive = false;
+    for (AFighterPawn* Fighter : InitiativeOrder)
+    {
+        if (!Fighter)
+        {
+            continue;
+        }
+        if (Fighter->bIsAttacker)
+        {
+            bAttackerAlive = true;
+        }
+        else
+        {
+            bDefenderAlive = true;
+        }
+
+        if (bAttackerAlive && bDefenderAlive)
+        {
+            break;
+        }
+    }
+
+    if (!bBattleConcluded && (!bAttackerAlive || !bDefenderAlive || InitiativeOrder.Num() == 0))
+    {
+        EndBattle();
+        return;
+    }
 
     if (InitiativeOrder.Num() == 0)
     {
@@ -486,6 +298,12 @@ void UGridBattleManager::AdvanceTurn()
 
 void UGridBattleManager::EndBattle()
 {
+    if (bBattleConcluded)
+    {
+        return;
+    }
+    bBattleConcluded = true;
+
     AttackerSurvivorUnitCount = 0;
     DefenderSurvivorUnitCount = 0;
     AttackerSurvivorArmyCost = 0;

--- a/Source/Skald/GridBattleManager.h
+++ b/Source/Skald/GridBattleManager.h
@@ -117,10 +117,6 @@ public:
     UFUNCTION(BlueprintCallable, Category="Battle")
     void InitBattle(const TArray<FFighter>& Attackers, const TArray<FFighter>& Defenders);
 
-    /** Begin the battle and resolve rounds until a victor is found. */
-    UFUNCTION(BlueprintCallable, Category="Skald|Battle")
-    void StartBattle();
-
     /** Set the seed for the internal random stream. */
     UFUNCTION(BlueprintCallable, Category="Skald|Battle")
     void SetRandomSeed(int32 Seed);
@@ -160,6 +156,14 @@ public:
     /** Total army cost of surviving defenders. Equivalent to GetDefenderSurvivors. */
     UFUNCTION(BlueprintCallable, BlueprintPure, Category="Skald|Battle")
     int32 GetDefenderSurvivorCost() const;
+
+    /** Total initial cost of the attacking army. */
+    UFUNCTION(BlueprintCallable, BlueprintPure, Category="Skald|Battle")
+    int32 GetAttackerInitialArmyCost() const { return AttackerInitialArmyCost; }
+
+    /** Total initial cost of the defending army. */
+    UFUNCTION(BlueprintCallable, BlueprintPure, Category="Skald|Battle")
+    int32 GetDefenderInitialArmyCost() const { return DefenderInitialArmyCost; }
 
       /** Fighter currently taking its turn. */
       UFUNCTION(BlueprintCallable, BlueprintPure, Category="Battle")
@@ -231,5 +235,8 @@ private:
 
     /** Whether fighters have been assigned to attacker or defender sides. */
     bool bTeamsAssigned = false;
+
+    /** Ensures EndBattle only broadcasts once per encounter. */
+    bool bBattleConcluded = false;
 };
 

--- a/Source/Skald/SkaldTypes.h
+++ b/Source/Skald/SkaldTypes.h
@@ -135,6 +135,57 @@ struct SKALD_API FS_BattlePayload
     /** Seed used for deterministic combat resolution. */
     UPROPERTY(BlueprintReadWrite, EditAnywhere)
     int32 RandomSeed = 0;
+
+    /** Map name to travel back to once the battle concludes. */
+    UPROPERTY(BlueprintReadWrite, EditAnywhere)
+    FString ReturnMap;
+};
+
+/** Serialized outcome of a resolved grid battle. */
+USTRUCT(BlueprintType)
+struct SKALD_API FGridBattleResolution
+{
+    GENERATED_BODY();
+
+    /** True when this structure holds valid resolution data. */
+    UPROPERTY(BlueprintReadWrite, EditAnywhere)
+    bool bValid = false;
+
+    /** Faction that won the battle (None for stalemates). */
+    UPROPERTY(BlueprintReadWrite, EditAnywhere)
+    ESkaldFaction WinningFaction = ESkaldFaction::None;
+
+    /** Player ID of the winning side (-1 for stalemates). */
+    UPROPERTY(BlueprintReadWrite, EditAnywhere)
+    int32 WinningPlayerID = -1;
+
+    /** Player ID that now owns the contested territory. */
+    UPROPERTY(BlueprintReadWrite, EditAnywhere)
+    int32 NewOwnerPlayerID = -1;
+
+    /** Total attacker casualties expressed in army-cost units. */
+    UPROPERTY(BlueprintReadWrite, EditAnywhere)
+    int32 AttackerCasualties = 0;
+
+    /** Total defender casualties expressed in army-cost units. */
+    UPROPERTY(BlueprintReadWrite, EditAnywhere)
+    int32 DefenderCasualties = 0;
+
+    /** Surviving attacker army cost that should garrison the captured territory. */
+    UPROPERTY(BlueprintReadWrite, EditAnywhere)
+    int32 AttackerSurvivorArmyCost = 0;
+
+    /** Surviving defender army cost that remains in the territory. */
+    UPROPERTY(BlueprintReadWrite, EditAnywhere)
+    int32 DefenderSurvivorArmyCost = 0;
+
+    /** Remaining army at the source territory after casualties. */
+    UPROPERTY(BlueprintReadWrite, EditAnywhere)
+    int32 SourceArmyRemaining = 0;
+
+    /** Remaining army at the target territory after casualties/application. */
+    UPROPERTY(BlueprintReadWrite, EditAnywhere)
+    int32 TargetArmyRemaining = 0;
 };
 
 USTRUCT(BlueprintType)

--- a/Source/Skald/Skald_BattleGameMode.cpp
+++ b/Source/Skald/Skald_BattleGameMode.cpp
@@ -6,13 +6,12 @@
 #include "Skald_GameState.h"
 #include "Skald_PlayerState.h"
 #include "Engine/World.h"
+#include "EngineUtils.h"
+#include "FighterPawn.h"
+#include "GridOverlayComponent.h"
 #include "Territory.h"
 #include "TimerManager.h"
 #include "WorldMap.h"
-
-namespace {
-constexpr int32 DefaultAIMaxCost = 10;
-}
 
 void ASkald_BattleGameMode::BeginPlay() {
   Super::BeginPlay();
@@ -26,58 +25,13 @@ void ASkald_BattleGameMode::BeginPlay() {
     BattleManager->SetRandomSeed(Seed);
     BattleManager->OnBattleEnded.AddDynamic(this,
                                            &ASkald_BattleGameMode::HandleBattleEnded);
-    if (USkaldGameInstance *GI = GetGameInstance<USkaldGameInstance>()) {
-      GI->GridBattleManager = BattleManager;
-    }
   }
 
   if (USkaldGameInstance *GI = GetGameInstance<USkaldGameInstance>()) {
-    if (GI->GridBattleManager) {
-      ASkaldGameState *GS = GetGameState<ASkaldGameState>();
-      if (GS) {
-        for (APlayerState *BasePS : GS->PlayerArray) {
-          ASkaldPlayerState *PS = Cast<ASkaldPlayerState>(BasePS);
-          if (!PS || !PS->bIsAI) {
-            continue;
-          }
-
-          TArray<FFighterDefinition> Definitions =
-              GI->GridBattleManager->GetFightersForFaction(PS->Faction);
-          if (Definitions.Num() <= 0) {
-            PS->bHasLockedIn = true;
-            continue;
-          }
-
-          const int32 MaxCost = GI->PendingBattle.ArmyCountSent > 0
-                                    ? GI->PendingBattle.ArmyCountSent
-                                    : DefaultAIMaxCost;
-          int32 CurrentCost = 0;
-
-          Algo::RandomShuffle(Definitions);
-
-          TArray<FFighter> Fighters;
-          for (const FFighterDefinition &Def : Definitions) {
-            if (CurrentCost + Def.Stats.ArmyCost > MaxCost) {
-              continue;
-            }
-            FFighter Fighter;
-            Fighter.Stats = Def.Stats;
-            Fighter.Faction = PS->Faction;
-            Fighters.Add(Fighter);
-            CurrentCost += Def.Stats.ArmyCost;
-          }
-
-          if (Fighters.Num() > 0) {
-            GI->GridBattleManager->InitBattle(Fighters, Fighters);
-            GI->GridBattleManager->RollInitiative();
-            GI->GridBattleManager->StartRound();
-          }
-
-          PS->bHasLockedIn = true;
-        }
-      }
-    }
+    GI->GridBattleManager = BattleManager;
   }
+
+  SetupPendingBattle();
 
   if (ASkaldGameState *GS = GetGameState<ASkaldGameState>()) {
     int32 ControllerCount = 0;
@@ -112,6 +66,190 @@ void ASkald_BattleGameMode::BeginPlay() {
         bHumanHasTerritory,
         TEXT("Human player does not own any territory after travel"));
   }
+}
+
+void ASkald_BattleGameMode::SetupPendingBattle() {
+  if (!HasAuthority()) {
+    return;
+  }
+
+  bBattleLaunched = false;
+
+  USkaldGameInstance *GI = GetGameInstance<USkaldGameInstance>();
+  if (!GI || !GI->GridBattleManager) {
+    return;
+  }
+
+  ASkaldGameState *GS = GetGameState<ASkaldGameState>();
+  if (!GS) {
+    return;
+  }
+
+  const FS_BattlePayload Battle = GI->PendingBattle;
+  ASkaldPlayerState *AttackerPS = GS->GetPlayerById(Battle.AttackerPlayerID);
+  ASkaldPlayerState *DefenderPS = GS->GetPlayerById(Battle.DefenderPlayerID);
+
+  const int32 AttackerBudget = FMath::Max(0, Battle.ArmyCountSent);
+  const int32 DefenderBudget =
+      Battle.DefenderArmyCount > 0 ? Battle.DefenderArmyCount : Battle.ArmyCountSent;
+
+  BeginPreBattleSelection(AttackerPS, DefenderPS, AttackerBudget, DefenderBudget);
+
+  AutoCommitAIArmy(AttackerPS, AttackerBudget);
+  AutoCommitAIArmy(DefenderPS, DefenderBudget);
+
+  TryLaunchBattle();
+}
+
+void ASkald_BattleGameMode::AutoCommitAIArmy(ASkaldPlayerState *PlayerState,
+                                             int32 Budget) const {
+  if (!PlayerState || !PlayerState->bIsAI || !BattleManager) {
+    return;
+  }
+
+  TArray<FFighterDefinition> Definitions =
+      BattleManager->GetFightersForFaction(PlayerState->Faction);
+  if (Definitions.Num() == 0) {
+    PlayerState->PendingArmy.Reset();
+    PlayerState->bArmyLockedIn = true;
+    return;
+  }
+
+  Algo::RandomShuffle(Definitions);
+
+  TArray<FFighterDefinition> Selection;
+  int32 CurrentCost = 0;
+  for (const FFighterDefinition &Def : Definitions) {
+    const int32 Cost = FMath::Max(Def.Stats.ArmyCost, 0);
+    if (Cost > 0 && Budget >= 0 && CurrentCost + Cost > Budget) {
+      continue;
+    }
+
+    Selection.Add(Def);
+    if (Cost > 0) {
+      CurrentCost += Cost;
+    }
+
+    if (Budget > 0 && CurrentCost >= Budget) {
+      break;
+    }
+  }
+
+  PlayerState->PendingArmy = Selection;
+  PlayerState->bArmyLockedIn = true;
+}
+
+void ASkald_BattleGameMode::SpawnFighterSide(const TArray<FFighterDefinition> &Roster,
+                                             bool bAsAttacker) {
+  if (!BattleManager || !GetWorld()) {
+    return;
+  }
+
+  USkaldGameInstance *GI = GetGameInstance<USkaldGameInstance>();
+  if (!GI) {
+    return;
+  }
+
+  UGridOverlayComponent *Grid = nullptr;
+  for (TActorIterator<AActor> It(GetWorld()); It; ++It) {
+    if (UGridOverlayComponent *Found =
+            It->FindComponentByClass<UGridOverlayComponent>()) {
+      Grid = Found;
+      break;
+    }
+  }
+
+  const int32 Edge = 3;
+  const int32 MaxX = UGridBattleManager::GridSize - 1;
+  const int32 MaxY = UGridBattleManager::GridSize - 1;
+
+  for (const FFighterDefinition &Def : Roster) {
+    FIntPoint Cell;
+    Cell.Y = GI->CombatRandomStream.RandRange(0, MaxY);
+    Cell.X = bAsAttacker ? GI->CombatRandomStream.RandRange(0, Edge - 1)
+                         : GI->CombatRandomStream.RandRange(MaxX - (Edge - 1), MaxX);
+
+    const FVector SpawnLoc = Grid ? Grid->GridToWorld(Cell) : FVector::ZeroVector;
+    FActorSpawnParameters Params;
+    Params.SpawnCollisionHandlingOverride =
+        ESpawnActorCollisionHandlingMethod::AdjustIfPossibleButAlwaysSpawn;
+    AFighterPawn *Pawn = GetWorld()->SpawnActor<AFighterPawn>(
+        AFighterPawn::StaticClass(), SpawnLoc, FRotator::ZeroRotator, Params);
+    if (Pawn) {
+      Pawn->Stats = Def.Stats;
+      Pawn->bIsAttacker = bAsAttacker;
+      BattleManager->RegisterFighter(Pawn, bAsAttacker);
+    }
+  }
+}
+
+void ASkald_BattleGameMode::TryLaunchBattle() {
+  if (bBattleLaunched || !HasAuthority()) {
+    return;
+  }
+
+  USkaldGameInstance *GI = GetGameInstance<USkaldGameInstance>();
+  if (!GI || !GI->GridBattleManager) {
+    return;
+  }
+
+  ASkaldGameState *GS = GetGameState<ASkaldGameState>();
+  if (!GS) {
+    return;
+  }
+
+  const FS_BattlePayload &Battle = GI->PendingBattle;
+  ASkaldPlayerState *AttackerPS = GS->GetPlayerById(Battle.AttackerPlayerID);
+  ASkaldPlayerState *DefenderPS = GS->GetPlayerById(Battle.DefenderPlayerID);
+
+  if ((AttackerPS && !AttackerPS->bArmyLockedIn) ||
+      (DefenderPS && !DefenderPS->bArmyLockedIn)) {
+    return;
+  }
+
+  TArray<FFighterDefinition> AttackerDefs =
+      AttackerPS ? AttackerPS->PendingArmy : TArray<FFighterDefinition>();
+  TArray<FFighterDefinition> DefenderDefs =
+      DefenderPS ? DefenderPS->PendingArmy : TArray<FFighterDefinition>();
+
+  TArray<FFighter> Attackers;
+  Attackers.Reserve(AttackerDefs.Num());
+  for (const FFighterDefinition &Def : AttackerDefs) {
+    FFighter Fighter;
+    Fighter.Stats = Def.Stats;
+    Fighter.Faction = AttackerPS ? AttackerPS->Faction : Def.Faction;
+    Attackers.Add(Fighter);
+  }
+
+  TArray<FFighter> Defenders;
+  Defenders.Reserve(DefenderDefs.Num());
+  for (const FFighterDefinition &Def : DefenderDefs) {
+    FFighter Fighter;
+    Fighter.Stats = Def.Stats;
+    Fighter.Faction = DefenderPS ? DefenderPS->Faction : Def.Faction;
+    Defenders.Add(Fighter);
+  }
+
+  GI->GridBattleManager->InitBattle(Attackers, Defenders);
+
+  SpawnFighterSide(AttackerDefs, /*bAsAttacker=*/true);
+  SpawnFighterSide(DefenderDefs, /*bAsAttacker=*/false);
+
+  GI->GridBattleManager->RollInitiative();
+  GI->GridBattleManager->StartRound();
+
+  if (AttackerPS) {
+    AttackerPS->bArmyLockedIn = false;
+    AttackerPS->PendingArmy.Reset();
+    AttackerPS->PendingArmyBudget = 0;
+  }
+  if (DefenderPS) {
+    DefenderPS->bArmyLockedIn = false;
+    DefenderPS->PendingArmy.Reset();
+    DefenderPS->PendingArmyBudget = 0;
+  }
+
+  bBattleLaunched = true;
 }
 
 void ASkald_BattleGameMode::TryInitializeWorldAndStart() {

--- a/Source/Skald/Skald_BattleGameMode.h
+++ b/Source/Skald/Skald_BattleGameMode.h
@@ -9,8 +9,20 @@ UCLASS()
 class SKALD_API ASkald_BattleGameMode : public ASkaldGameMode {
   GENERATED_BODY()
 
+public:
+  /** Attempt to start the tactical battle once both sides have supplied armies. */
+  void TryLaunchBattle();
+
 protected:
   virtual void BeginPlay() override;
   virtual void TryInitializeWorldAndStart() override;
+
+private:
+  void SetupPendingBattle();
+  void AutoCommitAIArmy(ASkaldPlayerState *PlayerState, int32 Budget) const;
+  void SpawnFighterSide(const TArray<FFighterDefinition> &Roster, bool bAsAttacker);
+
+  /** Ensures the battle only launches once per travel. */
+  bool bBattleLaunched = false;
 };
 

--- a/Source/Skald/Skald_GameInstance.cpp
+++ b/Source/Skald/Skald_GameInstance.cpp
@@ -11,6 +11,10 @@ void USkaldGameInstance::Init() {
     TakenFactions.Add(Faction);
   }
 
+  PendingBattle = FS_BattlePayload();
+  PendingBattleResolution = FGridBattleResolution();
+  bPendingBattleResolution = false;
+
   if (GEngine) {
     GEngine->OnNetworkFailure().AddUObject(
         this, &USkaldGameInstance::HandleNetworkFailure);
@@ -42,6 +46,8 @@ void USkaldGameInstance::HandleNetworkFailure(
   }
   OnFactionsUpdated.Broadcast();
   PendingBattle = FS_BattlePayload();
+  PendingBattleResolution = FGridBattleResolution();
+  bPendingBattleResolution = false;
   GridBattleManager = nullptr;
   SeedCombatRandomStream(FMath::Rand());
   SavedTurnIndex = 0;

--- a/Source/Skald/Skald_GameInstance.h
+++ b/Source/Skald/Skald_GameInstance.h
@@ -57,6 +57,14 @@ public:
   UPROPERTY(BlueprintReadWrite, Category = "Battle")
   FS_BattlePayload PendingBattle;
 
+  /** Serialized results waiting to be applied on the overworld. */
+  UPROPERTY(BlueprintReadWrite, Category = "Battle")
+  FGridBattleResolution PendingBattleResolution;
+
+  /** True when PendingBattleResolution contains unapplied data. */
+  UPROPERTY(BlueprintReadWrite, Category = "Battle")
+  bool bPendingBattleResolution = false;
+
   /** Runtime manager used to execute grid based battles. */
   UPROPERTY(BlueprintReadWrite, Category = "Battle")
   class UGridBattleManager *GridBattleManager = nullptr;

--- a/Source/Skald/Skald_GameMode.cpp
+++ b/Source/Skald/Skald_GameMode.cpp
@@ -457,20 +457,25 @@ void ASkaldGameMode::BeginPreBattleSelection(ASkaldPlayerState *A,
   if (!HasAuthority()) {
     return;
   }
-  if (!A || !D) {
-    return;
+
+  if (A) {
+    A->PendingArmyBudget = ABudget;
+    A->PendingArmy.Reset();
+    A->bArmyLockedIn = false;
+    if (ASkaldPlayerController *APC =
+            Cast<ASkaldPlayerController>(A->GetOwner())) {
+      APC->Client_ShowFighterSelection(ABudget, A->Faction);
+    }
   }
 
-  A->PendingArmyBudget = ABudget;
-  D->PendingArmyBudget = DBudget;
-
-  if (ASkaldPlayerController *APC =
-          Cast<ASkaldPlayerController>(A->GetOwner())) {
-    APC->Client_ShowFighterSelection(ABudget, A->Faction);
-  }
-  if (ASkaldPlayerController *DPC =
-          Cast<ASkaldPlayerController>(D->GetOwner())) {
-    DPC->Client_ShowFighterSelection(DBudget, D->Faction);
+  if (D) {
+    D->PendingArmyBudget = DBudget;
+    D->PendingArmy.Reset();
+    D->bArmyLockedIn = false;
+    if (ASkaldPlayerController *DPC =
+            Cast<ASkaldPlayerController>(D->GetOwner())) {
+      DPC->Client_ShowFighterSelection(DBudget, D->Faction);
+    }
   }
 }
 

--- a/Source/Skald/Skald_PlayerController.cpp
+++ b/Source/Skald/Skald_PlayerController.cpp
@@ -17,12 +17,14 @@
 #include "Skald_AIController.h"
 #include "Skald_GameInstance.h"
 #include "Skald_GameMode.h"
+#include "Skald_BattleGameMode.h"
 #include "Skald_GameState.h"
 #include "Skald_PlayerState.h"
 #include "Skald_TurnManager.h"
 #include "Territory.h"
 #include "TimerManager.h"
 #include "UI/BattleHUDWidget.h"
+#include "UI/BattleResultWidget.h"
 #include "UI/DeployWidget.h"
 #include "UI/FighterSelectionWidget.h"
 #include "UI/SkaldMainHUDWidget.h"
@@ -46,6 +48,7 @@ ASkaldPlayerController::ASkaldPlayerController() {
   // blueprint-derived widget that may not exist or may be corrupt.
   HUDWidgetClass = USkaldMainHUDWidget::StaticClass();
   BattleHUDWidgetClass = UBattleHUDWidget::StaticClass();
+  VictoryWidgetClass = UBattleResultWidget::StaticClass();
 
   static ConstructorHelpers::FClassFinder<UChoosePlayerWidget> ChooseBP(
       TEXT("/Game/Blueprints/UI/Skald_ChoosePlayerWidget"));
@@ -351,7 +354,19 @@ bool ASkaldPlayerController::Server_CommitArmy_Validate(
 void ASkaldPlayerController::Server_CommitArmy_Implementation(
     const TArray<FFighterDefinition> &Chosen) {
   ASkaldPlayerState *PS = GetPlayerState<ASkaldPlayerState>();
+  USkaldGameInstance *GI = GetGameInstance<USkaldGameInstance>();
+  if (!GI) {
+    return;
+  }
+  const FS_BattlePayload Battle = GI->PendingBattle;
+
   if (PS) {
+    const int32 PlayerID = PS->GetPlayerId();
+    if (PlayerID != Battle.AttackerPlayerID &&
+        PlayerID != Battle.DefenderPlayerID) {
+      return;
+    }
+
     TArray<FFighterDefinition> ValidFighters;
     int32 TotalCost = 0;
     for (const FFighterDefinition &Def : Chosen) {
@@ -370,100 +385,9 @@ void ASkaldPlayerController::Server_CommitArmy_Implementation(
     PS->bArmyLockedIn = true;
   }
 
-  UWorld *W = GetWorld();
-  if (!W) {
-    return;
-  }
-
-  ASkaldGameState *GS = W->GetGameState<ASkaldGameState>();
-  if (!GS) {
-    return;
-  }
-
-  int32 ReadyCount = 0;
-  ASkaldPlayerState *First = nullptr;
-  ASkaldPlayerState *Second = nullptr;
-  for (APlayerState *Base : GS->PlayerArray) {
-    if (ASkaldPlayerState *S = Cast<ASkaldPlayerState>(Base)) {
-      if (S->bArmyLockedIn) {
-        ++ReadyCount;
-        if (!First) {
-          First = S;
-        } else if (!Second) {
-          Second = S;
-        }
-      }
-    }
-  }
-
-  if (ReadyCount >= 2 && First && Second) {
-    if (USkaldGameInstance *GI = GetGameInstance<USkaldGameInstance>()) {
-      if (GI->GridBattleManager) {
-        TArray<FFighter> Attackers;
-        for (const FFighterDefinition &Def : First->PendingArmy) {
-          FFighter F;
-          F.Stats = Def.Stats;
-          F.Faction = First->Faction;
-          Attackers.Add(F);
-        }
-
-        TArray<FFighter> Defenders;
-        for (const FFighterDefinition &Def : Second->PendingArmy) {
-          FFighter F;
-          F.Stats = Def.Stats;
-          F.Faction = Second->Faction;
-          Defenders.Add(F);
-        }
-
-        GI->GridBattleManager->InitBattle(Attackers, Defenders);
-
-        UGridOverlayComponent *Grid = FindGridOverlay();
-        auto *BM = GI->GridBattleManager;
-        FRandomStream &RS = GI->CombatRandomStream;
-        const int32 Edge = 3;
-        const int32 MaxX = UGridBattleManager::GridSize - 1;
-        const int32 MaxY = UGridBattleManager::GridSize - 1;
-
-        auto SpawnAtCell = [&](const FIntPoint &Cell,
-                               const FFighterDefinition &Def,
-                               bool bAsAttacker) {
-          const FVector SpawnLoc =
-              Grid ? Grid->GridToWorld(Cell) : FVector::ZeroVector;
-          FActorSpawnParameters Params;
-          Params.SpawnCollisionHandlingOverride =
-              ESpawnActorCollisionHandlingMethod::
-                  AdjustIfPossibleButAlwaysSpawn;
-          AFighterPawn *Pawn =
-              W->SpawnActor<AFighterPawn>(AFighterPawn::StaticClass(), SpawnLoc,
-                                          FRotator::ZeroRotator, Params);
-          if (Pawn) {
-            Pawn->Stats = Def.Stats;
-            Pawn->bIsAttacker = bAsAttacker;
-            BM->RegisterFighter(Pawn, bAsAttacker);
-          }
-        };
-
-        for (const FFighterDefinition &Def : First->PendingArmy) {
-          FIntPoint Cell(RS.RandRange(0, Edge - 1), RS.RandRange(0, MaxY));
-          SpawnAtCell(Cell, Def, true);
-        }
-        for (const FFighterDefinition &Def : Second->PendingArmy) {
-          FIntPoint Cell(RS.RandRange(MaxX - (Edge - 1), MaxX),
-                         RS.RandRange(0, MaxY));
-          SpawnAtCell(Cell, Def, false);
-        }
-
-        BM->RollInitiative();
-        BM->StartRound();
-      }
-    }
-
-    First->bArmyLockedIn = false;
-    Second->bArmyLockedIn = false;
-    First->PendingArmy.Reset();
-    Second->PendingArmy.Reset();
-    First->PendingArmyBudget = 0;
-    Second->PendingArmyBudget = 0;
+  if (ASkald_BattleGameMode *BattleGM =
+          GetWorld()->GetAuthGameMode<ASkald_BattleGameMode>()) {
+    BattleGM->TryLaunchBattle();
   }
 }
 
@@ -492,6 +416,10 @@ void ASkaldPlayerController::InitializeBattleHUD() {
       GI->GridBattleManager->OnActiveFighterChanged.RemoveAll(this);
       GI->GridBattleManager->OnActiveFighterChanged.AddDynamic(
           this, &ASkaldPlayerController::HandleActiveFighterChanged);
+      GI->GridBattleManager->OnBattleEnded.RemoveDynamic(
+          this, &ASkaldPlayerController::HandleBattleEnded);
+      GI->GridBattleManager->OnBattleEnded.AddDynamic(
+          this, &ASkaldPlayerController::HandleBattleEnded);
       // Initial bind
       HandleActiveFighterChanged(GI->GridBattleManager->GetActiveFighter());
     }
@@ -1260,64 +1188,8 @@ void ASkaldPlayerController::HandleFighterSelectionLockedIn() {
     Selection->OnLockedIn.RemoveDynamic(
         this, &ASkaldPlayerController::HandleFighterSelectionLockedIn);
     Selection->RemoveFromParent();
-
-    if (CachedGameInstance && CachedGameInstance->GridBattleManager) {
-      TArray<FFighter> Fighters;
-      for (const FFighterDefinition &Def : Selection->ChosenFighters) {
-        FFighter Fighter;
-        Fighter.Stats = Def.Stats;
-        if (ASkaldPlayerState *PS = GetPlayerState<ASkaldPlayerState>()) {
-          Fighter.Faction = PS->Faction;
-        }
-        Fighters.Add(Fighter);
-      }
-      CachedGameInstance->GridBattleManager->InitBattle(Fighters, Fighters);
-
-      UGridOverlayComponent *Grid = FindGridOverlay();
-      UWorld *World = GetWorld();
-      auto *BM = CachedGameInstance->GridBattleManager;
-      FRandomStream &RS = CachedGameInstance->CombatRandomStream;
-
-      const int32 Edge = 3;
-      const int32 MaxX = UGridBattleManager::GridSize - 1;
-      const int32 MaxY = UGridBattleManager::GridSize - 1;
-
-      auto SpawnAtCell = [&](const FIntPoint &Cell,
-                             const FFighterDefinition &Def, bool bAsAttacker) {
-        const FVector SpawnLoc =
-            Grid ? Grid->GridToWorld(Cell) : FVector::ZeroVector;
-        FActorSpawnParameters Params;
-        Params.SpawnCollisionHandlingOverride =
-            ESpawnActorCollisionHandlingMethod::AdjustIfPossibleButAlwaysSpawn;
-        AFighterPawn *Pawn = World->SpawnActor<AFighterPawn>(
-            AFighterPawn::StaticClass(), SpawnLoc, FRotator::ZeroRotator,
-            Params);
-        if (Pawn) {
-          Pawn->Stats = Def.Stats;
-          Pawn->bIsAttacker = bAsAttacker;
-          BM->RegisterFighter(Pawn, bAsAttacker);
-        }
-      };
-
-      // Spawn attackers on the left edge
-      for (const FFighterDefinition &Def : Selection->ChosenFighters) {
-        FIntPoint Cell(RS.RandRange(0, Edge - 1), RS.RandRange(0, MaxY));
-        SpawnAtCell(Cell, Def, /*bAsAttacker=*/true);
-      }
-      // Spawn defenders on the right edge (mirror selection for now)
-      for (const FFighterDefinition &Def : Selection->ChosenFighters) {
-        FIntPoint Cell(RS.RandRange(MaxX - (Edge - 1), MaxX),
-                       RS.RandRange(0, MaxY));
-        SpawnAtCell(Cell, Def, /*bAsAttacker=*/false);
-      }
-
-      BM->RollInitiative();
-      BM->StartRound();
-      BM->OnBattleEnded.AddDynamic(this,
-                                   &ASkaldPlayerController::HandleBattleEnded);
-
-      InitializeBattleHUD();
-    }
+    Server_CommitArmy(Selection->ChosenFighters);
+    InitializeBattleHUD();
     FighterSelectionWidget = nullptr;
     if (MainHudWidget) {
       MainHudWidget->SetVisibility(ESlateVisibility::Collapsed);
@@ -1451,14 +1323,32 @@ void ASkaldPlayerController::HandleBattleEnded(ESkaldFaction WinningFaction,
     BattleHudWidget = nullptr;
   }
 
+  bool bPlayerWon = false;
+  bool bPlayerLost = false;
+  if (ASkaldPlayerState *PS = GetPlayerState<ASkaldPlayerState>()) {
+    if (WinningFaction != ESkaldFaction::None && PS->Faction == WinningFaction) {
+      bPlayerWon = true;
+    } else if (WinningFaction != ESkaldFaction::None) {
+      bPlayerLost = true;
+    }
+  }
+
+  if (!VictoryWidgetClass) {
+    VictoryWidgetClass = UBattleResultWidget::StaticClass();
+  }
+
   if (VictoryWidgetClass) {
     if (UUserWidget *Widget =
             CreateWidget<UUserWidget>(this, VictoryWidgetClass)) {
+      if (UBattleResultWidget *ResultWidget = Cast<UBattleResultWidget>(Widget)) {
+        ResultWidget->SetBattleOutcome(bPlayerWon, bPlayerLost, AttackerCasualties,
+                                       DefenderCasualties);
+      }
       Widget->AddToViewport();
     }
   }
 
-  if (TurnManager) {
-    TurnManager->ResolveGridBattleResult();
+  if (MainHudWidget) {
+    MainHudWidget->SetVisibility(ESlateVisibility::Collapsed);
   }
 }

--- a/Source/Skald/Skald_TurnManager.cpp
+++ b/Source/Skald/Skald_TurnManager.cpp
@@ -38,12 +38,12 @@ void ATurnManager::BeginPlay() {
 
   if (USkaldGameInstance *GI = GetGameInstance<USkaldGameInstance>()) {
     // Only resolve results when we are back on the world map
-    if (GI->GridBattleManager && bOnWorldMap) {
+    if (bOnWorldMap && (GI->GridBattleManager || GI->bPendingBattleResolution)) {
       ResolveGridBattleResult();
     }
 
     // On the battle map, listen for battle end and travel back on event
-    if (GI->GridBattleManager && !bOnWorldMap) {
+    if (!bOnWorldMap && GI->GridBattleManager) {
       GI->GridBattleManager->OnBattleEnded.AddDynamic(
           this, &ATurnManager::HandleGridBattleEnded);
     }
@@ -71,9 +71,22 @@ void ATurnManager::BeginPlay() {
 }
 
 void ATurnManager::HandleGridBattleEnded(ESkaldFaction /*WinningFaction*/, int32 /*AttackerCasualties*/, int32 /*DefenderCasualties*/) {
+  FString ReturnMapName;
+  if (!PendingBattle.ReturnMap.IsEmpty()) {
+    ReturnMapName = PendingBattle.ReturnMap;
+  } else if (USkaldGameInstance *GI = GetGameInstance<USkaldGameInstance>()) {
+    ReturnMapName = GI->PendingBattle.ReturnMap;
+  }
+
+  if (ReturnMapName.IsEmpty()) {
+    ReturnMapName = UGameplayStatics::GetCurrentLevelName(this, true);
+  }
+
+  ResolveGridBattleResult();
+
   if (UWorld *World = GetWorld()) {
     // Travel back to the overworld after the tactical battle ends
-    World->ServerTravel(TEXT("WorldMap"));
+    World->ServerTravel(ReturnMapName);
   }
 }
 
@@ -317,11 +330,16 @@ TArray<ASkaldPlayerController *> ATurnManager::GetControllers() const {
 void ATurnManager::TriggerGridBattle(const FS_BattlePayload &Battle) {
   FS_BattlePayload SeededBattle = Battle;
   SeededBattle.RandomSeed = FMath::Rand();
+  if (UWorld *World = GetWorld()) {
+    SeededBattle.ReturnMap = UGameplayStatics::GetCurrentLevelName(World, true);
+  }
   PendingBattle = SeededBattle;
 
   if (USkaldGameInstance *GI = GetGameInstance<USkaldGameInstance>()) {
     GI->SeedCombatRandomStream(SeededBattle.RandomSeed);
     GI->PendingBattle = SeededBattle;
+    GI->PendingBattleResolution = FGridBattleResolution();
+    GI->bPendingBattleResolution = false;
     if (!GI->GridBattleManager) {
       GI->GridBattleManager = NewObject<UGridBattleManager>(GI);
     }
@@ -354,20 +372,76 @@ void ATurnManager::TriggerGridBattle(const FS_BattlePayload &Battle) {
 
 void ATurnManager::ResolveGridBattleResult_Implementation() {
   USkaldGameInstance *GI = GetGameInstance<USkaldGameInstance>();
-  if (GI) {
-    GI->bIsInBattleMap = false;
-  }
-  if (!GI || !GI->GridBattleManager) {
+  if (!GI) {
     return;
   }
 
-  const FS_BattlePayload Battle = GI->PendingBattle;
-  PendingBattle = Battle;
+  GI->bIsInBattleMap = false;
+
+  // Always mirror the pending payload locally for reference.
+  PendingBattle = GI->PendingBattle;
+
+  // Capture the battle results from the active manager if available.
+  if (GI->GridBattleManager) {
+    FGridBattleResolution Resolution;
+    Resolution.bValid = true;
+    Resolution.AttackerSurvivorArmyCost =
+        GI->GridBattleManager->GetAttackerSurvivorCost();
+    Resolution.DefenderSurvivorArmyCost =
+        GI->GridBattleManager->GetDefenderSurvivorCost();
+    Resolution.AttackerCasualties = GI->GridBattleManager->GetAttackerInitialArmyCost() -
+                                    Resolution.AttackerSurvivorArmyCost;
+    Resolution.DefenderCasualties = GI->GridBattleManager->GetDefenderInitialArmyCost() -
+                                    Resolution.DefenderSurvivorArmyCost;
+
+    const FS_BattlePayload &Battle = GI->PendingBattle;
+    ASkaldGameState *GS = GetWorld()->GetGameState<ASkaldGameState>();
+    ESkaldFaction AttackerFaction = ESkaldFaction::None;
+    ESkaldFaction DefenderFaction = ESkaldFaction::None;
+    if (GS) {
+      if (ASkaldPlayerState *AttackerPS = GS->GetPlayerById(Battle.AttackerPlayerID)) {
+        AttackerFaction = AttackerPS->Faction;
+      }
+      if (ASkaldPlayerState *DefenderPS = GS->GetPlayerById(Battle.DefenderPlayerID)) {
+        DefenderFaction = DefenderPS->Faction;
+      }
+    }
+
+    const bool bAttackerVictory =
+        Resolution.AttackerSurvivorArmyCost > 0 &&
+        Resolution.DefenderSurvivorArmyCost <= 0;
+    const bool bDefenderVictory =
+        Resolution.DefenderSurvivorArmyCost > 0 &&
+        Resolution.AttackerSurvivorArmyCost <= 0;
+
+    if (bAttackerVictory) {
+      Resolution.WinningFaction = AttackerFaction;
+      Resolution.WinningPlayerID = Battle.AttackerPlayerID;
+      Resolution.NewOwnerPlayerID = Battle.AttackerPlayerID;
+    } else if (bDefenderVictory) {
+      Resolution.WinningFaction = DefenderFaction;
+      Resolution.WinningPlayerID = Battle.DefenderPlayerID;
+      Resolution.NewOwnerPlayerID = Battle.DefenderPlayerID;
+    } else {
+      Resolution.WinningFaction = ESkaldFaction::None;
+      Resolution.WinningPlayerID = Battle.DefenderPlayerID;
+      Resolution.NewOwnerPlayerID = Battle.DefenderPlayerID;
+    }
+
+    GI->PendingBattleResolution = Resolution;
+    GI->bPendingBattleResolution = true;
+    GI->GridBattleManager = nullptr;
+  }
+
+  if (!GI->bPendingBattleResolution || !GI->PendingBattleResolution.bValid) {
+    return;
+  }
 
   if (!CachedWorldMap) {
     return;
   }
 
+  const FS_BattlePayload Battle = GI->PendingBattle;
   ATerritory *Source = CachedWorldMap->GetTerritoryById(Battle.FromTerritoryID);
   ATerritory *Target =
       CachedWorldMap->GetTerritoryById(Battle.TargetTerritoryID);
@@ -375,47 +449,42 @@ void ATurnManager::ResolveGridBattleResult_Implementation() {
     return;
   }
 
-  const int32 AttackerID =
-      Source->OwningPlayer ? Source->OwningPlayer->GetPlayerId() : -1;
-  const int32 DefenderID =
-      Target->OwningPlayer ? Target->OwningPlayer->GetPlayerId() : -1;
+  FGridBattleResolution Resolution = GI->PendingBattleResolution;
+
   const int32 InitialSourceArmy = Source->ArmyUnits;
   const int32 InitialTargetArmy = Target->ArmyUnits;
 
-  const int32 AttackerSurvivors =
-      GI->GridBattleManager->GetAttackerSurvivorCost();
-  const int32 DefenderSurvivors =
-      GI->GridBattleManager->GetDefenderSurvivorCost();
+  Source->ArmyUnits = FMath::Max(0, InitialSourceArmy - Battle.ArmyCountSent);
 
-  // Army-cost totals for potential downstream use
-  const int32 AttackerSurvivorCost =
-      GI->GridBattleManager->GetAttackerSurvivorCost();
-  const int32 DefenderSurvivorCost =
-      GI->GridBattleManager->GetDefenderSurvivorCost();
-
-  Source->ArmyUnits -= Battle.ArmyCountSent;
-
-  int32 WinningPlayerID = DefenderID;
-  int32 NewOwnerPlayerID = DefenderID;
-  if (AttackerSurvivors > 0 && DefenderSurvivors <= 0) {
+  if (Resolution.AttackerSurvivorArmyCost > 0 &&
+      Resolution.DefenderSurvivorArmyCost <= 0) {
     Target->OwningPlayer = Source->OwningPlayer;
-    Target->ArmyUnits = AttackerSurvivors;
-    WinningPlayerID = AttackerID;
-    NewOwnerPlayerID = AttackerID;
+    Target->ArmyUnits = Resolution.AttackerSurvivorArmyCost;
   } else {
-    Target->ArmyUnits = DefenderSurvivors;
+    Target->ArmyUnits = Resolution.DefenderSurvivorArmyCost;
   }
 
-  const int32 AttackerCasualties =
-      InitialSourceArmy - (Source->ArmyUnits + AttackerSurvivors);
-  const int32 DefenderCasualties = InitialTargetArmy - DefenderSurvivors;
+  Resolution.SourceArmyRemaining = Source->ArmyUnits;
+  Resolution.TargetArmyRemaining = Target->ArmyUnits;
+
+  Resolution.AttackerCasualties =
+      InitialSourceArmy - (Source->ArmyUnits + Resolution.AttackerSurvivorArmyCost);
+  Resolution.DefenderCasualties =
+      InitialTargetArmy - Resolution.DefenderSurvivorArmyCost;
 
   Source->RefreshAppearance();
   Target->RefreshAppearance();
 
   GI->PendingBattle = FS_BattlePayload();
-  GI->GridBattleManager = nullptr;
   PendingBattle = FS_BattlePayload();
+
+  const int32 WinningPlayerID = Resolution.WinningPlayerID;
+  const int32 NewOwnerPlayerID = Resolution.NewOwnerPlayerID;
+  const int32 AttackerCasualties = Resolution.AttackerCasualties;
+  const int32 DefenderCasualties = Resolution.DefenderCasualties;
+
+  GI->bPendingBattleResolution = false;
+  GI->PendingBattleResolution = FGridBattleResolution();
 
   // Resume the saved turn sequence now that the battle has been resolved.
   if (GI->bResumeTurns) {

--- a/Source/Skald/UI/BattleResultWidget.cpp
+++ b/Source/Skald/UI/BattleResultWidget.cpp
@@ -1,0 +1,70 @@
+#include "UI/BattleResultWidget.h"
+
+#include "Blueprint/WidgetTree.h"
+#include "Components/TextBlock.h"
+#include "Components/VerticalBox.h"
+#include "Components/VerticalBoxSlot.h"
+
+void UBattleResultWidget::NativeConstruct() {
+  Super::NativeConstruct();
+  EnsureLayout();
+}
+
+void UBattleResultWidget::EnsureLayout() {
+  if (OutcomeText && CasualtyText) {
+    return;
+  }
+
+  if (!WidgetTree) {
+    return;
+  }
+
+  if (!WidgetTree->RootWidget) {
+    UVerticalBox *Box = WidgetTree->ConstructWidget<UVerticalBox>(
+        UVerticalBox::StaticClass(), TEXT("BattleResultRoot"));
+    WidgetTree->RootWidget = Box;
+  }
+
+  if (UVerticalBox *Box = Cast<UVerticalBox>(WidgetTree->RootWidget)) {
+    if (!OutcomeText) {
+      OutcomeText = WidgetTree->ConstructWidget<UTextBlock>(
+          UTextBlock::StaticClass(), TEXT("OutcomeText"));
+      OutcomeText->SetJustification(ETextJustify::Center);
+      Box->AddChildToVerticalBox(OutcomeText);
+    }
+
+    if (!CasualtyText) {
+      CasualtyText = WidgetTree->ConstructWidget<UTextBlock>(
+          UTextBlock::StaticClass(), TEXT("CasualtyText"));
+      CasualtyText->SetJustification(ETextJustify::Center);
+      Box->AddChildToVerticalBox(CasualtyText);
+    }
+  }
+}
+
+void UBattleResultWidget::SetBattleOutcome(bool bPlayerWon, bool bPlayerLost,
+                                           int32 AttackerCasualties,
+                                           int32 DefenderCasualties) {
+  EnsureLayout();
+
+  if (OutcomeText) {
+    FText OutcomeLabel;
+    if (bPlayerWon) {
+      OutcomeLabel = NSLOCTEXT("BattleResultWidget", "Victory", "Victory!");
+    } else if (bPlayerLost) {
+      OutcomeLabel = NSLOCTEXT("BattleResultWidget", "Defeat", "Defeat");
+    } else {
+      OutcomeLabel = NSLOCTEXT("BattleResultWidget", "Complete", "Battle Complete");
+    }
+    OutcomeText->SetText(OutcomeLabel);
+  }
+
+  if (CasualtyText) {
+    const FText CasualtyLabel = FText::Format(
+        NSLOCTEXT("BattleResultWidget", "CasualtiesFormat",
+                  "Attacker losses: {0}\nDefender losses: {1}"),
+        FText::AsNumber(AttackerCasualties),
+        FText::AsNumber(DefenderCasualties));
+    CasualtyText->SetText(CasualtyLabel);
+  }
+}

--- a/Source/Skald/UI/BattleResultWidget.h
+++ b/Source/Skald/UI/BattleResultWidget.h
@@ -1,0 +1,29 @@
+#pragma once
+
+#include "Blueprint/UserWidget.h"
+#include "BattleResultWidget.generated.h"
+
+class UTextBlock;
+
+/** Simple widget that displays battle outcome text and casualty totals. */
+UCLASS()
+class SKALD_API UBattleResultWidget : public UUserWidget {
+  GENERATED_BODY()
+
+public:
+  virtual void NativeConstruct() override;
+
+  /** Update the displayed outcome text. */
+  UFUNCTION(BlueprintCallable, Category = "Skald|Battle")
+  void SetBattleOutcome(bool bPlayerWon, bool bPlayerLost, int32 AttackerCasualties,
+                        int32 DefenderCasualties);
+
+private:
+  void EnsureLayout();
+
+  UPROPERTY()
+  UTextBlock *OutcomeText = nullptr;
+
+  UPROPERTY()
+  UTextBlock *CasualtyText = nullptr;
+};

--- a/docs/grid-battle-followup-tasks.md
+++ b/docs/grid-battle-followup-tasks.md
@@ -1,0 +1,30 @@
+# Grid Battle C++ Task Breakdown
+
+## Victory detection and EndBattle broadcast
+- Update `UGridBattleManager::AdvanceTurn` (or whichever server-side function removes dead fighters) to detect when only one faction remains in `InitiativeOrder` and call `EndBattle()` immediately instead of looping forever. Capture whether any defenders or attackers are still registered before the call so the survivor tallies remain correct.
+- Make sure this path only runs once per battle and that `OnBattleEnded` fires on all clients so downstream listeners (turn manager, controllers, HUD) receive the notification.
+
+## Remove the deprecated `StartBattle` simulator
+- Delete `UGridBattleManager::StartBattle` and any helper code that exists solely for that method so only the pawn-driven tactical mode remains. Verify nothing in the project references `StartBattle` after removal.
+- If any tests or blueprint exposures depend on the function, replace them with coverage around `InitBattle` + pawn-driven execution instead of leaving dead code paths behind.
+
+## Drive fighter spawning from `PendingBattle`
+- In `ASkald_BattleGameMode` and the fighter selection flow (`ASkaldPlayerController::HandleFighterSelectionLockedIn`), replace the "first two players" assumption with `USkaldGameInstance::PendingBattle`. Use the attacker/defender player IDs and army counts to decide which controllers must lock in, who is auto-filled by AI, and which roster spawns on each edge.
+- Ensure the budgets respect `FS_BattlePayload::ArmyCountSent` for the attacker and `PendingBattle.DefenderArmySize` (or equivalent) for the defending side so cost validation in the selection UI matches the world-map armies that travelled.
+- When spawning pawns, mark the correct `bIsAttacker` flag per side instead of mirroring the attacking list for defenders.
+
+## Auto-resolve world-map results after `OnBattleEnded`
+- When `UGridBattleManager::OnBattleEnded` fires, immediately call `ATurnManager::ResolveGridBattleResult` (or an equivalent authority-only entry point) so the overworld state updates even if no local controller triggers it manually.
+- Guard against duplicate calls by clearing `USkaldGameInstance::GridBattleManager` (or marking a flag) after resolution so subsequent `OnBattleEnded` broadcasts do not reapply the same casualties.
+
+## Sanitize battle-map travel targets
+- Replace the hard-coded `"WorldMap"` string inside `ATurnManager::HandleGridBattleEnded` with a value carried in `FS_BattlePayload` (e.g., the level we departed from) or the `ATurnManager::PendingBattle` data so that returning from combat works even if level names change.
+- Store the original map name when `TriggerGridBattle` initiates travel (perhaps by querying `GetWorld()->GetMapName()` before loading the battle map) and reuse it when travelling back.
+
+## Distinct AI army generation
+- Rework the AI setup in `ASkald_BattleGameMode::BeginPlay` to pull attacker and defender rosters separately. Use `PendingBattle` metadata (including defender budget) so the defending AI reflects the actual territory owner instead of mirroring the attacker list.
+- Ensure the spawned pawns register with `UGridBattleManager` on the correct side and that initiative rolls only happen after both sides are registered.
+
+## Battle conclusion UI hooks
+- Extend the HUD/controller battle widgets to listen for `UGridBattleManager::OnBattleEnded` and present a victory/defeat banner (or modal) that differentiates attacker vs. defender outcomes.
+- Tear down or hide battle-specific UI when the delegate fires and re-enable world-map widgets after the travel back to the overworld completes, preventing stuck buttons when the level transitions.


### PR DESCRIPTION
## Summary
- detect when only one faction remains in the grid battle, ensure EndBattle fires once, and expose initial army costs for casualty math
- track pending battle resolution metadata so the turn manager can travel back to the recorded map and automatically settle world-map armies
- drive battle rosters from PendingBattle (including AI auto-commit) and display a new BattleResultWidget when the fight ends

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cb3b303a8c83249df978348468de2f