### PR TITLE
Ensure initiative order controls army placement turn flow

### DIFF
--- a/Source/Skald/Skald_GameMode.cpp
+++ b/Source/Skald/Skald_GameMode.cpp
@@ -915,6 +915,7 @@ void ASkaldGameMode::BeginArmyPlacementPhase() {
     }
   }
 
+  ArmyPlacementLeader.Reset();
   PlacementIndex = -1;
   AdvanceArmyPlacement();
 }
@@ -974,9 +975,13 @@ void ASkaldGameMode::AdvanceArmyPlacement() {
       continue;
     }
 
-    if (PS->DeployableUnits <= 0) {
+    if (PS->IsEliminated) {
       ++PlacementIndex;
       continue;
+    }
+
+    if (!ArmyPlacementLeader.IsValid()) {
+      ArmyPlacementLeader = PC;
     }
 
     const FString PhaseString =
@@ -1020,8 +1025,10 @@ void ASkaldGameMode::AdvanceArmyPlacement() {
   }
 
   // All players have finished placing armies; start the main turn loop.
+  ASkaldPlayerController *StartingController = ArmyPlacementLeader.Get();
+  ArmyPlacementLeader.Reset();
   bTurnsStarted = true;
-  TurnManager->StartTurns();
+  TurnManager->StartTurns(StartingController);
 }
 
 bool ASkaldGameMode::InitializeWorld() {

--- a/Source/Skald/Skald_GameMode.h
+++ b/Source/Skald/Skald_GameMode.h
@@ -156,6 +156,9 @@ private:
   /** Index of the controller currently placing armies. */
   int32 PlacementIndex = 0;
 
+  /** Controller that opened army placement with the highest initiative roll. */
+  TWeakObjectPtr<ASkaldPlayerController> ArmyPlacementLeader;
+
   /** Register a newly connected player and update player data. */
   void RegisterPlayer(ASkaldPlayerController *PC);
 

--- a/Source/Skald/Skald_TurnManager.cpp
+++ b/Source/Skald/Skald_TurnManager.cpp
@@ -160,9 +160,9 @@ void ATurnManager::SyncGameStateTurnIndex() {
   }
 }
 
