### PR TITLE
Preserve battle participants during travel

### DIFF
--- a/Source/Skald/SkaldTypes.h
+++ b/Source/Skald/SkaldTypes.h
@@ -120,6 +120,30 @@ struct SKALD_API FS_BattlePayload
     UPROPERTY(BlueprintReadWrite, EditAnywhere)
     int32 DefenderArmyCount = 0;
 
+    /** Cached display name for the attacking player when travelling to the battle map. */
+    UPROPERTY(BlueprintReadWrite, EditAnywhere)
+    FString AttackerDisplayName;
+
+    /** Cached display name for the defending player when travelling to the battle map. */
+    UPROPERTY(BlueprintReadWrite, EditAnywhere)
+    FString DefenderDisplayName;
+
+    /** Faction the attacker was using on the world map. */
+    UPROPERTY(BlueprintReadWrite, EditAnywhere)
+    ESkaldFaction AttackerFaction = ESkaldFaction::None;
+
+    /** Faction the defender was using on the world map. */
+    UPROPERTY(BlueprintReadWrite, EditAnywhere)
+    ESkaldFaction DefenderFaction = ESkaldFaction::None;
+
+    /** True when the attacking player was controlled by AI at the time of travel. */
+    UPROPERTY(BlueprintReadWrite, EditAnywhere)
+    bool bAttackerIsAI = false;
+
+    /** True when the defending player was controlled by AI at the time of travel. */
+    UPROPERTY(BlueprintReadWrite, EditAnywhere)
+    bool bDefenderIsAI = false;
+
     UPROPERTY(BlueprintReadWrite, EditAnywhere)
     bool IsCapitalAttack = false;
 

--- a/Source/Skald/Skald_BattleGameMode.cpp
+++ b/Source/Skald/Skald_BattleGameMode.cpp
@@ -1,6 +1,7 @@
 #include "Skald_BattleGameMode.h"
 
 #include "Algo/RandomShuffle.h"
+#include "Algo/Sort.h"
 #include "GridBattleManager.h"
 #include "Skald_GameInstance.h"
 #include "Skald_GameState.h"
@@ -54,6 +55,86 @@ bool HasHumanOwnedTerritory(const ASkaldGameState *GameState,
   }
 
   return false;
+}
+
+ASkaldPlayerState *EnsureBattleParticipant(ASkaldGameState *GameState, UWorld *World,
+                                           int32 PlayerID, const FString &DisplayName,
+                                           ESkaldFaction Faction, bool bIsAI) {
+  if (!GameState || !World || PlayerID <= 0) {
+    return nullptr;
+  }
+
+  if (ASkaldPlayerState *Existing = GameState->GetPlayerById(PlayerID)) {
+    if (!DisplayName.IsEmpty()) {
+      Existing->PlayerDisplayName = DisplayName;
+    }
+    if (Faction != ESkaldFaction::None) {
+      Existing->Faction = Faction;
+    }
+    Existing->bIsAI = bIsAI;
+    return Existing;
+  }
+
+  for (APlayerState *BasePS : GameState->PlayerArray) {
+    ASkaldPlayerState *Candidate = Cast<ASkaldPlayerState>(BasePS);
+    if (!Candidate || Candidate->GetPlayerId() != PlayerID) {
+      continue;
+    }
+
+    if (!DisplayName.IsEmpty()) {
+      Candidate->PlayerDisplayName = DisplayName;
+    }
+    if (Faction != ESkaldFaction::None) {
+      Candidate->Faction = Faction;
+    }
+    Candidate->bIsAI = bIsAI;
+
+    bool bAddedToList = false;
+    if (!GameState->Players.Contains(Candidate)) {
+      GameState->Players.Add(Candidate);
+      GameState->Players.Sort([](ASkaldPlayerState *A, ASkaldPlayerState *B) {
+        if (!A) {
+          return false;
+        }
+        if (!B) {
+          return true;
+        }
+        return A->GetPlayerId() < B->GetPlayerId();
+      });
+      bAddedToList = true;
+    }
+    if (bAddedToList) {
+      GameState->OnPlayersUpdated.Broadcast();
+      GameState->ForceNetUpdate();
+    }
+
+    return Candidate;
+  }
+
+  FActorSpawnParameters Params;
+  Params.SpawnCollisionHandlingOverride =
+      ESpawnActorCollisionHandlingMethod::AlwaysSpawn;
+  ASkaldPlayerState *NewState = World->SpawnActor<ASkaldPlayerState>(
+      ASkaldPlayerState::StaticClass(), FVector::ZeroVector, FRotator::ZeroRotator,
+      Params);
+  if (!NewState) {
+    return nullptr;
+  }
+
+  NewState->SetPlayerId(PlayerID);
+  if (!DisplayName.IsEmpty()) {
+    NewState->PlayerDisplayName = DisplayName;
+  } else {
+    NewState->PlayerDisplayName = FString::Printf(TEXT("Player %d"), PlayerID);
+  }
+  if (Faction != ESkaldFaction::None) {
+    NewState->Faction = Faction;
+  }
+  NewState->bIsAI = bIsAI;
+
+  GameState->AddPlayerState(NewState);
+  GameState->ForceNetUpdate();
+  return NewState;
 }
 } // namespace
 
