### PR TITLE
Respect fighter mesh override when spawning in battles

### DIFF
--- a/Source/Skald/Skald_BattleGameMode.cpp
+++ b/Source/Skald/Skald_BattleGameMode.cpp
@@ -942,8 +942,21 @@ void ASkald_BattleGameMode::SpawnFighterSide(const TArray<FFighterDefinition> &R
     FActorSpawnParameters Params;
     Params.SpawnCollisionHandlingOverride =
         ESpawnActorCollisionHandlingMethod::AdjustIfPossibleButAlwaysSpawn;
+
+    UClass *DesiredClass = AFighterPawn::StaticClass();
+    if (UClass *SelectedClass = Def.MeshClass.Get()) {
+      if (SelectedClass->IsChildOf(AFighterPawn::StaticClass())) {
+        DesiredClass = SelectedClass;
+      } else {
+        UE_LOG(LogSkaldBattle, Warning,
+               TEXT("SpawnFighterSide: MeshClass %s for fighter %s is not an "
+                    "AFighterPawn; falling back to default."),
+               *GetNameSafe(SelectedClass), *Def.Id.ToString());
+      }
+    }
+
     AFighterPawn *Pawn = GetWorld()->SpawnActor<AFighterPawn>(
-        AFighterPawn::StaticClass(), SpawnLoc, FRotator::ZeroRotator, Params);
+        DesiredClass, SpawnLoc, FRotator::ZeroRotator, Params);
     if (Pawn) {
       Pawn->Stats = Def.Stats;
       Pawn->bIsAttacker = bAsAttacker;


### PR DESCRIPTION
## Summary
- update battle spawn logic to use the mesh override provided in each fighter definition
- fall back to the base fighter pawn when no override or an incompatible class is supplied
- log a warning when the configured mesh class is not an AFighterPawn subclass

## Testing
- not run (Unreal build not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68d3619f27048324899f1a2209d4ea91