### PR TITLE
Fix delegate include path for Skald player controller

### DIFF
--- a/Source/Skald/Skald_PlayerController.h
+++ b/Source/Skald/Skald_PlayerController.h
@@ -6,7 +6,7 @@
 #include "GridBattleManager.h"
 #include "SkaldTypes.h"
 #include "TimerManager.h"
-#include "Delegates/DelegateHandle.h"
+#include "Delegates/Delegate.h"
 #include "Skald_PlayerController.generated.h"
 
 class ATurnManager;


### PR DESCRIPTION
## Summary
- update the player controller header to include Delegates/Delegate.h instead of the removed DelegateHandle header so UE5.5 builds succeed

## Testing
- not run (Unreal build environment not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68cebcdaba4c832487c441d06d0c75a5