### PR TITLE
Use instanced mesh for grid highlights

### DIFF
--- a/Source/Skald/GridOverlayComponent.cpp
+++ b/Source/Skald/GridOverlayComponent.cpp
@@ -7,9 +7,52 @@
 #include "GridObstacleComponent.h"
 #include "Landscape.h"
 #include "LandscapeComponent.h"
+#include "Components/InstancedStaticMeshComponent.h"
+#include "Components/SceneComponent.h"
+#include "GameFramework/Actor.h"
 
 UGridOverlayComponent::UGridOverlayComponent() {
   PrimaryComponentTick.bCanEverTick = false;
+
+  HighlightMeshComponent =
+      CreateDefaultSubobject<UInstancedStaticMeshComponent>(TEXT("HighlightMesh"));
+  if (HighlightMeshComponent) {
+    HighlightMeshComponent->SetCollisionEnabled(ECollisionEnabled::NoCollision);
+    HighlightMeshComponent->SetGenerateOverlapEvents(false);
+    HighlightMeshComponent->SetCastShadow(false);
+    HighlightMeshComponent->bSelectable = false;
+    HighlightMeshComponent->SetCanEverAffectNavigation(false);
+    HighlightMeshComponent->NumCustomDataFloats = 4;
+  }
+}
+
+void UGridOverlayComponent::OnRegister() {
+  Super::OnRegister();
+
+  if (!HighlightMeshComponent) {
+    return;
+  }
+
+  if (HighlightMesh && HighlightMeshComponent->GetStaticMesh() != HighlightMesh) {
+    HighlightMeshComponent->SetStaticMesh(HighlightMesh);
+  }
+
+  if (HighlightMaterial && HighlightMeshComponent->GetMaterial(0) != HighlightMaterial) {
+    HighlightMeshComponent->SetMaterial(0, HighlightMaterial);
+  }
+
+  if (AActor *Owner = GetOwner()) {
+    if (USceneComponent *Root = Owner->GetRootComponent()) {
+      HighlightMeshComponent->AttachToComponent(
+          Root, FAttachmentTransformRules::KeepRelativeTransform);
+    }
+  }
+
+  HighlightMeshComponent->SetRelativeTransform(FTransform::Identity);
+
+  if (!HighlightMeshComponent->IsRegistered()) {
+    HighlightMeshComponent->RegisterComponent();
+  }
 }
 
 void UGridOverlayComponent::BeginPlay() {
@@ -129,23 +172,109 @@ void UGridOverlayComponent::SetOccupied(const FIntPoint &GridCoord,
   Cells[Index(GridCoord)] = bOccupied;
 }
 
-void UGridOverlayComponent::HighlightCell(const FIntPoint &GridCoord,
-                                          const FColor &Color, float Duration,
-                                          bool bPersistent) const {
-  if (!IsValidGrid(GridCoord) || !GetWorld()) {
+bool UGridOverlayComponent::EnsureHighlightComponentSetup() {
+  if (!HighlightMeshComponent) {
+    return false;
+  }
+
+  HighlightMeshComponent->SetCollisionEnabled(ECollisionEnabled::NoCollision);
+  HighlightMeshComponent->SetGenerateOverlapEvents(false);
+  HighlightMeshComponent->SetCastShadow(false);
+  HighlightMeshComponent->bSelectable = false;
+  HighlightMeshComponent->SetCanEverAffectNavigation(false);
+
+  if (HighlightMeshComponent->NumCustomDataFloats < 4) {
+    HighlightMeshComponent->NumCustomDataFloats = 4;
+  }
+
+  if (!HighlightMeshComponent->IsRegistered()) {
+    HighlightMeshComponent->RegisterComponent();
+  }
+
+  if (AActor *Owner = GetOwner()) {
+    if (USceneComponent *Root = Owner->GetRootComponent()) {
+      if (HighlightMeshComponent->GetAttachParent() != Root) {
+        HighlightMeshComponent->AttachToComponent(
+            Root, FAttachmentTransformRules::KeepRelativeTransform);
+      }
+    }
+  }
+
+  HighlightMeshComponent->SetRelativeTransform(FTransform::Identity);
+
+  if (HighlightMesh && HighlightMeshComponent->GetStaticMesh() != HighlightMesh) {
+    HighlightMeshComponent->SetStaticMesh(HighlightMesh);
+  }
+
+  if (HighlightMaterial &&
+      HighlightMeshComponent->GetMaterial(0) != HighlightMaterial) {
+    HighlightMeshComponent->SetMaterial(0, HighlightMaterial);
+  }
+
+  return HighlightMeshComponent->GetStaticMesh() != nullptr;
+}
+
+void UGridOverlayComponent::ApplyHighlightColor(int32 InstanceIndex,
+                                                const FLinearColor &Color) {
+  if (!HighlightMeshComponent || HighlightMeshComponent->NumCustomDataFloats < 4 ||
+      InstanceIndex == INDEX_NONE) {
     return;
   }
 
-  FVector Center = GridToWorld(GridCoord);
-  FVector Extent(CellSize * 0.5f, CellSize * 0.5f, 10.f);
-  Center.Z += Extent.Z; // raise the box above the ground
-  DrawDebugSolidBox(GetWorld(), Center, Extent, Color, bPersistent, Duration);
+  HighlightMeshComponent->SetCustomDataValue(InstanceIndex, 0, Color.R, false);
+  HighlightMeshComponent->SetCustomDataValue(InstanceIndex, 1, Color.G, false);
+  HighlightMeshComponent->SetCustomDataValue(InstanceIndex, 2, Color.B, false);
+  HighlightMeshComponent->SetCustomDataValue(InstanceIndex, 3, Color.A, true);
 }
 
-void UGridOverlayComponent::ClearHighlights() const {
+void UGridOverlayComponent::HighlightCell(const FIntPoint &GridCoord,
+                                          const FColor &Color, float /*Duration*/,
+                                          bool /*bPersistent*/) {
+  if (!IsValidGrid(GridCoord)) {
+    return;
+  }
+
+  if (!EnsureHighlightComponentSetup()) {
+    return;
+  }
+
+  const FVector WorldCenter =
+      GridToWorld(GridCoord) + FVector(0.f, 0.f, HighlightHeightOffset);
+  const float EffectiveCellSize = FMath::Max(CellSize, KINDA_SMALL_NUMBER);
+  const FVector InstanceScale(EffectiveCellSize / 100.f,
+                              EffectiveCellSize / 100.f, 1.f);
+  const FTransform WorldTransform(FQuat::Identity, WorldCenter, InstanceScale);
+  const FTransform ComponentTransform = HighlightMeshComponent->GetComponentTransform();
+  const FTransform RelativeTransform =
+      WorldTransform.GetRelativeTransform(ComponentTransform);
+
+  int32 InstanceIndex = INDEX_NONE;
+  if (int32 *ExistingIndex = HighlightedInstances.Find(GridCoord)) {
+    InstanceIndex = *ExistingIndex;
+    HighlightMeshComponent->UpdateInstanceTransform(InstanceIndex, RelativeTransform,
+                                                    false, true, true);
+  } else {
+    InstanceIndex = HighlightMeshComponent->AddInstance(RelativeTransform);
+    if (InstanceIndex == INDEX_NONE) {
+      return;
+    }
+    HighlightedInstances.Add(GridCoord, InstanceIndex);
+  }
+
+  ApplyHighlightColor(InstanceIndex, FLinearColor(Color));
+}
+
+void UGridOverlayComponent::ClearHighlights() {
+  HighlightedInstances.Empty();
+  if (HighlightMeshComponent) {
+    HighlightMeshComponent->ClearInstances();
+  }
+
+#if WITH_EDITOR
   if (GetWorld() && bFlushAllPersistentOnClear) {
     FlushPersistentDebugLines(GetWorld());
   }
+#endif
 }
 
 void UGridOverlayComponent::RegisterObstacle(UGridObstacleComponent *Obstacle) {

--- a/Source/Skald/GridOverlayComponent.h
+++ b/Source/Skald/GridOverlayComponent.h
@@ -8,6 +8,9 @@
 class AFighterPawn;
 class UGridObstacleComponent;
 struct FHitResult;
+class UInstancedStaticMeshComponent;
+class UMaterialInterface;
+class UStaticMesh;
 
 /**
  * Component that tracks grid cell occupancy and provides world/grid conversion.
@@ -20,6 +23,7 @@ class SKALD_API UGridOverlayComponent : public UActorComponent {
 public:
   UGridOverlayComponent();
 
+  virtual void OnRegister() override;
   virtual void BeginPlay() override;
 
   /** Convert a world location to grid coordinates. */
@@ -53,7 +57,7 @@ public:
   /** Draw a debug highlight box for a grid cell. */
   UFUNCTION(BlueprintCallable, Category = "Grid")
   void HighlightCell(const FIntPoint &GridCoord, const FColor &Color,
-                     float Duration = 0.f, bool bPersistent = false) const;
+                     float Duration = 0.f, bool bPersistent = false);
 
   /** Highlight all reachable movement cells for the fighter. */
   UFUNCTION(BlueprintCallable, Category = "Grid")
@@ -65,7 +69,7 @@ public:
 
   /** Remove any persistent highlights. */
   UFUNCTION(BlueprintCallable, Category = "Grid")
-    void ClearHighlights() const;
+  void ClearHighlights();
 
     /** Register an obstacle component so it can affect grid behaviour. */
     UFUNCTION(BlueprintCallable, Category = "Grid")
@@ -83,6 +87,18 @@ public:
   UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Grid|Landscape",
             meta = (EditCondition = "bTreatLandscapeAsObstacle"))
   float LandscapeSlopeThreshold = 45.f;
+
+  /** Mesh used for highlighting grid cells. */
+  UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category = "Grid|Highlight")
+  UStaticMesh *HighlightMesh = nullptr;
+
+  /** Material applied to the highlight mesh instances. */
+  UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category = "Grid|Highlight")
+  UMaterialInterface *HighlightMaterial = nullptr;
+
+  /** Vertical offset applied to highlight instances. */
+  UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Grid|Highlight")
+  float HighlightHeightOffset = 2.f;
 
 protected:
   /** Width of the grid in cells. */
@@ -112,17 +128,31 @@ protected:
   UPROPERTY()
   TArray<float> CellHeights;
 
+  /** Instanced mesh component used to render highlight quads. */
+  UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "Grid|Highlight")
+  UInstancedStaticMeshComponent *HighlightMeshComponent = nullptr;
+
+  /** Map grid coordinates to highlight instance indices for updates. */
+  UPROPERTY(Transient)
+  TMap<FIntPoint, int32> HighlightedInstances;
+
   /** Get linear array index for a grid coordinate. */
   int32 Index(const FIntPoint &GridCoord) const;
 
   /** Check whether grid coordinate is inside bounds. */
