### PR TITLE
Register player controller post-load delegate

### DIFF
--- a/Source/Skald/Skald_PlayerController.cpp
+++ b/Source/Skald/Skald_PlayerController.cpp
@@ -29,6 +29,7 @@
 #include "UI/FighterSelectionWidget.h"
 #include "UI/SkaldMainHUDWidget.h"
 #include "UObject/ConstructorHelpers.h"
+#include "UObject/CoreUObjectDelegates.h"
 #include "WorldMap.h"
 
 ASkaldPlayerController::ASkaldPlayerController() {
@@ -180,12 +181,22 @@ void ASkaldPlayerController::BeginPlay() {
     }
     InitializeFighterSelectionIfNeeded();
     DetectBattleMap();
+
+    if (!PostLoadMapHandle.IsValid()) {
+      PostLoadMapHandle =
+          FCoreUObjectDelegates::PostLoadMapWithWorld.AddUObject(
+              this, &ASkaldPlayerController::HandlePostLoadMap);
+    }
   }
 
   TryBindWorldMap();
 }
 
 void ASkaldPlayerController::EndPlay(const EEndPlayReason::Type EndPlayReason) {
+  if (PostLoadMapHandle.IsValid()) {
+    FCoreUObjectDelegates::PostLoadMapWithWorld.Remove(PostLoadMapHandle);
+    PostLoadMapHandle.Reset();
+  }
   Super::EndPlay(EndPlayReason);
 }
 
@@ -493,8 +504,13 @@ void ASkaldPlayerController::DetectBattleMap() {
   }
 }
 
-void ASkaldPlayerController::HandlePostLoadMap(UWorld * /*LoadedWorld*/) {
+void ASkaldPlayerController::HandlePostLoadMap(UWorld *LoadedWorld) {
+  if (!LoadedWorld || !IsLocalPlayerController()) {
+    return;
+  }
+
   InitializeFighterSelectionIfNeeded();
+  DetectBattleMap();
 }
 
 void ASkaldPlayerController::ShowTurnAnnouncement(const FString &PlayerName,

--- a/Source/Skald/Skald_PlayerController.h
+++ b/Source/Skald/Skald_PlayerController.h
@@ -6,6 +6,7 @@
 #include "GridBattleManager.h"
 #include "SkaldTypes.h"
 #include "TimerManager.h"
+#include "Delegates/DelegateHandle.h"
 #include "Skald_PlayerController.generated.h"
 
 class ATurnManager;
@@ -325,6 +326,9 @@ private:
 
   /** Timer used to poll for the world map actor until it exists. */
   FTimerHandle WorldMapSearchHandle;
+
+  /** Handle for the PostLoadMap delegate binding. */
+  FDelegateHandle PostLoadMapHandle;
 
   /** Whether the current map is a battle map. */
   UPROPERTY(BlueprintReadOnly, Category = "Turn",


### PR DESCRIPTION
## Summary
- register the Skald player controller with PostLoadMap so the delegate persists across seamless travel
- recompute battle map state after refreshing fighter selection whenever a new world loads
- guard the delegate callback and clear the handle during teardown to avoid crashes

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ceb021ff1c8324ab7003814b327e17