### PR TITLE
Preserve world map state on battle maps

### DIFF
--- a/Source/Skald/Skald_BattleGameMode.cpp
+++ b/Source/Skald/Skald_BattleGameMode.cpp
@@ -13,6 +13,50 @@
 #include "TimerManager.h"
 #include "WorldMap.h"
 
+namespace {
+bool HasHumanOwnedTerritory(const ASkaldGameState *GameState,
+                            const AWorldMap *WorldMap,
+                            const USkaldGameInstance *GameInstance) {
+  if (!GameState) {
+    return false;
+  }
+
+  auto IsHumanPlayerById = [GameState](int32 PlayerID) {
+    if (PlayerID <= 0) {
+      return false;
+    }
+    if (ASkaldPlayerState *Player = GameState->GetPlayerById(PlayerID)) {
+      return !Player->bIsAI;
+    }
+    return false;
+  };
+
+  if (WorldMap) {
+    for (ATerritory *Territory : WorldMap->Territories) {
+      if (!Territory) {
+        continue;
+      }
+      const int32 OwnerID =
+          Territory->OwningPlayer ? Territory->OwningPlayer->GetPlayerId() : 0;
+      if (IsHumanPlayerById(OwnerID)) {
+        return true;
+      }
+    }
+  }
+
+  if (GameInstance) {
+    for (const FS_Territory &TerritoryData :
+         GameInstance->CachedWorldMapTerritories) {
+      if (IsHumanPlayerById(TerritoryData.OwnerPlayerID)) {
+        return true;
+      }
+    }
+  }
+
+  return false;
+}
+} // namespace
+
 void ASkald_BattleGameMode::BeginPlay() {
   Super::BeginPlay();
 
@@ -27,7 +71,8 @@ void ASkald_BattleGameMode::BeginPlay() {
                                            &ASkald_BattleGameMode::HandleBattleEnded);
   }
 
-  if (USkaldGameInstance *GI = GetGameInstance<USkaldGameInstance>()) {
+  USkaldGameInstance *GI = GetGameInstance<USkaldGameInstance>();
+  if (GI) {
     GI->GridBattleManager = BattleManager;
   }
 
@@ -44,27 +89,15 @@ void ASkald_BattleGameMode::BeginPlay() {
                TEXT("PlayerCount %d != ControllerCount %d after travel"),
                GS->PlayerArray.Num(), ControllerCount);
 
-    bool bHumanHasTerritory = false;
-    if (WorldMap) {
-      for (APlayerState *BasePS : GS->PlayerArray) {
-        ASkaldPlayerState *PS = Cast<ASkaldPlayerState>(BasePS);
-        if (!PS || PS->bIsAI) {
-          continue;
-        }
-        for (ATerritory *Territory : WorldMap->Territories) {
-          if (WorldMap->IsOwnedBy(Territory, PS)) {
-            bHumanHasTerritory = true;
-            break;
-          }
-        }
-        if (bHumanHasTerritory) {
-          break;
-        }
-      }
+    const bool bHumanHasTerritory =
+        HasHumanOwnedTerritory(GS, WorldMap, GI);
+    if (!bHumanHasTerritory) {
+      const int32 CachedCount = GI ? GI->CachedWorldMapTerritories.Num() : 0;
+      UE_LOG(LogSkald, Warning,
+             TEXT("BeginPlay: Unable to confirm any human-owned territory after "
+                  "travel (WorldMap=%s, CachedTerritories=%d)"),
+             *GetNameSafe(WorldMap), CachedCount);
     }
-    ensureMsgf(
-        bHumanHasTerritory,
-        TEXT("Human player does not own any territory after travel"));
   }
 }
 
