### PR TITLE
Refine battle travel, HUD gating, and AI placement

### DIFF
--- a/Source/Skald/Skald_AIController.cpp
+++ b/Source/Skald/Skald_AIController.cpp
@@ -53,28 +53,6 @@ void ASkaldAIController::MakeAIDecision() {
     const ETurnPhase PrevPhase = Phase;
 
     if (Phase == ETurnPhase::ArmyPlacement) {
-      TArray<ATerritory *> OwnedTerritories;
-      for (ATerritory *Territory : WorldMap->Territories) {
-        if (Territory && Territory->OwningPlayer == PS) {
-          OwnedTerritories.Add(Territory);
-        }
-      }
-
-      int32 SpreadIndex = 0;
-      while (PS->DeployableUnits > 0 && OwnedTerritories.Num() > 0) {
-        ATerritory *TargetTerritory =
-            OwnedTerritories[SpreadIndex % OwnedTerritories.Num()];
-        ++TargetTerritory->ArmyUnits;
-        TargetTerritory->RefreshAppearance();
-        --PS->DeployableUnits;
-        ++SpreadIndex;
-      }
-
-      TurnManager->BroadcastDeployableUnits(PS);
-      if (ASkaldGameMode *GM =
-              GetWorld()->GetAuthGameMode<ASkaldGameMode>()) {
-        GM->AdvanceArmyPlacement();
-      }
       return;
     } else if (Phase == ETurnPhase::Reinforcement) {
       TArray<ATerritory *> OwnedTerritories;

--- a/Source/Skald/Skald_BattleGameMode.cpp
+++ b/Source/Skald/Skald_BattleGameMode.cpp
@@ -21,65 +21,51 @@
 
 namespace {
 bool HasHumanOwnedTerritory(const ASkaldGameState *GameState,
-                            const AWorldMap *WorldMap,
+                            const AWorldMap * /*WorldMap*/,
                             const USkaldGameInstance *GameInstance,
                             TSet<int32> &CachedHumanTerritories,
                             const TMap<int32, FS_Territory> *CachedTerritoryMap) {
   const FSkaldTravelState *TravelStatePtr =
       GameInstance ? &GameInstance->GetTravelState() : nullptr;
 
-  auto IsHumanPlayerById = [GameState](int32 PlayerID) {
-    if (!GameState || PlayerID <= 0) {
-      return false;
+  if (TravelStatePtr && TravelStatePtr->bValid) {
+    for (int32 TerritoryID : TravelStatePtr->HumanOwnedTerritories) {
+      if (TerritoryID > 0) {
+        CachedHumanTerritories.Add(TerritoryID);
+      }
     }
-    if (ASkaldPlayerState *Player = GameState->GetPlayerById(PlayerID)) {
-      return !Player->bIsAI;
-    }
-    return false;
-  };
+  }
 
   auto RegisterHumanTerritory = [&](int32 TerritoryID, int32 OwnerID) {
-    if (TerritoryID <= 0) {
+    if (TerritoryID <= 0 || CachedHumanTerritories.Contains(TerritoryID)) {
       return;
     }
 
-    if (CachedHumanTerritories.Contains(TerritoryID)) {
-      return;
+    bool bIsHuman = false;
+    if (OwnerID > 0 && GameState) {
+      if (ASkaldPlayerState *Player = GameState->GetPlayerById(OwnerID)) {
+        bIsHuman = !Player->bIsAI;
+      }
     }
 
-    if (IsHumanPlayerById(OwnerID)) {
-      CachedHumanTerritories.Add(TerritoryID);
-      return;
+    if (!bIsHuman && TravelStatePtr && TravelStatePtr->bValid) {
+      bIsHuman = TravelStatePtr->HumanOwnedTerritories.Contains(TerritoryID);
     }
 
-    if (TravelStatePtr && TravelStatePtr->bValid &&
-        TravelStatePtr->HumanOwnedTerritories.Contains(TerritoryID)) {
+    if (bIsHuman) {
       CachedHumanTerritories.Add(TerritoryID);
     }
   };
-
-  if (WorldMap) {
-    for (ATerritory *Territory : WorldMap->Territories) {
-      if (!Territory) {
-        continue;
-      }
-      const int32 OwnerID =
-          Territory->OwningPlayer ? Territory->OwningPlayer->GetPlayerId() : 0;
-      RegisterHumanTerritory(Territory->TerritoryID, OwnerID);
-    }
-  }
-
-  if (GameInstance) {
-    for (const FS_Territory &TerritoryData :
-         GameInstance->CachedWorldMapTerritories) {
-      RegisterHumanTerritory(TerritoryData.TerritoryID,
-                             TerritoryData.OwnerPlayerID);
-    }
-  }
 
   if (CachedTerritoryMap) {
     for (const TPair<int32, FS_Territory> &Pair : *CachedTerritoryMap) {
       const FS_Territory &Territory = Pair.Value;
+      RegisterHumanTerritory(Territory.TerritoryID, Territory.OwnerPlayerID);
+    }
+  }
+
+  if (GameInstance) {
+    for (const FS_Territory &Territory : GameInstance->CachedWorldMapTerritories) {
       RegisterHumanTerritory(Territory.TerritoryID, Territory.OwnerPlayerID);
     }
   }
@@ -97,6 +83,11 @@ ASkaldPlayerState *EnsureBattleParticipant(ASkaldGameState *GameState, UWorld *W
   if (ASkaldPlayerState *Existing = GameState->GetPlayerById(PlayerID)) {
     if (!DisplayName.IsEmpty()) {
       Existing->PlayerDisplayName = DisplayName;
+      Existing->SetPlayerName(DisplayName);
+    } else if (Existing->GetPlayerName().IsEmpty()) {
+      UE_LOG(LogSkald, Warning,
+             TEXT("EnsureBattleParticipant: Missing name for PlayerId %d"),
+             PlayerID);
     }
     if (Faction != ESkaldFaction::None) {
       Existing->Faction = Faction;
@@ -113,6 +104,11 @@ ASkaldPlayerState *EnsureBattleParticipant(ASkaldGameState *GameState, UWorld *W
 
     if (!DisplayName.IsEmpty()) {
       Candidate->PlayerDisplayName = DisplayName;
+      Candidate->SetPlayerName(DisplayName);
+    } else if (Candidate->GetPlayerName().IsEmpty()) {
+      UE_LOG(LogSkald, Warning,
+             TEXT("EnsureBattleParticipant: Missing name for PlayerId %d"),
+             PlayerID);
     }
     if (Faction != ESkaldFaction::None) {
       Candidate->Faction = Faction;
@@ -152,8 +148,11 @@ ASkaldPlayerState *EnsureBattleParticipant(ASkaldGameState *GameState, UWorld *W
   NewState->SetPlayerId(PlayerID);
   if (!DisplayName.IsEmpty()) {
     NewState->PlayerDisplayName = DisplayName;
+    NewState->SetPlayerName(DisplayName);
   } else {
-    NewState->PlayerDisplayName = FString::Printf(TEXT("Player %d"), PlayerID);
+    UE_LOG(LogSkald, Warning,
+           TEXT("EnsureBattleParticipant: Spawned PlayerState without name (Id=%d)"),
+           PlayerID);
   }
   if (Faction != ESkaldFaction::None) {
     NewState->Faction = Faction;
@@ -173,49 +172,39 @@ void ASkald_BattleGameMode::InitGame(const FString &Map, const FString &Options,
   ReadyControllers.Empty();
   CachedHumanTerritoryIDs.Reset();
   CachedTerritoryMap.Reset();
+  bPendingBattleSetupComplete = false;
+  bLoggedTravelCache = false;
+  if (UWorld *World = GetWorld()) {
+    World->GetTimerManager().ClearTimer(TravelBootstrapHandle);
+  }
 
   if (USkaldGameInstance *GI = GetGameInstance<USkaldGameInstance>()) {
     GI->SetTravelPending(false);
     const FSkaldTravelState &TravelState = GI->GetTravelState();
-    ExpectedControllers =
-        TravelState.bValid ? TravelState.ExpectedControllers : 0;
-    if (TravelState.bValid) {
-      for (int32 TerritoryID : TravelState.HumanOwnedTerritories) {
-        CachedHumanTerritoryIDs.Add(TerritoryID);
-      }
+    ExpectedControllers = TravelState.bValid ? TravelState.ExpectedControllers : 0;
 
-      if (TravelState.CachedTerritories.Num() > 0) {
-        CachedTerritoryMap.Reserve(TravelState.CachedTerritories.Num());
-        for (const FS_Territory &Territory : TravelState.CachedTerritories) {
-          CachedTerritoryMap.Add(Territory.TerritoryID, Territory);
-        }
-        GI->CachedWorldMapTerritories = TravelState.CachedTerritories;
+    if (TravelState.CachedTerritories.Num() > 0) {
+      CachedTerritoryMap.Reserve(TravelState.CachedTerritories.Num());
+      for (const FS_Territory &Territory : TravelState.CachedTerritories) {
+        CachedTerritoryMap.Add(Territory.TerritoryID, Territory);
       }
-    }
-
-    if (CachedTerritoryMap.Num() == 0 &&
-        GI->CachedWorldMapTerritories.Num() > 0) {
+      GI->CachedWorldMapTerritories = TravelState.CachedTerritories;
+    } else if (GI->CachedWorldMapTerritories.Num() > 0) {
       CachedTerritoryMap.Reserve(GI->CachedWorldMapTerritories.Num());
       for (const FS_Territory &Territory : GI->CachedWorldMapTerritories) {
         CachedTerritoryMap.Add(Territory.TerritoryID, Territory);
       }
     }
 
-    if (CachedHumanTerritoryIDs.Num() == 0 && CachedTerritoryMap.Num() > 0) {
-      for (const TPair<int32, FS_Territory> &Pair : CachedTerritoryMap) {
-        const FS_Territory &Territory = Pair.Value;
-        if (TravelState.bValid &&
-            TravelState.HumanOwnedTerritories.Contains(Territory.TerritoryID)) {
-          CachedHumanTerritoryIDs.Add(Territory.TerritoryID);
-        }
-      }
-    }
-
+    HasHumanOwnedTerritory(GetGameState<ASkaldGameState>(), WorldMap, GI,
+                           CachedHumanTerritoryIDs, &CachedTerritoryMap);
     if (CachedHumanTerritoryIDs.Num() > 0) {
+      bLoggedTravelCache = true;
       UE_LOG(LogSkald, Log,
              TEXT("BattleGM InitGame: Restored %d human territories from travel cache"),
              CachedHumanTerritoryIDs.Num());
     }
+
     UE_LOG(LogSkald, Log, TEXT("BattleGM InitGame: ExpectedControllers=%d"),
            ExpectedControllers);
   } else {
@@ -223,6 +212,8 @@ void ASkald_BattleGameMode::InitGame(const FString &Map, const FString &Options,
     UE_LOG(LogSkald, Warning,
            TEXT("BattleGM InitGame: GameInstance unavailable; waiting for controllers"));
   }
+
+  BootstrapFromTravelState();
 }
 
 void ASkald_BattleGameMode::BeginPlay() {
@@ -277,8 +268,6 @@ void ASkald_BattleGameMode::BeginPlay() {
            CachedHumanTerritoryIDs.Num());
   }
 
-  SetupPendingBattle();
-
   if (ASkaldGameState *GS = GetGameState<ASkaldGameState>()) {
     int32 ControllerCount = 0;
     for (FConstPlayerControllerIterator It =
@@ -292,23 +281,19 @@ void ASkald_BattleGameMode::BeginPlay() {
              GS->PlayerArray.Num(), ControllerCount);
     }
 
-    const bool bHumanHasTerritory =
-        HasHumanOwnedTerritory(GS, WorldMap, GI, CachedHumanTerritoryIDs,
-                               &CachedTerritoryMap);
-    if (!bHumanHasTerritory) {
-      const int32 CachedCount = CachedHumanTerritoryIDs.Num();
-      UE_LOG(LogSkald, Warning,
-             TEXT("BeginPlay: Unable to confirm any human-owned territory after "
-                  "travel (WorldMap=%s, CachedHumanTerritories=%d)"),
-             *GetNameSafe(WorldMap), CachedCount);
-    }
+    HasHumanOwnedTerritory(GS, WorldMap, GI, CachedHumanTerritoryIDs,
+                           &CachedTerritoryMap);
   }
 
-  TryStartBattle();
+  BootstrapFromTravelState();
 }
 
 void ASkald_BattleGameMode::SetupPendingBattle() {
   if (!HasAuthority()) {
+    return;
+  }
+
+  if (bPendingBattleSetupComplete) {
     return;
   }
 
@@ -329,16 +314,8 @@ void ASkald_BattleGameMode::SetupPendingBattle() {
     return;
   }
 
-  const bool bHumanHasTerritory =
-      HasHumanOwnedTerritory(GS, WorldMap, GI, CachedHumanTerritoryIDs,
-                             &CachedTerritoryMap);
-  if (!bHumanHasTerritory) {
-    const int32 CachedCount = CachedHumanTerritoryIDs.Num();
-    UE_LOG(LogSkald, Warning,
-           TEXT("SetupPendingBattle: No human-owned territory recorded before "
-                "launch (WorldMap=%s, CachedHumanTerritories=%d)"),
-           *GetNameSafe(WorldMap), CachedCount);
-  }
+  HasHumanOwnedTerritory(GS, WorldMap, GI, CachedHumanTerritoryIDs,
+                         &CachedTerritoryMap);
 
   const FS_BattlePayload Battle = GI->PendingBattle;
   ASkaldPlayerState *AttackerPS = EnsureBattleParticipant(
@@ -356,6 +333,63 @@ void ASkald_BattleGameMode::SetupPendingBattle() {
 
   AutoCommitAIArmy(AttackerPS, AttackerBudget);
   AutoCommitAIArmy(DefenderPS, DefenderBudget);
+
+  TryStartBattle();
+
+  bPendingBattleSetupComplete = true;
+}
+
+void ASkald_BattleGameMode::BootstrapFromTravelState() {
+  if (!HasAuthority()) {
+    return;
+  }
+
+  UWorld *World = GetWorld();
+  if (!World) {
+    return;
+  }
+
+  USkaldGameInstance *GI = GetGameInstance<USkaldGameInstance>();
+  if (!GI) {
+    return;
+  }
+
+  const FSkaldTravelState &TravelState = GI->GetTravelState();
+  if (!TravelState.bValid && ExpectedControllers <= 0) {
+    if (ASkaldGameState *GS = GetGameState<ASkaldGameState>()) {
+      ExpectedControllers = GS->PlayerArray.Num();
+    }
+  } else if (TravelState.bValid && ExpectedControllers <= 0) {
+    ExpectedControllers = TravelState.ExpectedControllers;
+  }
+
+  HasHumanOwnedTerritory(GetGameState<ASkaldGameState>(), WorldMap, GI,
+                         CachedHumanTerritoryIDs, &CachedTerritoryMap);
+  if (!bLoggedTravelCache && CachedHumanTerritoryIDs.Num() > 0) {
+    UE_LOG(LogSkald, Log,
+           TEXT("BattleGM InitGame: Restored %d human territories from travel cache"),
+           CachedHumanTerritoryIDs.Num());
+    bLoggedTravelCache = true;
+  }
+
+  ASkaldGameState *GS = GetGameState<ASkaldGameState>();
+  const int32 PlayerStates = GS ? GS->PlayerArray.Num() : 0;
+  if (ExpectedControllers <= 0 && PlayerStates > 0) {
+    ExpectedControllers = PlayerStates;
+  }
+
+  if (ExpectedControllers > 0 && PlayerStates < ExpectedControllers) {
+    World->GetTimerManager().SetTimer(TravelBootstrapHandle, this,
+                                      &ASkald_BattleGameMode::BootstrapFromTravelState,
+                                      0.25f, false);
+    return;
+  }
+
+  World->GetTimerManager().ClearTimer(TravelBootstrapHandle);
+
+  if (!bPendingBattleSetupComplete) {
+    SetupPendingBattle();
+  }
 
   TryStartBattle();
 }
@@ -445,23 +479,6 @@ void ASkald_BattleGameMode::SpawnFighterSide(const TArray<FFighterDefinition> &R
 void ASkald_BattleGameMode::TryLaunchBattle() {
   if (bBattleLaunched || !HasAuthority()) {
     return;
-  }
-
-  if (ExpectedControllers > 0) {
-    for (auto It = ReadyControllers.CreateIterator(); It; ++It) {
-      if (!It->IsValid()) {
-        It.RemoveCurrent();
-      }
-    }
-    const ASkaldGameState *GS = GetGameState<ASkaldGameState>();
-    const int32 PlayerStates = GS ? GS->PlayerArray.Num() : 0;
-    const int32 Controllers = ReadyControllers.Num();
-    if (Controllers < ExpectedControllers || PlayerStates < ExpectedControllers) {
-      UE_LOG(LogSkald, Log,
-             TEXT("TryLaunchBattle: Waiting for controllers. Ready=%d PlayerStates=%d Expected=%d"),
-             Controllers, PlayerStates, ExpectedControllers);
-      return;
-    }
   }
 
   USkaldGameInstance *GI = GetGameInstance<USkaldGameInstance>();
@@ -572,6 +589,7 @@ void ASkald_BattleGameMode::OnControllerReady(AController *Controller) {
          TEXT("OnControllerReady: %s ReadyControllers=%d Expected=%d"),
          *GetNameSafe(Controller), ReadyControllers.Num(), ExpectedControllers);
 
+  BootstrapFromTravelState();
   TryStartBattle();
 }
 
@@ -580,35 +598,41 @@ void ASkald_BattleGameMode::TryStartBattle() {
     return;
   }
 
+  if (!bPendingBattleSetupComplete) {
+    BootstrapFromTravelState();
+    if (!bPendingBattleSetupComplete) {
+      return;
+    }
+  }
+
   for (auto It = ReadyControllers.CreateIterator(); It; ++It) {
     if (!It->IsValid()) {
       It.RemoveCurrent();
     }
   }
 
-  if (ExpectedControllers == 0) {
-    if (const USkaldGameInstance *GI = GetGameInstance<USkaldGameInstance>()) {
-      const FSkaldTravelState &TravelState = GI->GetTravelState();
-      if (TravelState.bValid) {
-        ExpectedControllers = TravelState.ExpectedControllers;
-      }
-    }
+  const ASkaldGameState *GS = GetGameState<ASkaldGameState>();
+  const int32 PlayerStates = GS ? GS->PlayerArray.Num() : 0;
+  if (ExpectedControllers <= 0 && PlayerStates > 0) {
+    ExpectedControllers = PlayerStates;
+  }
 
-    if (ExpectedControllers == 0) {
-      UE_LOG(LogSkald, Warning,
-             TEXT("TryStartBattle: ExpectedControllers not ready; waiting."));
-      return;
+  TSet<int32> ReadyPlayerIDs;
+  for (const TWeakObjectPtr<AController> &WeakController : ReadyControllers) {
+    if (const AController *ReadyController = WeakController.Get()) {
+      if (const APlayerState *PS = ReadyController->PlayerState) {
+        ReadyPlayerIDs.Add(PS->GetPlayerId());
+      }
     }
   }
 
-  const ASkaldGameState *GS = GetGameState<ASkaldGameState>();
-  const int32 PlayerStates = GS ? GS->PlayerArray.Num() : 0;
-  const int32 ReadyCount = ReadyControllers.Num();
+  const int32 ReadyPlayerStates = ReadyPlayerIDs.Num();
   UE_LOG(LogSkald, Log,
-         TEXT("TryStartBattle: ReadyControllers=%d PlayerStates=%d Expected=%d"),
-         ReadyCount, PlayerStates, ExpectedControllers);
+         TEXT("TryStartBattle: ReadyPlayerStates=%d Expected=%d"),
+         ReadyPlayerStates, ExpectedControllers);
 
-  if (PlayerStates < ExpectedControllers || ReadyCount < ExpectedControllers) {
+  if (ExpectedControllers <= 0 || PlayerStates < ExpectedControllers ||
+      ReadyPlayerStates < ExpectedControllers) {
     return;
   }
 

--- a/Source/Skald/Skald_BattleGameMode.h
+++ b/Source/Skald/Skald_BattleGameMode.h
@@ -33,6 +33,7 @@ public:
   void OnControllerReady(AController *Controller);
 
 private:
+  void BootstrapFromTravelState();
   void SetupPendingBattle();
   void AutoCommitAIArmy(ASkaldPlayerState *PlayerState, int32 Budget) const;
   void SpawnFighterSide(const TArray<FFighterDefinition> &Roster, bool bAsAttacker);
@@ -53,5 +54,14 @@ private:
 
   /** Snapshot of overworld territory data captured prior to travel. */
   TMap<int32, FS_Territory> CachedTerritoryMap;
+
+  /** Timer used to defer readiness checks until all PlayerStates exist. */
+  FTimerHandle TravelBootstrapHandle;
+
+  /** True once SetupPendingBattle has executed for the current travel. */
+  bool bPendingBattleSetupComplete = false;
+
+  /** Ensure we only log the cache restoration message once. */
+  bool bLoggedTravelCache = false;
 };
 

--- a/Source/Skald/Skald_GameMode.cpp
+++ b/Source/Skald/Skald_GameMode.cpp
@@ -215,6 +215,7 @@ void ASkaldGameMode::RegisterPlayer(ASkaldPlayerController *PC) {
     if (GI) {
       if (PS->PlayerDisplayName.IsEmpty()) {
         PS->PlayerDisplayName = GI->DisplayName;
+        PS->SetPlayerName(PS->PlayerDisplayName);
       }
       if (PS->Faction == ESkaldFaction::None) {
         PS->Faction = GI->Faction;
@@ -224,7 +225,8 @@ void ASkaldGameMode::RegisterPlayer(ASkaldPlayerController *PC) {
     const int32 Index = GS->PlayerArray.IndexOfByKey(PS);
     if (PlayerDataArray.IsValidIndex(Index)) {
       PlayerDataArray[Index].PlayerID = PS->GetPlayerId();
-      PlayerDataArray[Index].PlayerName = PS->PlayerDisplayName;
+      PlayerDataArray[Index].PlayerName =
+          PS->GetResolvedPlayerName(TEXT("RegisterPlayer"));
       PlayerDataArray[Index].IsAI = PS->bIsAI;
       PlayerDataArray[Index].Faction = PS->Faction;
       PlayerDataArray[Index].Resources = PS->Resources;
@@ -369,6 +371,7 @@ void ASkaldGameMode::PopulateAIPlayers() {
     AIState->bIsAI = true;
     AIState->PlayerDisplayName =
         FString::Printf(TEXT("AI_%d"), GS->PlayerArray.Num());
+    AIState->SetPlayerName(AIState->PlayerDisplayName);
 
     TArray<ESkaldFaction> Taken;
     for (APlayerState *ExistingPS : GS->PlayerArray) {
@@ -441,7 +444,8 @@ void ASkaldGameMode::HandlePlayerLockedIn(ASkaldPlayerState *PS) {
   PS->bHasLockedIn = true;
 
   UE_LOG(LogSkald, Log, TEXT("HandlePlayerLockedIn: Player=%s bIsAI=%d"),
-         *PS->PlayerDisplayName, PS->bIsAI ? 1 : 0);
+         *PS->GetResolvedPlayerName(TEXT("HandlePlayerLockedIn")),
+         PS->bIsAI ? 1 : 0);
   ASkaldGameState *GS = GetGameState<ASkaldGameState>();
   UE_LOG(LogSkald, Log,
          TEXT("HandlePlayerLockedIn: TurnManager=%s ControllerCount=%d "
@@ -503,7 +507,8 @@ void ASkaldGameMode::HandlePlayerLockedIn(ASkaldPlayerState *PS) {
         return Data.PlayerID == PS->GetPlayerId();
       });
   if (PlayerData) {
-    PlayerData->PlayerName = PS->PlayerDisplayName;
+    PlayerData->PlayerName =
+        PS->GetResolvedPlayerName(TEXT("RegisterPlayer_PlayerData"));
     PlayerData->Faction = PS->Faction;
   }
 
@@ -632,7 +637,8 @@ void ASkaldGameMode::RefreshHUDs() {
     if (ASkaldPlayerState *SPS = Cast<ASkaldPlayerState>(PSBase)) {
       FS_PlayerData Data;
       Data.PlayerID = SPS->GetPlayerId();
-      Data.PlayerName = SPS->PlayerDisplayName;
+      Data.PlayerName =
+          SPS->GetResolvedPlayerName(TEXT("RefreshHUDs_Player"));
       Data.IsAI = SPS->bIsAI;
       Data.Faction = SPS->Faction;
       Data.Resources = SPS->Resources;
@@ -918,6 +924,7 @@ void ASkaldGameMode::ApplyLoadedGame(USkaldSaveGame *LoadedGame) {
     }
     PS->SetPlayerId(PlayerSave.PlayerID);
     PS->PlayerDisplayName = PlayerSave.PlayerName;
+    PS->SetPlayerName(PlayerSave.PlayerName);
     PS->Faction = PlayerSave.Faction;
     PS->Resources = PlayerSave.Resources;
     if (GS) {
@@ -1000,6 +1007,9 @@ void ASkaldGameMode::BeginArmyPlacementPhase() {
     return;
   }
 
+  GetWorldTimerManager().ClearTimer(ArmyPlacementFailsafeHandle);
+  bArmyPlacementFailsafeTriggered = false;
+
   // Ensure controllers are sorted before placement begins and set phase.
   TurnManager->SortControllersByInitiative();
   TurnManager->StartArmyPlacementPhase();
@@ -1080,6 +1090,8 @@ void ASkaldGameMode::AdvanceArmyPlacement() {
     return;
   }
 
+  GetWorldTimerManager().ClearTimer(ArmyPlacementFailsafeHandle);
+
   const TArray<ASkaldPlayerController *> Controllers =
       TurnManager->GetControllers();
   const int32 NumControllers = Controllers.Num();
@@ -1128,13 +1140,25 @@ void ASkaldGameMode::AdvanceArmyPlacement() {
     }
 
     // Announce whose placement turn it is.
-    const FString PlayerName = PS->PlayerDisplayName;
+    const FString PlayerName =
+        PS->GetResolvedPlayerName(TEXT("AdvanceArmyPlacement_Announcement"));
     for (ASkaldPlayerController *Controller : Controllers) {
       const bool bIsActive = Controller == PC;
       Controller->ShowTurnAnnouncement(PlayerName, bIsActive);
       if (USkaldMainHUDWidget *HUD = Controller->GetHUDWidget()) {
         HUD->UpdateTurnBanner(PS->GetPlayerId(), 1);
       }
+    }
+
+    if (PS->bIsAI) {
+      WorldMap->AutoPlaceUnitsForAI(PS);
+      TurnManager->BroadcastDeployableUnits(PS);
+      bArmyPlacementFailsafeTriggered = false;
+      TurnManager->EndCurrentPhase();
+      GetWorldTimerManager().SetTimer(ArmyPlacementFailsafeHandle, this,
+                                      &ASkaldGameMode::HandleArmyPlacementFailsafe,
+                                      2.0f, false);
+      return;
     }
 
     // Hand control to the active player (AI or human) to deploy units.
@@ -1149,6 +1173,26 @@ void ASkaldGameMode::AdvanceArmyPlacement() {
   ArmyPlacementLeader.Reset();
   bTurnsStarted = true;
   TurnManager->StartTurns(StartingController);
+}
+
+void ASkaldGameMode::HandleArmyPlacementFailsafe() {
+  GetWorldTimerManager().ClearTimer(ArmyPlacementFailsafeHandle);
+
+  if (!TurnManager) {
+    return;
+  }
+
+  if (TurnManager->GetCurrentPhase() != ETurnPhase::ArmyPlacement) {
+    return;
+  }
+
+  if (!bArmyPlacementFailsafeTriggered) {
+    UE_LOG(LogSkald, Warning,
+           TEXT("Army placement failsafe triggered; forcing EndCurrentPhase"));
+    bArmyPlacementFailsafeTriggered = true;
+  }
+
+  TurnManager->EndCurrentPhase();
 }
 
 bool ASkaldGameMode::InitializeWorld() {
@@ -1377,9 +1421,10 @@ bool ASkaldGameMode::InitializeWorld() {
   }
 
   if (HighestPS) {
-    const FString Message =
-        FString::Printf(TEXT("%s wins initiative with a roll of %d"),
-                        *HighestPS->PlayerDisplayName, HighestRoll);
+    const FString Message = FString::Printf(
+        TEXT("%s wins initiative with a roll of %d"),
+        *HighestPS->GetResolvedPlayerName(TEXT("InitializeWorld_Initiative")),
+        HighestRoll);
     for (FConstPlayerControllerIterator It =
              GetWorld()->GetPlayerControllerIterator();
          It; ++It) {

--- a/Source/Skald/Skald_GameMode.h
+++ b/Source/Skald/Skald_GameMode.h
@@ -175,6 +175,12 @@ private:
   /** Controller that opened army placement with the highest initiative roll. */
   TWeakObjectPtr<ASkaldPlayerController> ArmyPlacementLeader;
 
+  /** Failsafe to ensure AI army placement advances the phase. */
+  FTimerHandle ArmyPlacementFailsafeHandle;
+
+  /** Guard to avoid logging the failsafe warning multiple times. */
+  bool bArmyPlacementFailsafeTriggered = false;
+
   /** Register a newly connected player and update player data. */
   void RegisterPlayer(ASkaldPlayerController *PC);
 
@@ -186,4 +192,7 @@ private:
 
   /** Remove invalid player states before re-registering controllers. */
   void CleanupStalePlayerStates();
+
+  /** Callback fired by the failsafe timer if the AI does not advance. */
+  void HandleArmyPlacementFailsafe();
 };

--- a/Source/Skald/Skald_PlayerController.cpp
+++ b/Source/Skald/Skald_PlayerController.cpp
@@ -44,6 +44,17 @@
 
 #include "Engine/World.h"
 
+namespace {
+FString ResolvePlayerName(const ASkaldPlayerState *PlayerState,
+                          const TCHAR *Context) {
+  if (!PlayerState) {
+    return TEXT("Neutral");
+  }
+
+  return PlayerState->GetResolvedPlayerName(Context);
+}
+}
+
 ASkaldPlayerController::ASkaldPlayerController() {
   TurnManager = nullptr;
   HUDRef = nullptr;
@@ -190,9 +201,15 @@ void ASkaldPlayerController::BeginPlay() {
 
   CacheGameReferences();
 
+  DetectBattleMap();
+
   if (IsLocalPlayerController() && GetLocalPlayer() != nullptr) {
-    InitializeHUDWidget();
-    ShowMainHUD();
+    if (!bIsBattleMap) {
+      InitializeHUDWidget();
+      ShowMainHUD();
+    } else {
+      UE_LOG(LogSkald, Log, TEXT("[HUD] Skipping MainHUD in BattleGameMode"));
+    }
     if (CachedGameInstance && CachedGameInstance->bIsMultiplayer &&
         !CachedGameInstance->bIsHost) {
       if (GEngine) {
@@ -211,7 +228,6 @@ void ASkaldPlayerController::BeginPlay() {
       HandleFactionLockedIn();
     }
     InitializeFighterSelectionIfNeeded();
-    DetectBattleMap();
   }
 
   TryBindWorldMap();
@@ -436,9 +452,18 @@ void ASkaldPlayerController::ShowFighterSelectionUI(int32 MaxBudget,
   FighterSelectionWidget->MaxCost = MaxBudget;
   FighterSelectionWidget->ChosenFighters.Reset();
   FighterSelectionWidget->CurrentCost = 0;
-  FighterSelectionWidget->AvailableFighters =
+  const TArray<FFighterDefinition> Available =
       UFighterDataLibrary::GetFightersForFaction(this, Faction);
-  FighterSelectionWidget->PopulateFighterList();
+  FighterSelectionWidget->SetAvailableFighters(Available);
+  if (Available.Num() > 0) {
+    UE_LOG(LogSkald, Log,
+           TEXT("SkaldUI: [FighterSelection] Populated %d fighter entries."),
+           Available.Num());
+  } else {
+    UE_LOG(LogSkald, Warning,
+           TEXT("SkaldUI: [FighterSelection] No fighters available for faction %d"),
+           static_cast<int32>(Faction));
+  }
   FighterSelectionWidget->UpdateCostDisplay();
 
   FighterSelectionWidget->AddToViewport(30);
@@ -572,9 +597,6 @@ void ASkaldPlayerController::HideOverworldHUDForBattle() {
 
   bBattleHUDVisible = false;
   bBattleHUDReadyToShow = false;
-
-  InitializeBattleHUD();
-
   if (BattleHudWidget) {
     BattleHudWidget->SetVisibility(ESlateVisibility::Collapsed);
   }
@@ -678,9 +700,9 @@ void ASkaldPlayerController::DetectBattleMap() {
 
   if (bIsBattleMap) {
     HideOverworldHUDForBattle();
-    bBattleHUDReadyToShow = true;
     if (CachedGameInstance && CachedGameInstance->GridBattleManager &&
-        CachedGameInstance->GridBattleManager->GetActiveFighter()) {
+        CachedGameInstance->GridBattleManager->GetActiveFighter() &&
+        bBattleHUDReadyToShow) {
       EnsureBattleHUDVisible();
     }
   } else {
@@ -758,18 +780,9 @@ void ASkaldPlayerController::EndPhase() {
       PS->DeployableUnits = 0;
       TurnManager->BroadcastDeployableUnits(PS);
     }
-
-    if (!CachedGameMode) {
-      CachedGameMode = GetWorld()->GetAuthGameMode<ASkaldGameMode>();
-    }
-
-    if (CachedGameMode) {
-      CachedGameMode->AdvanceArmyPlacement();
-    }
-    return;
   }
 
-  TurnManager->AdvancePhase();
+  TurnManager->EndCurrentPhase();
 }
 
 bool ASkaldPlayerController::ValidateAttack(int32 FromID, int32 ToID,
@@ -863,12 +876,14 @@ void ASkaldPlayerController::ServerHandleAttack_Implementation(int32 FromID,
     Battle.IsCapitalAttack = Target->bIsCapital;
     if (AttackerPS) {
       Battle.AttackerFaction = AttackerPS->Faction;
-      Battle.AttackerDisplayName = AttackerPS->PlayerDisplayName;
+      Battle.AttackerDisplayName =
+          ResolvePlayerName(AttackerPS, TEXT("ServerHandleAttack_Attacker"));
       Battle.bAttackerIsAI = AttackerPS->bIsAI;
     }
     if (DefenderPS) {
       Battle.DefenderFaction = DefenderPS->Faction;
-      Battle.DefenderDisplayName = DefenderPS->PlayerDisplayName;
+      Battle.DefenderDisplayName =
+          ResolvePlayerName(DefenderPS, TEXT("ServerHandleAttack_Defender"));
       Battle.bDefenderIsAI = DefenderPS->bIsAI;
     }
     if (bUseSiege && CachedGameMode) {
@@ -930,9 +945,8 @@ void ASkaldPlayerController::ServerHandleAttack_Implementation(int32 FromID,
     for (ASkaldPlayerController *Controller : TurnManager->GetControllers()) {
       if (USkaldMainHUDWidget *HUD =
               Controller ? Controller->GetHUDWidget() : nullptr) {
-        FString OwnerName = Target->OwningPlayer
-                                ? Target->OwningPlayer->PlayerDisplayName
-                                : TEXT("Neutral");
+        const FString OwnerName =
+            ResolvePlayerName(Target->OwningPlayer, TEXT("ServerHandleAttack_Update"));
         HUD->UpdateTerritoryInfo(Target->TerritoryName, OwnerName,
                                  Target->ArmyUnits);
       }
@@ -1000,14 +1014,12 @@ void ASkaldPlayerController::ServerHandleMove_Implementation(int32 FromID,
     for (ASkaldPlayerController *Controller : TurnManager->GetControllers()) {
       if (USkaldMainHUDWidget *HUD =
               Controller ? Controller->GetHUDWidget() : nullptr) {
-        FString SourceOwner = Source->OwningPlayer
-                                  ? Source->OwningPlayer->PlayerDisplayName
-                                  : TEXT("Neutral");
+        const FString SourceOwner =
+            ResolvePlayerName(Source->OwningPlayer, TEXT("ServerHandleMove_Source"));
         HUD->UpdateTerritoryInfo(Source->TerritoryName, SourceOwner,
                                  Source->ArmyUnits);
-        FString TargetOwner = Target->OwningPlayer
-                                  ? Target->OwningPlayer->PlayerDisplayName
-                                  : TEXT("Neutral");
+        const FString TargetOwner =
+            ResolvePlayerName(Target->OwningPlayer, TEXT("ServerHandleMove_Target"));
         HUD->UpdateTerritoryInfo(Target->TerritoryName, TargetOwner,
                                  Target->ArmyUnits);
       }
@@ -1257,8 +1269,8 @@ void ASkaldPlayerController::HandleTerritorySelected(ATerritory *Terr) {
     return;
   }
 
-  FString OwnerName = Terr->OwningPlayer ? Terr->OwningPlayer->PlayerDisplayName
-                                         : TEXT("Neutral");
+  const FString OwnerName =
+      ResolvePlayerName(Terr->OwningPlayer, TEXT("HandleTerritorySelected"));
   MainHUD->UpdateTerritoryInfo(Terr->TerritoryName, OwnerName,
                                      Terr->ArmyUnits);
   MainHUD->OnTerritoryClickedUI(Terr);
@@ -1311,7 +1323,7 @@ void ASkaldPlayerController::BuildPlayerDataArray(
     if (ASkaldPlayerState *PS = Cast<ASkaldPlayerState>(PSBase)) {
       FS_PlayerData Data;
       Data.PlayerID = PS->GetPlayerId();
-      Data.PlayerName = PS->PlayerDisplayName;
+      Data.PlayerName = PS->GetResolvedPlayerName(TEXT("BuildPlayerDataArray"));
       Data.IsAI = PS->bIsAI;
       Data.Faction = PS->Faction;
       Data.Resources = PS->Resources;
@@ -1374,9 +1386,8 @@ void ASkaldPlayerController::HandleWorldStateChanged() {
   if (AWorldMap *WorldMap = Cast<AWorldMap>(UGameplayStatics::GetActorOfClass(
           GetWorld(), AWorldMap::StaticClass()))) {
     if (ATerritory *Terr = WorldMap->SelectedTerritory) {
-      FString OwnerName = Terr->OwningPlayer
-                              ? Terr->OwningPlayer->PlayerDisplayName
-                              : TEXT("Neutral");
+      const FString OwnerName = ResolvePlayerName(
+          Terr->OwningPlayer, TEXT("HandleWorldStateChanged"));
       MainHUD->UpdateTerritoryInfo(Terr->TerritoryName, OwnerName,
                                          Terr->ArmyUnits);
     }

--- a/Source/Skald/Skald_PlayerState.cpp
+++ b/Source/Skald/Skald_PlayerState.cpp
@@ -2,6 +2,7 @@
 #include "Engine/World.h"
 #include "EngineUtils.h"
 #include "Net/UnrealNetwork.h"
+#include "Skald.h"
 #include "Skald_GameState.h"
 #include "Skald_PlayerController.h"
 #include "Territory.h"
@@ -9,8 +10,24 @@
 
 ASkaldPlayerState::ASkaldPlayerState()
     : DeployableUnits(0), InitiativeRoll(0), Resources(0),
-      PlayerDisplayName(TEXT("Player")), Faction(ESkaldFaction::None),
-      bIsAI(false), bHasLockedIn(false), IsEliminated(false) {}
+      PlayerDisplayName(TEXT("")), Faction(ESkaldFaction::None), bIsAI(false),
+      bHasLockedIn(false), IsEliminated(false) {}
+
+FString ASkaldPlayerState::GetResolvedPlayerName(const TCHAR *Context) const {
+  FString Name = GetPlayerName();
+  if (Name.IsEmpty()) {
+    Name = PlayerDisplayName;
+  }
+
+  if (Name.IsEmpty()) {
+    UE_LOG(LogSkald, Warning,
+           TEXT("%s: PlayerState %s missing assigned name"), Context,
+           *GetName());
+    Name = TEXT("Unknown");
+  }
+
+  return Name;
+}
 
 void ASkaldPlayerState::GetLifetimeReplicatedProps(
     TArray<FLifetimeProperty> &OutLifetimeProps) const {

--- a/Source/Skald/Skald_PlayerState.h
+++ b/Source/Skald/Skald_PlayerState.h
@@ -16,6 +16,10 @@ class SKALD_API ASkaldPlayerState : public APlayerState {
 public:
   ASkaldPlayerState();
 
+  /** Retrieve the player name, logging if none has been assigned. */
+  FString GetResolvedPlayerName(const TCHAR *Context = TEXT("SkaldPlayerState"))
+      const;
+
   /** Deployable units available for placement. */
   UPROPERTY(BlueprintReadWrite, ReplicatedUsing = OnRep_DeployableUnits,
             Category = "PlayerState")

--- a/Source/Skald/Skald_TurnManager.cpp
+++ b/Source/Skald/Skald_TurnManager.cpp
@@ -15,6 +15,17 @@
 #include "UI/SkaldMainHUDWidget.h"
 #include "WorldMap.h"
 
+namespace {
+FString GetResolvedPlayerName(const ASkaldPlayerState *PlayerState,
+                              const TCHAR *Context) {
+  if (!PlayerState) {
+    return TEXT("Unknown");
+  }
+
+  return PlayerState->GetResolvedPlayerName(Context);
+}
+} // namespace
+
 ATurnManager::ATurnManager() {
   PrimaryActorTick.bCanEverTick = false;
   bReplicates = true;
@@ -231,7 +242,8 @@ void ATurnManager::StartTurns(ASkaldPlayerController *StartingController) {
   }
 
   ASkaldPlayerState *PS = CurrentController->GetPlayerState<ASkaldPlayerState>();
-  const FString PlayerName = PS ? PS->PlayerDisplayName : TEXT("Unknown");
+  const FString PlayerName =
+      GetResolvedPlayerName(PS, TEXT("StartTurns_Current"));
   ApplyReinforcementsAndResources(PS, TEXT("StartTurns"));
 
   CurrentPhase = ETurnPhase::Reinforcement;
@@ -285,7 +297,8 @@ void ATurnManager::AdvanceTurn() {
   if (PreviousController) {
     if (ASkaldPlayerState *PrevPS =
             PreviousController->GetPlayerState<ASkaldPlayerState>()) {
-      PreviousPlayerName = PrevPS->PlayerDisplayName;
+      PreviousPlayerName =
+          GetResolvedPlayerName(PrevPS, TEXT("AdvanceTurn_Previous"));
     }
   }
 
@@ -322,7 +335,8 @@ void ATurnManager::AdvanceTurn() {
           Controllers[CurrentIndex].Get()) {
     ASkaldPlayerState *PS =
         CurrentController->GetPlayerState<ASkaldPlayerState>();
-    const FString PlayerName = PS ? PS->PlayerDisplayName : TEXT("Unknown");
+    const FString PlayerName =
+        GetResolvedPlayerName(PS, TEXT("AdvanceTurn_Current"));
     ApplyReinforcementsAndResources(PS, TEXT("AdvanceTurn"));
 
     CurrentPhase = ETurnPhase::Reinforcement;
@@ -617,8 +631,17 @@ void ATurnManager::ClientBattleResolved_Implementation(
        It; ++It) {
     if (ASkaldPlayerController *PC = Cast<ASkaldPlayerController>(It->Get())) {
       if (USkaldMainHUDWidget *HUD = PC->GetHUDWidget()) {
+        FString WinnerName = TEXT("Unknown");
+        if (ASkaldGameState *GSLocal =
+                GetWorld()->GetGameState<ASkaldGameState>()) {
+          if (ASkaldPlayerState *WinnerPS =
+                  GSLocal->GetPlayerById(WinningPlayerID)) {
+            WinnerName =
+                GetResolvedPlayerName(WinnerPS, TEXT("ClientBattleResolved"));
+          }
+        }
         const FString Msg = FString::Printf(
-            TEXT("Player %d won: A-%d D-%d casualties"), WinningPlayerID,
+            TEXT("%s won: A-%d D-%d casualties"), *WinnerName,
             AttackerCasualties, DefenderCasualties);
         HUD->UpdateInitiativeText(Msg);
       }
@@ -679,6 +702,25 @@ void ATurnManager::AdvancePhase() {
   }
 
   BroadcastCurrentPhase();
+}
+
+void ATurnManager::EndCurrentPhase() {
+  if (const UWorld *W = GetWorld()) {
+    if (const auto *GI = W->GetGameInstance<USkaldGameInstance>()) {
+      if (GI->bTravelPending) {
+        return;
+      }
+    }
+  }
+
+  if (CurrentPhase == ETurnPhase::ArmyPlacement) {
+    if (ASkaldGameMode *GM = GetWorld()->GetAuthGameMode<ASkaldGameMode>()) {
+      GM->AdvanceArmyPlacement();
+    }
+    return;
+  }
+
+  AdvancePhase();
 }
 
 void ATurnManager::BroadcastDeployableUnits(ASkaldPlayerState *ForPlayer) {

--- a/Source/Skald/Skald_TurnManager.h
+++ b/Source/Skald/Skald_TurnManager.h
@@ -50,6 +50,10 @@ public:
   UFUNCTION(BlueprintCallable, Category = "Turn")
   void AdvancePhase();
 
+  /** Resolve the active phase immediately, progressing when appropriate. */
+  UFUNCTION(BlueprintCallable, Category = "Turn")
+  void EndCurrentPhase();
+
   /** Update all players' HUDs with the specified player's deployable units. */
   UFUNCTION(BlueprintCallable, Category = "Turn")
   void BroadcastDeployableUnits(class ASkaldPlayerState *ForPlayer);

--- a/Source/Skald/Territory.cpp
+++ b/Source/Skald/Territory.cpp
@@ -289,8 +289,10 @@ void ATerritory::UpdateLabel() {
     return;
   }
 
-  const FString OwnerName =
-      OwningPlayer ? OwningPlayer->PlayerDisplayName : TEXT("Neutral");
+  const FString OwnerName = OwningPlayer
+                               ? OwningPlayer->GetResolvedPlayerName(
+                                     TEXT("Territory::UpdateLabel"))
+                               : TEXT("Neutral");
   const FString Text = FString::Printf(TEXT("%s\nOwner: %s\nUnits: %d"),
                                        *TerritoryName, *OwnerName, ArmyUnits);
   LabelComponent->SetText(FText::FromString(Text));

--- a/Source/Skald/UI/SkaldMainHUDWidget.cpp
+++ b/Source/Skald/UI/SkaldMainHUDWidget.cpp
@@ -602,7 +602,8 @@ void USkaldMainHUDWidget::HandlePlayersUpdated() {
     if (ASkaldPlayerState *PS = Cast<ASkaldPlayerState>(PSBase)) {
       FS_PlayerData Data;
       Data.PlayerID = PS->GetPlayerId();
-      Data.PlayerName = PS->PlayerDisplayName;
+      Data.PlayerName =
+          PS->GetResolvedPlayerName(TEXT("SkaldMainHUDWidget::RefreshPlayers"));
       Data.IsAI = PS->bIsAI;
       Data.Faction = PS->Faction;
       Players.Add(Data);
@@ -740,7 +741,11 @@ void USkaldMainHUDWidget::HandleAttackApproved() {
             if (Source->OwningPlayer) {
               Battle.AttackerPlayerID = Source->OwningPlayer->GetPlayerId();
               Battle.AttackerFaction = Source->OwningPlayer->Faction;
-              Battle.AttackerDisplayName = Source->OwningPlayer->PlayerDisplayName;
+              Battle.AttackerDisplayName = Source->OwningPlayer
+                                                 ? Source->OwningPlayer
+                                                       ->GetResolvedPlayerName(
+                                                           TEXT("HUD_Attack_Attacker"))
+                                                 : TEXT("Neutral");
               Battle.bAttackerIsAI = Source->OwningPlayer->bIsAI;
             }
             if (bUseSiege && Source->BuiltSiegeID > 0) {
@@ -752,7 +757,11 @@ void USkaldMainHUDWidget::HandleAttackApproved() {
             if (Target->OwningPlayer) {
               Battle.DefenderPlayerID = Target->OwningPlayer->GetPlayerId();
               Battle.DefenderFaction = Target->OwningPlayer->Faction;
-              Battle.DefenderDisplayName = Target->OwningPlayer->PlayerDisplayName;
+              Battle.DefenderDisplayName = Target->OwningPlayer
+                                                 ? Target->OwningPlayer
+                                                       ->GetResolvedPlayerName(
+                                                           TEXT("HUD_Attack_Defender"))
+                                                 : TEXT("Neutral");
               Battle.bDefenderIsAI = Target->OwningPlayer->bIsAI;
             }
             Battle.IsCapitalAttack = Target->bIsCapital;

--- a/Source/Skald/WorldMap.cpp
+++ b/Source/Skald/WorldMap.cpp
@@ -437,3 +437,44 @@ bool AWorldMap::IsOwnedBy(const ATerritory *Territory,
   }
   return Territory->OwningPlayer->GetPlayerId() == Player->GetPlayerId();
 }
+
+int32 AWorldMap::AutoPlaceUnitsForAI(ASkaldPlayerState *PlayerState) {
+  if (!PlayerState || PlayerState->DeployableUnits <= 0) {
+    return 0;
+  }
+
+  TArray<ATerritory *> OwnedTerritories;
+  for (ATerritory *Territory : Territories) {
+    if (Territory && Territory->OwningPlayer == PlayerState) {
+      OwnedTerritories.Add(Territory);
+    }
+  }
+
+  if (OwnedTerritories.Num() == 0) {
+    UE_LOG(LogSkald, Warning,
+           TEXT("AutoPlaceUnitsForAI: PlayerState %d owns no territories"),
+           PlayerState->GetPlayerId());
+    return 0;
+  }
+
+  int32 UnitsPlaced = 0;
+  int32 Remaining = PlayerState->DeployableUnits;
+  int32 Index = 0;
+
+  while (Remaining > 0 && OwnedTerritories.Num() > 0) {
+    ATerritory *Target = OwnedTerritories[Index % OwnedTerritories.Num()];
+    if (!Target) {
+      ++Index;
+      continue;
+    }
+
+    ++Target->ArmyUnits;
+    Target->RefreshAppearance();
+    ++UnitsPlaced;
+    --Remaining;
+    ++Index;
+  }
+
+  PlayerState->DeployableUnits = Remaining;
+  return UnitsPlaced;
+}

--- a/Source/Skald/WorldMap.h
+++ b/Source/Skald/WorldMap.h
@@ -137,5 +137,9 @@ public:
   bool IsOwnedBy(const ATerritory *Territory,
                  const ASkaldPlayerState *Player) const;
 
+  /** Automatically distribute remaining deployable units across owned territories. */
+  UFUNCTION(BlueprintCallable, Category = "WorldMap")
+  int32 AutoPlaceUnitsForAI(ASkaldPlayerState *PlayerState);
+
 protected:
 };


### PR DESCRIPTION
## Summary
- cache a pure battle travel snapshot in the game instance and let the battle game mode rehydrate from cached territory data while logging the expected travel diagnostics
- gate battle start on PlayerState readiness, wire fighter selection to populate its roster before the viewport is updated, and keep the overworld HUD off the battle map
- resolve all player-facing names through PlayerState, update territory and HUD labels, and add AI auto-placement with a failsafe timer driven by the turn manager’s new EndCurrentPhase helper

## Testing
- Not run (Unreal build environment unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68d00a93d95883249d6fe5b36f115ab6