-    bool IsValidGrid(const FIntPoint &GridCoord) const;
+  bool IsValidGrid(const FIntPoint &GridCoord) const;
 
-    /** Obstacles currently registered with this grid. */
-    UPROPERTY()
-    TArray<UGridObstacleComponent *> Obstacles;
+  /** Obstacles currently registered with this grid. */
+  UPROPERTY()
+  TArray<UGridObstacleComponent *> Obstacles;
 
-    /** Process a landscape hit to potentially flag a cell as blocked. */
-    void HandleLandscapeHit(const FHitResult &Hit, const FIntPoint &Cell,
-                            int32 CellIndex);
+  /** Process a landscape hit to potentially flag a cell as blocked. */
+  void HandleLandscapeHit(const FHitResult &Hit, const FIntPoint &Cell,
+                          int32 CellIndex);
+
+  /** Ensure the instanced highlight component is ready for use. */
+  bool EnsureHighlightComponentSetup();
+
+  /** Apply highlight color as per-instance custom data. */
+  void ApplyHighlightColor(int32 InstanceIndex, const FLinearColor &Color);
 };


### PR DESCRIPTION
## Summary
- add an instanced static mesh component and configurable mesh/material options to grid highlights
- replace debug box drawing with instanced mesh instances driven by GridToWorld placement and per-cell bookkeeping
- clear highlight instances through the component and keep the optional persistent debug flush for editor builds only

## Testing
- not run (Unreal Engine tooling not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68d33c8cee1483248e481ed5622220cc