### PR TITLE
Fix CoreUObject delegate setup for player controller

### DIFF
--- a/Source/Skald/Skald.Build.cs
+++ b/Source/Skald/Skald.Build.cs
@@ -11,7 +11,6 @@ public class Skald : ModuleRules
                 PublicDependencyModuleNames.AddRange(new string[]
                 {
                         "Core",
-                        "CoreUObject",
                         "Engine",
                         "InputCore",
                         "UMG",
@@ -23,6 +22,8 @@ public class Skald : ModuleRules
 
                 PrivateDependencyModuleNames.AddRange(new string[]
                 {
+                        "CoreUObject",
+                        "Engine",
                         "Slate",
                         "SlateCore",
                         "UMG",

--- a/Source/Skald/Skald_PlayerController.cpp
+++ b/Source/Skald/Skald_PlayerController.cpp
@@ -4,7 +4,6 @@
 #include "ChoosePlayerWidget.h"
 #include "Components/InputComponent.h"
 #include "Engine/Engine.h"
-#include "Engine/World.h"                 // UWorld
 #include "EngineUtils.h"
 #include "FighterDataLibrary.h"
 #include "FighterPawn.h"
@@ -30,8 +29,18 @@
 #include "UI/FighterSelectionWidget.h"
 #include "UI/SkaldMainHUDWidget.h"
 #include "UObject/ConstructorHelpers.h"
-#include "UObject/CoreUObjectDelegates.h"
 #include "WorldMap.h"
+
+// Portable include for FCoreUObjectDelegates across UE versions
+#if __has_include("UObject/CoreUObjectDelegates.h")
+    #include "UObject/CoreUObjectDelegates.h"
+#elif __has_include("UObject/Package.h")
+    #include "UObject/Package.h"
+#else
+    #include "UObject/UObjectGlobals.h"
+#endif
+
+#include "Engine/World.h"
 
 ASkaldPlayerController::ASkaldPlayerController() {
   TurnManager = nullptr;
@@ -159,6 +168,15 @@ void ASkaldPlayerController::InitializeChoosePlayerWidget() {
 
 void ASkaldPlayerController::BeginPlay() {
   Super::BeginPlay();
+
+  if (PostLoadMapHandle.IsValid()) {
+    FCoreUObjectDelegates::PostLoadMapWithWorld.Remove(PostLoadMapHandle);
+    PostLoadMapHandle.Reset();
+  }
+
+  PostLoadMapHandle = FCoreUObjectDelegates::PostLoadMapWithWorld.AddUObject(
+      this, &ASkaldPlayerController::HandlePostLoadMap);
+
   CacheGameReferences();
 
   if (IsLocalPlayerController() && GetLocalPlayer() != nullptr) {
@@ -182,14 +200,6 @@ void ASkaldPlayerController::BeginPlay() {
     }
     InitializeFighterSelectionIfNeeded();
     DetectBattleMap();
-
-    if (PostLoadMapHandle.IsValid()) {
-      FCoreUObjectDelegates::PostLoadMapWithWorld.Remove(PostLoadMapHandle);
-      PostLoadMapHandle.Reset();
-    }
-
-    PostLoadMapHandle = FCoreUObjectDelegates::PostLoadMapWithWorld.AddUObject(
-        this, &ASkaldPlayerController::HandlePostLoadMap);
   }
 
   TryBindWorldMap();


### PR DESCRIPTION
## Summary
- move CoreUObject dependency to the private module list and ensure other engine modules remain available
- add a version-resilient include block for FCoreUObjectDelegates in the player controller
- bind and unbind the PostLoadMap delegate on begin/end play without gating on local-only checks

## Testing
- not run (project build not run in this environment)

------
https://chatgpt.com/codex/tasks/task_e_68cf57a31a1c8324965cc93596f6ab92