### PR TITLE
Fix AI controller ready hook call

### DIFF
--- a/Source/Skald/Skald_AIController.cpp
+++ b/Source/Skald/Skald_AIController.cpp
@@ -21,7 +21,7 @@ void ASkaldAIController::BeginPlay() {
   if (UWorld *World = GetWorld()) {
     if (ASkald_BattleGameMode *BattleGM =
             World->GetAuthGameMode<ASkald_BattleGameMode>()) {
-      BattleGM->OnAIControllerReady(this);
+      BattleGM->OnControllerReady(this);
     }
   }
 }

--- a/Source/Skald/Skald_BattleGameMode.h
+++ b/Source/Skald/Skald_BattleGameMode.h
@@ -2,6 +2,7 @@
 
 #include "CoreMinimal.h"
 #include "Skald_GameMode.h"
+#include "AIController.h"
 #include "Skald_BattleGameMode.generated.h"
 
 class AAIController;


### PR DESCRIPTION
## Summary
- call the battle game mode's generic ready hook from the AI controller so Skald's AI controller (a player controller subclass) can register without type issues
- include the AI controller header in the battle game mode to satisfy build dependencies

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cf73217edc832486dea625b3768c11