### PR TITLE
Fix PostLoadMap delegate handling in player controller

### DIFF
--- a/Source/Skald/Skald_PlayerController.cpp
+++ b/Source/Skald/Skald_PlayerController.cpp
@@ -3,7 +3,7 @@
 #include "ChoosePlayerWidget.h"
 #include "Components/InputComponent.h"
 #include "Engine/Engine.h"
-#include "Engine/World.h"
+#include "Engine/World.h"                 // UWorld
 #include "EngineUtils.h"
 #include "FighterDataLibrary.h"
 #include "FighterPawn.h"
@@ -29,6 +29,7 @@
 #include "UI/FighterSelectionWidget.h"
 #include "UI/SkaldMainHUDWidget.h"
 #include "UObject/ConstructorHelpers.h"
+#include "UObject/CoreUObjectDelegates.h" // FCoreUObjectDelegates::PostLoadMapWithWorld
 #include "WorldMap.h"
 
 ASkaldPlayerController::ASkaldPlayerController() {
@@ -181,27 +182,24 @@ void ASkaldPlayerController::BeginPlay() {
     InitializeFighterSelectionIfNeeded();
     DetectBattleMap();
 
-    if (CachedGameInstance && !PostLoadMapHandle.IsValid()) {
-      PostLoadMapHandle = CachedGameInstance->GetOnWorldChanged().AddUObject(
-          this, &ASkaldPlayerController::HandleWorldChanged);
-    if (!PostLoadMapHandle.IsValid()) {
-      PostLoadMapHandle =
-          FWorldDelegates::OnPostLoadMapWithWorld.AddUObject(
-              this, &ASkaldPlayerController::HandlePostLoadMap);
+    if (PostLoadMapHandle.IsValid()) {
+      FCoreUObjectDelegates::PostLoadMapWithWorld.Remove(PostLoadMapHandle);
+      PostLoadMapHandle.Reset();
     }
+
+    PostLoadMapHandle = FCoreUObjectDelegates::PostLoadMapWithWorld.AddUObject(
+        this, &ASkaldPlayerController::HandlePostLoadMap);
   }
 
   TryBindWorldMap();
 }
 
 void ASkaldPlayerController::EndPlay(const EEndPlayReason::Type EndPlayReason) {
-  if (CachedGameInstance && PostLoadMapHandle.IsValid()) {
-    CachedGameInstance->GetOnWorldChanged().Remove(PostLoadMapHandle);
   if (PostLoadMapHandle.IsValid()) {
-    FWorldDelegates::OnPostLoadMapWithWorld.Remove(PostLoadMapHandle);
+    FCoreUObjectDelegates::PostLoadMapWithWorld.Remove(PostLoadMapHandle);
     PostLoadMapHandle.Reset();
   }
-  PostLoadMapHandle.Reset();
+
   Super::EndPlay(EndPlayReason);
 }
 
@@ -550,15 +548,6 @@ void ASkaldPlayerController::HandlePostLoadMap(UWorld *LoadedWorld) {
 
   InitializeFighterSelectionIfNeeded();
   DetectBattleMap();
-}
-
-void ASkaldPlayerController::HandleWorldChanged(UWorld *OldWorld,
-                                                UWorld *NewWorld) {
-  if (!IsLocalPlayerController() || !NewWorld) {
-    return;
-  }
-
-  HandlePostLoadMap(NewWorld);
 }
 
 void ASkaldPlayerController::ShowTurnAnnouncement(const FString &PlayerName,

--- a/Source/Skald/Skald_PlayerController.h
+++ b/Source/Skald/Skald_PlayerController.h
@@ -22,6 +22,7 @@ class UFighterSelectionWidget;
 class AWorldMap;
 class AFighterPawn;
 class UGridOverlayComponent;
+class UWorld;
 
 /** Command issued by the player during a battle. */
 UENUM()
@@ -39,8 +40,6 @@ class SKALD_API ASkaldPlayerController : public APlayerController {
 
 public:
   ASkaldPlayerController();
-
-  virtual void BeginPlay() override;
 
   virtual void OnRep_PlayerState() override;
 
@@ -156,9 +155,11 @@ protected:
   UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Input")
   EMouseCaptureMode DefaultMouseCaptureMode;
 
-  virtual void SetupInputComponent() override;
+  virtual void BeginPlay() override;
 
   virtual void EndPlay(const EEndPlayReason::Type EndPlayReason) override;
+
+  virtual void SetupInputComponent() override;
 
   /** Begin selecting a move destination. */
   UFUNCTION()
@@ -329,7 +330,8 @@ private:
   /** Timer used to poll for the world map actor until it exists. */
   FTimerHandle WorldMapSearchHandle;
 
-  /** Handle for the game instance world change delegate binding. */
+  void HandlePostLoadMap(UWorld *LoadedWorld);
+
   FDelegateHandle PostLoadMapHandle;
 
   /** Whether the current map is a battle map. */
@@ -339,12 +341,6 @@ private:
 
   /** Detect if the current level is a battle map and update bIsBattleMap. */
   void DetectBattleMap();
-
-  /** Re-run fighter selection setup after level transitions. */
-  void HandlePostLoadMap(UWorld *LoadedWorld);
-
-  /** Forward world change notifications to HandlePostLoadMap for this controller. */
-  void HandleWorldChanged(UWorld *OldWorld, UWorld *NewWorld);
 
   void BuildPlayerDataArray(TArray<FS_PlayerData> &OutPlayers) const;
 


### PR DESCRIPTION
## Summary
- update the player controller to bind map load events through FCoreUObjectDelegates::PostLoadMapWithWorld and clean up the handle safely
- move BeginPlay/EndPlay declarations to the protected section and expose the PostLoadMap handler and delegate handle in the header

## Testing
- not run (engine not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68ceeb362f9c8324a4eff3491ac02fe7