### PR TITLE
Fix controller readiness and module dependencies

### DIFF
--- a/Source/Skald/Skald.Build.cs
+++ b/Source/Skald/Skald.Build.cs
@@ -11,8 +11,10 @@ public class Skald : ModuleRules
                 PublicDependencyModuleNames.AddRange(new string[]
                 {
                         "Core",
+                        "CoreUObject",
                         "Engine",
                         "InputCore",
+                        "AIModule",
                         "UMG",
                         "Slate",
                         "SlateCore",

--- a/Source/Skald/Skald_BattleGameMode.cpp
+++ b/Source/Skald/Skald_BattleGameMode.cpp
@@ -2,7 +2,6 @@
 
 #include "Algo/RandomShuffle.h"
 #include "Algo/Sort.h"
-#include "AIController.h"
 #include "GridBattleManager.h"
 #include "Skald.h"
 #include "Skald_GameInstance.h"
@@ -11,6 +10,9 @@
 #include "Engine/World.h"
 #include "EngineUtils.h"
 #include "FighterPawn.h"
+#include "GameFramework/Controller.h"
+#include "GameFramework/GameStateBase.h"
+#include "GameFramework/PlayerController.h"
 #include "GridOverlayComponent.h"
 #include "Territory.h"
 #include "TimerManager.h"
@@ -466,11 +468,8 @@ void ASkald_BattleGameMode::PostLogin(APlayerController *NewPlayer) {
   TryStartBattle();
 }
 
-void ASkald_BattleGameMode::OnAIControllerReady(AAIController *AI) {
-  if (AI) {
-    ReadyControllers.Add(AI);
-  }
-
+void ASkald_BattleGameMode::OnAIControllerReady(AController *Controller) {
+  ReadyControllers.Add(Controller);
   TryStartBattle();
 }
 

--- a/Source/Skald/Skald_BattleGameMode.h
+++ b/Source/Skald/Skald_BattleGameMode.h
@@ -4,6 +4,8 @@
 #include "Skald_GameMode.h"
 #include "Skald_BattleGameMode.generated.h"
 
+class AController;
+
 /** GameMode dedicated to resolving grid-based battles. */
 UCLASS()
 class SKALD_API ASkald_BattleGameMode : public ASkaldGameMode {
@@ -20,7 +22,7 @@ protected:
 
 public:
   // Called by the AI controller when it’s ready (BeginPlay)
-  void OnAIControllerReady(class AAIController *AI);
+  void OnAIControllerReady(AController *Controller);
 
 private:
   void SetupPendingBattle();

--- a/Source/Skald/Skald_TurnManager.cpp
+++ b/Source/Skald/Skald_TurnManager.cpp
@@ -398,9 +398,9 @@ void ATurnManager::TriggerGridBattle(const FS_BattlePayload &Battle) {
 
       if (CachedWorldMap) {
         for (ATerritory *Territory : CachedWorldMap->Territories) {
-          const ASkaldPlayerState *Owner =
+          const ASkaldPlayerState *TerritoryOwner =
               Territory ? Territory->OwningPlayer : nullptr;
-          if (Owner && !Owner->bIsAI) {
+          if (TerritoryOwner && !TerritoryOwner->bIsAI) {
             TravelState.HumanOwnedTerritories.AddUnique(
                 Territory->TerritoryID);
           }


### PR DESCRIPTION
## Summary
- allow the battle game mode ready callback to accept generic controllers and drop the direct AIController include
- add AIModule as a public dependency so AI headers are available where included
- rename the cached world map owner pointer in the turn manager to avoid shadowing the actor member

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cf6533ba708324991dd5038afa053d