### PR TITLE
Normalize logging categories

### DIFF
--- a/Source/Skald/LoadGameWidget.cpp
+++ b/Source/Skald/LoadGameWidget.cpp
@@ -1,5 +1,6 @@
 #include "LoadGameWidget.h"
 #include "Skald.h"
+#include "SkaldLogging.h"
 #include "Components/Button.h"
 #include "Kismet/GameplayStatics.h"
 #include "LobbyMenuWidget.h"

--- a/Source/Skald/SaveGameWidget.cpp
+++ b/Source/Skald/SaveGameWidget.cpp
@@ -3,6 +3,7 @@
 #include "Kismet/GameplayStatics.h"
 #include "LobbyMenuWidget.h"
 #include "Skald.h"
+#include "SkaldLogging.h"
 #include "SkaldSaveGame.h"
 #include "Skald_GameMode.h"
 #include "SlotNameConstants.h"

--- a/Source/Skald/Skald.h
+++ b/Source/Skald/Skald.h
@@ -3,6 +3,5 @@
 #pragma once
 
 #include "CoreMinimal.h"
-
-DECLARE_LOG_CATEGORY_EXTERN(LogSkald, Log, All);
+#include "SkaldLogging.h"
 

--- a/Source/Skald/SkaldLogging.h
+++ b/Source/Skald/SkaldLogging.h
@@ -2,6 +2,7 @@
 
 #include "CoreMinimal.h"
 
+// Declarations ONLY (extern). Do NOT DEFINE here.
 DECLARE_LOG_CATEGORY_EXTERN(LogSkald, Log, All);
 DECLARE_LOG_CATEGORY_EXTERN(LogSkaldBattle, Log, All);
 DECLARE_LOG_CATEGORY_EXTERN(LogSkaldUI, Log, All);

--- a/Source/Skald/Skald_AIController.cpp
+++ b/Source/Skald/Skald_AIController.cpp
@@ -4,6 +4,7 @@
 #include "GameFramework/Controller.h"
 #include "Kismet/GameplayStatics.h"
 #include "Skald.h"
+#include "SkaldLogging.h"
 #include "Skald_BattleGameMode.h"
 #include "Skald_GameMode.h"
 #include "Skald_PlayerState.h"

--- a/Source/Skald/Skald_GameInstance.cpp
+++ b/Source/Skald/Skald_GameInstance.cpp
@@ -3,6 +3,7 @@
 #include "Engine/Engine.h"
 #include "Kismet/GameplayStatics.h"
 #include "Skald.h"
+#include "SkaldLogging.h"
 #include "Blueprint/UserWidget.h"
 #include "Skald_PlayerController.h"
 #include "UI/SkaldUIHelpers.h"

--- a/Source/Skald/Skald_GameMode.cpp
+++ b/Source/Skald/Skald_GameMode.cpp
@@ -7,6 +7,7 @@
 #include "GridBattleManager.h"
 #include "Kismet/GameplayStatics.h"
 #include "Skald.h"
+#include "SkaldLogging.h"
 #include "SkaldSaveGame.h"
 #include "Skald_AIController.h"
 #include "Skald_GameInstance.h"

--- a/Source/Skald/Skald_PlayerCharacter.cpp
+++ b/Source/Skald/Skald_PlayerCharacter.cpp
@@ -1,5 +1,6 @@
 #include "Skald_PlayerCharacter.h"
 #include "Skald.h"
+#include "SkaldLogging.h"
 #include "WorldMap.h"
 #include "Territory.h"
 #include "Skald_PlayerController.h"

--- a/Source/Skald/Skald_PlayerState.cpp
+++ b/Source/Skald/Skald_PlayerState.cpp
@@ -3,6 +3,7 @@
 #include "EngineUtils.h"
 #include "Net/UnrealNetwork.h"
 #include "Skald.h"
+#include "SkaldLogging.h"
 #include "Skald_GameState.h"
 #include "Skald_PlayerController.h"
 #include "Territory.h"

--- a/Source/Skald/Skald_TurnManager.cpp
+++ b/Source/Skald/Skald_TurnManager.cpp
@@ -6,6 +6,7 @@
 #include "Kismet/GameplayStatics.h"
 #include "Net/UnrealNetwork.h"
 #include "Skald.h"
+#include "SkaldLogging.h"
 #include "Skald_GameInstance.h"
 #include "Skald_GameMode.h"
 #include "Skald_GameState.h"

--- a/Source/Skald/Territory.cpp
+++ b/Source/Skald/Territory.cpp
@@ -8,6 +8,7 @@
 #include "Materials/MaterialInterface.h"
 #include "Net/UnrealNetwork.h"
 #include "Skald.h"
+#include "SkaldLogging.h"
 #include "SkaldTypes.h"
 #include "Skald_PlayerController.h"
 #include "Skald_PlayerState.h"

--- a/Source/Skald/UI/SkaldMainHUDWidget.cpp
+++ b/Source/Skald/UI/SkaldMainHUDWidget.cpp
@@ -6,6 +6,7 @@
 #include "Engine/Engine.h"
 #include "Kismet/GameplayStatics.h"
 #include "Skald.h"
+#include "SkaldLogging.h"
 #include "SkaldTypes.h"
 #include "Skald_AIController.h"
 #include "Skald_GameInstance.h"

--- a/Source/Skald/WorldMap.cpp
+++ b/Source/Skald/WorldMap.cpp
@@ -8,6 +8,7 @@
 #include "Engine/World.h"
 #include "Materials/MaterialInterface.h"
 #include "Skald.h"
+#include "SkaldLogging.h"
 #include "Skald_GameMode.h"
 #include "Skald_PlayerState.h"
 #include "Templates/Function.h"


### PR DESCRIPTION
## Summary
- ensure the shared logging header only declares Skald categories and include it from the primary project header
- include SkaldLogging.h in every source file that emits LogSkald, LogSkaldBattle, or LogSkaldUI messages

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d2da8cf420832498ade1228a191cae