### PR TITLE
Derive CoreUObject delegate usage from engine macros

### DIFF
--- a/Source/Skald/Skald_PlayerController.cpp
+++ b/Source/Skald/Skald_PlayerController.cpp
@@ -35,16 +35,30 @@
 #include "WorldMap.h"
 
 #if !defined(SKALD_USE_CORE_UOBJECT_DELEGATES)
-// Projects that target engine variants lacking FCoreUObjectDelegates can
-// override this at build time to use the fallback implementations below.
-#if defined(__has_include)
+// Follow engine feature detection to determine whether CoreUObject delegates
+// are available. Only override this manually if the project is certain the
+// CoreUObject header exists.
+#if defined(UE_WITH_COREUOBJECT)
+#if UE_WITH_COREUOBJECT
+#define SKALD_USE_CORE_UOBJECT_DELEGATES 1
+#else
+#define SKALD_USE_CORE_UOBJECT_DELEGATES 0
+#endif
+#elif defined(__has_include)
 #if __has_include("UObject/CoreUObjectDelegates.h")
 #define SKALD_USE_CORE_UOBJECT_DELEGATES 1
 #else
 #define SKALD_USE_CORE_UOBJECT_DELEGATES 0
 #endif
-#else
+#elif defined(_MSC_VER)
+#include <yvals_core.h>
+#if defined(_HAS_INCLUDE) && _HAS_INCLUDE("UObject/CoreUObjectDelegates.h")
 #define SKALD_USE_CORE_UOBJECT_DELEGATES 1
+#else
+#define SKALD_USE_CORE_UOBJECT_DELEGATES 0
+#endif
+#else
+#define SKALD_USE_CORE_UOBJECT_DELEGATES 0
 #endif
 #endif
 


### PR DESCRIPTION
## Summary
- derive `SKALD_USE_CORE_UOBJECT_DELEGATES` from engine feature macros and header detection
- add an MSVC-specific include fallback and clarify the accompanying comment

## Testing
- not run (Unreal build tools are not available in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68cf485f291883248e368f02dd491638