### PR TITLE
Fix shadowing of PendingControllers local variable

### DIFF
--- a/Source/Skald/Skald_BattleGameMode.cpp
+++ b/Source/Skald/Skald_BattleGameMode.cpp
@@ -441,11 +441,11 @@ void ASkald_BattleGameMode::ProcessDeferredControllers() {
     return;
   }
 
-  TArray<TWeakObjectPtr<AController>> PendingControllers =
+  TArray<TWeakObjectPtr<AController>> LocalPendingControllers =
       DeferredReadyControllers;
   DeferredReadyControllers.Reset();
 
-  for (const TWeakObjectPtr<AController> &WeakController : PendingControllers) {
+  for (const TWeakObjectPtr<AController> &WeakController : LocalPendingControllers) {
     if (AController *Controller = WeakController.Get()) {
       OnControllerReady(Controller);
     }


### PR DESCRIPTION
## Summary
- rename the local PendingControllers array in ProcessDeferredControllers to LocalPendingControllers to avoid shadowing the class member

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d22fbb6f408324bf5bc51e9e1d3582