### PR TITLE
Ensure battle HUD initializes when fighters lock in

### DIFF
--- a/Source/Skald/Skald_PlayerController.cpp
+++ b/Source/Skald/Skald_PlayerController.cpp
@@ -650,20 +650,26 @@ void ASkaldPlayerController::InitializeBattleHUD() {
     }
   }
 
-  // Bind to active-fighter changes
-  if (USkaldGameInstance *GI = GetGameInstance<USkaldGameInstance>()) {
-    if (GI->GridBattleManager) {
-      GI->GridBattleManager->OnActiveFighterChanged.RemoveAll(this);
-      GI->GridBattleManager->OnActiveFighterChanged.AddDynamic(
-          this, &ASkaldPlayerController::HandleActiveFighterChanged);
-      GI->GridBattleManager->OnBattleEnded.RemoveDynamic(
-          this, &ASkaldPlayerController::HandleBattleEnded);
-      GI->GridBattleManager->OnBattleEnded.AddDynamic(
-          this, &ASkaldPlayerController::HandleBattleEnded);
-      // Initial bind
-      HandleActiveFighterChanged(GI->GridBattleManager->GetActiveFighter());
-    }
+  USkaldGameInstance *GI = CachedGameInstance;
+  if (!GI) {
+    GI = GetGameInstance<USkaldGameInstance>();
+    CachedGameInstance = GI;
   }
+
+  AFighterPawn *ActiveFighter = nullptr;
+  // Bind to active-fighter changes
+  if (GI && GI->GridBattleManager) {
+    GI->GridBattleManager->OnActiveFighterChanged.RemoveAll(this);
+    GI->GridBattleManager->OnActiveFighterChanged.AddDynamic(
+        this, &ASkaldPlayerController::HandleActiveFighterChanged);
+    GI->GridBattleManager->OnBattleEnded.RemoveDynamic(
+        this, &ASkaldPlayerController::HandleBattleEnded);
+    GI->GridBattleManager->OnBattleEnded.AddDynamic(
+        this, &ASkaldPlayerController::HandleBattleEnded);
+    ActiveFighter = GI->GridBattleManager->GetActiveFighter();
+  }
+
+  HandleActiveFighterChanged(ActiveFighter);
 }
 
 void ASkaldPlayerController::ShowOverworldHUD() {
@@ -1561,6 +1567,10 @@ void ASkaldPlayerController::HandleFighterSelectionLockedIn() {
 
   bBattleHUDReadyToShow = true;
 
+  // Ensure the HUD is initialized so the controller is bound to active-fighter
+  // updates even if no pawn has been selected yet.
+  InitializeBattleHUD();
+
   UWidgetBlueprintLibrary::SetInputMode_GameAndUIEx(
       this, nullptr, EMouseLockMode::DoNotLock, false);
   bShowMouseCursor = true;
@@ -1574,8 +1584,11 @@ void ASkaldPlayerController::HandleFighterSelectionLockedIn() {
     CachedGameInstance = GetGameInstance<USkaldGameInstance>();
   }
   if (CachedGameInstance && CachedGameInstance->GridBattleManager &&
-      CachedGameInstance->GridBattleManager->GetActiveFighter()) {
-    EnsureBattleHUDVisible();
+      !bBattleHUDVisible) {
+    if (AFighterPawn *ActiveFighter =
+            CachedGameInstance->GridBattleManager->GetActiveFighter()) {
+      EnsureBattleHUDVisible();
+    }
   }
 }
 


### PR DESCRIPTION
## Summary
- initialize the battle HUD when fighters are locked in so the controller always binds to active-fighter updates
- allow InitializeBattleHUD to reuse the cached game instance and safely handle cases where no active fighter is selected yet
- avoid showing the HUD twice by only forcing visibility when an active fighter already exists and the HUD is still hidden

## Testing
- not run (not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68d32cf117c883248602995a6a701a8d