### PR TITLE
Refactor HUD lifecycle and input modes for UI widgets

### DIFF
--- a/Source/Skald/ChoosePlayerWidget.cpp
+++ b/Source/Skald/ChoosePlayerWidget.cpp
@@ -12,6 +12,9 @@ void UChoosePlayerWidget::NativeConstruct()
 {
     Super::NativeConstruct();
 
+    SetIsFocusable(true);
+    SetFocus();
+
     if (FactionComboBox)
     {
         FactionComboBox->ClearOptions();

--- a/Source/Skald/LoadGameWidget.cpp
+++ b/Source/Skald/LoadGameWidget.cpp
@@ -91,7 +91,7 @@ void ULoadGameWidget::HandleLoadSlot(int32 SlotIndex)
 
         if (APlayerController* PC = GetOwningPlayer())
         {
-            PC->SetInputMode(FInputModeGameOnly());
+            UWidgetBlueprintLibrary::SetInputMode_GameOnly(PC);
             PC->bShowMouseCursor = false;
         }
 

--- a/Source/Skald/Skald_GameInstance.cpp
+++ b/Source/Skald/Skald_GameInstance.cpp
@@ -1,10 +1,11 @@
 #include "Skald_GameInstance.h"
 
 #include "Engine/Engine.h"
-#include "Engine/GameViewportClient.h"
 #include "Kismet/GameplayStatics.h"
 #include "Skald.h"
 #include "Blueprint/UserWidget.h"
+#include "Skald_PlayerController.h"
+#include "UI/SkaldUIHelpers.h"
 
 void USkaldGameInstance::Init() {
   Super::Init();
@@ -63,31 +64,31 @@ void USkaldGameInstance::ShowDeployWidget() {
     return;
   }
 
-  if (DeployWidgetSlateHandle.IsValid()) {
-    // Already displayed via the viewport.
-    return;
-  }
-
-  if (UWorld *World = GetWorld()) {
-    if (UGameViewportClient *Viewport = World->GetGameViewport()) {
-      DeployWidgetSlateHandle = DeployWidget->TakeWidget();
-      Viewport->AddViewportWidgetContent(DeployWidgetSlateHandle.ToSharedRef());
+  if (!DeployWidget->IsInViewport()) {
+    DeployWidget->AddToViewport();
+    if (UWorld *World = GetWorld()) {
+      if (APlayerController *PC = World->GetFirstPlayerController()) {
+        FocusWidgetUIOnly(PC, DeployWidget);
+      }
     }
   }
 }
 
 void USkaldGameInstance::HideDeployWidget() {
-  if (!DeployWidgetSlateHandle.IsValid()) {
+  if (!DeployWidget) {
     return;
   }
 
-  if (UWorld *World = GetWorld()) {
-    if (UGameViewportClient *Viewport = World->GetGameViewport()) {
-      Viewport->RemoveViewportWidgetContent(DeployWidgetSlateHandle.ToSharedRef());
-    }
+  if (DeployWidget->IsInViewport()) {
+    DeployWidget->RemoveFromParent();
   }
 
-  DeployWidgetSlateHandle.Reset();
+  if (UWorld *World = GetWorld()) {
+    if (ASkaldPlayerController *PC =
+            Cast<ASkaldPlayerController>(World->GetFirstPlayerController())) {
+      PC->ShowMainHUD();
+    }
+  }
 }
 
 void USkaldGameInstance::HandleNetworkFailure(

--- a/Source/Skald/Skald_GameInstance.h
+++ b/Source/Skald/Skald_GameInstance.h
@@ -128,9 +128,6 @@ public:
   UPROPERTY(Transient)
   TObjectPtr<UUserWidget> DeployWidget = nullptr;
 
-  /** Slate handle returned by TakeWidget when the deploy widget is shown. */
-  TSharedPtr<SWidget> DeployWidgetSlateHandle;
-
   UFUNCTION(BlueprintCallable)
   void SetTravelState(const FSkaldTravelState &InState);
 

--- a/Source/Skald/Skald_PlayerController.cpp
+++ b/Source/Skald/Skald_PlayerController.cpp
@@ -1,6 +1,7 @@
 #include "Skald_PlayerController.h"
 
 #include "Blueprint/UserWidget.h"
+#include "Blueprint/WidgetBlueprintLibrary.h"
 #include "ChoosePlayerWidget.h"
 #include "Components/InputComponent.h"
 #include "Engine/Engine.h"
@@ -46,7 +47,7 @@
 ASkaldPlayerController::ASkaldPlayerController() {
   TurnManager = nullptr;
   HUDRef = nullptr;
-  MainHudWidget = nullptr;
+  MainHUD = nullptr;
   BattleHudWidget = nullptr;
   BattleResultWidget = nullptr;
   CurrentCommandMode = EBattleCommandMode::None;
@@ -59,7 +60,7 @@ ASkaldPlayerController::ASkaldPlayerController() {
 
   // Default to the native HUD widget class. This avoids loading a
   // blueprint-derived widget that may not exist or may be corrupt.
-  HUDWidgetClass = USkaldMainHUDWidget::StaticClass();
+  MainHUDClass = USkaldMainHUDWidget::StaticClass();
   BattleHUDWidgetClass = UBattleHUDWidget::StaticClass();
   VictoryWidgetClass = UBattleResultWidget::StaticClass();
 
@@ -97,46 +98,51 @@ void ASkaldPlayerController::CacheGameReferences() {
 }
 
 void ASkaldPlayerController::InitializeHUDWidget() {
-  if (!HUDWidgetClass) {
+  if (MainHUD) {
+    return;
+  }
+
+  if (!MainHUDClass) {
     UE_LOG(LogSkald, Warning,
-           TEXT("HUDWidgetClass is null; HUD will not be displayed."));
+           TEXT("MainHUDClass is null; HUD will not be displayed."));
     return;
   }
 
-  MainHudWidget = CreateWidget<USkaldMainHUDWidget>(this, HUDWidgetClass);
-  if (!MainHudWidget) {
+  MainHUD = CreateWidget<USkaldMainHUDWidget>(this, MainHUDClass);
+  if (!MainHUD) {
     return;
   }
 
-  HUDRef = MainHudWidget;
-  MainHudWidget->AddToViewport();
-  MainHudWidget->SetVisibility(ESlateVisibility::Hidden);
+  HUDRef = MainHUD;
+  MainHUD->AddToViewport(10);
+  MainHUD->SetIsFocusable(true);
+  MainHUD->SetVisibility(ESlateVisibility::Hidden);
 
   if (CachedGameState) {
     TArray<FS_PlayerData> Players;
     BuildPlayerDataArray(Players);
     const ASkaldPlayerState *CurrentPS = CachedGameState->GetCurrentPlayer();
     const int32 CurrentID = CurrentPS ? CurrentPS->GetPlayerId() : -1;
-    MainHudWidget->RefreshFromState(CurrentID, /*TurnNumber*/ 1,
-                                    ETurnPhase::Reinforcement, Players);
+    MainHUD->RefreshFromState(CurrentID, /*TurnNumber*/ 1,
+                              ETurnPhase::Reinforcement, Players);
   }
 
   // Ensure local player details are registered with the HUD once available.
   OnRep_PlayerState();
 
-  MainHudWidget->OnAttackRequested.AddDynamic(
+  MainHUD->OnAttackRequested.AddDynamic(
       this, &ASkaldPlayerController::HandleAttackRequested);
-  MainHudWidget->OnMoveRequested.AddDynamic(
+  MainHUD->OnMoveRequested.AddDynamic(
       this, &ASkaldPlayerController::HandleMoveRequested);
-  MainHudWidget->OnEndAttackRequested.AddDynamic(
+  MainHUD->OnEndAttackRequested.AddDynamic(
       this, &ASkaldPlayerController::HandleEndAttackRequested);
-  MainHudWidget->OnEndMovementRequested.AddDynamic(
+  MainHUD->OnEndMovementRequested.AddDynamic(
       this, &ASkaldPlayerController::HandleEndMovementRequested);
-  MainHudWidget->OnEngineeringRequested.AddDynamic(
+  MainHUD->OnEngineeringRequested.AddDynamic(
       this, &ASkaldPlayerController::HandleEngineeringRequested);
-  MainHudWidget->OnBuildSiegeRequested.AddDynamic(
+  MainHUD->OnBuildSiegeRequested.AddDynamic(
       this, &ASkaldPlayerController::HandleBuildSiegeRequested);
-  MainHudWidget->OnDigTreasureRequested.AddDynamic(
+  MainHUD->OnDigTreasureRequested.AddDynamic(
       this, &ASkaldPlayerController::HandleDigTreasureRequested);
 
   // Notify the game mode that the HUD is now ready so world start checks can
@@ -182,6 +188,7 @@ void ASkaldPlayerController::BeginPlay() {
 
   if (IsLocalPlayerController() && GetLocalPlayer() != nullptr) {
     InitializeHUDWidget();
+    ShowMainHUD();
     if (CachedGameInstance && CachedGameInstance->bIsMultiplayer &&
         !CachedGameInstance->bIsHost) {
       if (GEngine) {
@@ -212,7 +219,52 @@ void ASkaldPlayerController::EndPlay(const EEndPlayReason::Type EndPlayReason) {
     PostLoadMapHandle.Reset();
   }
 
+  if (MainHUD) {
+    MainHUD->RemoveFromParent();
+    MainHUD = nullptr;
+    HUDRef = nullptr;
+  }
+
+  if (ChoosePlayerWidget) {
+    ChoosePlayerWidget->RemoveFromParent();
+    ChoosePlayerWidget = nullptr;
+  }
+
+  if (CurrentSelectionWidget) {
+    CurrentSelectionWidget->RemoveFromParent();
+    CurrentSelectionWidget = nullptr;
+  }
+
+  if (BattleHudWidget) {
+    BattleHudWidget->RemoveFromParent();
+    BattleHudWidget = nullptr;
+  }
+
+  if (BattleResultWidget) {
+    BattleResultWidget->RemoveFromParent();
+    BattleResultWidget = nullptr;
+  }
+
   Super::EndPlay(EndPlayReason);
+}
+
+void ASkaldPlayerController::ShowMainHUD() {
+  if (MainHUD) {
+    MainHUD->SetVisibility(ESlateVisibility::SelfHitTestInvisible);
+    UWidgetBlueprintLibrary::SetInputMode_GameAndUIEx(
+        this, MainHUD, EMouseLockMode::DoNotLock, /*bHideCursorDuringCapture*/
+        false);
+    bShowMouseCursor = true;
+    MainHUD->SetFocus();
+  }
+}
+
+void ASkaldPlayerController::HideMainHUD() {
+  if (MainHUD) {
+    MainHUD->SetVisibility(ESlateVisibility::Collapsed);
+    UWidgetBlueprintLibrary::SetInputMode_GameOnly(this);
+    bShowMouseCursor = false;
+  }
 }
 
 void ASkaldPlayerController::TryBindWorldMap() {
@@ -237,15 +289,15 @@ void ASkaldPlayerController::TryBindWorldMap() {
 void ASkaldPlayerController::OnRep_PlayerState() {
   Super::OnRep_PlayerState();
 
-  if (!MainHudWidget) {
+  if (!MainHUD) {
     return;
   }
 
   if (ASkaldPlayerState *PS = GetPlayerState<ASkaldPlayerState>()) {
-    MainHudWidget->LocalPlayerID = PS->GetPlayerId();
-    MainHudWidget->UpdateResources(PS->Resources);
-    MainHudWidget->SyncPhaseButtons(MainHudWidget->CurrentPlayerID ==
-                                    MainHudWidget->LocalPlayerID);
+    MainHUD->LocalPlayerID = PS->GetPlayerId();
+    MainHUD->UpdateResources(PS->Resources);
+    MainHUD->SyncPhaseButtons(MainHUD->CurrentPlayerID ==
+                                    MainHUD->LocalPlayerID);
   }
 }
 
@@ -350,8 +402,7 @@ void ASkaldPlayerController::HandleLockedIn() {
   CurrentSelectionWidget->RemoveFromParent();
   CurrentSelectionWidget = nullptr;
 
-  FInputModeGameOnly Mode;
-  SetInputMode(Mode);
+  UWidgetBlueprintLibrary::SetInputMode_GameOnly(this);
   bShowMouseCursor = false;
 }
 
@@ -452,9 +503,7 @@ void ASkaldPlayerController::InitializeBattleHUD() {
 }
 
 void ASkaldPlayerController::ShowOverworldHUD() {
-  if (MainHudWidget) {
-    MainHudWidget->SetVisibility(ESlateVisibility::Visible);
-  }
+  ShowMainHUD();
 
   if (BattleHudWidget) {
     BattleHudWidget->RemoveFromParent();
@@ -463,9 +512,7 @@ void ASkaldPlayerController::ShowOverworldHUD() {
 }
 
 void ASkaldPlayerController::HideOverworldHUDForBattle() {
-  if (MainHudWidget) {
-    MainHudWidget->SetVisibility(ESlateVisibility::Collapsed);
-  }
+  HideMainHUD();
 
   InitializeBattleHUD();
 
@@ -562,9 +609,9 @@ void ASkaldPlayerController::HandlePostLoadMap(UWorld *LoadedWorld) {
 
 void ASkaldPlayerController::ShowTurnAnnouncement(const FString &PlayerName,
                                                   bool bIsMyTurn) {
-  if (MainHudWidget) {
-    MainHudWidget->ShowTurnAnnouncement(PlayerName);
-    MainHudWidget->ShowTurnMessage(bIsMyTurn);
+  if (MainHUD) {
+    MainHUD->ShowTurnAnnouncement(PlayerName);
+    MainHUD->ShowTurnMessage(bIsMyTurn);
   } else if (GEngine) {
     const FString Message = FString::Printf(TEXT("%s's Turn"), *PlayerName);
     GEngine->AddOnScreenDebugMessage(-1, 4.f, FColor::Yellow, Message);
@@ -572,16 +619,20 @@ void ASkaldPlayerController::ShowTurnAnnouncement(const FString &PlayerName,
 }
 
 void ASkaldPlayerController::NotifyTurnEnded(const FString &PlayerName) {
-  if (MainHudWidget) {
-    MainHudWidget->ShowTurnEnded(PlayerName);
+  if (MainHUD) {
+    MainHUD->ShowTurnEnded(PlayerName);
   }
 }
 
 void ASkaldPlayerController::StartTurn() {
-  FInputModeGameAndUI Mode;
-  Mode.SetWidgetToFocus(nullptr);
-  Mode.SetLockMouseToViewportBehavior(EMouseLockMode::DoNotLock);
-  SetInputMode(Mode);
+  if (MainHUD) {
+    UWidgetBlueprintLibrary::SetInputMode_GameAndUIEx(
+        this, MainHUD, EMouseLockMode::DoNotLock, false);
+    MainHUD->SetFocus();
+  } else {
+    UWidgetBlueprintLibrary::SetInputMode_GameAndUIEx(
+        this, nullptr, EMouseLockMode::DoNotLock, false);
+  }
   bShowMouseCursor = true;
   bEnableClickEvents = true;
   bEnableMouseOverEvents = true;
@@ -603,7 +654,8 @@ void ASkaldPlayerController::StartTurn() {
 }
 
 void ASkaldPlayerController::EndTurn() {
-  SetInputMode(FInputModeGameOnly());
+  UWidgetBlueprintLibrary::SetInputMode_GameOnly(this);
+  bShowMouseCursor = false;
   if (!EnsureTurnManager(TEXT("EndTurn"))) {
     return;
   }
@@ -1043,10 +1095,10 @@ void ASkaldPlayerController::HandleEngineeringPhase() {
   }
 
   UE_LOG(LogSkald, Log, TEXT("Engineering phase started"));
-  if (MainHudWidget) {
-    MainHudWidget->CancelAttackSelection();
-    MainHudWidget->CancelMoveSelection();
-    MainHudWidget->UpdateInitiativeText(TEXT("Engineering Phase"));
+  if (MainHUD) {
+    MainHUD->CancelAttackSelection();
+    MainHUD->CancelMoveSelection();
+    MainHUD->UpdateInitiativeText(TEXT("Engineering Phase"));
   }
 }
 
@@ -1060,10 +1112,10 @@ void ASkaldPlayerController::HandleTreasurePhase() {
   }
 
   UE_LOG(LogSkald, Log, TEXT("Treasure phase started"));
-  if (MainHudWidget) {
-    MainHudWidget->CancelAttackSelection();
-    MainHudWidget->CancelMoveSelection();
-    MainHudWidget->UpdateInitiativeText(TEXT("Treasure Phase"));
+  if (MainHUD) {
+    MainHUD->CancelAttackSelection();
+    MainHUD->CancelMoveSelection();
+    MainHUD->UpdateInitiativeText(TEXT("Treasure Phase"));
   }
 }
 
@@ -1077,10 +1129,10 @@ void ASkaldPlayerController::HandleMovementPhase() {
   }
 
   UE_LOG(LogSkald, Log, TEXT("Movement phase started"));
-  if (MainHudWidget) {
-    MainHudWidget->CancelAttackSelection();
-    MainHudWidget->BeginMoveSelection();
-    MainHudWidget->UpdateInitiativeText(TEXT("Movement Phase"));
+  if (MainHUD) {
+    MainHUD->CancelAttackSelection();
+    MainHUD->BeginMoveSelection();
+    MainHUD->UpdateInitiativeText(TEXT("Movement Phase"));
   }
 }
 
@@ -1094,9 +1146,9 @@ void ASkaldPlayerController::HandleEndTurnPhase() {
   }
 
   UE_LOG(LogSkald, Log, TEXT("EndTurn phase started"));
-  if (MainHudWidget) {
-    MainHudWidget->ShowEndingTurn();
-    MainHudWidget->UpdateInitiativeText(TEXT("End Turn Phase"));
+  if (MainHUD) {
+    MainHUD->ShowEndingTurn();
+    MainHUD->UpdateInitiativeText(TEXT("End Turn Phase"));
   }
 }
 
@@ -1110,29 +1162,29 @@ void ASkaldPlayerController::HandleRevoltPhase() {
   }
 
   UE_LOG(LogSkald, Log, TEXT("Revolt phase started"));
-  if (MainHudWidget) {
-    MainHudWidget->HideEndingTurn();
-    MainHudWidget->UpdateInitiativeText(TEXT("Revolt Phase"));
+  if (MainHUD) {
+    MainHUD->HideEndingTurn();
+    MainHUD->UpdateInitiativeText(TEXT("Revolt Phase"));
   }
 }
 
 void ASkaldPlayerController::HandleTerritorySelected(ATerritory *Terr) {
-  if (!Terr || !MainHudWidget) {
+  if (!Terr || !MainHUD) {
     return;
   }
 
   FString OwnerName = Terr->OwningPlayer ? Terr->OwningPlayer->PlayerDisplayName
                                          : TEXT("Neutral");
-  MainHudWidget->UpdateTerritoryInfo(Terr->TerritoryName, OwnerName,
+  MainHUD->UpdateTerritoryInfo(Terr->TerritoryName, OwnerName,
                                      Terr->ArmyUnits);
-  MainHudWidget->OnTerritoryClickedUI(Terr);
+  MainHUD->OnTerritoryClickedUI(Terr);
 }
 
 void ASkaldPlayerController::NotifyActionError_Implementation(
     const FString &Message) {
   UE_LOG(LogSkald, Warning, TEXT("%s"), *Message);
-  if (MainHudWidget) {
-    MainHudWidget->ShowErrorMessage(Message);
+  if (MainHUD) {
+    MainHUD->ShowErrorMessage(Message);
   } else if (GEngine) {
     GEngine->AddOnScreenDebugMessage(-1, 4.f, FColor::Red, Message);
   }
@@ -1186,29 +1238,29 @@ void ASkaldPlayerController::BuildPlayerDataArray(
 }
 
 void ASkaldPlayerController::HandlePlayersUpdated() {
-  if (!MainHudWidget || !CachedGameState) {
+  if (!MainHUD || !CachedGameState) {
     return;
   }
   TArray<FS_PlayerData> Players;
   BuildPlayerDataArray(Players);
-  MainHudWidget->RefreshPlayerList(Players);
+  MainHUD->RefreshPlayerList(Players);
 
   if (ASkaldPlayerState *LocalPS = GetPlayerState<ASkaldPlayerState>()) {
-    MainHudWidget->UpdateResources(LocalPS->Resources);
+    MainHUD->UpdateResources(LocalPS->Resources);
   }
 }
 
 void ASkaldPlayerController::HandleFactionsUpdated() {
-  if (!MainHudWidget || !CachedGameState) {
+  if (!MainHUD || !CachedGameState) {
     return;
   }
 
   TArray<FS_PlayerData> Players;
   BuildPlayerDataArray(Players);
-  MainHudWidget->RefreshPlayerList(Players);
+  MainHUD->RefreshPlayerList(Players);
 
   if (ASkaldPlayerState *LocalPS = GetPlayerState<ASkaldPlayerState>()) {
-    MainHudWidget->UpdateResources(LocalPS->Resources);
+    MainHUD->UpdateResources(LocalPS->Resources);
   }
 }
 
@@ -1227,11 +1279,11 @@ void ASkaldPlayerController::HandleWorldStateChanged() {
     ShowOverworldHUD();
   }
 
-  if (!MainHudWidget) {
+  if (!MainHUD) {
     return;
   }
 
-  MainHudWidget->SetVisibility(ESlateVisibility::Visible);
+  ShowMainHUD();
 
   // Update territory info for the currently selected territory if available.
   if (AWorldMap *WorldMap = Cast<AWorldMap>(UGameplayStatics::GetActorOfClass(
@@ -1240,7 +1292,7 @@ void ASkaldPlayerController::HandleWorldStateChanged() {
       FString OwnerName = Terr->OwningPlayer
                               ? Terr->OwningPlayer->PlayerDisplayName
                               : TEXT("Neutral");
-      MainHudWidget->UpdateTerritoryInfo(Terr->TerritoryName, OwnerName,
+      MainHUD->UpdateTerritoryInfo(Terr->TerritoryName, OwnerName,
                                          Terr->ArmyUnits);
     }
   }
@@ -1249,16 +1301,16 @@ void ASkaldPlayerController::HandleWorldStateChanged() {
   if (CachedGameState) {
     TArray<FS_PlayerData> Players;
     BuildPlayerDataArray(Players);
-    MainHudWidget->RefreshPlayerList(Players);
+    MainHUD->RefreshPlayerList(Players);
   }
 
   // Update deploy/phase banners.
   if (ASkaldPlayerState *PS = GetPlayerState<ASkaldPlayerState>()) {
-    MainHudWidget->UpdateDeployableUnits(PS->DeployableUnits);
-    MainHudWidget->UpdateResources(PS->Resources);
+    MainHUD->UpdateDeployableUnits(PS->DeployableUnits);
+    MainHUD->UpdateResources(PS->Resources);
   }
   if (TurnManager) {
-    MainHudWidget->UpdatePhaseBanner(TurnManager->GetCurrentPhase());
+    MainHUD->UpdatePhaseBanner(TurnManager->GetCurrentPhase());
   }
 }
 
@@ -1277,29 +1329,25 @@ void ASkaldPlayerController::HandleFactionLockedIn() {
     ChoosePlayerWidget = nullptr;
   }
 
-  if (MainHudWidget) {
-    MainHudWidget->SetVisibility(ESlateVisibility::Visible);
+  if (MainHUD) {
+    ShowMainHUD();
     if (CachedGameState) {
       TArray<FS_PlayerData> Players;
       BuildPlayerDataArray(Players);
-      MainHudWidget->RefreshPlayerList(Players);
+      MainHUD->RefreshPlayerList(Players);
     }
     if (ASkaldPlayerState *PS = GetPlayerState<ASkaldPlayerState>()) {
-      MainHudWidget->LocalPlayerID = PS->GetPlayerId();
-      MainHudWidget->UpdateDeployableUnits(PS->DeployableUnits);
-      MainHudWidget->UpdateResources(PS->Resources);
-      MainHudWidget->SyncPhaseButtons(MainHudWidget->CurrentPlayerID ==
-                                      MainHudWidget->LocalPlayerID);
+      MainHUD->LocalPlayerID = PS->GetPlayerId();
+      MainHUD->UpdateDeployableUnits(PS->DeployableUnits);
+      MainHUD->UpdateResources(PS->Resources);
+      MainHUD->SyncPhaseButtons(MainHUD->CurrentPlayerID ==
+                                      MainHUD->LocalPlayerID);
     }
     if (TurnManager) {
-      MainHudWidget->UpdatePhaseBanner(TurnManager->GetCurrentPhase());
+      MainHUD->UpdatePhaseBanner(TurnManager->GetCurrentPhase());
     }
   }
 
-  FInputModeGameAndUI Mode;
-  Mode.SetWidgetToFocus(nullptr);
-  Mode.SetLockMouseToViewportBehavior(EMouseLockMode::DoNotLock);
-  SetInputMode(Mode);
   bShowMouseCursor = true;
   bEnableClickEvents = true;
   bEnableMouseOverEvents = true;
@@ -1329,10 +1377,8 @@ void ASkaldPlayerController::HandleFighterSelectionLockedIn() {
     HideOverworldHUDForBattle();
   }
 
-  FInputModeGameAndUI Mode;
-  Mode.SetWidgetToFocus(nullptr);
-  Mode.SetLockMouseToViewportBehavior(EMouseLockMode::DoNotLock);
-  SetInputMode(Mode);
+  UWidgetBlueprintLibrary::SetInputMode_GameAndUIEx(
+      this, nullptr, EMouseLockMode::DoNotLock, false);
   bShowMouseCursor = true;
   bEnableClickEvents = true;
   bEnableMouseOverEvents = true;
@@ -1487,9 +1533,7 @@ void ASkaldPlayerController::HandleBattleEnded(ESkaldFaction WinningFaction,
     }
   }
 
-  if (MainHudWidget) {
-    MainHudWidget->SetVisibility(ESlateVisibility::Collapsed);
-  }
+  HideMainHUD();
 
   if (!CachedGameInstance) {
     CachedGameInstance = GetGameInstance<USkaldGameInstance>();

--- a/Source/Skald/Skald_PlayerController.h
+++ b/Source/Skald/Skald_PlayerController.h
@@ -67,7 +67,13 @@ public:
 
   /** Accessor for the main HUD widget instance. */
   UFUNCTION(BlueprintCallable, Category = "UI")
-  USkaldMainHUDWidget *GetHUDWidget() const { return MainHudWidget; }
+  USkaldMainHUDWidget *GetHUDWidget() const { return MainHUD; }
+
+  UFUNCTION(BlueprintCallable)
+  void ShowMainHUD();
+
+  UFUNCTION(BlueprintCallable)
+  void HideMainHUD();
 
   /** Retrieve the turn manager controlling this player. */
   UFUNCTION(BlueprintCallable, BlueprintPure, Category = "Turn")
@@ -88,7 +94,7 @@ protected:
   /** Widget class to instantiate for the player's HUD.
    *  Settable via Blueprint or loaded in the constructor. */
   UPROPERTY(EditDefaultsOnly, BlueprintReadWrite, Category = "UI")
-  TSubclassOf<UUserWidget> HUDWidgetClass;
+  TSubclassOf<USkaldMainHUDWidget> MainHUDClass;
 
   /** Widget class used for in-battle HUD. */
   UPROPERTY(EditDefaultsOnly, BlueprintReadWrite, Category = "UI")
@@ -110,7 +116,7 @@ protected:
   /** Typed reference to the main HUD widget. */
   UPROPERTY(BlueprintReadOnly, Category = "UI",
             meta = (AllowPrivateAccess = "true"))
-  TObjectPtr<USkaldMainHUDWidget> MainHudWidget;
+  TObjectPtr<USkaldMainHUDWidget> MainHUD;
 
   /** Typed reference to the battle HUD widget. */
   UPROPERTY(BlueprintReadOnly, Category = "UI",

--- a/Source/Skald/Tests/DeployUnitsReplicationTest.h
+++ b/Source/Skald/Tests/DeployUnitsReplicationTest.h
@@ -19,6 +19,6 @@ UCLASS()
 class ADeployTestPlayerController : public ASkaldPlayerController {
     GENERATED_BODY()
 public:
-    void SetHUD(USkaldMainHUDWidget* InHUD) { MainHudWidget = InHUD; }
+    void SetHUD(USkaldMainHUDWidget* InHUD) { MainHUD = InHUD; }
 };
 

--- a/Source/Skald/Tests/FullTurnFlowTest.cpp
+++ b/Source/Skald/Tests/FullTurnFlowTest.cpp
@@ -44,7 +44,7 @@ bool FSkaldFullTurnFlowTest::RunTest(const FString &Parameters) {
   HUD->ResourcesText = NewObject<UTextBlock>(HUD);
 
   FObjectProperty *HUDProp = FindFProperty<FObjectProperty>(
-      ASkaldPlayerController::StaticClass(), TEXT("MainHudWidget"));
+      ASkaldPlayerController::StaticClass(), TEXT("MainHUD"));
   FObjectProperty *HUDRefProp = FindFProperty<FObjectProperty>(
       ASkaldPlayerController::StaticClass(), TEXT("HUDRef"));
   HUDProp->SetObjectPropertyValue_InContainer(PC, HUD);

--- a/Source/Skald/Tests/PlayerControllerValidationTest.cpp
+++ b/Source/Skald/Tests/PlayerControllerValidationTest.cpp
@@ -10,7 +10,7 @@ void UTestHUDWidget::ShowErrorMessage(const FString& Message)
 
 void ATestPlayerController::SetHUD(USkaldMainHUDWidget* InHUD)
 {
-    MainHudWidget = InHUD;
+    MainHUD = InHUD;
 }
 
 IMPLEMENT_SIMPLE_AUTOMATION_TEST(FSkaldPlayerControllerValidationFeedbackTest,

--- a/Source/Skald/UI/DeployWidget.cpp
+++ b/Source/Skald/UI/DeployWidget.cpp
@@ -11,6 +11,9 @@
 void UDeployWidget::NativeConstruct() {
   Super::NativeConstruct();
 
+  SetIsFocusable(true);
+  SetFocus();
+
   if (AcceptButton) {
     AcceptButton->OnClicked.AddDynamic(this, &UDeployWidget::HandleAccept);
   }

--- a/Source/Skald/UI/FighterSelectionWidget.cpp
+++ b/Source/Skald/UI/FighterSelectionWidget.cpp
@@ -80,6 +80,8 @@ void UFighterSelectionWidget::NativePreConstruct()
 
 void UFighterSelectionWidget::NativeConstruct() {
   Super::NativeConstruct();
+  SetIsFocusable(true);
+  SetFocus();
   if (LockInButton) {
     LockInButton->OnClicked.AddDynamic(this, &UFighterSelectionWidget::LockIn);
   }

--- a/Source/Skald/UI/SkaldMainHUDWidget.cpp
+++ b/Source/Skald/UI/SkaldMainHUDWidget.cpp
@@ -4,7 +4,6 @@
 #include "Components/VerticalBox.h"
 #include "Components/Widget.h"
 #include "Engine/Engine.h"
-#include "Engine/GameViewportClient.h"
 #include "Kismet/GameplayStatics.h"
 #include "Skald.h"
 #include "SkaldTypes.h"
@@ -18,6 +17,7 @@
 #include "Territory.h"
 #include "UI/ConfirmAttackWidget.h"
 #include "UI/DeployWidget.h"
+#include "UI/SkaldUIHelpers.h"
 #include "UObject/ConstructorHelpers.h"
 #include "WorldMap.h"
 #include "TimerManager.h"
@@ -46,6 +46,9 @@ USkaldMainHUDWidget::USkaldMainHUDWidget(
 
 void USkaldMainHUDWidget::NativeConstruct() {
   Super::NativeConstruct();
+
+  SetIsFocusable(true);
+  SetFocus();
 
   // Ensure the full-screen HUD doesn't swallow world clicks.
   if (UWidget *Root = GetRootWidget()) {
@@ -815,17 +818,9 @@ void USkaldMainHUDWidget::HandleDeployClicked() {
       CreateWidget<UDeployWidget>(GetWorld(), DeployWidgetClass);
   if (ActiveDeployWidget) {
     ActiveDeployWidget->Setup(Territory, PS, this, PS->DeployableUnits);
-    ActiveDeployWidgetSlateHandle.Reset();
-    if (UWorld *World = GetWorld()) {
-      if (UGameViewportClient *Viewport = World->GetGameViewport()) {
-        ActiveDeployWidgetSlateHandle = ActiveDeployWidget->TakeWidget();
-        Viewport->AddViewportWidgetContent(
-            ActiveDeployWidgetSlateHandle.ToSharedRef());
-      } else {
-        ActiveDeployWidget->AddToViewport();
-      }
-    } else {
-      ActiveDeployWidget->AddToViewport();
+    ActiveDeployWidget->AddToViewport();
+    if (APlayerController *PC = GetOwningPlayer()) {
+      FocusWidgetUIOnly(PC, ActiveDeployWidget);
     }
   } else {
     UE_LOG(LogSkald, Warning,
@@ -839,17 +834,14 @@ void USkaldMainHUDWidget::ClearDeployWidget() {
     return;
   }
 
-  if (ActiveDeployWidgetSlateHandle.IsValid()) {
-    if (UWorld *World = GetWorld()) {
-      if (UGameViewportClient *Viewport = World->GetGameViewport()) {
-        Viewport->RemoveViewportWidgetContent(
-            ActiveDeployWidgetSlateHandle.ToSharedRef());
-      }
-    }
-    ActiveDeployWidgetSlateHandle.Reset();
-  } else if (ActiveDeployWidget->IsInViewport()) {
+  if (ActiveDeployWidget->IsInViewport()) {
     ActiveDeployWidget->RemoveFromParent();
   }
 
   ActiveDeployWidget = nullptr;
+
+  if (ASkaldPlayerController *PC =
+          Cast<ASkaldPlayerController>(GetOwningPlayer())) {
+    PC->ShowMainHUD();
+  }
 }

--- a/Source/Skald/UI/SkaldMainHUDWidget.h
+++ b/Source/Skald/UI/SkaldMainHUDWidget.h
@@ -325,9 +325,6 @@ protected:
   UPROPERTY()
   UDeployWidget *ActiveDeployWidget = nullptr;
 
-  /** Slate handle when the deploy widget is added via the viewport. */
-  TSharedPtr<SWidget> ActiveDeployWidgetSlateHandle;
-
   UPROPERTY()
   TArray<ATerritory *> HighlightedTerritories;
 

--- a/Source/Skald/UI/SkaldUIHelpers.h
+++ b/Source/Skald/UI/SkaldUIHelpers.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "Blueprint/UserWidget.h"
+#include "Blueprint/WidgetBlueprintLibrary.h"
 #include "GameFramework/PlayerController.h"
 
 static inline void FocusWidgetUIOnly(APlayerController *PC, UUserWidget *Widget) {
@@ -9,14 +10,9 @@ static inline void FocusWidgetUIOnly(APlayerController *PC, UUserWidget *Widget)
   }
 
   Widget->SetIsFocusable(true);
+  Widget->SetFocus();
 
-  FInputModeUIOnly Mode;
-  if (TSharedPtr<SWidget> Cached = Widget->GetCachedWidget()) {
-    Mode.SetWidgetToFocus(Cached);
-  } else {
-    Mode.SetWidgetToFocus(Widget->TakeWidget());
-  }
-  Mode.SetLockMouseToViewportBehavior(EMouseLockMode::DoNotLock);
-  PC->SetInputMode(Mode);
+  UWidgetBlueprintLibrary::SetInputMode_UIOnlyEx(
+      PC, Widget, EMouseLockMode::DoNotLock, false);
   PC->bShowMouseCursor = true;
 }


### PR DESCRIPTION
## Summary
- manage the main HUD lifecycle from the player controller, creating it on BeginPlay, tearing it down on EndPlay, and exposing blueprint helpers to show or hide it with proper input modes
- swap Slate-based viewport attachment for AddToViewport/RemoveFromParent in both the main HUD and game instance deploy overlays, and update the shared helper to use WidgetBlueprintLibrary input helpers
- ensure gameplay widgets such as the HUD, deploy dialog, fighter selection, and player choice screens are focusable so focus transitions no longer trigger log warnings

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cf79fe01e88324bf0321fb664fc040