### PR TITLE
Implement server lock-in flow for fighter selection

### DIFF
--- a/Source/Skald/Skald_BattleGameMode.cpp
+++ b/Source/Skald/Skald_BattleGameMode.cpp
@@ -553,6 +553,42 @@ void ASkald_BattleGameMode::ProcessDeferredControllers() {
   }
 }
 
+void ASkald_BattleGameMode::BeginPreBattleSelection(ASkaldPlayerState *AttackerPS,
+                                                    ASkaldPlayerState *DefenderPS,
+                                                    int32 AttackerBudget,
+                                                    int32 DefenderBudget)
+{
+  if (!HasAuthority()) {
+    return;
+  }
+
+  if (AttackerPS) {
+    AttackerPS->PendingArmyBudget = AttackerBudget;
+    AttackerPS->PendingArmy.Reset();
+    AttackerPS->bArmyLockedIn = false;
+
+    if (!AttackerPS->bIsAI) {
+      if (ASkaldPlayerController *APC =
+              Cast<ASkaldPlayerController>(AttackerPS->GetOwner())) {
+        APC->Client_ShowFighterSelection(AttackerBudget, AttackerPS->Faction);
+      }
+    }
+  }
+
+  if (DefenderPS) {
+    DefenderPS->PendingArmyBudget = DefenderBudget;
+    DefenderPS->PendingArmy.Reset();
+    DefenderPS->bArmyLockedIn = false;
+
+    if (!DefenderPS->bIsAI) {
+      if (ASkaldPlayerController *DPC =
+              Cast<ASkaldPlayerController>(DefenderPS->GetOwner())) {
+        DPC->Client_ShowFighterSelection(DefenderBudget, DefenderPS->Faction);
+      }
+    }
+  }
+}
+
 void ASkald_BattleGameMode::SetupPendingBattle() {
   if (!HasAuthority()) {
     return;
@@ -742,6 +778,8 @@ void ASkald_BattleGameMode::SetupPendingBattle() {
     return;
   }
 
+  LockedInPlayers.Reset();
+
   BeginPreBattleSelection(AttackerPS, DefenderPS, AttackerBudget, DefenderBudget);
   UE_LOG(LogSkaldBattle, Log,
          TEXT("BattleGM: BeginPreBattleSelection started (AttackerID=%d DefenderID=%d Budgets=%d/%d)"),
@@ -751,12 +789,21 @@ void ASkald_BattleGameMode::SetupPendingBattle() {
   AutoCommitAIArmy(AttackerPS, AttackerPS->bIsAI ? AttackerBudget : 0);
   AutoCommitAIArmy(DefenderPS, DefenderPS->bIsAI ? DefenderBudget : 0);
 
+  if (AttackerPS && AttackerPS->bIsAI && AttackerPS->bArmyLockedIn) {
+    LockedInPlayers.Add(AttackerPS->GetPlayerId());
+  }
+  if (DefenderPS && DefenderPS->bIsAI && DefenderPS->bArmyLockedIn) {
+    LockedInPlayers.Add(DefenderPS->GetPlayerId());
+  }
+
   bSetupCompleted = true;
   GI->PendingBattle = Battle;
 
-  GS->SetBattlePhase(EBattlePhase::Deploy);
+  TryAdvanceAfterLockIn();
 
-  UE_LOG(LogSkaldBattle, Log, TEXT("SetupPendingBattle completed. Phase=Deploy"));
+  UE_LOG(LogSkaldBattle, Log,
+         TEXT("SetupPendingBattle completed. Awaiting lock-in (AttackerAI=%d DefenderAI=%d)"),
+         AttackerPS->bIsAI ? 1 : 0, DefenderPS->bIsAI ? 1 : 0);
 
   TryStartBattle();
 }
@@ -1001,6 +1048,7 @@ void ASkald_BattleGameMode::TryLaunchBattle() {
   }
 
   bBattleLaunched = true;
+  LockedInPlayers.Reset();
 }
 
 void ASkald_BattleGameMode::TryInitializeWorldAndStart() {
@@ -1134,5 +1182,174 @@ void ASkald_BattleGameMode::TryStartBattle() {
   }
 
   TryLaunchBattle();
+}
+
+void ASkald_BattleGameMode::HandleHumanLockIn(
+    ASkaldPlayerController *PC,
+    const TArray<FFighterDefinition> &SelectedFighters)
+{
+  if (!PC) {
+    return;
+  }
+
+  ASkaldPlayerState *PS = PC->GetPlayerState<ASkaldPlayerState>();
+  if (!PS) {
+    PC->Client_OnLockInResult(false, TEXT("No PlayerState"));
+    return;
+  }
+
+  if (PS->bIsAI) {
+    PC->Client_OnLockInResult(false, TEXT("AI controllers cannot lock in"));
+    return;
+  }
+
+  USkaldGameInstance *GI = GetGameInstance<USkaldGameInstance>();
+  if (!GI) {
+    PC->Client_OnLockInResult(false, TEXT("GameInstance unavailable"));
+    return;
+  }
+
+  const FS_BattlePayload &Battle = GI->PendingBattle;
+  const int32 PlayerId = PS->GetPlayerId();
+  if (PlayerId != Battle.AttackerPlayerID &&
+      PlayerId != Battle.DefenderPlayerID) {
+    PC->Client_OnLockInResult(false, TEXT("Not part of pending battle"));
+    return;
+  }
+
+  if (LockedInPlayers.Contains(PlayerId)) {
+    PC->Client_OnLockInResult(true, TEXT("Already locked"));
+    return;
+  }
+
+  FString FailureReason;
+  if (!ValidateAndRecordSelection(PS, SelectedFighters, FailureReason)) {
+    UE_LOG(LogSkaldBattle, Warning,
+           TEXT("HandleHumanLockIn: validation failed for PlayerId=%d (%s)"),
+           PlayerId, *FailureReason);
+    PC->Client_OnLockInResult(false, FailureReason);
+    return;
+  }
+
+  LockedInPlayers.Add(PlayerId);
+  UE_LOG(LogSkaldBattle, Log,
+         TEXT("HandleHumanLockIn: PlayerId=%d locked selection"), PlayerId);
+  PC->Client_OnLockInResult(true, TEXT("Committed"));
+
+  TryAdvanceAfterLockIn();
+}
+
+bool ASkald_BattleGameMode::AreBothParticipantsLocked() const
+{
+  const USkaldGameInstance *GI = GetGameInstance<USkaldGameInstance>();
+  if (!GI) {
+    return false;
+  }
+
+  const FS_BattlePayload &Battle = GI->PendingBattle;
+  if (Battle.AttackerPlayerID <= 0 || Battle.DefenderPlayerID <= 0) {
+    return LockedInPlayers.Num() >= 2;
+  }
+
+  return LockedInPlayers.Contains(Battle.AttackerPlayerID) &&
+         LockedInPlayers.Contains(Battle.DefenderPlayerID);
+}
+
+void ASkald_BattleGameMode::TryAdvanceAfterLockIn()
+{
+  if (!AreBothParticipantsLocked()) {
+    return;
+  }
+
+  if (ASkaldGameState *GS = GetGameState<ASkaldGameState>()) {
+    if (GS->BattlePhase != EBattlePhase::Deploy) {
+      UE_LOG(LogSkaldBattle, Log,
+             TEXT("Both participants locked in -> advancing to Deploy"));
+    }
+    GS->SetBattlePhase(EBattlePhase::Deploy);
+  } else {
+    UE_LOG(LogSkaldBattle, Warning,
+           TEXT("TryAdvanceAfterLockIn: GameState unavailable"));
+  }
+
+  TryStartBattle();
+}
+
+bool ASkald_BattleGameMode::ValidateAndRecordSelection(
+    ASkaldPlayerState *PlayerState,
+    const TArray<FFighterDefinition> &SelectedFighters,
+    FString &OutReason)
+{
+  OutReason.Reset();
+
+  if (!PlayerState) {
+    OutReason = TEXT("Invalid player");
+    return false;
+  }
+
+  if (!BattleManager) {
+    OutReason = TEXT("Battle data unavailable");
+    return false;
+  }
+
+  const int32 Budget = PlayerState->PendingArmyBudget;
+  if (SelectedFighters.Num() == 0 && Budget > 0) {
+    OutReason = TEXT("No fighters selected");
+    return false;
+  }
+
+  TArray<FFighterDefinition> Available =
+      BattleManager->GetFightersForFaction(PlayerState->Faction);
+  TMap<FName, FFighterDefinition> AvailableById;
+  AvailableById.Reserve(Available.Num());
+  for (const FFighterDefinition &Def : Available) {
+    AvailableById.Add(Def.Id, Def);
+  }
+
+  TArray<FFighterDefinition> ValidSelection;
+  ValidSelection.Reserve(SelectedFighters.Num());
+  int32 TotalCost = 0;
+
+  for (const FFighterDefinition &Requested : SelectedFighters) {
+    const FName FighterId = Requested.Id;
+    if (FighterId.IsNone()) {
+      OutReason = TEXT("Invalid fighter in selection");
+      break;
+    }
+
+    const FFighterDefinition *Canonical = AvailableById.Find(FighterId);
+    if (!Canonical) {
+      OutReason = TEXT("Invalid fighter in selection");
+      break;
+    }
+
+    const int32 Cost = FMath::Max(Canonical->Stats.ArmyCost, 0);
+    if (Budget >= 0 && TotalCost + Cost > Budget) {
+      OutReason = TEXT("Selection exceeds budget");
+      break;
+    }
+
+    ValidSelection.Add(*Canonical);
+    TotalCost += Cost;
+  }
+
+  if (!OutReason.IsEmpty()) {
+    return false;
+  }
+
+  if (Budget >= 0 && TotalCost > Budget) {
+    OutReason = TEXT("Selection exceeds budget");
+    return false;
+  }
+
+  PlayerState->PendingArmy = MoveTemp(ValidSelection);
+  PlayerState->bArmyLockedIn = true;
+
+  UE_LOG(LogSkaldBattle, Log,
+         TEXT("ValidateAndRecordSelection: Player %d locked in %d fighters (Cost=%d / Budget=%d)"),
+         PlayerState->GetPlayerId(), PlayerState->PendingArmy.Num(), TotalCost,
+         Budget);
+
+  return true;
 }
 

--- a/Source/Skald/Skald_BattleGameMode.h
+++ b/Source/Skald/Skald_BattleGameMode.h
@@ -22,6 +22,13 @@ public:
   // Returns true once we’ve detected at least two valid controllers and kicked off setup.
   bool TrySetupBattleWhenReady();
 
+  void BeginPreBattleSelection(class ASkaldPlayerState* AttackerPS,
+                               class ASkaldPlayerState* DefenderPS,
+                               int32 AttackerBudget, int32 DefenderBudget);
+
+  void HandleHumanLockIn(class ASkaldPlayerController* PC,
+                         const TArray<FFighterDefinition>& SelectedFighters);
+
 protected:
   virtual void InitGame(const FString &Map, const FString &Options,
                         FString &Error) override;
@@ -41,6 +48,12 @@ private:
   void AutoCommitAIArmy(ASkaldPlayerState *PlayerState, int32 Budget) const;
   void SpawnFighterSide(const TArray<FFighterDefinition> &Roster, bool bAsAttacker);
   void TryStartBattle();
+
+  bool AreBothParticipantsLocked() const;
+  void TryAdvanceAfterLockIn();
+  bool ValidateAndRecordSelection(ASkaldPlayerState *PlayerState,
+                                  const TArray<FFighterDefinition> &SelectedFighters,
+                                  FString &OutReason);
 
   bool IsSoloMatch() const;
   void PollBattleBootstrap();
@@ -72,5 +85,8 @@ private:
 
   /** Ensure we only log the cache restoration message once. */
   bool bLoggedTravelCache = false;
+
+  /** Tracks which participant player IDs have finalised their selection. */
+  TSet<int32> LockedInPlayers;
 };
 

--- a/Source/Skald/Skald_PlayerController.cpp
+++ b/Source/Skald/Skald_PlayerController.cpp
@@ -461,13 +461,11 @@ void ASkaldPlayerController::ShowFighterSelectionUI(int32 MaxBudget,
     return;
   }
 
-  FighterSelectionWidget->OnLockedIn.RemoveAll(this);
-  FighterSelectionWidget->OnLockedIn.AddDynamic(
-      this, &ASkaldPlayerController::HandleFighterSelectionLockedIn);
   FighterSelectionWidget->PlayerFaction = Faction;
   FighterSelectionWidget->MaxCost = MaxBudget;
   FighterSelectionWidget->ChosenFighters.Reset();
   FighterSelectionWidget->CurrentCost = 0;
+  FighterSelectionWidget->SetLockInButtonEnabled(true);
   const TArray<FFighterDefinition> Available =
       UFighterDataLibrary::GetFightersForFaction(this, Faction);
   FighterSelectionWidget->SetAvailableFighters(Available);
@@ -511,11 +509,58 @@ void ASkaldPlayerController::Client_ShowDeployUI_Implementation() {
   ShowDeployUIInternal();
 }
 
+void ASkaldPlayerController::Server_LockInSelection_Implementation(
+    const TArray<FFighterDefinition> &SelectedFighters)
+{
+  UE_LOG(LogSkaldBattle, Log,
+         TEXT("Server_LockInSelection: %s sent %d fighters"), *GetName(),
+         SelectedFighters.Num());
+
+  if (ASkald_BattleGameMode *GameMode =
+          GetWorld()->GetAuthGameMode<ASkald_BattleGameMode>())
+  {
+    GameMode->HandleHumanLockIn(this, SelectedFighters);
+  }
+}
+
+void ASkaldPlayerController::Client_OnLockInResult_Implementation(
+    bool bSuccess, const FString &Reason)
+{
+  UE_LOG(LogSkaldUI, Log, TEXT("LockIn result: %s (%s)"),
+         bSuccess ? TEXT("SUCCESS") : TEXT("FAIL"), *Reason);
+
+  if (!bSuccess)
+  {
+    if (!Reason.IsEmpty())
+    {
+      UE_LOG(LogSkaldUI, Warning, TEXT("LockIn failed: %s"), *Reason);
+    }
+
+    if (IsLocalController() && GEngine && !Reason.IsEmpty())
+    {
+      GEngine->AddOnScreenDebugMessage(-1, 5.f, FColor::Red, Reason);
+    }
+
+    if (FighterSelectionWidget)
+    {
+      FighterSelectionWidget->SetLockInButtonEnabled(true);
+    }
+    return;
+  }
+
+  HandleFighterSelectionLockedIn();
+}
+
 void ASkaldPlayerController::HandleBattlePhaseChanged() {
   if (const ASkaldGameState *SGS =
           GetWorld() ? GetWorld()->GetGameState<ASkaldGameState>() : nullptr) {
     if (SGS->BattlePhase == EBattlePhase::Deploy) {
       if (HasAuthority()) {
+        if (const ASkaldPlayerState *PS = GetPlayerState<ASkaldPlayerState>()) {
+          if (PS->bIsAI) {
+            return;
+          }
+        }
         Client_ShowDeployUI();
       } else {
         ShowDeployUIInternal();
@@ -1509,18 +1554,10 @@ void ASkaldPlayerController::HandleFactionLockedIn() {
 }
 
 void ASkaldPlayerController::HandleFighterSelectionLockedIn() {
-  if (!FighterSelectionWidget) {
-    return;
+  if (UFighterSelectionWidget *Selection = FighterSelectionWidget) {
+    Selection->RemoveFromParent();
+    FighterSelectionWidget = nullptr;
   }
-
-  UFighterSelectionWidget *Selection = FighterSelectionWidget;
-  Selection->OnLockedIn.RemoveDynamic(
-      this, &ASkaldPlayerController::HandleFighterSelectionLockedIn);
-  const TArray<FFighterDefinition> LockedFighters = Selection->ChosenFighters;
-  Selection->RemoveFromParent();
-  FighterSelectionWidget = nullptr;
-
-  Server_CommitArmy(LockedFighters);
 
   bBattleHUDReadyToShow = true;
 

--- a/Source/Skald/Skald_PlayerController.h
+++ b/Source/Skald/Skald_PlayerController.h
@@ -93,6 +93,12 @@ public:
   UFUNCTION(Server, Reliable, WithValidation)
   void Server_CommitArmy(const TArray<FFighterDefinition> &Chosen);
 
+  UFUNCTION(Server, Reliable)
+  void Server_LockInSelection(const TArray<FFighterDefinition> &SelectedFighters);
+
+  UFUNCTION(Client, Reliable)
+  void Client_OnLockInResult(bool bSuccess, const FString &Reason);
+
   UFUNCTION()
   void HandleBattlePhaseChanged();
 

--- a/Source/Skald/UI/FighterSelectionWidget.cpp
+++ b/Source/Skald/UI/FighterSelectionWidget.cpp
@@ -3,8 +3,27 @@
 #include "Components/Button.h"
 #include "Components/ScrollBox.h"
 #include "Components/TextBlock.h"
+#include "Skald_PlayerController.h"
 
 DEFINE_LOG_CATEGORY_STATIC(LogSkaldUI, Log, All);
+
+bool UFighterSelectionWidget::Initialize()
+{
+  const bool bInitialized = Super::Initialize();
+  if (LockInButton)
+  {
+    LockInButton->OnClicked.Clear();
+    LockInButton->OnClicked.AddDynamic(this, &UFighterSelectionWidget::HandleLockInClicked);
+    LockInButton->SetIsEnabled(true);
+  }
+  else
+  {
+    UE_LOG(LogSkaldUI, Warning,
+           TEXT("FighterSelection: LockInButton not bound (name mismatch?)"));
+  }
+
+  return bInitialized;
+}
 
 void UFighterEntryWidget::NativeConstruct() {
   Super::NativeConstruct();
@@ -66,6 +85,14 @@ void UFighterSelectionWidget::SetAvailableFighters(const TArray<FFighterDefiniti
     PopulateFighterList();
 }
 
+void UFighterSelectionWidget::SetLockInButtonEnabled(bool bEnabled)
+{
+  if (LockInButton)
+  {
+    LockInButton->SetIsEnabled(bEnabled);
+  }
+}
+
 void UFighterSelectionWidget::NativePreConstruct()
 {
     Super::NativePreConstruct();
@@ -82,9 +109,7 @@ void UFighterSelectionWidget::NativeConstruct() {
   Super::NativeConstruct();
   SetIsFocusable(true);
   SetFocus();
-  if (LockInButton) {
-    LockInButton->OnClicked.AddDynamic(this, &UFighterSelectionWidget::LockIn);
-  }
+  SetLockInButtonEnabled(true);
   UpdateCostDisplay();
   PopulateFighterList();
 }
@@ -140,10 +165,43 @@ bool UFighterSelectionWidget::ChooseFighter(const FFighterDefinition &Fighter) {
 }
 
 void UFighterSelectionWidget::LockIn() {
-  // Prevent empty or over-budget lock-ins.
-  if (ChosenFighters.Num() == 0 || CurrentCost > MaxCost) {
+  HandleLockInClicked();
+}
+
+void UFighterSelectionWidget::GatherSelectedFighters(
+    TArray<FFighterDefinition> &OutFighters) const
+{
+  OutFighters.Reset();
+  OutFighters.Append(ChosenFighters);
+}
+
+void UFighterSelectionWidget::HandleLockInClicked()
+{
+  UE_LOG(LogSkaldUI, Log, TEXT("FighterSelection: Lock In clicked (client)"));
+
+  SetLockInButtonEnabled(false);
+
+  TArray<FFighterDefinition> SelectedFighters;
+  GatherSelectedFighters(SelectedFighters);
+
+  bool bSubmitted = false;
+  if (APlayerController *PC = GetOwningPlayer())
+  {
+    if (ASkaldPlayerController *SkaldPC = Cast<ASkaldPlayerController>(PC))
+    {
+      SkaldPC->Server_LockInSelection(SelectedFighters);
+      bSubmitted = true;
+    }
+  }
+
+  if (!bSubmitted)
+  {
+    UE_LOG(LogSkaldUI, Warning,
+           TEXT("FighterSelection: Unable to submit lock-in (no owning player)"));
+    SetLockInButtonEnabled(true);
     return;
   }
+
   OnLockedIn.Broadcast();
 }
 

--- a/Source/Skald/UI/FighterSelectionWidget.h
+++ b/Source/Skald/UI/FighterSelectionWidget.h
@@ -95,6 +95,7 @@ class SKALD_API UFighterSelectionWidget : public UUserWidget {
   GENERATED_BODY()
 
 public:
+  virtual bool Initialize() override;
   virtual void NativeConstruct() override;
   virtual void NativePreConstruct() override;
 
@@ -123,10 +124,6 @@ public:
   UPROPERTY(BlueprintReadOnly, meta = (BindWidgetOptional))
   UScrollBox *FighterList;
 
-  /** Button that finalises the fighter selection. */
-  UPROPERTY(BlueprintReadOnly, meta = (BindWidgetOptional))
-  UButton *LockInButton;
-
   /** Text displaying the current/maximum cost. */
   UPROPERTY(BlueprintReadOnly, meta = (BindWidgetOptional))
   UTextBlock *CostDisplayText;
@@ -151,6 +148,10 @@ public:
   UFUNCTION(BlueprintCallable, Category = "Skald|Fighter")
   void LockIn();
 
+  /** Enable or disable the Lock In button. */
+  UFUNCTION(BlueprintCallable, Category = "Skald|Fighter")
+  void SetLockInButtonEnabled(bool bEnabled);
+
   // Ensure this is PUBLIC (not protected)
   /** Check whether a fighter can be afforded with remaining cost. */
   UFUNCTION(BlueprintCallable, BlueprintPure, Category = "Skald|Fighter")
@@ -168,4 +169,13 @@ public:
   /** Update cost display text from current/max cost. */
   UFUNCTION(BlueprintCallable, Category = "Skald|Fighter")
   void UpdateCostDisplay();
+
+private:
+  UPROPERTY(BlueprintReadOnly, meta = (BindWidget, AllowPrivateAccess = "true"))
+  UButton *LockInButton = nullptr;
+
+  UFUNCTION()
+  void HandleLockInClicked();
+
+  void GatherSelectedFighters(TArray<FFighterDefinition> &OutFighters) const;
 };


### PR DESCRIPTION
## Summary
- submit fighter selections through the lock-in button by calling the player controller RPC and disable the button while awaiting the server
- add server/client RPCs on the player controller to forward selections to the battle game mode and respond to the UI, while avoiding deploy UI calls for AI controllers
- track locked-in players in the battle game mode, validate and record human selections, gate phase transitions on both sides locking in, and prevent fighter selection UI from being shown to AI controllers

## Testing
- not run (Unreal project)

------
https://chatgpt.com/codex/tasks/task_e_68d2c3af24008324b4dc47794b19c4a2