### PR TITLE
Enable fighter pawn replication

### DIFF
--- a/Source/Skald/FighterPawn.cpp
+++ b/Source/Skald/FighterPawn.cpp
@@ -5,11 +5,15 @@
 #include "EngineUtils.h"
 #include "GridBattleManager.h"
 #include "GridOverlayComponent.h"
+#include "Net/UnrealNetwork.h"
 #include "Skald_GameInstance.h"
 #include "TimerManager.h"
 
 AFighterPawn::AFighterPawn() {
   PrimaryActorTick.bCanEverTick = false;
+
+  bReplicates = true;
+  SetReplicateMovement(true);
 
   DisplayMesh =
       CreateDefaultSubobject<UStaticMeshComponent>(TEXT("DisplayMesh"));
@@ -20,6 +24,15 @@ AFighterPawn::AFighterPawn() {
 
   ActionsRemaining = 0;
   CurrentCell = FIntPoint::ZeroValue;
+}
+
+void AFighterPawn::GetLifetimeReplicatedProps(
+    TArray<FLifetimeProperty> &OutLifetimeProps) const {
+  Super::GetLifetimeReplicatedProps(OutLifetimeProps);
+
+  DOREPLIFETIME(AFighterPawn, Stats);
+  DOREPLIFETIME(AFighterPawn, bIsAttacker);
+  DOREPLIFETIME(AFighterPawn, ActionsRemaining);
 }
 
 void AFighterPawn::BeginPlay() {
@@ -236,4 +249,16 @@ void AFighterPawn::Destroyed() {
   }
   CurrentCell = FIntPoint::ZeroValue;
   Super::Destroyed();
+}
+
+void AFighterPawn::OnRep_Stats(const FFighterStats &OldStats) {
+  if (Stats.Health != OldStats.Health) {
+    const bool bHadListeners = OnHealthChanged.IsBound();
+    OnHealthChanged.Broadcast(Stats.Health);
+    if (!bHadListeners) {
+      UpdateHealthDisplay(Stats.Health);
+    }
+  } else if (!OnHealthChanged.IsBound()) {
+    UpdateHealthDisplay(Stats.Health);
+  }
 }

--- a/Source/Skald/FighterPawn.h
+++ b/Source/Skald/FighterPawn.h
@@ -20,6 +20,8 @@ public:
   AFighterPawn();
 
   virtual void BeginPlay() override;
+  virtual void GetLifetimeReplicatedProps(
+      TArray<FLifetimeProperty> &OutLifetimeProps) const override;
 
   /** Prepare the fighter for its activation. */
   UFUNCTION(BlueprintCallable, Category = "Fighter")
@@ -41,15 +43,17 @@ public:
   UGridOverlayComponent *GetGrid();
 
   /** Statistics describing this fighter. */
-  UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "Fighter")
+  UPROPERTY(BlueprintReadWrite, EditAnywhere, ReplicatedUsing = OnRep_Stats,
+            Category = "Fighter")
   FFighterStats Stats;
 
   /** True if this fighter belongs to the attacking side. */
-  UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "Fighter")
+  UPROPERTY(BlueprintReadWrite, EditAnywhere, Replicated,
+            Category = "Fighter")
   bool bIsAttacker = false;
 
   /** Actions remaining for the current activation. */
-  UPROPERTY(BlueprintReadOnly, Category = "Fighter")
+  UPROPERTY(BlueprintReadOnly, Replicated, Category = "Fighter")
   int32 ActionsRemaining;
 
   /** Mesh used to display the fighter. */
@@ -80,6 +84,10 @@ private:
   /** Update the health widget with a new value. */
   UFUNCTION()
   void UpdateHealthDisplay(int32 NewHealth);
+
+  /** Respond when the fighter stats replicate to clients. */
+  UFUNCTION()
+  void OnRep_Stats(const FFighterStats &OldStats);
 
   /** Retrieve or create a damage widget from the pool. */
   UUserWidget *GetDamageWidgetFromPool();


### PR DESCRIPTION
## Summary
- enable replication on fighter pawns and their movement so clients receive actor updates
- replicate fighter stats, side flag, and actions remaining for UI-driven logic
- broadcast health updates on replicated stat changes to refresh client widgets

## Testing
- not run (Unreal build unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68cdd64d241c8324bce97320b5368ce5