### PR TITLE
Fix turn advancement after removing defeated fighters

### DIFF
--- a/Source/Skald/GridBattleManager.cpp
+++ b/Source/Skald/GridBattleManager.cpp
@@ -280,14 +280,33 @@ void UGridBattleManager::AdvanceTurn()
         return;
     }
 
-    if (InitiativeOrder.Num() == 0)
+    const int32 NumFighters = InitiativeOrder.Num();
+    if (NumFighters == 0)
     {
         ActiveFighter = nullptr;
         OnActiveFighterChanged.Broadcast(ActiveFighter);
         return;
     }
 
-    CurrentTurn = (CurrentTurn + 1) % InitiativeOrder.Num();
+    int32 NextTurnIndex = INDEX_NONE;
+    if (ActiveFighter)
+    {
+        const int32 ActiveIndex = InitiativeOrder.IndexOfByKey(ActiveFighter);
+        if (ActiveIndex != INDEX_NONE)
+        {
+            NextTurnIndex = (ActiveIndex + 1) % NumFighters;
+        }
+    }
+
+    if (NextTurnIndex == INDEX_NONE)
+    {
+        CurrentTurn = CurrentTurn % NumFighters;
+    }
+    else
+    {
+        CurrentTurn = NextTurnIndex;
+    }
+
     ActiveFighter = InitiativeOrder[CurrentTurn];
     OnActiveFighterChanged.Broadcast(ActiveFighter);
     if (ActiveFighter)


### PR DESCRIPTION
## Summary
- adjust turn advancement to derive the next turn from the surviving fighters
- ensure the fighter selected after removals correctly reflects the updated initiative order

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68cb68e9306883249bf243cb70513510