### PR TITLE
Populate pending battle before travel and improve battle startup

### DIFF
--- a/Source/Skald/Skald_BattleGameMode.cpp
+++ b/Source/Skald/Skald_BattleGameMode.cpp
@@ -299,6 +299,8 @@ void ASkald_BattleGameMode::SetupPendingBattle() {
 
   bBattleLaunched = false;
 
+  UE_LOG(LogSkald, Log, TEXT("BattleGM SetupPendingBattle called"));
+
   USkaldGameInstance *GI = GetGameInstance<USkaldGameInstance>();
   if (!GI || !GI->GridBattleManager) {
     return;
@@ -317,7 +319,52 @@ void ASkald_BattleGameMode::SetupPendingBattle() {
   HasHumanOwnedTerritory(GS, WorldMap, GI, CachedHumanTerritoryIDs,
                          &CachedTerritoryMap);
 
-  const FS_BattlePayload Battle = GI->PendingBattle;
+  FS_BattlePayload Battle = GI->PendingBattle;
+
+  auto IsEmptyBattle = [](const FS_BattlePayload &Payload) {
+    return Payload.AttackerPlayerID <= 0 || Payload.DefenderPlayerID <= 0;
+  };
+
+  if (IsEmptyBattle(Battle)) {
+    const FSkaldTravelState &TravelState = GI->GetTravelState();
+    auto ResolveOwnerId = [&](int32 TerritoryId) -> int32 {
+      if (const FS_Territory *Territory = CachedTerritoryMap.Find(TerritoryId)) {
+        return Territory->OwnerPlayerID;
+      }
+      return 0;
+    };
+
+    Battle.FromTerritoryID = TravelState.AttackerTerritory;
+    Battle.TargetTerritoryID = TravelState.DefenderTerritory;
+    Battle.AttackerPlayerID = ResolveOwnerId(TravelState.AttackerTerritory);
+    Battle.DefenderPlayerID = ResolveOwnerId(TravelState.DefenderTerritory);
+
+    if (ASkaldPlayerState *AttackerState =
+            GS->GetPlayerById(Battle.AttackerPlayerID)) {
+      Battle.AttackerDisplayName = AttackerState->PlayerDisplayName;
+      Battle.AttackerFaction = AttackerState->Faction;
+      Battle.bAttackerIsAI = AttackerState->bIsAI;
+    }
+    if (ASkaldPlayerState *DefenderState =
+            GS->GetPlayerById(Battle.DefenderPlayerID)) {
+      Battle.DefenderDisplayName = DefenderState->PlayerDisplayName;
+      Battle.DefenderFaction = DefenderState->Faction;
+      Battle.bDefenderIsAI = DefenderState->bIsAI;
+    }
+
+    if (Battle.DefenderArmyCount <= 0) {
+      Battle.DefenderArmyCount = Battle.ArmyCountSent;
+    }
+
+    GI->PendingBattle = Battle;
+  }
+
+  UE_LOG(LogSkald, Log,
+         TEXT("BattleGM SetupPendingBattle: AttackerID=%d Name=%s Faction=%d DefenderID=%d Name=%s Faction=%d"),
+         Battle.AttackerPlayerID, *Battle.AttackerDisplayName,
+         static_cast<int32>(Battle.AttackerFaction), Battle.DefenderPlayerID,
+         *Battle.DefenderDisplayName, static_cast<int32>(Battle.DefenderFaction));
+
   ASkaldPlayerState *AttackerPS = EnsureBattleParticipant(
       GS, World, Battle.AttackerPlayerID, Battle.AttackerDisplayName,
       Battle.AttackerFaction, Battle.bAttackerIsAI);
@@ -329,10 +376,22 @@ void ASkald_BattleGameMode::SetupPendingBattle() {
   const int32 DefenderBudget =
       Battle.DefenderArmyCount > 0 ? Battle.DefenderArmyCount : Battle.ArmyCountSent;
 
+  UE_LOG(LogSkald, Log,
+         TEXT("BattleGM: Calling BeginPreBattleSelection (A:%d, D:%d, Budgets %d/%d)"),
+         Battle.AttackerPlayerID, Battle.DefenderPlayerID, AttackerBudget,
+         DefenderBudget);
+
   BeginPreBattleSelection(AttackerPS, DefenderPS, AttackerBudget, DefenderBudget);
 
-  AutoCommitAIArmy(AttackerPS, AttackerBudget);
-  AutoCommitAIArmy(DefenderPS, DefenderBudget);
+  AutoCommitAIArmy(AttackerPS,
+                   AttackerPS && AttackerPS->bIsAI ? AttackerBudget : 0);
+  AutoCommitAIArmy(DefenderPS,
+                   DefenderPS && DefenderPS->bIsAI ? DefenderBudget : 0);
+
+  UE_LOG(LogSkald, Log,
+         TEXT("BattleGM: Selection started (A:%d, D:%d, Budgets %d/%d)"),
+         Battle.AttackerPlayerID, Battle.DefenderPlayerID, AttackerBudget,
+         DefenderBudget);
 
   TryStartBattle();
 
@@ -611,28 +670,22 @@ void ASkald_BattleGameMode::TryStartBattle() {
     }
   }
 
-  const ASkaldGameState *GS = GetGameState<ASkaldGameState>();
-  const int32 PlayerStates = GS ? GS->PlayerArray.Num() : 0;
-  if (ExpectedControllers <= 0 && PlayerStates > 0) {
-    ExpectedControllers = PlayerStates;
+  ASkaldGameState *GS = GetGameState<ASkaldGameState>();
+  if (!GS) {
+    return;
   }
 
-  TSet<int32> ReadyPlayerIDs;
-  for (const TWeakObjectPtr<AController> &WeakController : ReadyControllers) {
-    if (const AController *ReadyController = WeakController.Get()) {
-      if (const APlayerState *PS = ReadyController->PlayerState) {
-        ReadyPlayerIDs.Add(PS->GetPlayerId());
-      }
-    }
+  const int32 ReadyPlayerStates = GS->PlayerArray.Num();
+  if (ExpectedControllers <= 0 && ReadyPlayerStates > 0) {
+    ExpectedControllers = ReadyPlayerStates;
   }
 
-  const int32 ReadyPlayerStates = ReadyPlayerIDs.Num();
-  UE_LOG(LogSkald, Log,
+  const int32 NeededPlayerStates = FMath::Max(2, ExpectedControllers);
+  UE_LOG(LogSkald, Verbose,
          TEXT("TryStartBattle: ReadyPlayerStates=%d Expected=%d"),
-         ReadyPlayerStates, ExpectedControllers);
+         ReadyPlayerStates, NeededPlayerStates);
 
-  if (ExpectedControllers <= 0 || PlayerStates < ExpectedControllers ||
-      ReadyPlayerStates < ExpectedControllers) {
+  if (ReadyPlayerStates < 2) {
     return;
   }
 

--- a/Source/Skald/Skald_PlayerController.cpp
+++ b/Source/Skald/Skald_PlayerController.cpp
@@ -455,11 +455,10 @@ void ASkaldPlayerController::ShowFighterSelectionUI(int32 MaxBudget,
   const TArray<FFighterDefinition> Available =
       UFighterDataLibrary::GetFightersForFaction(this, Faction);
   FighterSelectionWidget->SetAvailableFighters(Available);
-  if (Available.Num() > 0) {
-    UE_LOG(LogSkald, Log,
-           TEXT("SkaldUI: [FighterSelection] Populated %d fighter entries."),
-           Available.Num());
-  } else {
+  UE_LOG(LogSkald, Log,
+         TEXT("FighterSelectionWidget: Populated %d entries for faction %d"),
+         Available.Num(), static_cast<int32>(Faction));
+  if (Available.Num() == 0) {
     UE_LOG(LogSkald, Warning,
            TEXT("SkaldUI: [FighterSelection] No fighters available for faction %d"),
            static_cast<int32>(Faction));

--- a/Source/Skald/Skald_TurnManager.cpp
+++ b/Source/Skald/Skald_TurnManager.cpp
@@ -402,7 +402,6 @@ void ATurnManager::TriggerGridBattle(const FS_BattlePayload &Battle) {
 
   if (USkaldGameInstance *GI = GetGameInstance<USkaldGameInstance>()) {
     GI->SeedCombatRandomStream(SeededBattle.RandomSeed);
-    GI->PendingBattle = SeededBattle;
     GI->PendingBattleResolution = FGridBattleResolution();
     GI->bPendingBattleResolution = false;
     if (!GI->GridBattleManager) {
@@ -456,6 +455,57 @@ void ATurnManager::TriggerGridBattle(const FS_BattlePayload &Battle) {
       }
 
       GI->SetTravelState(TravelState);
+
+      FS_BattlePayload PendingPayload = SeededBattle;
+
+      auto ResolveOwnerPS = [&](int32 TerritoryId) -> ASkaldPlayerState * {
+        if (CachedWorldMap) {
+          for (ATerritory *Territory : CachedWorldMap->Territories) {
+            if (Territory && Territory->TerritoryID == TerritoryId) {
+              return Territory->OwningPlayer;
+            }
+          }
+        }
+        for (const FS_Territory &Territory : GI->CachedWorldMapTerritories) {
+          if (Territory.TerritoryID == TerritoryId) {
+            if (ASkaldGameState *GS = GetGameState<ASkaldGameState>()) {
+              return GS->GetPlayerById(Territory.OwnerPlayerID);
+            }
+          }
+        }
+        return nullptr;
+      };
+
+      ASkaldPlayerState *AttPS =
+          ResolveOwnerPS(TravelState.AttackerTerritory);
+      ASkaldPlayerState *DefPS =
+          ResolveOwnerPS(TravelState.DefenderTerritory);
+
+      PendingPayload.AttackerPlayerID =
+          AttPS ? AttPS->GetPlayerId() : PendingPayload.AttackerPlayerID;
+      PendingPayload.DefenderPlayerID =
+          DefPS ? DefPS->GetPlayerId() : PendingPayload.DefenderPlayerID;
+      PendingPayload.AttackerDisplayName = AttPS
+                                               ? AttPS->PlayerDisplayName
+                                               : PendingPayload.AttackerDisplayName;
+      PendingPayload.DefenderDisplayName = DefPS
+                                               ? DefPS->PlayerDisplayName
+                                               : PendingPayload.DefenderDisplayName;
+      PendingPayload.AttackerFaction = AttPS ? AttPS->Faction
+                                             : PendingPayload.AttackerFaction;
+      PendingPayload.DefenderFaction = DefPS ? DefPS->Faction
+                                             : PendingPayload.DefenderFaction;
+      PendingPayload.bAttackerIsAI = AttPS ? AttPS->bIsAI
+                                           : PendingPayload.bAttackerIsAI;
+      PendingPayload.bDefenderIsAI = DefPS ? DefPS->bIsAI
+                                           : PendingPayload.bDefenderIsAI;
+
+      if (PendingPayload.DefenderArmyCount <= 0) {
+        PendingPayload.DefenderArmyCount = PendingPayload.ArmyCountSent;
+      }
+
+      PendingBattle = PendingPayload;
+      GI->PendingBattle = PendingPayload;
       GI->SetTravelPending(true);
       GI->bIsInBattleMap = true;
     }
@@ -782,7 +832,7 @@ void ATurnManager::BroadcastResources(ASkaldPlayerState *ForPlayer) {
 void ATurnManager::BroadcastCurrentPhase() {
   if (const UWorld *W = GetWorld()) {
     if (const auto *GI = W->GetGameInstance<USkaldGameInstance>()) {
-      if (GI->bTravelPending) {
+      if (GI->bTravelPending || GI->bIsInBattleMap) {
         return;
       }
     }


### PR DESCRIPTION
## Summary
- seed and cache the pending battle payload on the overworld before travelling, resolving territory owners and suppressing turn broadcasts while in a battle map
- rebuild missing battle payload data on the battle game mode, kick off selection for both sides with detailed logging, and gate battle launch on available player states
- log the number of fighter entries pushed to the selection UI for debugging

## Testing
- not run (Unreal build not available in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68d01c40c1e08324a9c2852414a0b1f6