### PR TITLE
Fix HUD focus regression

### DIFF
--- a/Source/Skald/Skald_PlayerController.cpp
+++ b/Source/Skald/Skald_PlayerController.cpp
@@ -252,12 +252,12 @@ void ASkaldPlayerController::EndPlay(const EEndPlayReason::Type EndPlayReason) {
 void ASkaldPlayerController::ShowMainHUD() {
   if (MainHUD) {
     MainHUD->SetVisibility(ESlateVisibility::SelfHitTestInvisible);
-    UWidgetBlueprintLibrary::SetInputMode_GameAndUIEx(
-        this, MainHUD, EMouseLockMode::DoNotLock, /*bHideCursorDuringCapture*/
-        false);
-    bShowMouseCursor = true;
-    MainHUD->SetFocus();
   }
+
+  UWidgetBlueprintLibrary::SetInputMode_GameAndUIEx(
+      this, nullptr, EMouseLockMode::DoNotLock, /*bHideCursorDuringCapture*/
+      false);
+  bShowMouseCursor = true;
 }
 
 void ASkaldPlayerController::HideMainHUD() {
@@ -626,14 +626,8 @@ void ASkaldPlayerController::NotifyTurnEnded(const FString &PlayerName) {
 }
 
 void ASkaldPlayerController::StartTurn() {
-  if (MainHUD) {
-    UWidgetBlueprintLibrary::SetInputMode_GameAndUIEx(
-        this, MainHUD, EMouseLockMode::DoNotLock, false);
-    MainHUD->SetFocus();
-  } else {
-    UWidgetBlueprintLibrary::SetInputMode_GameAndUIEx(
-        this, nullptr, EMouseLockMode::DoNotLock, false);
-  }
+  UWidgetBlueprintLibrary::SetInputMode_GameAndUIEx(
+      this, nullptr, EMouseLockMode::DoNotLock, false);
   bShowMouseCursor = true;
   bEnableClickEvents = true;
   bEnableMouseOverEvents = true;


### PR DESCRIPTION
## Summary
- avoid focusing the main HUD when it is shown so world input bindings keep working
- ensure StartTurn restores Game+UI input mode without a focused widget to prevent keyboard capture

## Testing
- not run (Unreal build environment not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68cfd5eda0b48324bc389ef25dea027c