@@ -83,6 +116,16 @@ void ASkald_BattleGameMode::SetupPendingBattle() {
   ASkaldGameState *GS = GetGameState<ASkaldGameState>();
   if (!GS) {
     return;
+  }
+
+  const bool bHumanHasTerritory =
+      HasHumanOwnedTerritory(GS, WorldMap, GI);
+  if (!bHumanHasTerritory) {
+    const int32 CachedCount = GI ? GI->CachedWorldMapTerritories.Num() : 0;
+    UE_LOG(LogSkald, Warning,
+           TEXT("SetupPendingBattle: No human-owned territory recorded before "
+                "launch (WorldMap=%s, CachedTerritories=%d)"),
+           *GetNameSafe(WorldMap), CachedCount);
   }
 
   const FS_BattlePayload Battle = GI->PendingBattle;

--- a/Source/Skald/Skald_GameInstance.h
+++ b/Source/Skald/Skald_GameInstance.h
@@ -73,6 +73,10 @@ public:
   UPROPERTY(BlueprintReadWrite, Category = "Battle")
   bool bIsInBattleMap = false;
 
+  /** Snapshot of the overworld territories captured before travelling. */
+  UPROPERTY(BlueprintReadWrite, Category = "Battle")
+  TArray<FS_Territory> CachedWorldMapTerritories;
+
   /** Random stream used for deterministic combat rolls. */
   UPROPERTY()
   FRandomStream CombatRandomStream;

--- a/Source/Skald/Skald_GameMode.cpp
+++ b/Source/Skald/Skald_GameMode.cpp
@@ -427,13 +427,50 @@ void ASkaldGameMode::HandlePlayerLockedIn(ASkaldPlayerState *PS) {
          TurnManager ? TurnManager->GetControllerCount() : 0,
          GS ? GS->PlayerArray.Num() : 0);
 
-  if (!WorldMap) {
+  USkaldGameInstance *GI = GetGameInstance<USkaldGameInstance>();
+  const bool bIsBattleMap = GI && GI->bIsInBattleMap;
+
+  if (!WorldMap && !bIsBattleMap) {
     WorldMap = Cast<AWorldMap>(UGameplayStatics::GetActorOfClass(
         GetWorld(), AWorldMap::StaticClass()));
     if (!WorldMap) {
       WorldMap = GetWorld()->SpawnActor<AWorldMap>();
     }
   }
+
+  if (WorldMap && GI && !bIsBattleMap) {
+    TArray<FS_Territory> TerritorySnapshots;
+    TerritorySnapshots.Reserve(WorldMap->Territories.Num());
+    for (ATerritory *Territory : WorldMap->Territories) {
+      if (!Territory) {
+        continue;
+      }
+
+      FS_Territory TerrData;
+      TerrData.TerritoryID = Territory->TerritoryID;
+      TerrData.TerritoryName = Territory->TerritoryName;
+      TerrData.OwnerPlayerID =
+          Territory->OwningPlayer ? Territory->OwningPlayer->GetPlayerId() : 0;
+      TerrData.IsCapital = Territory->bIsCapital;
+      TerrData.CapitalOwner = TerrData.OwnerPlayerID;
+      TerrData.ArmyUnits = Territory->ArmyUnits;
+      TerrData.ContinentID = Territory->ContinentID;
+      TerrData.AdjacentIDs.Reset();
+      for (ATerritory *Adj : Territory->AdjacentTerritories) {
+        if (Adj) {
+          TerrData.AdjacentIDs.Add(Adj->TerritoryID);
+        }
+      }
+      TerrData.Location = Territory->GetActorLocation();
+      TerrData.HasTreasure = Territory->bHasTreasure;
+      TerrData.BuiltSiegeID = Territory->BuiltSiegeID;
+
+      TerritorySnapshots.Add(MoveTemp(TerrData));
+    }
+
+    GI->CachedWorldMapTerritories = MoveTemp(TerritorySnapshots);
+  }
+
   if (!TurnManager) {
     TurnManager = GetWorld()->SpawnActor<ATurnManager>();
   }


### PR DESCRIPTION
## Summary
- stop spawning fallback world maps while travelling to battles and cache overworld territory data in the game instance instead
- allow the battle game mode to validate human-owned territories using the cached snapshot and log when information is missing
- emit a regression log when preparing battles if no human territory ownership can be confirmed

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68cdf8ba3b68832490cd7a20e7ffc41b