### PR TITLE
Fix UHT error for grid overlay pending occupancy updates

### DIFF
--- a/Source/Skald/GridOverlayComponent.cpp
+++ b/Source/Skald/GridOverlayComponent.cpp
@@ -155,11 +155,11 @@ void UGridOverlayComponent::BeginPlay() {
   RebuildBaseGridInstances();
 
   if (PendingOccupancyUpdates.Num() > 0) {
-    const TArray<TPair<FIntPoint, bool>> OccupancyToApply =
+    const TArray<FPendingGridOccupancyUpdate> OccupancyToApply =
         PendingOccupancyUpdates;
     PendingOccupancyUpdates.Empty();
-    for (const TPair<FIntPoint, bool> &Update : OccupancyToApply) {
-      SetOccupied(Update.Key, Update.Value);
+    for (const FPendingGridOccupancyUpdate &Update : OccupancyToApply) {
+      SetOccupied(Update.GridCoord, Update.bOccupied);
     }
   }
 }
@@ -252,13 +252,13 @@ void UGridOverlayComponent::SetOccupied(const FIntPoint &GridCoord,
     return;
   }
   if (!bHasInitializedGrid) {
-    for (TPair<FIntPoint, bool> &Pending : PendingOccupancyUpdates) {
-      if (Pending.Key == GridCoord) {
-        Pending.Value = bOccupied;
+    for (FPendingGridOccupancyUpdate &Pending : PendingOccupancyUpdates) {
+      if (Pending.GridCoord == GridCoord) {
+        Pending.bOccupied = bOccupied;
         return;
       }
     }
-    PendingOccupancyUpdates.Add(TPair<FIntPoint, bool>(GridCoord, bOccupied));
+    PendingOccupancyUpdates.Add(FPendingGridOccupancyUpdate(GridCoord, bOccupied));
     return;
   }
 

--- a/Source/Skald/GridOverlayComponent.h
+++ b/Source/Skald/GridOverlayComponent.h
@@ -3,7 +3,6 @@
 #include "Components/ActorComponent.h"
 #include "CoreMinimal.h"
 #include "GridBattleManager.h"
-#include "Templates/Pair.h"
 #include "GridOverlayComponent.generated.h"
 
 class AFighterPawn;
@@ -12,6 +11,22 @@ struct FHitResult;
 class UInstancedStaticMeshComponent;
 class UMaterialInterface;
 class UStaticMesh;
+
+USTRUCT()
+struct FPendingGridOccupancyUpdate {
+  GENERATED_BODY()
+
+  FPendingGridOccupancyUpdate() = default;
+
+  FPendingGridOccupancyUpdate(const FIntPoint &InGridCoord, bool bInOccupied)
+      : GridCoord(InGridCoord), bOccupied(bInOccupied) {}
+
+  UPROPERTY()
+  FIntPoint GridCoord = FIntPoint::ZeroValue;
+
+  UPROPERTY()
+  bool bOccupied = false;
+};
 
 /**
  * Component that tracks grid cell occupancy and provides world/grid conversion.
@@ -207,7 +222,7 @@ protected:
 
   /** Occupancy updates received before the grid initialises. */
   UPROPERTY(Transient)
-  TArray<TPair<FIntPoint, bool>> PendingOccupancyUpdates;
+  TArray<FPendingGridOccupancyUpdate> PendingOccupancyUpdates;
 
   /** Whether the grid has completed its initial world sampling. */
   bool bHasInitializedGrid = false;


### PR DESCRIPTION
## Summary
- replace the transient pending occupancy storage with a reflected struct so UnrealHeaderTool can parse the header
- update the grid overlay logic to use the new struct and drop the unused TPair include

## Testing
- not run (Unreal build tools are not available in this container)


------
https://chatgpt.com/codex/tasks/task_e_68d35b5041808324a3b6955d129b80ba