### PR TITLE
Fix log category setup and widget initialization

### DIFF
--- a/Source/Skald/Skald.cpp
+++ b/Source/Skald/Skald.cpp
@@ -3,6 +3,4 @@
 #include "Skald.h"
 #include "Modules/ModuleManager.h"
 
-DEFINE_LOG_CATEGORY(LogSkald);
-
 IMPLEMENT_PRIMARY_GAME_MODULE( FDefaultGameModuleImpl, Skald, "Skald" );

--- a/Source/Skald/SkaldLogging.cpp
+++ b/Source/Skald/SkaldLogging.cpp
@@ -1,0 +1,5 @@
+#include "SkaldLogging.h"
+
+DEFINE_LOG_CATEGORY(LogSkald);
+DEFINE_LOG_CATEGORY(LogSkaldBattle);
+DEFINE_LOG_CATEGORY(LogSkaldUI);

--- a/Source/Skald/SkaldLogging.h
+++ b/Source/Skald/SkaldLogging.h
@@ -2,4 +2,6 @@
 
 #include "CoreMinimal.h"
 
+DECLARE_LOG_CATEGORY_EXTERN(LogSkald, Log, All);
 DECLARE_LOG_CATEGORY_EXTERN(LogSkaldBattle, Log, All);
+DECLARE_LOG_CATEGORY_EXTERN(LogSkaldUI, Log, All);

--- a/Source/Skald/Skald_GameState.cpp
+++ b/Source/Skald/Skald_GameState.cpp
@@ -5,8 +5,6 @@
 #include "Engine/World.h"
 #include "SkaldLogging.h"
 
-DEFINE_LOG_CATEGORY(LogSkaldBattle);
-
 ASkaldGameState::ASkaldGameState()
     : CurrentTurnIndex(0)
 {

--- a/Source/Skald/UI/FighterSelectionWidget.cpp
+++ b/Source/Skald/UI/FighterSelectionWidget.cpp
@@ -3,13 +3,12 @@
 #include "Components/Button.h"
 #include "Components/ScrollBox.h"
 #include "Components/TextBlock.h"
+#include "SkaldLogging.h"
 #include "Skald_PlayerController.h"
-
-DEFINE_LOG_CATEGORY_STATIC(LogSkaldUI, Log, All);
 
 bool UFighterSelectionWidget::Initialize()
 {
-  const bool bInitialized = Super::Initialize();
+  const bool bSuperInitialized = Super::Initialize();
   if (LockInButton)
   {
     LockInButton->OnClicked.Clear();
@@ -22,7 +21,7 @@ bool UFighterSelectionWidget::Initialize()
            TEXT("FighterSelection: LockInButton not bound (name mismatch?)"));
   }
 
-  return bInitialized;
+  return bSuperInitialized;
 }
 
 void UFighterEntryWidget::NativeConstruct() {


### PR DESCRIPTION
## Summary
- avoid shadowing UUserWidget::bInitialized in the fighter selection widget and log when the lock-in button binding is missing
- centralize Skald logging category declarations and definitions, including the UI category used across widgets and controllers

## Testing
- Not run (Unreal build not available in container)

------
https://chatgpt.com/codex/tasks/task_e_68d2d2af95fc8324a03b800123549c9f