### PR TITLE
Fix HUD player ID caching after renumbering

### DIFF
--- a/Source/Skald/Skald_GameMode.cpp
+++ b/Source/Skald/Skald_GameMode.cpp
@@ -816,6 +816,8 @@ void ASkaldGameMode::TryInitializeWorldAndStart() {
     }
   }
 
+  GS->OnPlayersUpdated.Broadcast();
+
   UE_LOG(LogSkald, Log,
          TEXT("TryInitializeWorldAndStart: Listing player lock states"));
   for (APlayerState *PSBase : GS->PlayerArray) {

--- a/Source/Skald/Skald_PlayerState.cpp
+++ b/Source/Skald/Skald_PlayerState.cpp
@@ -95,3 +95,25 @@ void ASkaldPlayerState::OnRep_IsAI() {
     }
   }
 }
+
+void ASkaldPlayerState::OnRep_PlayerId() {
+  Super::OnRep_PlayerId();
+
+  if (APlayerController *PC = GetOwner<APlayerController>()) {
+    if (ASkaldPlayerController *SkaldPC = Cast<ASkaldPlayerController>(PC)) {
+      if (USkaldMainHUDWidget *HUD = SkaldPC->GetHUDWidget()) {
+        const bool bLocalIdChanged = (HUD->LocalPlayerID != GetPlayerId());
+        HUD->LocalPlayerID = GetPlayerId();
+        if (bLocalIdChanged) {
+          HUD->SyncPhaseButtons(HUD->CurrentPlayerID == HUD->LocalPlayerID);
+        }
+      }
+    }
+  }
+
+  if (UWorld *World = GetWorld()) {
+    if (ASkaldGameState *GS = World->GetGameState<ASkaldGameState>()) {
+      GS->OnPlayersUpdated.Broadcast();
+    }
+  }
+}

--- a/Source/Skald/Skald_PlayerState.h
+++ b/Source/Skald/Skald_PlayerState.h
@@ -84,6 +84,9 @@ public:
   UFUNCTION()
   void OnRep_IsAI();
 
+  UFUNCTION()
+  virtual void OnRep_PlayerId() override;
+
   virtual void GetLifetimeReplicatedProps(
       TArray<FLifetimeProperty> &OutLifetimeProps) const override;
 };

--- a/Source/Skald/UI/SkaldMainHUDWidget.cpp
+++ b/Source/Skald/UI/SkaldMainHUDWidget.cpp
@@ -598,6 +598,13 @@ void USkaldMainHUDWidget::HandlePlayersUpdated() {
     return;
   }
 
+  int32 NewLocalPlayerId = LocalPlayerID;
+  if (APlayerController *PC = GetOwningPlayer()) {
+    if (ASkaldPlayerState *LocalPS = PC->GetPlayerState<ASkaldPlayerState>()) {
+      NewLocalPlayerId = LocalPS->GetPlayerId();
+    }
+  }
+
   TArray<FS_PlayerData> Players;
   for (APlayerState *PSBase : GameState->PlayerArray) {
     if (ASkaldPlayerState *PS = Cast<ASkaldPlayerState>(PSBase)) {
@@ -612,6 +619,12 @@ void USkaldMainHUDWidget::HandlePlayersUpdated() {
   }
 
   RefreshPlayerList(Players);
+
+  const bool bLocalIdChanged = (NewLocalPlayerId != LocalPlayerID);
+  LocalPlayerID = NewLocalPlayerId;
+  if (bLocalIdChanged) {
+    SyncPhaseButtons(CurrentPlayerID == LocalPlayerID);
+  }
 }
 
 void USkaldMainHUDWidget::HandleTurnIndexChanged(int32 /*NewTurnIndex*/) {


### PR DESCRIPTION
## Summary
- update Skald player states to broadcast PlayerId changes and refresh owning HUDs when ids are renumbered
- ensure the game mode notifies listeners after compacting player ids
- have the main HUD recalculate the local player id when the player roster updates so turn buttons reflect the new value

## Testing
- not run (Unreal build tooling is unavailable in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68d2edabac748324ba87b15691fdc482