### PR TITLE
Bind post-load handling via game instance world change

### DIFF
--- a/Source/Skald/Skald_PlayerController.cpp
+++ b/Source/Skald/Skald_PlayerController.cpp
@@ -29,7 +29,6 @@
 #include "UI/FighterSelectionWidget.h"
 #include "UI/SkaldMainHUDWidget.h"
 #include "UObject/ConstructorHelpers.h"
-#include "UObject/CoreUObjectDelegates.h"
 #include "WorldMap.h"
 
 ASkaldPlayerController::ASkaldPlayerController() {
@@ -182,10 +181,9 @@ void ASkaldPlayerController::BeginPlay() {
     InitializeFighterSelectionIfNeeded();
     DetectBattleMap();
 
-    if (!PostLoadMapHandle.IsValid()) {
-      PostLoadMapHandle =
-          FCoreUObjectDelegates::PostLoadMapWithWorld.AddUObject(
-              this, &ASkaldPlayerController::HandlePostLoadMap);
+    if (CachedGameInstance && !PostLoadMapHandle.IsValid()) {
+      PostLoadMapHandle = CachedGameInstance->GetOnWorldChanged().AddUObject(
+          this, &ASkaldPlayerController::HandleWorldChanged);
     }
   }
 
@@ -193,10 +191,10 @@ void ASkaldPlayerController::BeginPlay() {
 }
 
 void ASkaldPlayerController::EndPlay(const EEndPlayReason::Type EndPlayReason) {
-  if (PostLoadMapHandle.IsValid()) {
-    FCoreUObjectDelegates::PostLoadMapWithWorld.Remove(PostLoadMapHandle);
-    PostLoadMapHandle.Reset();
+  if (CachedGameInstance && PostLoadMapHandle.IsValid()) {
+    CachedGameInstance->GetOnWorldChanged().Remove(PostLoadMapHandle);
   }
+  PostLoadMapHandle.Reset();
   Super::EndPlay(EndPlayReason);
 }
 
@@ -545,6 +543,15 @@ void ASkaldPlayerController::HandlePostLoadMap(UWorld *LoadedWorld) {
 
   InitializeFighterSelectionIfNeeded();
   DetectBattleMap();
+}
+
+void ASkaldPlayerController::HandleWorldChanged(UWorld *OldWorld,
+                                                UWorld *NewWorld) {
+  if (!IsLocalPlayerController() || !NewWorld) {
+    return;
+  }
+
+  HandlePostLoadMap(NewWorld);
 }
 
 void ASkaldPlayerController::ShowTurnAnnouncement(const FString &PlayerName,

--- a/Source/Skald/Skald_PlayerController.h
+++ b/Source/Skald/Skald_PlayerController.h
@@ -329,7 +329,7 @@ private:
   /** Timer used to poll for the world map actor until it exists. */
   FTimerHandle WorldMapSearchHandle;
 
-  /** Handle for the PostLoadMap delegate binding. */
+  /** Handle for the game instance world change delegate binding. */
   FDelegateHandle PostLoadMapHandle;
 
   /** Whether the current map is a battle map. */
@@ -342,6 +342,9 @@ private:
 
   /** Re-run fighter selection setup after level transitions. */
   void HandlePostLoadMap(UWorld *LoadedWorld);
+
+  /** Forward world change notifications to HandlePostLoadMap for this controller. */
+  void HandleWorldChanged(UWorld *OldWorld, UWorld *NewWorld);
 
   void BuildPlayerDataArray(TArray<FS_PlayerData> &OutPlayers) const;
 


### PR DESCRIPTION
## Summary
- bind the player controller's post-load handling through the game instance world change delegate instead of the unavailable world delegate
- cleanly remove the binding when the controller ends play

## Testing
- Not run (Unreal build tools are unavailable in this environment)

------
https://chatgpt.com/codex/tasks/task_e_68cee14ecfd48324b2f7254245267078