### PR TITLE
Fix TurnManager cached territory game state lookup

### DIFF
--- a/Source/Skald/Skald_TurnManager.cpp
+++ b/Source/Skald/Skald_TurnManager.cpp
@@ -468,8 +468,11 @@ void ATurnManager::TriggerGridBattle(const FS_BattlePayload &Battle) {
         }
         for (const FS_Territory &Territory : GI->CachedWorldMapTerritories) {
           if (Territory.TerritoryID == TerritoryId) {
-            if (ASkaldGameState *GS = GetGameState<ASkaldGameState>()) {
-              return GS->GetPlayerById(Territory.OwnerPlayerID);
+            if (UWorld *World = GetWorld()) {
+              if (ASkaldGameState *GS =
+                      World->GetGameState<ASkaldGameState>()) {
+                return GS->GetPlayerById(Territory.OwnerPlayerID);
+              }
             }
           }
         }


### PR DESCRIPTION
## Summary
- ensure TurnManager resolves cached territory owners via the world game state before accessing player data

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d027214b1083248147d72e79acc442