### PR TITLE
Allow automation tests to access army placement phase

### DIFF
--- a/Source/Skald/Skald_GameMode.h
+++ b/Source/Skald/Skald_GameMode.h
@@ -14,6 +14,11 @@ class AWorldMap;
 class APlayerController;
 class USkaldSaveGame;
 
+#if WITH_AUTOMATION_TESTS
+class FArmyPlacementInitiativeOrderTest;
+class FAIArmyPlacementAutoAdvanceTest;
+#endif // WITH_AUTOMATION_TESTS
+
 DECLARE_DYNAMIC_MULTICAST_DELEGATE_OneParam(FSkaldGameOver, ASkaldPlayerState *,
                                             Winner);
 
@@ -23,6 +28,12 @@ DECLARE_DYNAMIC_MULTICAST_DELEGATE_OneParam(FSkaldGameOver, ASkaldPlayerState *,
 UCLASS(Blueprintable, BlueprintType)
 class SKALD_API ASkaldGameMode : public AGameModeBase {
   GENERATED_BODY()
+
+#if WITH_AUTOMATION_TESTS
+  // Allow automation tests to drive protected game flow entry points.
+  friend class FArmyPlacementInitiativeOrderTest;
+  friend class FAIArmyPlacementAutoAdvanceTest;
+#endif // WITH_AUTOMATION_TESTS
 
 public:
   ASkaldGameMode();


### PR DESCRIPTION
## Summary
- forward declare automation test classes when tests are enabled
- grant them friend access so they can call BeginArmyPlacementPhase during test setup
- document why the friends exist to keep encapsulation rationale clear

## Testing
- not run (unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68cde32517f483248614e8ab3ca11de1