-void ATurnManager::StartTurns() {
+void ATurnManager::StartTurns(ASkaldPlayerController *StartingController) {
   SortControllersByInitiative();
-  CurrentIndex = 0;
+
   if (Controllers.Num() == 0) {
     UE_LOG(LogSkald, Error,
            TEXT("StartTurns failed: no controllers registered"));
@@ -173,22 +173,44 @@ void ATurnManager::StartTurns() {
     return;
   }
 
-  if (!Controllers.IsValidIndex(CurrentIndex) ||
-      !Controllers[CurrentIndex].IsValid()) {
+  int32 StartIndex = INDEX_NONE;
+  if (StartingController) {
+    StartIndex = Controllers.IndexOfByPredicate(
+        [StartingController](const TWeakObjectPtr<ASkaldPlayerController> &Ptr) {
+          return Ptr.Get() == StartingController;
+        });
+  }
+
+  if (StartIndex == INDEX_NONE) {
+    for (int32 i = 0; i < Controllers.Num(); ++i) {
+      if (Controllers[i].IsValid()) {
+        StartIndex = i;
+        break;
+      }
+    }
+  }
+
+  if (StartIndex == INDEX_NONE || !Controllers.IsValidIndex(StartIndex) ||
+      !Controllers[StartIndex].IsValid()) {
     UE_LOG(LogSkald, Error,
-           TEXT("StartTurns failed: invalid starting controller"));
+           TEXT("StartTurns failed: could not find a valid starting controller"));
     if (GEngine) {
-      GEngine->AddOnScreenDebugMessage(
-          -1, 5.f, FColor::Red,
-          TEXT("StartTurns: invalid starting controller"));
+      GEngine->AddOnScreenDebugMessage(-1, 5.f, FColor::Red,
+                                       TEXT("StartTurns: no valid starting player"));
     }
     return;
   }
 
+  CurrentIndex = StartIndex;
+
   ASkaldPlayerController *CurrentController = Controllers[CurrentIndex].Get();
-  ASkaldPlayerState *PS =
-      CurrentController ? CurrentController->GetPlayerState<ASkaldPlayerState>()
-                        : nullptr;
+  if (!CurrentController) {
+    UE_LOG(LogSkald, Error,
+           TEXT("StartTurns failed: starting controller pointer invalid"));
+    return;
+  }
+
+  ASkaldPlayerState *PS = CurrentController->GetPlayerState<ASkaldPlayerState>();
   const FString PlayerName = PS ? PS->PlayerDisplayName : TEXT("Unknown");
   ApplyReinforcementsAndResources(PS, TEXT("StartTurns"));
 
@@ -218,12 +240,10 @@ void ATurnManager::StartTurns() {
     }
   }
 
-  if (CurrentController) {
-    SyncGameStateTurnIndex();
-    CurrentController->StartTurn();
-    if (ASkaldGameMode *GM = GetWorld()->GetAuthGameMode<ASkaldGameMode>()) {
-      GM->CheckVictoryConditions();
-    }
+  SyncGameStateTurnIndex();
+  CurrentController->StartTurn();
+  if (ASkaldGameMode *GM = GetWorld()->GetAuthGameMode<ASkaldGameMode>()) {
+    GM->CheckVictoryConditions();
   }
 
   OnWorldStateChanged.Broadcast();

--- a/Source/Skald/Skald_TurnManager.h
+++ b/Source/Skald/Skald_TurnManager.h
@@ -36,7 +36,7 @@ public:
   void StartArmyPlacementPhase();
 
   UFUNCTION(BlueprintCallable, Category = "Turn")
-  void StartTurns();
+  void StartTurns(ASkaldPlayerController *StartingController = nullptr);
 
   UFUNCTION(BlueprintCallable, Category = "Turn")
   void AdvanceTurn();

--- a/Source/Skald/Tests/ArmyPlacementInitiativeTest.cpp
+++ b/Source/Skald/Tests/ArmyPlacementInitiativeTest.cpp
@@ -1,0 +1,246 @@
+#include "Misc/AutomationTest.h"
+#include "Skald_AIController.h"
+#include "Skald_GameMode.h"
+#include "Skald_GameState.h"
+#include "Skald_PlayerController.h"
+#include "Skald_PlayerState.h"
+#include "Skald_TurnManager.h"
+#include "Territory.h"
+#include "Tests/AutomationEditorCommon.h"
+#include "UObject/UnrealType.h"
+#include "WorldMap.h"
+
+namespace {
+void SetObjectProperty(UObject *Target, const TCHAR *PropertyName, UObject *Value) {
+  if (!Target) {
+    return;
+  }
+  if (FObjectProperty *Prop = FindFProperty<FObjectProperty>(Target->GetClass(), PropertyName)) {
+    Prop->SetObjectPropertyValue_InContainer(Target, Value);
+  }
+}
+
+int32 GetCurrentTurnManagerIndex(ATurnManager *TurnManager) {
+  if (!TurnManager) {
+    return INDEX_NONE;
+  }
+  if (FIntProperty *Prop = FindFProperty<FIntProperty>(ATurnManager::StaticClass(), TEXT("CurrentIndex"))) {
+    return Prop->GetPropertyValue_InContainer(TurnManager);
+  }
+  return INDEX_NONE;
+}
+
+void AttachGameModeToWorld(UWorld *World, ASkaldGameMode *GameMode) {
+  if (!World || !GameMode) {
+    return;
+  }
+  if (FObjectProperty *Prop =
+          FindFProperty<FObjectProperty>(UWorld::StaticClass(), TEXT("AuthorityGameMode"))) {
+    Prop->SetObjectPropertyValue_InContainer(World, GameMode);
+  }
+}
+
+void ConfigureController(ASkaldPlayerController *Controller, ASkaldPlayerState *PlayerState,
+                         int32 PlayerId, const FString &DisplayName, int32 Initiative) {
+  if (!Controller || !PlayerState) {
+    return;
+  }
+  Controller->PlayerState = PlayerState;
+  PlayerState->SetOwner(Controller);
+  PlayerState->SetPlayerId(PlayerId);
+  PlayerState->PlayerDisplayName = DisplayName;
+  PlayerState->InitiativeRoll = Initiative;
+}
+
+} // namespace
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FArmyPlacementInitiativeOrderTest,
+                                 "Skald.Turn.ArmyPlacement.InitiativeOrder",
+                                 EAutomationTestFlags::EditorContext |
+                                     EAutomationTestFlags::EngineFilter)
+
+bool FArmyPlacementInitiativeOrderTest::RunTest(const FString &Parameters) {
+  UWorld *World = FAutomationEditorCommonUtils::CreateNewMap();
+  TestNotNull(TEXT("World created"), World);
+  if (!World) {
+    return false;
+  }
+
+  ASkaldGameMode *GameMode = World->SpawnActor<ASkaldGameMode>();
+  ATurnManager *TurnManager = World->SpawnActor<ATurnManager>();
+  AWorldMap *Map = World->SpawnActor<AWorldMap>();
+  ATerritory *TerritoryA = World->SpawnActor<ATerritory>();
+  ATerritory *TerritoryB = World->SpawnActor<ATerritory>();
+  ASkaldPlayerController *ControllerA = World->SpawnActor<ASkaldPlayerController>();
+  ASkaldPlayerController *ControllerB = World->SpawnActor<ASkaldPlayerController>();
+  ASkaldPlayerState *StateA = World->SpawnActor<ASkaldPlayerState>();
+  ASkaldPlayerState *StateB = World->SpawnActor<ASkaldPlayerState>();
+
+  TestNotNull(TEXT("GameMode"), GameMode);
+  TestNotNull(TEXT("TurnManager"), TurnManager);
+  TestNotNull(TEXT("WorldMap"), Map);
+  TestNotNull(TEXT("TerritoryA"), TerritoryA);
+  TestNotNull(TEXT("TerritoryB"), TerritoryB);
+  TestNotNull(TEXT("ControllerA"), ControllerA);
+  TestNotNull(TEXT("ControllerB"), ControllerB);
+  TestNotNull(TEXT("StateA"), StateA);
+  TestNotNull(TEXT("StateB"), StateB);
+  if (!GameMode || !TurnManager || !Map || !TerritoryA || !TerritoryB || !ControllerA ||
+      !ControllerB || !StateA || !StateB) {
+    return false;
+  }
+
+  AttachGameModeToWorld(World, GameMode);
+  GameMode->InitGameState();
+  ASkaldGameState *GameState = GameMode->GetGameState<ASkaldGameState>();
+  TestNotNull(TEXT("GameState initialised"), GameState);
+  if (!GameState) {
+    return false;
+  }
+
+  ConfigureController(ControllerA, StateA, 1, TEXT("PlayerA"), 6);
+  ConfigureController(ControllerB, StateB, 2, TEXT("PlayerB"), 3);
+  GameState->AddPlayerState(StateA);
+  GameState->AddPlayerState(StateB);
+
+  TerritoryA->TerritoryID = 1;
+  TerritoryA->OwningPlayer = StateA;
+  TerritoryA->ArmyUnits = 1;
+  TerritoryB->TerritoryID = 2;
+  TerritoryB->OwningPlayer = StateB;
+  TerritoryB->ArmyUnits = 1;
+  Map->Territories = {TerritoryA, TerritoryB};
+
+  SetObjectProperty(GameMode, TEXT("TurnManager"), TurnManager);
+  SetObjectProperty(GameMode, TEXT("WorldMap"), Map);
+  SetObjectProperty(TurnManager, TEXT("CachedWorldMap"), Map);
+  SetObjectProperty(ControllerA, TEXT("CachedGameMode"), GameMode);
+  SetObjectProperty(ControllerB, TEXT("CachedGameMode"), GameMode);
+
+  TurnManager->RegisterController(ControllerA);
+  TurnManager->RegisterController(ControllerB);
+
+  GameMode->BeginArmyPlacementPhase();
+
+  const int32 IndexA = GameState->PlayerArray.IndexOfByKey(StateA);
+  const int32 IndexB = GameState->PlayerArray.IndexOfByKey(StateB);
+  TestTrue(TEXT("PlayerA index valid"), IndexA != INDEX_NONE);
+  TestTrue(TEXT("PlayerB index valid"), IndexB != INDEX_NONE);
+  TestEqual(TEXT("PlayerA deployable units"), StateA->DeployableUnits, 1);
+  TestEqual(TEXT("PlayerB deployable units"), StateB->DeployableUnits, 1);
+  TestEqual(TEXT("Army placement begins with initiative winner"), GameState->CurrentTurnIndex,
+            IndexA);
+
+  ControllerA->ServerDeployUnits(TerritoryA->TerritoryID, 1);
+  TestEqual(TEXT("PlayerA spent units"), StateA->DeployableUnits, 0);
+  ControllerA->EndPhase();
+  TestEqual(TEXT("Second player receives placement turn"), GameState->CurrentTurnIndex, IndexB);
+
+  ControllerB->ServerDeployUnits(TerritoryB->TerritoryID, 1);
+  TestEqual(TEXT("PlayerB spent units"), StateB->DeployableUnits, 0);
+  ControllerB->EndPhase();
+
+  TestEqual(TEXT("Turn advanced to reinforcement"), TurnManager->GetCurrentPhase(),
+            ETurnPhase::Reinforcement);
+
+  const int32 CurrentIndex = GetCurrentTurnManagerIndex(TurnManager);
+  const TArray<ASkaldPlayerController *> Controllers = TurnManager->GetControllers();
+  const int32 ExpectedIndex = Controllers.IndexOfByKey(ControllerA);
+  TestEqual(TEXT("Initiative winner starts main turn"), CurrentIndex, ExpectedIndex);
+  TestEqual(TEXT("GameState turn index reset to initiative winner"), GameState->CurrentTurnIndex,
+            IndexA);
+
+  return true;
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FAIArmyPlacementAutoAdvanceTest,
+                                 "Skald.Turn.ArmyPlacement.AIAutoAdvance",
+                                 EAutomationTestFlags::EditorContext |
+                                     EAutomationTestFlags::EngineFilter)
+
+bool FAIArmyPlacementAutoAdvanceTest::RunTest(const FString &Parameters) {
+  UWorld *World = FAutomationEditorCommonUtils::CreateNewMap();
+  TestNotNull(TEXT("World created"), World);
+  if (!World) {
+    return false;
+  }
+
+  ASkaldGameMode *GameMode = World->SpawnActor<ASkaldGameMode>();
+  ATurnManager *TurnManager = World->SpawnActor<ATurnManager>();
+  AWorldMap *Map = World->SpawnActor<AWorldMap>();
+  ATerritory *TerritoryAI = World->SpawnActor<ATerritory>();
+  ATerritory *TerritoryHuman = World->SpawnActor<ATerritory>();
+  ASkaldAIController *AIController = World->SpawnActor<ASkaldAIController>();
+  ASkaldPlayerController *HumanController = World->SpawnActor<ASkaldPlayerController>();
+  ASkaldPlayerState *AIState = World->SpawnActor<ASkaldPlayerState>();
+  ASkaldPlayerState *HumanState = World->SpawnActor<ASkaldPlayerState>();
+
+  TestNotNull(TEXT("GameMode"), GameMode);
+  TestNotNull(TEXT("TurnManager"), TurnManager);
+  TestNotNull(TEXT("WorldMap"), Map);
+  TestNotNull(TEXT("AI Territory"), TerritoryAI);
+  TestNotNull(TEXT("Human Territory"), TerritoryHuman);
+  TestNotNull(TEXT("AI Controller"), AIController);
+  TestNotNull(TEXT("Human Controller"), HumanController);
+  TestNotNull(TEXT("AI State"), AIState);
+  TestNotNull(TEXT("Human State"), HumanState);
+  if (!GameMode || !TurnManager || !Map || !TerritoryAI || !TerritoryHuman || !AIController ||
+      !HumanController || !AIState || !HumanState) {
+    return false;
+  }
+
+  AttachGameModeToWorld(World, GameMode);
+  GameMode->InitGameState();
+  ASkaldGameState *GameState = GameMode->GetGameState<ASkaldGameState>();
+  TestNotNull(TEXT("GameState initialised"), GameState);
+  if (!GameState) {
+    return false;
+  }
+
+  ConfigureController(AIController, AIState, 1, TEXT("AI"), 6);
+  ConfigureController(HumanController, HumanState, 2, TEXT("Human"), 3);
+  AIState->bIsAI = true;
+  GameState->AddPlayerState(AIState);
+  GameState->AddPlayerState(HumanState);
+
+  TerritoryAI->TerritoryID = 1;
+  TerritoryAI->OwningPlayer = AIState;
+  TerritoryAI->ArmyUnits = 1;
+  TerritoryHuman->TerritoryID = 2;
+  TerritoryHuman->OwningPlayer = HumanState;
+  TerritoryHuman->ArmyUnits = 1;
+  Map->Territories = {TerritoryAI, TerritoryHuman};
+
+  SetObjectProperty(GameMode, TEXT("TurnManager"), TurnManager);
+  SetObjectProperty(GameMode, TEXT("WorldMap"), Map);
+  SetObjectProperty(TurnManager, TEXT("CachedWorldMap"), Map);
+  SetObjectProperty(AIController, TEXT("CachedGameMode"), GameMode);
+  SetObjectProperty(HumanController, TEXT("CachedGameMode"), GameMode);
+
+  TurnManager->RegisterController(AIController);
+  TurnManager->RegisterController(HumanController);
+
+  GameMode->BeginArmyPlacementPhase();
+
+  const int32 HumanIndex = GameState->PlayerArray.IndexOfByKey(HumanState);
+  TestTrue(TEXT("Human player index valid"), HumanIndex != INDEX_NONE);
+  TestEqual(TEXT("AI spent deployable units"), AIState->DeployableUnits, 0);
+  TestEqual(TEXT("AI territory reinforced"), TerritoryAI->ArmyUnits, 2);
+  TestEqual(TEXT("Human player's placement turn"), GameState->CurrentTurnIndex, HumanIndex);
+
+  HumanController->ServerDeployUnits(TerritoryHuman->TerritoryID, 1);
+  TestEqual(TEXT("Human spent deployable units"), HumanState->DeployableUnits, 0);
+  HumanController->EndPhase();
+
+  TestEqual(TEXT("Main turn advanced to reinforcement"), TurnManager->GetCurrentPhase(),
+            ETurnPhase::Reinforcement);
+  const int32 CurrentIndex = GetCurrentTurnManagerIndex(TurnManager);
+  const TArray<ASkaldPlayerController *> Controllers = TurnManager->GetControllers();
+  const int32 ExpectedIndex = Controllers.IndexOfByKey(AIController);
+  TestEqual(TEXT("AI with initiative begins normal turn"), CurrentIndex, ExpectedIndex);
+
+  const int32 AIIndex = GameState->PlayerArray.IndexOfByKey(AIState);
+  TestEqual(TEXT("GameState turn index returned to AI"), GameState->CurrentTurnIndex, AIIndex);
+
+  return true;
+}


### PR DESCRIPTION
## Summary
- capture the initiative leader during the army placement phase and start normal turns from that controller
- update the turn manager to accept an explicit starting controller while skipping eliminated players during placement
- add automation coverage for human and AI initiative handling in the army placement flow

## Testing
- ./RunTests.sh *(fails: script not available in repo)*

------
https://chatgpt.com/codex/tasks/task_e_68cc71a013908324a12060fe75f781ab