### PR TITLE
Handle pointer-aware sorting in battle game mode

### DIFF
--- a/Source/Skald/Skald_BattleGameMode.cpp
+++ b/Source/Skald/Skald_BattleGameMode.cpp
@@ -3,6 +3,7 @@
 #include "Algo/RandomShuffle.h"
 #include "Algo/Sort.h"
 #include "GridBattleManager.h"
+#include "Skald.h"
 #include "Skald_GameInstance.h"
 #include "Skald_GameState.h"
 #include "Skald_PlayerState.h"
@@ -92,14 +93,12 @@ ASkaldPlayerState *EnsureBattleParticipant(ASkaldGameState *GameState, UWorld *W
     bool bAddedToList = false;
     if (!GameState->Players.Contains(Candidate)) {
       GameState->Players.Add(Candidate);
-      GameState->Players.Sort([](ASkaldPlayerState *A, ASkaldPlayerState *B) {
-        if (!A) {
-          return false;
-        }
-        if (!B) {
-          return true;
-        }
-        return A->GetPlayerId() < B->GetPlayerId();
+      GameState->Players.RemoveAll([](const ASkaldPlayerState* Player) {
+        return Player == nullptr;
+      });
+      GameState->Players.Sort([](const ASkaldPlayerState& A,
+                                 const ASkaldPlayerState& B) {
+        return A.GetPlayerId() < B.GetPlayerId();
       });
       bAddedToList = true;
     }

--- a/Source/Skald/Skald_GameMode.h
+++ b/Source/Skald/Skald_GameMode.h
@@ -14,7 +14,7 @@ class AWorldMap;
 class APlayerController;
 class USkaldSaveGame;
 
-#if WITH_AUTOMATION_TESTS
+#if defined(WITH_AUTOMATION_TESTS) && WITH_AUTOMATION_TESTS
 class FArmyPlacementInitiativeOrderTest;
 class FAIArmyPlacementAutoAdvanceTest;
 #endif // WITH_AUTOMATION_TESTS
@@ -29,7 +29,7 @@ UCLASS(Blueprintable, BlueprintType)
 class SKALD_API ASkaldGameMode : public AGameModeBase {
   GENERATED_BODY()
 
-#if WITH_AUTOMATION_TESTS
+#if defined(WITH_AUTOMATION_TESTS) && WITH_AUTOMATION_TESTS
   // Allow automation tests to drive protected game flow entry points.
   friend class FArmyPlacementInitiativeOrderTest;
   friend class FAIArmyPlacementAutoAdvanceTest;


### PR DESCRIPTION
## Summary
- remove null player entries before sorting the battle game state roster
- compare player ids using reference-based sort predicate compatible with UE 5.5 pointer dereference wrapper

## Testing
- not run (Unreal Engine build environment unavailable in container)

------
https://chatgpt.com/codex/tasks/task_e_68ce1184b05c8324907888340cbb856c