### PR TITLE
Fix Engine World header include paths in tests

### DIFF
--- a/Source/Skald/Tests/BattleResolutionSyncTest.cpp
+++ b/Source/Skald/Tests/BattleResolutionSyncTest.cpp
@@ -6,7 +6,7 @@
 #include "Skald_PlayerState.h"
 #include "Territory.h"
 #include "WorldMap.h"
-#include "Engine\World.h"
+#include "Engine/World.h"
 
 IMPLEMENT_SIMPLE_AUTOMATION_TEST(FSkaldBattleResolutionSyncTest, "Skald.Multiplayer.BattleResolutionSync", EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
 bool FSkaldBattleResolutionSyncTest::RunTest(const FString& Parameters) {

--- a/Source/Skald/Tests/ReinforcementResourceTest.cpp
+++ b/Source/Skald/Tests/ReinforcementResourceTest.cpp
@@ -5,7 +5,7 @@
 #include "Skald_PlayerState.h"
 #include "Territory.h"
 #include "WorldMap.h"
-#include "Engine\World.h"
+#include "Engine/World.h"
 
 IMPLEMENT_SIMPLE_AUTOMATION_TEST(FSkaldReinforcementResourceTest, "Skald.TurnManager.ResourceAccumulation", EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
 bool FSkaldReinforcementResourceTest::RunTest(const FString& Parameters) {

--- a/Source/Skald/Tests/TerritoryMoveTest.cpp
+++ b/Source/Skald/Tests/TerritoryMoveTest.cpp
@@ -2,7 +2,7 @@
 #include "Tests/AutomationEditorCommon.h"
 #include "Territory.h"
 #include "Skald_PlayerState.h"
-#include "Engine\World.h"
+#include "Engine/World.h"
 #include "Components/TextRenderComponent.h"
 
 IMPLEMENT_SIMPLE_AUTOMATION_TEST(FSkaldTerritoryMoveValidTest, "Skald.Territory.Move.Valid", EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)

--- a/Source/Skald/Tests/TurnManagerTest.cpp
+++ b/Source/Skald/Tests/TurnManagerTest.cpp
@@ -3,7 +3,7 @@
 #include "Skald_TurnManager.h"
 #include "Skald_PlayerController.h"
 #include "Skald_PlayerState.h"
-#include "Engine\World.h"
+#include "Engine/World.h"
 
 IMPLEMENT_SIMPLE_AUTOMATION_TEST(FSkaldTurnManagerPhaseTest, "Skald.TurnManager.PhaseTransitions", EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
 bool FSkaldTurnManagerPhaseTest::RunTest(const FString& Parameters) {

--- a/Source/Skald/Tests/WorldMapDefaultTableTest.cpp
+++ b/Source/Skald/Tests/WorldMapDefaultTableTest.cpp
@@ -1,7 +1,7 @@
 #include "Misc/AutomationTest.h"
 #include "WorldMap.h"
 #include "Tests/AutomationEditorCommon.h"
-#include "Engine\\World.h"
+#include "Engine/World.h"
 
 IMPLEMENT_SIMPLE_AUTOMATION_TEST(FWorldMapDefaultTableTest, "Skald.WorldMap.DefaultTableUnset", EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
 

--- a/Source/Skald/Tests/WorldMapFindPathTest.cpp
+++ b/Source/Skald/Tests/WorldMapFindPathTest.cpp
@@ -3,7 +3,7 @@
 #include "WorldMap.h"
 #include "Territory.h"
 #include "Skald_PlayerState.h"
-#include "Engine\World.h"
+#include "Engine/World.h"
 
 IMPLEMENT_SIMPLE_AUTOMATION_TEST(FWorldMapFindPathValidTest, "Skald.WorldMap.FindPath.Valid", EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
 bool FWorldMapFindPathValidTest::RunTest(const FString& Parameters) {


### PR DESCRIPTION
## Summary
- replace backslash includes for Engine World header in test sources with forward slashes so the files resolve on all platforms

## Testing
- not run (Unreal build tools unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68ce0c04536c8324803f8352ab0a09ad