### PR TITLE
Fix controller readiness path and resolve shadowing

### DIFF
--- a/Source/Skald/Skald_AIController.cpp
+++ b/Source/Skald/Skald_AIController.cpp
@@ -1,5 +1,7 @@
 #include "Skald_AIController.h"
+#include "AIController.h"
 #include "Engine/World.h"
+#include "GameFramework/Controller.h"
 #include "Kismet/GameplayStatics.h"
 #include "Skald.h"
 #include "Skald_BattleGameMode.h"
@@ -21,7 +23,7 @@ void ASkaldAIController::BeginPlay() {
   if (UWorld *World = GetWorld()) {
     if (ASkald_BattleGameMode *BattleGM =
             World->GetAuthGameMode<ASkald_BattleGameMode>()) {
-      BattleGM->OnAIControllerReady(this);
+      BattleGM->OnControllerReady(this);
     }
   }
 }

--- a/Source/Skald/Skald_BattleGameMode.cpp
+++ b/Source/Skald/Skald_BattleGameMode.cpp
@@ -658,8 +658,6 @@ void ASkald_BattleGameMode::PostLogin(APlayerController *NewPlayer) {
 }
 
 void ASkald_BattleGameMode::OnAIControllerReady(AAIController *Controller) {
-  UE_LOG(LogSkald, Log, TEXT("BattleGM OnAIControllerReady: %s"),
-         *GetNameSafe(Controller));
   OnControllerReady(Controller);
 }
 

--- a/Source/Skald/Skald_TurnManager.cpp
+++ b/Source/Skald/Skald_TurnManager.cpp
@@ -442,8 +442,8 @@ void ATurnManager::TriggerGridBattle(const FS_BattlePayload &Battle) {
     TravelState.AttackerTerritory = SeededBattle.FromTerritoryID;
     TravelState.DefenderTerritory = SeededBattle.TargetTerritoryID;
 
-    auto AppendHumanOwnership = [&](ASkaldPlayerState *Owner, int32 TerritoryID) {
-      if (Owner && !Owner->bIsAI && TerritoryID > 0) {
+    auto AppendHumanOwnership = [&](ASkaldPlayerState *OwnerPS, int32 TerritoryID) {
+      if (OwnerPS && !OwnerPS->bIsAI && TerritoryID > 0) {
         TravelState.HumanOwnedTerritories.AddUnique(TerritoryID);
       }
     };
@@ -456,13 +456,13 @@ void ATurnManager::TriggerGridBattle(const FS_BattlePayload &Battle) {
           continue;
         }
 
-        ASkaldPlayerState *Owner = Territory->OwningPlayer;
-        AppendHumanOwnership(Owner, Territory->TerritoryID);
+        ASkaldPlayerState *OwnerPS = Territory->OwningPlayer;
+        AppendHumanOwnership(OwnerPS, Territory->TerritoryID);
 
         FS_Territory Snapshot;
         Snapshot.TerritoryID = Territory->TerritoryID;
         Snapshot.TerritoryName = Territory->TerritoryName;
-        Snapshot.OwnerPlayerID = Owner ? Owner->GetPlayerId() : 0;
+        Snapshot.OwnerPlayerID = OwnerPS ? OwnerPS->GetPlayerId() : 0;
         Snapshot.IsCapital = Territory->bIsCapital;
         Snapshot.CapitalOwner = Snapshot.OwnerPlayerID;
         Snapshot.ArmyUnits = Territory->ArmyUnits;
@@ -483,8 +483,8 @@ void ATurnManager::TriggerGridBattle(const FS_BattlePayload &Battle) {
       TerritorySnapshots = GI->CachedWorldMapTerritories;
       for (const FS_Territory &Snapshot : TerritorySnapshots) {
         if (Snapshot.OwnerPlayerID > 0 && GS) {
-          if (ASkaldPlayerState *Owner = GS->GetPlayerById(Snapshot.OwnerPlayerID)) {
-            AppendHumanOwnership(Owner, Snapshot.TerritoryID);
+          if (ASkaldPlayerState *OwnerPS = GS->GetPlayerById(Snapshot.OwnerPlayerID)) {
+            AppendHumanOwnership(OwnerPS, Snapshot.TerritoryID);
           }
         }
       }


### PR DESCRIPTION
## Summary
- route AI readiness through the shared controller hook in the battle game mode
- adjust the AI controller to invoke the generic readiness entry point and include required headers
- rename local owner variables in the turn manager to avoid shadowing warnings

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d19342215083248b82caaab35a7965