### PR TITLE
Fix player controller shadowing in deploy handler

### DIFF
--- a/Source/Skald/UI/SkaldMainHUDWidget.cpp
+++ b/Source/Skald/UI/SkaldMainHUDWidget.cpp
@@ -819,7 +819,8 @@ void USkaldMainHUDWidget::HandleDeployClicked() {
   if (ActiveDeployWidget) {
     ActiveDeployWidget->Setup(Territory, PS, this, PS->DeployableUnits);
     ActiveDeployWidget->AddToViewport();
-    if (APlayerController *PC = GetOwningPlayer()) {
+    PC = GetOwningPlayer();
+    if (PC) {
       FocusWidgetUIOnly(PC, ActiveDeployWidget);
     }
   } else {


### PR DESCRIPTION
## Summary
- reuse the existing owning player controller pointer when focusing the deploy widget to avoid local variable shadowing warnings in MSVC

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cfc7ba40a88324b978728728c8aef1