### PR TITLE
Guard CoreUObject delegate include behind feature macro

### DIFF
--- a/Source/Skald/Skald_PlayerController.cpp
+++ b/Source/Skald/Skald_PlayerController.cpp
@@ -29,8 +29,52 @@
 #include "UI/FighterSelectionWidget.h"
 #include "UI/SkaldMainHUDWidget.h"
 #include "UObject/ConstructorHelpers.h"
-#include "UObject/CoreUObjectDelegates.h" // FCoreUObjectDelegates::PostLoadMapWithWorld
 #include "WorldMap.h"
+
+#ifndef SKALD_USE_CORE_UOBJECT_DELEGATES
+// Projects that target engine variants lacking FCoreUObjectDelegates can
+// override this at build time to use the fallback implementation below.
+#define SKALD_USE_CORE_UOBJECT_DELEGATES 0
+#endif
+
+#if SKALD_USE_CORE_UOBJECT_DELEGATES
+#include "UObject/CoreUObjectDelegates.h" // FCoreUObjectDelegates::PostLoadMapWithWorld
+#endif
+
+namespace Skald
+{
+namespace PlayerController
+{
+namespace Private
+{
+static FDelegateHandle RegisterPostLoadMapDelegate(ASkaldPlayerController *Controller)
+{
+#if SKALD_USE_CORE_UOBJECT_DELEGATES
+  return FCoreUObjectDelegates::PostLoadMapWithWorld.AddUObject(
+      Controller, &ASkaldPlayerController::HandlePostLoadMap);
+#else
+  return FWorldDelegates::OnPostLoadMapWithWorld.AddUObject(
+      Controller, &ASkaldPlayerController::HandlePostLoadMap);
+#endif
+}
+
+static void UnregisterPostLoadMapDelegate(FDelegateHandle &Handle)
+{
+  if (!Handle.IsValid())
+  {
+    return;
+  }
+
+#if SKALD_USE_CORE_UOBJECT_DELEGATES
+  FCoreUObjectDelegates::PostLoadMapWithWorld.Remove(Handle);
+#else
+  FWorldDelegates::OnPostLoadMapWithWorld.Remove(Handle);
+#endif
+  Handle.Reset();
+}
+} // namespace Private
+} // namespace PlayerController
+} // namespace Skald
 
 ASkaldPlayerController::ASkaldPlayerController() {
   TurnManager = nullptr;
@@ -182,23 +226,19 @@ void ASkaldPlayerController::BeginPlay() {
     InitializeFighterSelectionIfNeeded();
     DetectBattleMap();
 
-    if (PostLoadMapHandle.IsValid()) {
-      FCoreUObjectDelegates::PostLoadMapWithWorld.Remove(PostLoadMapHandle);
-      PostLoadMapHandle.Reset();
-    }
+    Skald::PlayerController::Private::UnregisterPostLoadMapDelegate(
+        PostLoadMapHandle);
 
-    PostLoadMapHandle = FCoreUObjectDelegates::PostLoadMapWithWorld.AddUObject(
-        this, &ASkaldPlayerController::HandlePostLoadMap);
+    PostLoadMapHandle =
+        Skald::PlayerController::Private::RegisterPostLoadMapDelegate(this);
   }
 
   TryBindWorldMap();
 }
 
 void ASkaldPlayerController::EndPlay(const EEndPlayReason::Type EndPlayReason) {
-  if (PostLoadMapHandle.IsValid()) {
-    FCoreUObjectDelegates::PostLoadMapWithWorld.Remove(PostLoadMapHandle);
-    PostLoadMapHandle.Reset();
-  }
+  Skald::PlayerController::Private::UnregisterPostLoadMapDelegate(
+      PostLoadMapHandle);
 
   Super::EndPlay(EndPlayReason);
 }


### PR DESCRIPTION
## Summary
- gate the `CoreUObjectDelegates` include behind the `SKALD_USE_CORE_UOBJECT_DELEGATES` switch so builds without the header use the fallback path
- retain the shared helper that swaps between `FCoreUObjectDelegates` and `FWorldDelegates` based on the macro

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cf30ca554c8324afd2bec58c1699fd