### PR TITLE
Handle battle result widget lifecycle

### DIFF
--- a/Source/Skald/Skald_PlayerController.cpp
+++ b/Source/Skald/Skald_PlayerController.cpp
@@ -36,6 +36,7 @@ ASkaldPlayerController::ASkaldPlayerController() {
   HUDRef = nullptr;
   MainHudWidget = nullptr;
   BattleHudWidget = nullptr;
+  BattleResultWidget = nullptr;
   CurrentCommandMode = EBattleCommandMode::None;
   bHasInitialized = false;
 
@@ -1093,9 +1094,16 @@ void ASkaldPlayerController::HandleFactionsUpdated() {
 }
 
 void ASkaldPlayerController::HandleWorldStateChanged() {
+  if (BattleResultWidget) {
+    BattleResultWidget->RemoveFromParent();
+    BattleResultWidget = nullptr;
+  }
+
   if (!MainHudWidget) {
     return;
   }
+
+  MainHudWidget->SetVisibility(ESlateVisibility::Visible);
 
   // Update territory info for the currently selected territory if available.
   if (AWorldMap *WorldMap = Cast<AWorldMap>(UGameplayStatics::GetActorOfClass(
@@ -1337,6 +1345,11 @@ void ASkaldPlayerController::HandleBattleEnded(ESkaldFaction WinningFaction,
     VictoryWidgetClass = UBattleResultWidget::StaticClass();
   }
 
+  if (BattleResultWidget) {
+    BattleResultWidget->RemoveFromParent();
+    BattleResultWidget = nullptr;
+  }
+
   if (VictoryWidgetClass) {
     if (UUserWidget *Widget =
             CreateWidget<UUserWidget>(this, VictoryWidgetClass)) {
@@ -1344,7 +1357,8 @@ void ASkaldPlayerController::HandleBattleEnded(ESkaldFaction WinningFaction,
         ResultWidget->SetBattleOutcome(bPlayerWon, bPlayerLost, AttackerCasualties,
                                        DefenderCasualties);
       }
-      Widget->AddToViewport();
+      BattleResultWidget = Widget;
+      BattleResultWidget->AddToViewport();
     }
   }
 

--- a/Source/Skald/Skald_PlayerController.h
+++ b/Source/Skald/Skald_PlayerController.h
@@ -117,6 +117,11 @@ protected:
             meta = (AllowPrivateAccess = "true"))
   TObjectPtr<UBattleHUDWidget> BattleHudWidget;
 
+  /** Battle result widget displayed after combat resolves. */
+  UPROPERTY(BlueprintReadOnly, Category = "UI",
+            meta = (AllowPrivateAccess = "true"))
+  UUserWidget *BattleResultWidget;
+
   /** Fighter selection widget used during battle setup. */
   UPROPERTY(BlueprintReadOnly, Category = "UI",
             meta = (AllowPrivateAccess = "true"))


### PR DESCRIPTION
## Summary
- add a stored pointer for the battle result widget on the player controller
- track the battle result widget when a battle ends and collapse the HUD
- remove the stored widget and restore the HUD when the overworld resumes

## Testing
- not run (not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68cb66cf67c48324bb414027738605e7