### PR TITLE
Respect safe spawn location for fighters

### DIFF
--- a/Source/Skald/Skald_BattleGameMode.cpp
+++ b/Source/Skald/Skald_BattleGameMode.cpp
@@ -964,10 +964,16 @@ void ASkald_BattleGameMode::SpawnFighterSide(const TArray<FFighterDefinition> &R
     AFighterPawn *Pawn = GetWorld()->SpawnActor<AFighterPawn>(
         DesiredClass, SpawnLoc, FRotator::ZeroRotator, Params);
     if (Pawn) {
-      if (Grid) {
-        FVector AdjustedLocation = BaseSpawnLoc;
-        AdjustedLocation.Z += Pawn->GetSimpleCollisionHalfHeight();
-        Pawn->SetActorLocation(AdjustedLocation);
+      const float RequestedHalfHeight = SpawnLoc.Z - BaseSpawnLoc.Z;
+      const float ActualHalfHeight = Pawn->GetSimpleCollisionHalfHeight();
+
+      if (!FMath::IsNearlyEqual(ActualHalfHeight, RequestedHalfHeight,
+                                KINDA_SMALL_NUMBER)) {
+        FVector AdjustedLocation = Pawn->GetActorLocation();
+        AdjustedLocation.Z += ActualHalfHeight - RequestedHalfHeight;
+
+        FHitResult HitResult;
+        Pawn->SetActorLocation(AdjustedLocation, /*bSweep*/ true, &HitResult);
       }
       Pawn->Stats = Def.Stats;
       Pawn->bIsAttacker = bAsAttacker;


### PR DESCRIPTION
## Summary
- preserve SpawnActor's safe placement and only adjust height when the pawn's collision half height changes
- sweep when applying the height correction so we do not teleport fighters into blocking geometry

## Testing
- not run (Unreal project)

------
https://chatgpt.com/codex/tasks/task_e_68d3ee2c9ad88324848a589c9e8ab276