### PR TITLE
Fix automation macro guard and missing log include

### DIFF
--- a/Source/Skald/Skald_BattleGameMode.cpp
+++ b/Source/Skald/Skald_BattleGameMode.cpp
@@ -3,6 +3,7 @@
 #include "Algo/RandomShuffle.h"
 #include "Algo/Sort.h"
 #include "GridBattleManager.h"
+#include "Skald.h"
 #include "Skald_GameInstance.h"
 #include "Skald_GameState.h"
 #include "Skald_PlayerState.h"

--- a/Source/Skald/Skald_GameMode.h
+++ b/Source/Skald/Skald_GameMode.h
@@ -14,7 +14,7 @@ class AWorldMap;
 class APlayerController;
 class USkaldSaveGame;
 
-#if WITH_AUTOMATION_TESTS
+#if defined(WITH_AUTOMATION_TESTS) && WITH_AUTOMATION_TESTS
 class FArmyPlacementInitiativeOrderTest;
 class FAIArmyPlacementAutoAdvanceTest;
 #endif // WITH_AUTOMATION_TESTS
@@ -29,7 +29,7 @@ UCLASS(Blueprintable, BlueprintType)
 class SKALD_API ASkaldGameMode : public AGameModeBase {
   GENERATED_BODY()
 
-#if WITH_AUTOMATION_TESTS
+#if defined(WITH_AUTOMATION_TESTS) && WITH_AUTOMATION_TESTS
   // Allow automation tests to drive protected game flow entry points.
   friend class FArmyPlacementInitiativeOrderTest;
   friend class FAIArmyPlacementAutoAdvanceTest;


### PR DESCRIPTION
## Summary
- guard automation-only declarations against builds where WITH_AUTOMATION_TESTS is undefined
- include the module log header in the battle game mode so UE_LOG uses LogSkald

## Testing
- not run (Unreal Engine build environment unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68ce1184b05c8324907888340cbb856c