### PR TITLE
Prevent recursive battle bootstrap

### DIFF
--- a/Source/Skald/Skald_BattleGameMode.cpp
+++ b/Source/Skald/Skald_BattleGameMode.cpp
@@ -334,9 +334,11 @@ void ASkald_BattleGameMode::SetupPendingBattle() {
   AutoCommitAIArmy(AttackerPS, AttackerBudget);
   AutoCommitAIArmy(DefenderPS, DefenderBudget);
 
-  TryStartBattle();
-
+  // Mark setup complete before attempting to start the battle to avoid
+  // TryStartBattle -> BootstrapFromTravelState -> SetupPendingBattle recursion.
   bPendingBattleSetupComplete = true;
+
+  TryStartBattle();
 }
 
 void ASkald_BattleGameMode::BootstrapFromTravelState() {


### PR DESCRIPTION
## Summary
- set the pending battle setup flag before invoking TryStartBattle
- document the change to avoid the bootstrap/start recursion loop

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d01992dbd48324afbf3bc93317c78f