### PR TITLE
Guard turn flow during travel and fix deploy widget removal

### DIFF
--- a/Source/Skald/Skald_BattleGameMode.cpp
+++ b/Source/Skald/Skald_BattleGameMode.cpp
@@ -2,6 +2,7 @@
 
 #include "Algo/RandomShuffle.h"
 #include "Algo/Sort.h"
+#include "AIController.h"
 #include "GridBattleManager.h"
 #include "Skald.h"
 #include "Skald_GameInstance.h"
@@ -140,6 +141,26 @@ ASkaldPlayerState *EnsureBattleParticipant(ASkaldGameState *GameState, UWorld *W
 }
 } // namespace
 
+void ASkald_BattleGameMode::InitGame(const FString &Map, const FString &Options,
+                                     FString &Error) {
+  Super::InitGame(Map, Options, Error);
+
+  ReadyControllers.Empty();
+
+  if (USkaldGameInstance *GI = GetGameInstance<USkaldGameInstance>()) {
+    GI->SetTravelPending(false);
+    const FSkaldTravelState &TravelState = GI->GetTravelState();
+    ExpectedControllers =
+        TravelState.bValid ? TravelState.ExpectedControllers : 0;
+    UE_LOG(LogSkald, Log, TEXT("BattleGM InitGame: ExpectedControllers=%d"),
+           ExpectedControllers);
+  } else {
+    ExpectedControllers = 0;
+    UE_LOG(LogSkald, Warning,
+           TEXT("BattleGM InitGame: GameInstance unavailable; waiting for controllers"));
+  }
+}
+
 void ASkald_BattleGameMode::BeginPlay() {
   Super::BeginPlay();
 
@@ -159,11 +180,11 @@ void ASkald_BattleGameMode::BeginPlay() {
   USkaldGameInstance *GI = GetGameInstance<USkaldGameInstance>();
   if (GI) {
     GI->GridBattleManager = BattleManager;
-    const FSkaldTravelState &TravelState = GI->GetTravelState();
-    ExpectedControllers = TravelState.bValid ? TravelState.ExpectedControllers : 0;
-    UE_LOG(LogSkald, Log,
-           TEXT("BattleGM BeginPlay: ExpectedControllers=%d"),
-           ExpectedControllers);
+    if (ExpectedControllers == 0) {
+      const FSkaldTravelState &TravelState = GI->GetTravelState();
+      ExpectedControllers =
+          TravelState.bValid ? TravelState.ExpectedControllers : 0;
+    }
   } else {
     ExpectedControllers = 0;
   }
@@ -462,14 +483,31 @@ void ASkald_BattleGameMode::PostLogin(APlayerController *NewPlayer) {
   Super::PostLogin(NewPlayer);
 
   if (NewPlayer) {
-    ReadyControllers.Add(NewPlayer);
+    OnControllerReady(NewPlayer);
   }
-
-  TryStartBattle();
 }
 
-void ASkald_BattleGameMode::OnAIControllerReady(AController *Controller) {
+void ASkald_BattleGameMode::OnAIControllerReady(AAIController *Controller) {
+  OnControllerReady(Controller);
+}
+
+void ASkald_BattleGameMode::OnControllerReady(AController *Controller) {
+  if (!IsValid(Controller)) {
+    return;
+  }
+
+  for (auto It = ReadyControllers.CreateIterator(); It; ++It) {
+    if (!It->IsValid()) {
+      It.RemoveCurrent();
+    }
+  }
+
   ReadyControllers.Add(Controller);
+
+  UE_LOG(LogSkald, Log,
+         TEXT("OnControllerReady: %s ReadyControllers=%d Expected=%d"),
+         *GetNameSafe(Controller), ReadyControllers.Num(), ExpectedControllers);
+
   TryStartBattle();
 }
 
@@ -484,25 +522,32 @@ void ASkald_BattleGameMode::TryStartBattle() {
     }
   }
 
-  const int32 Controllers = ReadyControllers.Num();
+  if (ExpectedControllers == 0) {
+    if (const USkaldGameInstance *GI = GetGameInstance<USkaldGameInstance>()) {
+      const FSkaldTravelState &TravelState = GI->GetTravelState();
+      if (TravelState.bValid) {
+        ExpectedControllers = TravelState.ExpectedControllers;
+      }
+    }
+
+    if (ExpectedControllers == 0) {
+      UE_LOG(LogSkald, Warning,
+             TEXT("TryStartBattle: ExpectedControllers not ready; waiting."));
+      return;
+    }
+  }
+
   const ASkaldGameState *GS = GetGameState<ASkaldGameState>();
   const int32 PlayerStates = GS ? GS->PlayerArray.Num() : 0;
-
+  const int32 ReadyCount = ReadyControllers.Num();
   UE_LOG(LogSkald, Log,
          TEXT("TryStartBattle: ReadyControllers=%d PlayerStates=%d Expected=%d"),
-         Controllers, PlayerStates, ExpectedControllers);
+         ReadyCount, PlayerStates, ExpectedControllers);
 
-  if (ExpectedControllers <= 0) {
-    UE_LOG(LogSkald, Warning,
-           TEXT("TryStartBattle: ExpectedControllers not provided; launching immediately"));
-    TryLaunchBattle();
+  if (PlayerStates < ExpectedControllers || ReadyCount < ExpectedControllers) {
     return;
   }
 
-  if (Controllers >= ExpectedControllers && PlayerStates >= ExpectedControllers) {
-    UE_LOG(LogSkald, Log,
-           TEXT("TryStartBattle: All controllers ready, launching battle"));
-    TryLaunchBattle();
-  }
+  TryLaunchBattle();
 }
 

--- a/Source/Skald/Skald_BattleGameMode.h
+++ b/Source/Skald/Skald_BattleGameMode.h
@@ -4,6 +4,7 @@
 #include "Skald_GameMode.h"
 #include "Skald_BattleGameMode.generated.h"
 
+class AAIController;
 class AController;
 
 /** GameMode dedicated to resolving grid-based battles. */
@@ -16,13 +17,18 @@ public:
   void TryLaunchBattle();
 
 protected:
+  virtual void InitGame(const FString &Map, const FString &Options,
+                        FString &Error) override;
   virtual void BeginPlay() override;
   virtual void PostLogin(APlayerController *NewPlayer) override;
   virtual void TryInitializeWorldAndStart() override;
 
 public:
   // Called by the AI controller when it’s ready (BeginPlay)
-  void OnAIControllerReady(AController *Controller);
+  void OnAIControllerReady(AAIController *Controller);
+
+  UFUNCTION(BlueprintCallable)
+  void OnControllerReady(AController *Controller);
 
 private:
   void SetupPendingBattle();
@@ -34,6 +40,7 @@ private:
   bool bBattleLaunched = false;
 
   // Expected count comes from GameInstance travel state
+  UPROPERTY(VisibleAnywhere, Transient)
   int32 ExpectedControllers = 0;
 
   // Track who has arrived/ready on the new map

--- a/Source/Skald/Skald_GameInstance.cpp
+++ b/Source/Skald/Skald_GameInstance.cpp
@@ -1,8 +1,10 @@
 #include "Skald_GameInstance.h"
 
 #include "Engine/Engine.h"
+#include "Engine/GameViewportClient.h"
 #include "Kismet/GameplayStatics.h"
 #include "Skald.h"
+#include "Blueprint/UserWidget.h"
 
 void USkaldGameInstance::Init() {
   Super::Init();
@@ -31,8 +33,61 @@ void USkaldGameInstance::SetTravelState(const FSkaldTravelState &InState) {
          TravelState.DefenderTerritory, TravelState.HumanOwnedTerritories.Num());
 }
 
+void USkaldGameInstance::SetTravelPending(bool bInPending) {
+  if (bTravelPending == bInPending) {
+    return;
+  }
+
+  bTravelPending = bInPending;
+  UE_LOG(LogSkald, Log, TEXT("GameInstance travel pending set: %s"),
+         bTravelPending ? TEXT("true") : TEXT("false"));
+}
+
 void USkaldGameInstance::SeedCombatRandomStream(int32 Seed) {
   CombatRandomStream.Initialize(Seed);
+}
+
+void USkaldGameInstance::ShowDeployWidget() {
+  if (!DeployWidget) {
+    TSubclassOf<UUserWidget> WidgetClass = DeployWidgetClass;
+    if (!WidgetClass) {
+      UE_LOG(LogSkald, Warning,
+             TEXT("ShowDeployWidget: DeployWidgetClass not set."));
+      return;
+    }
+
+    DeployWidget = CreateWidget<UUserWidget>(this, WidgetClass);
+  }
+
+  if (!DeployWidget) {
+    return;
+  }
+
+  if (DeployWidgetSlateHandle.IsValid()) {
+    // Already displayed via the viewport.
+    return;
+  }
+
+  if (UWorld *World = GetWorld()) {
+    if (UGameViewportClient *Viewport = World->GetGameViewport()) {
+      DeployWidgetSlateHandle = DeployWidget->TakeWidget();
+      Viewport->AddViewportWidgetContent(DeployWidgetSlateHandle.ToSharedRef());
+    }
+  }
+}
+
+void USkaldGameInstance::HideDeployWidget() {
+  if (!DeployWidgetSlateHandle.IsValid()) {
+    return;
+  }
+
+  if (UWorld *World = GetWorld()) {
+    if (UGameViewportClient *Viewport = World->GetGameViewport()) {
+      Viewport->RemoveViewportWidgetContent(DeployWidgetSlateHandle.ToSharedRef());
+    }
+  }
+
+  DeployWidgetSlateHandle.Reset();
 }
 
 void USkaldGameInstance::HandleNetworkFailure(

--- a/Source/Skald/Skald_GameInstance.h
+++ b/Source/Skald/Skald_GameInstance.h
@@ -7,6 +7,8 @@
 #include "Skald_GameInstance.generated.h"
 
 class UGridBattleManager;
+class SWidget;
+class UUserWidget;
 class USkaldSaveGame;
 class UNetDriver;
 
@@ -94,6 +96,10 @@ public:
   UPROPERTY(BlueprintReadWrite, Category = "Battle")
   bool bIsInBattleMap = false;
 
+  /** True while a ServerTravel call is in flight. */
+  UPROPERTY(Transient)
+  bool bTravelPending = false;
+
   /** Snapshot of the overworld territories captured before travelling. */
   UPROPERTY(BlueprintReadWrite, Category = "Battle")
   TArray<FS_Territory> CachedWorldMapTerritories;
@@ -114,11 +120,32 @@ public:
   UPROPERTY(BlueprintReadWrite, Category = "Turn")
   bool bResumeTurns = false;
 
+  /** Widget class used when showing the deploy overlay via the viewport. */
+  UPROPERTY(EditDefaultsOnly, Category = "UI")
+  TSubclassOf<UUserWidget> DeployWidgetClass;
+
+  /** Deploy widget instance owned by the game instance for Slate insertion. */
+  UPROPERTY(Transient)
+  TObjectPtr<UUserWidget> DeployWidget = nullptr;
+
+  /** Slate handle returned by TakeWidget when the deploy widget is shown. */
+  TSharedPtr<SWidget> DeployWidgetSlateHandle;
+
   UFUNCTION(BlueprintCallable)
   void SetTravelState(const FSkaldTravelState &InState);
 
+  /** Toggle the travel pending guard and log the change. */
+  UFUNCTION(BlueprintCallable)
+  void SetTravelPending(bool bInPending);
+
   UFUNCTION(BlueprintCallable, BlueprintPure)
   const FSkaldTravelState &GetTravelState() const { return TravelState; }
+
+  UFUNCTION(BlueprintCallable)
+  void ShowDeployWidget();
+
+  UFUNCTION(BlueprintCallable)
+  void HideDeployWidget();
 
   /** Seed the combat random stream so all clients use the same sequence. */
   UFUNCTION(BlueprintCallable, Category = "Battle")

--- a/Source/Skald/Skald_GameMode.cpp
+++ b/Source/Skald/Skald_GameMode.cpp
@@ -44,6 +44,15 @@ ASkaldGameMode::ASkaldGameMode() {
   NextSiegeID = 1;
 }
 
+void ASkaldGameMode::InitGame(const FString &Map, const FString &Options,
+                              FString &Error) {
+  Super::InitGame(Map, Options, Error);
+
+  if (USkaldGameInstance *GI = GetGameInstance<USkaldGameInstance>()) {
+    GI->SetTravelPending(false);
+  }
+}
+
 void ASkaldGameMode::BeginPlay() {
   Super::BeginPlay();
 
@@ -1509,6 +1518,9 @@ void ASkaldGameMode::CheckVictoryConditions() {
   if (RemainingPlayers == 1 && WinningPlayer) {
     OnGameOver.Broadcast(WinningPlayer);
     if (UWorld *WorldToTravel = GetWorld()) {
+      if (USkaldGameInstance *GI = GetGameInstance<USkaldGameInstance>()) {
+        GI->SetTravelPending(true);
+      }
       WorldToTravel->ServerTravel(TEXT("EndScreen"));
     }
   }

--- a/Source/Skald/Skald_GameMode.h
+++ b/Source/Skald/Skald_GameMode.h
@@ -37,6 +37,8 @@ class SKALD_API ASkaldGameMode : public AGameModeBase {
 
 public:
   ASkaldGameMode();
+  virtual void InitGame(const FString &Map, const FString &Options,
+                        FString &Error) override;
   virtual void PostLogin(APlayerController *NewPlayer) override;
   virtual void Logout(AController *Exiting) override;
   virtual void HandleSeamlessTravelPlayer(AController *&C) override;

--- a/Source/Skald/Skald_PlayerController.cpp
+++ b/Source/Skald/Skald_PlayerController.cpp
@@ -1034,6 +1034,14 @@ void ASkaldPlayerController::ServerDigTreasure_Implementation(
 }
 
 void ASkaldPlayerController::HandleEngineeringPhase() {
+  if (const UWorld *W = GetWorld()) {
+    if (const auto *GI = W->GetGameInstance<USkaldGameInstance>()) {
+      if (GI->bTravelPending) {
+        return;
+      }
+    }
+  }
+
   UE_LOG(LogSkald, Log, TEXT("Engineering phase started"));
   if (MainHudWidget) {
     MainHudWidget->CancelAttackSelection();
@@ -1043,6 +1051,14 @@ void ASkaldPlayerController::HandleEngineeringPhase() {
 }
 
 void ASkaldPlayerController::HandleTreasurePhase() {
+  if (const UWorld *W = GetWorld()) {
+    if (const auto *GI = W->GetGameInstance<USkaldGameInstance>()) {
+      if (GI->bTravelPending) {
+        return;
+      }
+    }
+  }
+
   UE_LOG(LogSkald, Log, TEXT("Treasure phase started"));
   if (MainHudWidget) {
     MainHudWidget->CancelAttackSelection();
@@ -1052,6 +1068,14 @@ void ASkaldPlayerController::HandleTreasurePhase() {
 }
 
 void ASkaldPlayerController::HandleMovementPhase() {
+  if (const UWorld *W = GetWorld()) {
+    if (const auto *GI = W->GetGameInstance<USkaldGameInstance>()) {
+      if (GI->bTravelPending) {
+        return;
+      }
+    }
+  }
+
   UE_LOG(LogSkald, Log, TEXT("Movement phase started"));
   if (MainHudWidget) {
     MainHudWidget->CancelAttackSelection();
@@ -1061,6 +1085,14 @@ void ASkaldPlayerController::HandleMovementPhase() {
 }
 
 void ASkaldPlayerController::HandleEndTurnPhase() {
+  if (const UWorld *W = GetWorld()) {
+    if (const auto *GI = W->GetGameInstance<USkaldGameInstance>()) {
+      if (GI->bTravelPending) {
+        return;
+      }
+    }
+  }
+
   UE_LOG(LogSkald, Log, TEXT("EndTurn phase started"));
   if (MainHudWidget) {
     MainHudWidget->ShowEndingTurn();
@@ -1069,6 +1101,14 @@ void ASkaldPlayerController::HandleEndTurnPhase() {
 }
 
 void ASkaldPlayerController::HandleRevoltPhase() {
+  if (const UWorld *W = GetWorld()) {
+    if (const auto *GI = W->GetGameInstance<USkaldGameInstance>()) {
+      if (GI->bTravelPending) {
+        return;
+      }
+    }
+  }
+
   UE_LOG(LogSkald, Log, TEXT("Revolt phase started"));
   if (MainHudWidget) {
     MainHudWidget->HideEndingTurn();

--- a/Source/Skald/Skald_TurnManager.cpp
+++ b/Source/Skald/Skald_TurnManager.cpp
@@ -84,6 +84,10 @@ void ATurnManager::HandleGridBattleEnded(ESkaldFaction /*WinningFaction*/, int32
 
   ResolveGridBattleResult();
 
+  if (USkaldGameInstance *GI = GetGameInstance<USkaldGameInstance>()) {
+    GI->SetTravelPending(true);
+  }
+
   if (UWorld *World = GetWorld()) {
     // Travel back to the overworld after the tactical battle ends
     World->ServerTravel(ReturnMapName);
@@ -98,6 +102,14 @@ void ATurnManager::RegisterController(ASkaldPlayerController *Controller) {
 }
 
 void ATurnManager::StartArmyPlacementPhase() {
+  if (const UWorld *W = GetWorld()) {
+    if (const auto *GI = W->GetGameInstance<USkaldGameInstance>()) {
+      if (GI->bTravelPending) {
+        return;
+      }
+    }
+  }
+
   CurrentPhase = ETurnPhase::ArmyPlacement;
   CurrentIndex = 0;
   BroadcastCurrentPhase();
@@ -161,6 +173,14 @@ void ATurnManager::SyncGameStateTurnIndex() {
 }
 
 void ATurnManager::StartTurns(ASkaldPlayerController *StartingController) {
+  if (const UWorld *W = GetWorld()) {
+    if (const auto *GI = W->GetGameInstance<USkaldGameInstance>()) {
+      if (GI->bTravelPending) {
+        return;
+      }
+    }
+  }
+
   SortControllersByInitiative();
 
   if (Controllers.Num() == 0) {
@@ -250,6 +270,14 @@ void ATurnManager::StartTurns(ASkaldPlayerController *StartingController) {
 }
 
 void ATurnManager::AdvanceTurn() {
+  if (const UWorld *W = GetWorld()) {
+    if (const auto *GI = W->GetGameInstance<USkaldGameInstance>()) {
+      if (GI->bTravelPending) {
+        return;
+      }
+    }
+  }
+
   ASkaldPlayerController *PreviousController =
       Controllers.IsValidIndex(CurrentIndex) ? Controllers[CurrentIndex].Get()
                                              : nullptr;
@@ -411,6 +439,7 @@ void ATurnManager::TriggerGridBattle(const FS_BattlePayload &Battle) {
       TravelState.DefenderTerritory = SeededBattle.TargetTerritoryID;
 
       GI->SetTravelState(TravelState);
+      GI->SetTravelPending(true);
       GI->bIsInBattleMap = true;
     }
     World->ServerTravel(MapToLoad);
@@ -598,6 +627,14 @@ void ATurnManager::ClientBattleResolved_Implementation(
 }
 
 void ATurnManager::BeginAttackPhase() {
+  if (const UWorld *W = GetWorld()) {
+    if (const auto *GI = W->GetGameInstance<USkaldGameInstance>()) {
+      if (GI->bTravelPending) {
+        return;
+      }
+    }
+  }
+
   // Enter the attack phase and notify all listeners so they can swap controls.
   CurrentPhase = ETurnPhase::Attack;
 
@@ -605,6 +642,14 @@ void ATurnManager::BeginAttackPhase() {
 }
 
 void ATurnManager::AdvancePhase() {
+  if (const UWorld *W = GetWorld()) {
+    if (const auto *GI = W->GetGameInstance<USkaldGameInstance>()) {
+      if (GI->bTravelPending) {
+        return;
+      }
+    }
+  }
+
   if (CurrentPhase == ETurnPhase::Reinforcement) {
     BeginAttackPhase();
     return;
@@ -634,6 +679,14 @@ void ATurnManager::AdvancePhase() {
 }
 
 void ATurnManager::BroadcastDeployableUnits(ASkaldPlayerState *ForPlayer) {
+  if (const UWorld *W = GetWorld()) {
+    if (const auto *GI = W->GetGameInstance<USkaldGameInstance>()) {
+      if (GI->bTravelPending) {
+        return;
+      }
+    }
+  }
+
   if (!ForPlayer) {
     return;
   }
@@ -653,6 +706,14 @@ void ATurnManager::BroadcastDeployableUnits(ASkaldPlayerState *ForPlayer) {
 }
 
 void ATurnManager::BroadcastResources(ASkaldPlayerState *ForPlayer) {
+  if (const UWorld *W = GetWorld()) {
+    if (const auto *GI = W->GetGameInstance<USkaldGameInstance>()) {
+      if (GI->bTravelPending) {
+        return;
+      }
+    }
+  }
+
   if (!ForPlayer) {
     return;
   }
@@ -674,6 +735,14 @@ void ATurnManager::BroadcastResources(ASkaldPlayerState *ForPlayer) {
 }
 
 void ATurnManager::BroadcastCurrentPhase() {
+  if (const UWorld *W = GetWorld()) {
+    if (const auto *GI = W->GetGameInstance<USkaldGameInstance>()) {
+      if (GI->bTravelPending) {
+        return;
+      }
+    }
+  }
+
   const FString PhaseString = UEnum::GetValueAsString(CurrentPhase);
   UE_LOG(LogSkald, Log, TEXT("BroadcastCurrentPhase: %s"), *PhaseString);
   if (GEngine) {

--- a/Source/Skald/UI/DeployWidget.cpp
+++ b/Source/Skald/UI/DeployWidget.cpp
@@ -37,7 +37,11 @@ void UDeployWidget::Setup(ATerritory *InTerritory, ASkaldPlayerState *InPlayerSt
 
 void UDeployWidget::HandleAccept() {
   if (!Territory || !PlayerState || !OwningHUD.IsValid()) {
-    RemoveFromParent();
+    if (OwningHUD.IsValid()) {
+      OwningHUD->ClearDeployWidget();
+    } else if (IsInViewport()) {
+      RemoveFromParent();
+    }
     return;
   }
 
@@ -78,16 +82,18 @@ void UDeployWidget::HandleAccept() {
     }
   }
 
-  RemoveFromParent();
   if (OwningHUD.IsValid()) {
     OwningHUD->ClearDeployWidget();
+  } else if (IsInViewport()) {
+    RemoveFromParent();
   }
 }
 
 void UDeployWidget::HandleDecline() {
-  RemoveFromParent();
   if (OwningHUD.IsValid()) {
     OwningHUD->ClearDeployWidget();
+  } else if (IsInViewport()) {
+    RemoveFromParent();
   }
 }
 

--- a/Source/Skald/UI/SkaldMainHUDWidget.cpp
+++ b/Source/Skald/UI/SkaldMainHUDWidget.cpp
@@ -4,6 +4,7 @@
 #include "Components/VerticalBox.h"
 #include "Components/Widget.h"
 #include "Engine/Engine.h"
+#include "Engine/GameViewportClient.h"
 #include "Kismet/GameplayStatics.h"
 #include "Skald.h"
 #include "SkaldTypes.h"
@@ -814,7 +815,18 @@ void USkaldMainHUDWidget::HandleDeployClicked() {
       CreateWidget<UDeployWidget>(GetWorld(), DeployWidgetClass);
   if (ActiveDeployWidget) {
     ActiveDeployWidget->Setup(Territory, PS, this, PS->DeployableUnits);
-    ActiveDeployWidget->AddToViewport();
+    ActiveDeployWidgetSlateHandle.Reset();
+    if (UWorld *World = GetWorld()) {
+      if (UGameViewportClient *Viewport = World->GetGameViewport()) {
+        ActiveDeployWidgetSlateHandle = ActiveDeployWidget->TakeWidget();
+        Viewport->AddViewportWidgetContent(
+            ActiveDeployWidgetSlateHandle.ToSharedRef());
+      } else {
+        ActiveDeployWidget->AddToViewport();
+      }
+    } else {
+      ActiveDeployWidget->AddToViewport();
+    }
   } else {
     UE_LOG(LogSkald, Warning,
            TEXT("HandleDeployClicked failed: could not create widget"));
@@ -823,8 +835,21 @@ void USkaldMainHUDWidget::HandleDeployClicked() {
 }
 
 void USkaldMainHUDWidget::ClearDeployWidget() {
-  if (ActiveDeployWidget) {
-    ActiveDeployWidget->RemoveFromParent();
-    ActiveDeployWidget = nullptr;
+  if (!ActiveDeployWidget) {
+    return;
   }
+
+  if (ActiveDeployWidgetSlateHandle.IsValid()) {
+    if (UWorld *World = GetWorld()) {
+      if (UGameViewportClient *Viewport = World->GetGameViewport()) {
+        Viewport->RemoveViewportWidgetContent(
+            ActiveDeployWidgetSlateHandle.ToSharedRef());
+      }
+    }
+    ActiveDeployWidgetSlateHandle.Reset();
+  } else if (ActiveDeployWidget->IsInViewport()) {
+    ActiveDeployWidget->RemoveFromParent();
+  }
+
+  ActiveDeployWidget = nullptr;
 }

--- a/Source/Skald/UI/SkaldMainHUDWidget.h
+++ b/Source/Skald/UI/SkaldMainHUDWidget.h
@@ -13,6 +13,7 @@ class ATerritory;
 class UConfirmAttackWidget;
 class UDeployWidget;
 class UWidget;
+class SWidget;
 class ASkaldGameMode;
 class ASkaldGameState;
 class USkaldGameInstance;
@@ -323,6 +324,9 @@ protected:
 
   UPROPERTY()
   UDeployWidget *ActiveDeployWidget = nullptr;
+
+  /** Slate handle when the deploy widget is added via the viewport. */
+  TSharedPtr<SWidget> ActiveDeployWidgetSlateHandle;
 
   UPROPERTY()
   TArray<ATerritory *> HighlightedTerritories;


### PR DESCRIPTION
## Summary
- add a travel pending flag to the game instance with logging and clear it when new maps initialise
- gate turn manager and player controller phase entry points while travel is pending and ensure travel calls set the flag
- tighten battle game mode readiness by caching expected controllers in InitGame and tracking controller readiness through a shared helper
- fix deploy widget presentation by storing the Slate handle and removing it through the viewport path to avoid RemoveFromParent warnings

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cf6bdfbd94832487656d343ab3a80f