### PR TITLE
Defer battle start until controllers ready

### DIFF
--- a/Source/Skald/Private/LobbyPlayerController.cpp
+++ b/Source/Skald/Private/LobbyPlayerController.cpp
@@ -1,6 +1,7 @@
 #include "LobbyPlayerController.h"
 #include "Blueprint/UserWidget.h"
 #include "LobbyMenuWidget.h"
+#include "UI/SkaldUIHelpers.h"
 
 void ALobbyPlayerController::BeginPlay()
 {
@@ -20,10 +21,7 @@ void ALobbyPlayerController::InitLobbyUI()
 
     LobbyWidgetInstance->AddToViewport();
 
-    FInputModeUIOnly Mode;
-    Mode.SetWidgetToFocus(LobbyWidgetInstance->TakeWidget());
-    Mode.SetLockMouseToViewportBehavior(EMouseLockMode::DoNotLock);
-    SetInputMode(Mode);
+    FocusWidgetUIOnly(this, LobbyWidgetInstance);
 
     bShowMouseCursor = true;
     bEnableClickEvents = true;

--- a/Source/Skald/Skald_AIController.cpp
+++ b/Source/Skald/Skald_AIController.cpp
@@ -2,6 +2,7 @@
 #include "Engine/World.h"
 #include "Kismet/GameplayStatics.h"
 #include "Skald.h"
+#include "Skald_BattleGameMode.h"
 #include "Skald_GameMode.h"
 #include "Skald_PlayerState.h"
 #include "Skald_TurnManager.h"
@@ -12,6 +13,17 @@
 
 namespace {
 constexpr int32 MaxAIIterations = 100;
+}
+
+void ASkaldAIController::BeginPlay() {
+  Super::BeginPlay();
+
+  if (UWorld *World = GetWorld()) {
+    if (ASkald_BattleGameMode *BattleGM =
+            World->GetAuthGameMode<ASkald_BattleGameMode>()) {
+      BattleGM->OnAIControllerReady(this);
+    }
+  }
 }
 
 void ASkaldAIController::StartTurn() { MakeAIDecision(); }

--- a/Source/Skald/Skald_AIController.h
+++ b/Source/Skald/Skald_AIController.h
@@ -12,6 +12,7 @@ class SKALD_API ASkaldAIController : public ASkaldPlayerController {
   GENERATED_BODY()
 
 public:
+  virtual void BeginPlay() override;
   virtual void StartTurn() override;
 
   /** Execute the AI's decision making for the current turn. */

--- a/Source/Skald/Skald_BattleGameMode.cpp
+++ b/Source/Skald/Skald_BattleGameMode.cpp
@@ -2,6 +2,7 @@
 
 #include "Algo/RandomShuffle.h"
 #include "Algo/Sort.h"
+#include "AIController.h"
 #include "GridBattleManager.h"
 #include "Skald.h"
 #include "Skald_GameInstance.h"
@@ -140,6 +141,8 @@ ASkaldPlayerState *EnsureBattleParticipant(ASkaldGameState *GameState, UWorld *W
 void ASkald_BattleGameMode::BeginPlay() {
   Super::BeginPlay();
 
+  ReadyControllers.Empty();
+
   if (!BattleManager) {
     UClass *ClassToUse = BattleManagerClass ? *BattleManagerClass
                                             : UGridBattleManager::StaticClass();
@@ -154,6 +157,39 @@ void ASkald_BattleGameMode::BeginPlay() {
   USkaldGameInstance *GI = GetGameInstance<USkaldGameInstance>();
   if (GI) {
     GI->GridBattleManager = BattleManager;
+    const FSkaldTravelState &TravelState = GI->GetTravelState();
+    ExpectedControllers = TravelState.bValid ? TravelState.ExpectedControllers : 0;
+    UE_LOG(LogSkald, Log,
+           TEXT("BattleGM BeginPlay: ExpectedControllers=%d"),
+           ExpectedControllers);
+  } else {
+    ExpectedControllers = 0;
+  }
+
+  const FSkaldTravelState *TravelStatePtr = nullptr;
+  if (!WorldMap) {
+    for (TActorIterator<AWorldMap> It(GetWorld()); It; ++It) {
+      WorldMap = *It;
+      break;
+    }
+  }
+
+  if (GI) {
+    TravelStatePtr = &GI->GetTravelState();
+  }
+
+  if (WorldMap && TravelStatePtr && TravelStatePtr->bValid &&
+      TravelStatePtr->HumanOwnedTerritories.Num() > 0) {
+    int32 ReacquiredCount = 0;
+    for (ATerritory *Territory : WorldMap->Territories) {
+      if (Territory &&
+          TravelStatePtr->HumanOwnedTerritories.Contains(Territory->TerritoryID)) {
+        ++ReacquiredCount;
+      }
+    }
+    UE_LOG(LogSkald, Log,
+           TEXT("BattleGM BeginPlay: Reacquired %d of %d cached human territories"),
+           ReacquiredCount, TravelStatePtr->HumanOwnedTerritories.Num());
   }
 
   SetupPendingBattle();
@@ -165,9 +201,11 @@ void ASkald_BattleGameMode::BeginPlay() {
          It; ++It) {
       ++ControllerCount;
     }
-    ensureMsgf(GS->PlayerArray.Num() == ControllerCount,
-               TEXT("PlayerCount %d != ControllerCount %d after travel"),
-               GS->PlayerArray.Num(), ControllerCount);
+    if (GS->PlayerArray.Num() != ControllerCount) {
+      UE_LOG(LogSkald, Verbose,
+             TEXT("BattleGM BeginPlay: PlayerStates=%d ControllerCount=%d"),
+             GS->PlayerArray.Num(), ControllerCount);
+    }
 
     const bool bHumanHasTerritory =
         HasHumanOwnedTerritory(GS, WorldMap, GI);
@@ -179,6 +217,8 @@ void ASkald_BattleGameMode::BeginPlay() {
              *GetNameSafe(WorldMap), CachedCount);
     }
   }
+
+  TryStartBattle();
 }
 
 void ASkald_BattleGameMode::SetupPendingBattle() {
@@ -230,7 +270,7 @@ void ASkald_BattleGameMode::SetupPendingBattle() {
   AutoCommitAIArmy(AttackerPS, AttackerBudget);
   AutoCommitAIArmy(DefenderPS, DefenderBudget);
 
-  TryLaunchBattle();
+  TryStartBattle();
 }
 
 void ASkald_BattleGameMode::AutoCommitAIArmy(ASkaldPlayerState *PlayerState,
@@ -320,6 +360,23 @@ void ASkald_BattleGameMode::TryLaunchBattle() {
     return;
   }
 
+  if (ExpectedControllers > 0) {
+    for (auto It = ReadyControllers.CreateIterator(); It; ++It) {
+      if (!It->IsValid()) {
+        It.RemoveCurrent();
+      }
+    }
+    const ASkaldGameState *GS = GetGameState<ASkaldGameState>();
+    const int32 PlayerStates = GS ? GS->PlayerArray.Num() : 0;
+    const int32 Controllers = ReadyControllers.Num();
+    if (Controllers < ExpectedControllers || PlayerStates < ExpectedControllers) {
+      UE_LOG(LogSkald, Log,
+             TEXT("TryLaunchBattle: Waiting for controllers. Ready=%d PlayerStates=%d Expected=%d"),
+             Controllers, PlayerStates, ExpectedControllers);
+      return;
+    }
+  }
+
   USkaldGameInstance *GI = GetGameInstance<USkaldGameInstance>();
   if (!GI || !GI->GridBattleManager) {
     return;
@@ -397,5 +454,56 @@ void ASkald_BattleGameMode::TryInitializeWorldAndStart() {
   bWorldInitialized = true;
   bTurnsStarted = true;
   GetWorldTimerManager().ClearTimer(RetryInitTimerHandle);
+}
+
+void ASkald_BattleGameMode::PostLogin(APlayerController *NewPlayer) {
+  Super::PostLogin(NewPlayer);
+
+  if (NewPlayer) {
+    ReadyControllers.Add(NewPlayer);
+  }
+
+  TryStartBattle();
+}
+
+void ASkald_BattleGameMode::OnAIControllerReady(AAIController *AI) {
+  if (AI) {
+    ReadyControllers.Add(AI);
+  }
+
+  TryStartBattle();
+}
+
+void ASkald_BattleGameMode::TryStartBattle() {
+  if (bBattleLaunched) {
+    return;
+  }
+
+  for (auto It = ReadyControllers.CreateIterator(); It; ++It) {
+    if (!It->IsValid()) {
+      It.RemoveCurrent();
+    }
+  }
+
+  const int32 Controllers = ReadyControllers.Num();
+  const ASkaldGameState *GS = GetGameState<ASkaldGameState>();
+  const int32 PlayerStates = GS ? GS->PlayerArray.Num() : 0;
+
+  UE_LOG(LogSkald, Log,
+         TEXT("TryStartBattle: ReadyControllers=%d PlayerStates=%d Expected=%d"),
+         Controllers, PlayerStates, ExpectedControllers);
+
+  if (ExpectedControllers <= 0) {
+    UE_LOG(LogSkald, Warning,
+           TEXT("TryStartBattle: ExpectedControllers not provided; launching immediately"));
+    TryLaunchBattle();
+    return;
+  }
+
+  if (Controllers >= ExpectedControllers && PlayerStates >= ExpectedControllers) {
+    UE_LOG(LogSkald, Log,
+           TEXT("TryStartBattle: All controllers ready, launching battle"));
+    TryLaunchBattle();
+  }
 }
 

--- a/Source/Skald/Skald_BattleGameMode.h
+++ b/Source/Skald/Skald_BattleGameMode.h
@@ -15,14 +15,26 @@ public:
 
 protected:
   virtual void BeginPlay() override;
+  virtual void PostLogin(APlayerController *NewPlayer) override;
   virtual void TryInitializeWorldAndStart() override;
+
+public:
+  // Called by the AI controller when it’s ready (BeginPlay)
+  void OnAIControllerReady(class AAIController *AI);
 
 private:
   void SetupPendingBattle();
   void AutoCommitAIArmy(ASkaldPlayerState *PlayerState, int32 Budget) const;
   void SpawnFighterSide(const TArray<FFighterDefinition> &Roster, bool bAsAttacker);
+  void TryStartBattle();
 
   /** Ensures the battle only launches once per travel. */
   bool bBattleLaunched = false;
+
+  // Expected count comes from GameInstance travel state
+  int32 ExpectedControllers = 0;
+
+  // Track who has arrived/ready on the new map
+  TSet<TWeakObjectPtr<AController>> ReadyControllers;
 };
 

--- a/Source/Skald/Skald_GameInstance.cpp
+++ b/Source/Skald/Skald_GameInstance.cpp
@@ -2,6 +2,7 @@
 
 #include "Engine/Engine.h"
 #include "Kismet/GameplayStatics.h"
+#include "Skald.h"
 
 void USkaldGameInstance::Init() {
   Super::Init();
@@ -19,6 +20,15 @@ void USkaldGameInstance::Init() {
     GEngine->OnNetworkFailure().AddUObject(
         this, &USkaldGameInstance::HandleNetworkFailure);
   }
+}
+
+void USkaldGameInstance::SetTravelState(const FSkaldTravelState &InState) {
+  TravelState = InState;
+  TravelState.bValid = true;
+  UE_LOG(LogSkald, Log,
+         TEXT("GameInstance travel state set: Expected=%d Attacker=%d Defender=%d HumanTerritories=%d"),
+         TravelState.ExpectedControllers, TravelState.AttackerTerritory,
+         TravelState.DefenderTerritory, TravelState.HumanOwnedTerritories.Num());
 }
 
 void USkaldGameInstance::SeedCombatRandomStream(int32 Seed) {

--- a/Source/Skald/Skald_GameInstance.h
+++ b/Source/Skald/Skald_GameInstance.h
@@ -10,6 +10,27 @@ class UGridBattleManager;
 class USkaldSaveGame;
 class UNetDriver;
 
+USTRUCT(BlueprintType)
+struct FSkaldTravelState
+{
+  GENERATED_BODY()
+
+  UPROPERTY(BlueprintReadWrite, EditAnywhere)
+  int32 ExpectedControllers = 0;
+
+  UPROPERTY(BlueprintReadWrite, EditAnywhere)
+  TArray<int32> HumanOwnedTerritories;
+
+  UPROPERTY(BlueprintReadWrite, EditAnywhere)
+  int32 AttackerTerritory = -1;
+
+  UPROPERTY(BlueprintReadWrite, EditAnywhere)
+  int32 DefenderTerritory = -1;
+
+  UPROPERTY(BlueprintReadWrite, EditAnywhere)
+  bool bValid = false;
+};
+
 DECLARE_DYNAMIC_MULTICAST_DELEGATE(FSkaldFactionsUpdated);
 /** Game instance storing player selections from the lobby. */
 UCLASS()
@@ -93,6 +114,12 @@ public:
   UPROPERTY(BlueprintReadWrite, Category = "Turn")
   bool bResumeTurns = false;
 
+  UFUNCTION(BlueprintCallable)
+  void SetTravelState(const FSkaldTravelState &InState);
+
+  UFUNCTION(BlueprintCallable, BlueprintPure)
+  const FSkaldTravelState &GetTravelState() const { return TravelState; }
+
   /** Seed the combat random stream so all clients use the same sequence. */
   UFUNCTION(BlueprintCallable, Category = "Battle")
   void SeedCombatRandomStream(int32 Seed);
@@ -106,4 +133,8 @@ public:
   /** Save game loaded when transitioning from the main menu. */
   UPROPERTY(BlueprintReadWrite, Category = "SaveGame")
   USkaldSaveGame *LoadedSaveGame = nullptr;
+
+private:
+  UPROPERTY()
+  FSkaldTravelState TravelState;
 };

--- a/Source/Skald/Skald_PlayerController.cpp
+++ b/Source/Skald/Skald_PlayerController.cpp
@@ -28,6 +28,7 @@
 #include "UI/DeployWidget.h"
 #include "UI/FighterSelectionWidget.h"
 #include "UI/SkaldMainHUDWidget.h"
+#include "UI/SkaldUIHelpers.h"
 #include "UObject/ConstructorHelpers.h"
 #include "WorldMap.h"
 
@@ -161,7 +162,7 @@ void ASkaldPlayerController::InitializeChoosePlayerWidget() {
   ChoosePlayerWidget->AddToViewport();
 
   // While the player is choosing their faction, restrict controls to the UI.
-  SetInputMode(FInputModeUIOnly());
+  FocusWidgetUIOnly(this, ChoosePlayerWidget);
   SetIgnoreMoveInput(true);
   SetIgnoreLookInput(true);
 }
@@ -336,9 +337,7 @@ void ASkaldPlayerController::Client_ShowFighterSelection_Implementation(
       this, &ASkaldPlayerController::HandleLockedIn);
 
   CurrentSelectionWidget->AddToViewport();
-  FInputModeUIOnly Mode;
-  SetInputMode(Mode);
-  bShowMouseCursor = true;
+  FocusWidgetUIOnly(this, CurrentSelectionWidget);
 }
 
 void ASkaldPlayerController::HandleLockedIn() {

--- a/Source/Skald/Skald_TurnManager.cpp
+++ b/Source/Skald/Skald_TurnManager.cpp
@@ -387,6 +387,30 @@ void ATurnManager::TriggerGridBattle(const FS_BattlePayload &Battle) {
       }
     }
     if (USkaldGameInstance *GI = GetGameInstance<USkaldGameInstance>()) {
+      FSkaldTravelState TravelState;
+      int32 ValidControllers = 0;
+      for (const TWeakObjectPtr<ASkaldPlayerController> &Ptr : Controllers) {
+        if (Ptr.IsValid()) {
+          ++ValidControllers;
+        }
+      }
+      TravelState.ExpectedControllers = ValidControllers;
+
+      if (CachedWorldMap) {
+        for (ATerritory *Territory : CachedWorldMap->Territories) {
+          const ASkaldPlayerState *Owner =
+              Territory ? Territory->OwningPlayer : nullptr;
+          if (Owner && !Owner->bIsAI) {
+            TravelState.HumanOwnedTerritories.AddUnique(
+                Territory->TerritoryID);
+          }
+        }
+      }
+
+      TravelState.AttackerTerritory = SeededBattle.FromTerritoryID;
+      TravelState.DefenderTerritory = SeededBattle.TargetTerritoryID;
+
+      GI->SetTravelState(TravelState);
       GI->bIsInBattleMap = true;
     }
     World->ServerTravel(MapToLoad);

--- a/Source/Skald/UI/SkaldUIHelpers.h
+++ b/Source/Skald/UI/SkaldUIHelpers.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include "Blueprint/UserWidget.h"
+#include "GameFramework/PlayerController.h"
+
+static inline void FocusWidgetUIOnly(APlayerController *PC, UUserWidget *Widget) {
+  if (!PC || !Widget) {
+    return;
+  }
+
+  Widget->SetIsFocusable(true);
+
+  FInputModeUIOnly Mode;
+  if (TSharedPtr<SWidget> Cached = Widget->GetCachedWidget()) {
+    Mode.SetWidgetToFocus(Cached);
+  } else {
+    Mode.SetWidgetToFocus(Widget->TakeWidget());
+  }
+  Mode.SetLockMouseToViewportBehavior(EMouseLockMode::DoNotLock);
+  PC->SetInputMode(Mode);
+  PC->bShowMouseCursor = true;
+}


### PR DESCRIPTION
## Summary
- add a travel state payload to the game instance so BattleMap travel persists controller/territory info
- populate the travel state prior to ServerTravel and let the battle game mode reacquire data after loading while waiting for controllers to report ready
- introduce a reusable FocusWidgetUIOnly helper and apply it to lobby/selection screens to fix UI-only input mode focus issues

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cf5e0f2fa08324b7ac81226417200b