### PR TITLE
Fix fighter spawn height alignment

### DIFF
--- a/Source/Skald/FighterPawn.cpp
+++ b/Source/Skald/FighterPawn.cpp
@@ -1,7 +1,9 @@
 #include "FighterPawn.h"
 #include "Blueprint/UserWidget.h"
+#include "Components/CapsuleComponent.h"
 #include "Components/StaticMeshComponent.h"
 #include "Components/TextBlock.h"
+#include "Engine/CollisionProfile.h"
 #include "EngineUtils.h"
 #include "GridBattleManager.h"
 #include "GridOverlayComponent.h"
@@ -15,15 +17,26 @@ AFighterPawn::AFighterPawn() {
   bReplicates = true;
   SetReplicateMovement(true);
 
+  CollisionComponent =
+      CreateDefaultSubobject<UCapsuleComponent>(TEXT("CollisionComponent"));
+  CollisionComponent->InitCapsuleSize(40.f, 88.f);
+  CollisionComponent->SetCollisionProfileName(
+      UCollisionProfile::Pawn_ProfileName);
+  CollisionComponent->SetCanEverAffectNavigation(false);
+  RootComponent = CollisionComponent;
+
   DisplayMesh =
       CreateDefaultSubobject<UStaticMeshComponent>(TEXT("DisplayMesh"));
-  RootComponent = DisplayMesh;
+  DisplayMesh->SetupAttachment(CollisionComponent);
+  DisplayMesh->SetCollisionEnabled(ECollisionEnabled::NoCollision);
 
   HealthWidget = CreateDefaultSubobject<UWidgetComponent>(TEXT("HealthWidget"));
   HealthWidget->SetupAttachment(DisplayMesh);
 
   ActionsRemaining = 0;
   CurrentCell = FIntPoint::ZeroValue;
+
+  UpdateMeshOffset();
 }
 
 void AFighterPawn::GetLifetimeReplicatedProps(
@@ -33,6 +46,11 @@ void AFighterPawn::GetLifetimeReplicatedProps(
   DOREPLIFETIME(AFighterPawn, Stats);
   DOREPLIFETIME(AFighterPawn, bIsAttacker);
   DOREPLIFETIME(AFighterPawn, ActionsRemaining);
+}
+
+void AFighterPawn::OnConstruction(const FTransform &Transform) {
+  Super::OnConstruction(Transform);
+  UpdateMeshOffset();
 }
 
 void AFighterPawn::BeginPlay() {
@@ -45,8 +63,13 @@ void AFighterPawn::BeginPlay() {
   OnHealthChanged.AddDynamic(this, &AFighterPawn::UpdateHealthDisplay);
   OnHealthChanged.Broadcast(Stats.Health);
 
+  UpdateMeshOffset();
+
   if (UGridOverlayComponent *Grid = GetGrid()) {
     CurrentCell = Grid->WorldToGrid(GetActorLocation());
+    FVector AlignedLocation = Grid->GridToWorld(CurrentCell);
+    AlignedLocation.Z += GetSimpleCollisionHalfHeight();
+    SetActorLocation(AlignedLocation);
     Grid->SetOccupied(CurrentCell, true);
   }
 
@@ -113,7 +136,7 @@ void AFighterPawn::MoveToCell(FIntPoint TargetCell) {
   FVector NewLocation = GetActorLocation();
   if (Grid) {
     NewLocation = Grid->GridToWorld(TargetCell);
-    NewLocation.Z = Grid->GetCellHeight(TargetCell);
+    NewLocation.Z += GetSimpleCollisionHalfHeight();
   }
   SetActorLocation(NewLocation);
   ActionsRemaining -= Distance;
@@ -218,6 +241,13 @@ void AFighterPawn::PerformAttack(AFighterPawn *Target) {
 
   if (Grid) {
     Grid->ClearHighlights();
+  }
+}
+
+void AFighterPawn::UpdateMeshOffset() {
+  if (DisplayMesh && CollisionComponent) {
+    const float HalfHeight = CollisionComponent->GetUnscaledCapsuleHalfHeight();
+    DisplayMesh->SetRelativeLocation(FVector(0.f, 0.f, -HalfHeight));
   }
 }
 

--- a/Source/Skald/FighterPawn.h
+++ b/Source/Skald/FighterPawn.h
@@ -8,6 +8,7 @@
 #include "FighterPawn.generated.h"
 
 class UGridOverlayComponent;
+class UCapsuleComponent;
 
 DECLARE_DYNAMIC_MULTICAST_DELEGATE_OneParam(FOnHealthChanged, int32, NewHealth);
 
@@ -19,6 +20,7 @@ class SKALD_API AFighterPawn : public APawn {
 public:
   AFighterPawn();
 
+  virtual void OnConstruction(const FTransform &Transform) override;
   virtual void BeginPlay() override;
   virtual void GetLifetimeReplicatedProps(
       TArray<FLifetimeProperty> &OutLifetimeProps) const override;
@@ -60,6 +62,11 @@ public:
   UPROPERTY(VisibleAnywhere, BlueprintReadOnly)
   UStaticMeshComponent *DisplayMesh;
 
+  /** Collision capsule used for movement and placement. */
+  UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "Fighter",
+            meta = (AllowPrivateAccess = "true"))
+  UCapsuleComponent *CollisionComponent;
+
   /** Widget displaying the current health. */
   UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "Fighter|UI")
   UWidgetComponent *HealthWidget;
@@ -91,6 +98,9 @@ private:
 
   /** Retrieve or create a damage widget from the pool. */
   UUserWidget *GetDamageWidgetFromPool();
+
+  /** Align the visible mesh with the collision capsule. */
+  void UpdateMeshOffset();
 
   /** Pool of reusable damage widgets to avoid repeated allocations. */
   UPROPERTY()

--- a/Source/Skald/Skald_BattleGameMode.cpp
+++ b/Source/Skald/Skald_BattleGameMode.cpp
@@ -938,11 +938,6 @@ void ASkald_BattleGameMode::SpawnFighterSide(const TArray<FFighterDefinition> &R
     Cell.X = bAsAttacker ? GI->CombatRandomStream.RandRange(0, Edge - 1)
                          : GI->CombatRandomStream.RandRange(MaxX - (Edge - 1), MaxX);
 
-    const FVector SpawnLoc = Grid ? Grid->GridToWorld(Cell) : FVector::ZeroVector;
-    FActorSpawnParameters Params;
-    Params.SpawnCollisionHandlingOverride =
-        ESpawnActorCollisionHandlingMethod::AdjustIfPossibleButAlwaysSpawn;
-
     UClass *DesiredClass = AFighterPawn::StaticClass();
     if (UClass *SelectedClass = Def.MeshClass.Get()) {
       if (SelectedClass->IsChildOf(AFighterPawn::StaticClass())) {
@@ -955,9 +950,25 @@ void ASkald_BattleGameMode::SpawnFighterSide(const TArray<FFighterDefinition> &R
       }
     }
 
+    const FVector BaseSpawnLoc =
+        Grid ? Grid->GridToWorld(Cell) : FVector::ZeroVector;
+    FVector SpawnLoc = BaseSpawnLoc;
+    if (const AFighterPawn *DefaultPawn =
+            DesiredClass->GetDefaultObject<AFighterPawn>()) {
+      SpawnLoc.Z += DefaultPawn->GetSimpleCollisionHalfHeight();
+    }
+    FActorSpawnParameters Params;
+    Params.SpawnCollisionHandlingOverride =
+        ESpawnActorCollisionHandlingMethod::AdjustIfPossibleButAlwaysSpawn;
+
     AFighterPawn *Pawn = GetWorld()->SpawnActor<AFighterPawn>(
         DesiredClass, SpawnLoc, FRotator::ZeroRotator, Params);
     if (Pawn) {
+      if (Grid) {
+        FVector AdjustedLocation = BaseSpawnLoc;
+        AdjustedLocation.Z += Pawn->GetSimpleCollisionHalfHeight();
+        Pawn->SetActorLocation(AdjustedLocation);
+      }
       Pawn->Stats = Def.Stats;
       Pawn->bIsAttacker = bAsAttacker;
       BattleManager->RegisterFighter(Pawn, bAsAttacker);


### PR DESCRIPTION
## Summary
- add a collision capsule root to `AFighterPawn` and keep its mesh aligned with the capsule
- offset pawn placement and movement to account for the capsule half height so fighters rest on the grid surface
- adjust the battle spawn routine to apply the collision-aware height offset after spawning each pawn

## Testing
- not run (Unreal build not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68d3e82022a48324b8727e03d6ce8fee