### PR TITLE
Refactor LogSkaldBattle category setup

### DIFF
--- a/Source/Skald/SkaldLogging.h
+++ b/Source/Skald/SkaldLogging.h
@@ -1,0 +1,5 @@
+#pragma once
+
+#include "CoreMinimal.h"
+
+DECLARE_LOG_CATEGORY_EXTERN(LogSkaldBattle, Log, All);

--- a/Source/Skald/Skald_BattleGameMode.cpp
+++ b/Source/Skald/Skald_BattleGameMode.cpp
@@ -1,6 +1,5 @@
 #include "Skald_BattleGameMode.h"
-
-DEFINE_LOG_CATEGORY(LogSkaldBattle);
+#include "SkaldLogging.h"
 
 #include "Algo/RandomShuffle.h"
 #include "Algo/Sort.h"

--- a/Source/Skald/Skald_BattleGameMode.h
+++ b/Source/Skald/Skald_BattleGameMode.h
@@ -4,12 +4,11 @@
 #include "Skald_GameMode.h"
 #include "SkaldTypes.h"
 #include "AIController.h"
+#include "SkaldLogging.h"
 #include "Skald_BattleGameMode.generated.h"
 
 class AAIController;
 class AController;
-
-DECLARE_LOG_CATEGORY_EXTERN(LogSkaldBattle, Log, All);
 
 /** GameMode dedicated to resolving grid-based battles. */
 UCLASS()

--- a/Source/Skald/Skald_GameState.cpp
+++ b/Source/Skald/Skald_GameState.cpp
@@ -3,8 +3,9 @@
 #include "Net/UnrealNetwork.h"
 #include "Skald_PlayerController.h"
 #include "Engine/World.h"
+#include "SkaldLogging.h"
 
-DECLARE_LOG_CATEGORY_EXTERN(LogSkaldBattle, Log, All);
+DEFINE_LOG_CATEGORY(LogSkaldBattle);
 
 ASkaldGameState::ASkaldGameState()
     : CurrentTurnIndex(0)

--- a/Source/Skald/Skald_PlayerController.cpp
+++ b/Source/Skald/Skald_PlayerController.cpp
@@ -19,6 +19,7 @@
 #include "Skald_GameInstance.h"
 #include "Skald_GameMode.h"
 #include "Skald_BattleGameMode.h"
+#include "SkaldLogging.h"
 #include "Skald_GameState.h"
 #include "Skald_PlayerState.h"
 #include "Skald_TurnManager.h"


### PR DESCRIPTION
## Summary
- add a shared SkaldLogging header that declares the LogSkaldBattle category
- define the category once in Skald_GameState.cpp and include the header where needed
- update call sites to include the shared header instead of redefining the category

## Testing
- not run (Unreal Engine build environment unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68d1c19b325c83248e042569e5cac502