### PR TITLE
Fix post-load map delegate include

### DIFF
--- a/Source/Skald/Skald_PlayerController.cpp
+++ b/Source/Skald/Skald_PlayerController.cpp
@@ -29,7 +29,6 @@
 #include "UI/FighterSelectionWidget.h"
 #include "UI/SkaldMainHUDWidget.h"
 #include "UObject/ConstructorHelpers.h"
-#include "UObject/CoreUObjectDelegates.h"
 #include "WorldMap.h"
 
 ASkaldPlayerController::ASkaldPlayerController() {
@@ -184,7 +183,7 @@ void ASkaldPlayerController::BeginPlay() {
 
     if (!PostLoadMapHandle.IsValid()) {
       PostLoadMapHandle =
-          FCoreUObjectDelegates::PostLoadMapWithWorld.AddUObject(
+          FWorldDelegates::OnPostLoadMapWithWorld.AddUObject(
               this, &ASkaldPlayerController::HandlePostLoadMap);
     }
   }
@@ -194,7 +193,7 @@ void ASkaldPlayerController::BeginPlay() {
 
 void ASkaldPlayerController::EndPlay(const EEndPlayReason::Type EndPlayReason) {
   if (PostLoadMapHandle.IsValid()) {
-    FCoreUObjectDelegates::PostLoadMapWithWorld.Remove(PostLoadMapHandle);
+    FWorldDelegates::OnPostLoadMapWithWorld.Remove(PostLoadMapHandle);
     PostLoadMapHandle.Reset();
   }
   Super::EndPlay(EndPlayReason);


### PR DESCRIPTION
## Summary
- replace the missing CoreUObject delegate header by using the available world delegates when binding to the post-load map event

## Testing
- Not run (Unreal build tools are unavailable in this environment)

------
https://chatgpt.com/codex/tasks/task_e_68cee14ecfd48324b2f7254245267078