@@ -118,6 +199,11 @@ void ASkald_BattleGameMode::SetupPendingBattle() {
     return;
   }
 
+  UWorld *World = GetWorld();
+  if (!World) {
+    return;
+  }
+
   const bool bHumanHasTerritory =
       HasHumanOwnedTerritory(GS, WorldMap, GI);
   if (!bHumanHasTerritory) {
@@ -129,8 +215,12 @@ void ASkald_BattleGameMode::SetupPendingBattle() {
   }
 
   const FS_BattlePayload Battle = GI->PendingBattle;
-  ASkaldPlayerState *AttackerPS = GS->GetPlayerById(Battle.AttackerPlayerID);
-  ASkaldPlayerState *DefenderPS = GS->GetPlayerById(Battle.DefenderPlayerID);
+  ASkaldPlayerState *AttackerPS = EnsureBattleParticipant(
+      GS, World, Battle.AttackerPlayerID, Battle.AttackerDisplayName,
+      Battle.AttackerFaction, Battle.bAttackerIsAI);
+  ASkaldPlayerState *DefenderPS = EnsureBattleParticipant(
+      GS, World, Battle.DefenderPlayerID, Battle.DefenderDisplayName,
+      Battle.DefenderFaction, Battle.bDefenderIsAI);
 
   const int32 AttackerBudget = FMath::Max(0, Battle.ArmyCountSent);
   const int32 DefenderBudget =
@@ -241,9 +331,18 @@ void ASkald_BattleGameMode::TryLaunchBattle() {
     return;
   }
 
+  UWorld *World = GetWorld();
+  if (!World) {
+    return;
+  }
+
   const FS_BattlePayload &Battle = GI->PendingBattle;
-  ASkaldPlayerState *AttackerPS = GS->GetPlayerById(Battle.AttackerPlayerID);
-  ASkaldPlayerState *DefenderPS = GS->GetPlayerById(Battle.DefenderPlayerID);
+  ASkaldPlayerState *AttackerPS = EnsureBattleParticipant(
+      GS, World, Battle.AttackerPlayerID, Battle.AttackerDisplayName,
+      Battle.AttackerFaction, Battle.bAttackerIsAI);
+  ASkaldPlayerState *DefenderPS = EnsureBattleParticipant(
+      GS, World, Battle.DefenderPlayerID, Battle.DefenderDisplayName,
+      Battle.DefenderFaction, Battle.bDefenderIsAI);
 
   if ((AttackerPS && !AttackerPS->bArmyLockedIn) ||
       (DefenderPS && !DefenderPS->bArmyLockedIn)) {

--- a/Source/Skald/Skald_GameMode.cpp
+++ b/Source/Skald/Skald_GameMode.cpp
@@ -240,14 +240,28 @@ void ASkaldGameMode::CleanupStalePlayerStates() {
     return;
   }
 
+  USkaldGameInstance *GI = GetGameInstance<USkaldGameInstance>();
+  const bool bIsBattleMap = GI && GI->bIsInBattleMap;
+  const FS_BattlePayload BattleSnapshot =
+      bIsBattleMap ? GI->PendingBattle : FS_BattlePayload();
+
   bool bRemovedAny = false;
   for (int32 i = GS->PlayerArray.Num() - 1; i >= 0; --i) {
     APlayerState *BasePS = GS->PlayerArray[i];
     AController *OwningController =
         BasePS ? Cast<AController>(BasePS->GetOwner()) : nullptr;
     if (!IsValid(OwningController)) {
+      ASkaldPlayerState *SkaldPS = Cast<ASkaldPlayerState>(BasePS);
+      const bool bPreserveForBattle =
+          bIsBattleMap && SkaldPS &&
+          (SkaldPS->GetPlayerId() == BattleSnapshot.AttackerPlayerID ||
+           SkaldPS->GetPlayerId() == BattleSnapshot.DefenderPlayerID);
+      if (bPreserveForBattle) {
+        continue;
+      }
+
       GS->PlayerArray.RemoveAt(i);
-      if (ASkaldPlayerState *SkaldPS = Cast<ASkaldPlayerState>(BasePS)) {
+      if (SkaldPS) {
         GS->Players.RemoveSwap(SkaldPS);
       }
       bRemovedAny = true;

--- a/Source/Skald/Skald_PlayerController.cpp
+++ b/Source/Skald/Skald_PlayerController.cpp
@@ -662,6 +662,16 @@ void ASkaldPlayerController::ServerHandleAttack_Implementation(int32 FromID,
     Battle.TargetTerritoryID = ToID;
     Battle.ArmyCountSent = ArmySent;
     Battle.IsCapitalAttack = Target->bIsCapital;
+    if (AttackerPS) {
+      Battle.AttackerFaction = AttackerPS->Faction;
+      Battle.AttackerDisplayName = AttackerPS->PlayerDisplayName;
+      Battle.bAttackerIsAI = AttackerPS->bIsAI;
+    }
+    if (DefenderPS) {
+      Battle.DefenderFaction = DefenderPS->Faction;
+      Battle.DefenderDisplayName = DefenderPS->PlayerDisplayName;
+      Battle.bDefenderIsAI = DefenderPS->bIsAI;
+    }
     if (bUseSiege && CachedGameMode) {
       const int32 SiegeID = CachedGameMode->ConsumeSiege(FromID);
       if (SiegeID > 0) {

--- a/Source/Skald/UI/SkaldMainHUDWidget.cpp
+++ b/Source/Skald/UI/SkaldMainHUDWidget.cpp
@@ -735,6 +735,9 @@ void USkaldMainHUDWidget::HandleAttackApproved() {
           if (ATerritory *Source = WorldMap->GetTerritoryById(SourceID)) {
             if (Source->OwningPlayer) {
               Battle.AttackerPlayerID = Source->OwningPlayer->GetPlayerId();
+              Battle.AttackerFaction = Source->OwningPlayer->Faction;
+              Battle.AttackerDisplayName = Source->OwningPlayer->PlayerDisplayName;
+              Battle.bAttackerIsAI = Source->OwningPlayer->bIsAI;
             }
             if (bUseSiege && Source->BuiltSiegeID > 0) {
               Battle.AssignedSiegeIDs.Add(Source->BuiltSiegeID);
@@ -744,6 +747,9 @@ void USkaldMainHUDWidget::HandleAttackApproved() {
           if (ATerritory *Target = WorldMap->GetTerritoryById(TargetID)) {
             if (Target->OwningPlayer) {
               Battle.DefenderPlayerID = Target->OwningPlayer->GetPlayerId();
+              Battle.DefenderFaction = Target->OwningPlayer->Faction;
+              Battle.DefenderDisplayName = Target->OwningPlayer->PlayerDisplayName;
+              Battle.bDefenderIsAI = Target->OwningPlayer->bIsAI;
             }
             Battle.IsCapitalAttack = Target->bIsCapital;
           }


### PR DESCRIPTION
## Summary
- cache attacker/defender names, factions, and AI flags in `FS_BattlePayload` when attacks are triggered from the UI or player controller
- keep pending battle participants from being pruned during seamless travel and recreate missing player states on the battle map so AI armies can auto-commit
- ensure `TryLaunchBattle` rehydrates participants from the cached snapshot before verifying that both armies are locked in

## Testing
- not run (Unreal Engine build tools are unavailable in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68cdff7b03588324b2ee02921236e6a2