### PR TITLE
Implement round-based fighter activation flow

### DIFF
--- a/Source/Skald/FighterPawn.cpp
+++ b/Source/Skald/FighterPawn.cpp
@@ -11,6 +11,11 @@
 #include "Skald_GameInstance.h"
 #include "TimerManager.h"
 
+namespace
+{
+constexpr int32 ActionsPerActivation = 2;
+}
+
 AFighterPawn::AFighterPawn() {
   PrimaryActorTick.bCanEverTick = false;
 
@@ -34,6 +39,8 @@ AFighterPawn::AFighterPawn() {
   HealthWidget->SetupAttachment(DisplayMesh);
 
   ActionsRemaining = 0;
+  bHasActivatedThisRound = false;
+  bIsCurrentlyActive = false;
   CurrentCell = FIntPoint::ZeroValue;
 
   UpdateMeshOffset();
@@ -46,6 +53,8 @@ void AFighterPawn::GetLifetimeReplicatedProps(
   DOREPLIFETIME(AFighterPawn, Stats);
   DOREPLIFETIME(AFighterPawn, bIsAttacker);
   DOREPLIFETIME(AFighterPawn, ActionsRemaining);
+  DOREPLIFETIME(AFighterPawn, bHasActivatedThisRound);
+  DOREPLIFETIME(AFighterPawn, bIsCurrentlyActive);
 }
 
 void AFighterPawn::OnConstruction(const FTransform &Transform) {
@@ -83,7 +92,26 @@ void AFighterPawn::BeginPlay() {
   }
 }
 
-void AFighterPawn::BeginActivation() { ActionsRemaining = Stats.Movement; }
+void AFighterPawn::BeginActivation() {
+  if (!IsAlive()) {
+    return;
+  }
+
+  ActionsRemaining = ActionsPerActivation;
+  bIsCurrentlyActive = true;
+  bHasActivatedThisRound = true;
+}
+
+void AFighterPawn::ResetActivationState() {
+  ActionsRemaining = 0;
+  bHasActivatedThisRound = false;
+  bIsCurrentlyActive = false;
+}
+
+void AFighterPawn::FinishActivation() {
+  ActionsRemaining = 0;
+  bIsCurrentlyActive = false;
+}
 
 UGridOverlayComponent *AFighterPawn::GetGrid() {
   if (!CachedGrid) {
@@ -118,9 +146,12 @@ UUserWidget *AFighterPawn::GetDamageWidgetFromPool() {
 }
 
 void AFighterPawn::MoveToCell(FIntPoint TargetCell) {
-  int32 Distance = FMath::Abs(TargetCell.X - CurrentCell.X) +
-                   FMath::Abs(TargetCell.Y - CurrentCell.Y);
-  if (Distance > ActionsRemaining) {
+  if (!bIsCurrentlyActive || ActionsRemaining <= 0) {
+    return;
+  }
+  const int32 Distance = FMath::Abs(TargetCell.X - CurrentCell.X) +
+                         FMath::Abs(TargetCell.Y - CurrentCell.Y);
+  if (Distance > Stats.Movement) {
     return;
   }
   UGridOverlayComponent *Grid = GetGrid();
@@ -139,18 +170,7 @@ void AFighterPawn::MoveToCell(FIntPoint TargetCell) {
     NewLocation.Z += GetSimpleCollisionHalfHeight();
   }
   SetActorLocation(NewLocation);
-  ActionsRemaining -= Distance;
-
-  if (ActionsRemaining <= 0) {
-    if (UWorld *World = GetWorld()) {
-      if (USkaldGameInstance *GI =
-              Cast<USkaldGameInstance>(World->GetGameInstance())) {
-        if (GI->GridBattleManager) {
-          GI->GridBattleManager->AdvanceTurn();
-        }
-      }
-    }
-  }
+  ActionsRemaining = FMath::Max(0, ActionsRemaining - 1);
 
   if (Grid) {
     Grid->SetOccupied(TargetCell, true);
@@ -159,7 +179,8 @@ void AFighterPawn::MoveToCell(FIntPoint TargetCell) {
 }
 
 void AFighterPawn::PerformAttack(AFighterPawn *Target) {
-  if (!Target || ActionsRemaining <= 0 || !Target->IsAlive()) {
+  if (!bIsCurrentlyActive || ActionsRemaining <= 0 || !Target ||
+      !Target->IsAlive()) {
     return;
   }
 
@@ -226,18 +247,7 @@ void AFighterPawn::PerformAttack(AFighterPawn *Target) {
   if (!Target->IsAlive()) {
     Target->Destroy();
   }
-  --ActionsRemaining;
-
-  if (ActionsRemaining <= 0) {
-    if (UWorld *World = GetWorld()) {
-      if (USkaldGameInstance *GI =
-              Cast<USkaldGameInstance>(World->GetGameInstance())) {
-        if (GI->GridBattleManager) {
-          GI->GridBattleManager->AdvanceTurn();
-        }
-      }
-    }
-  }
+  ActionsRemaining = FMath::Max(0, ActionsRemaining - 1);
 
   if (Grid) {
     Grid->ClearHighlights();
@@ -266,6 +276,7 @@ void AFighterPawn::UpdateHealthDisplay(int32 NewHealth) {
 }
 
 void AFighterPawn::Destroyed() {
+  FinishActivation();
   if (UGridOverlayComponent *Grid = GetGrid()) {
     Grid->SetOccupied(CurrentCell, false);
   }

--- a/Source/Skald/FighterPawn.h
+++ b/Source/Skald/FighterPawn.h
@@ -29,6 +29,14 @@ public:
   UFUNCTION(BlueprintCallable, Category = "Fighter")
   void BeginActivation();
 
+  /** Clear round-based activation flags. */
+  UFUNCTION(BlueprintCallable, Category = "Fighter")
+  void ResetActivationState();
+
+  /** Mark this fighter's turn as complete. */
+  UFUNCTION(BlueprintCallable, Category = "Fighter")
+  void FinishActivation();
+
   /** Move to the specified grid cell if actions remain. */
   UFUNCTION(BlueprintCallable, Category = "Fighter")
   void MoveToCell(FIntPoint TargetCell);
@@ -57,6 +65,14 @@ public:
   /** Actions remaining for the current activation. */
   UPROPERTY(BlueprintReadOnly, Replicated, Category = "Fighter")
   int32 ActionsRemaining;
+
+  /** True once the fighter has activated during the current round. */
+  UPROPERTY(BlueprintReadOnly, Replicated, Category = "Fighter")
+  bool bHasActivatedThisRound;
+
+  /** True while this fighter is currently taking its activation. */
+  UPROPERTY(BlueprintReadOnly, Replicated, Category = "Fighter")
+  bool bIsCurrentlyActive;
 
   /** Mesh used to display the fighter. */
   UPROPERTY(VisibleAnywhere, BlueprintReadOnly)
@@ -111,4 +127,8 @@ private:
 
   /** Cached grid overlay component. */
   UGridOverlayComponent *CachedGrid = nullptr;
+
+public:
+  /** Returns true if the fighter has already activated this round. */
+  bool HasActivatedThisRound() const { return bHasActivatedThisRound; }
 };

--- a/Source/Skald/GridBattleManager.cpp
+++ b/Source/Skald/GridBattleManager.cpp
@@ -17,7 +17,12 @@ void UGridBattleManager::InitBattle(const TArray<FFighter>& Attackers, const TAr
 {
     AttackerTeam = Attackers;
     DefenderTeam = Defenders;
-    CurrentRound = 1;
+    CurrentRound = 0;
+    InitiativeOrder.Empty();
+    ActiveFighter = nullptr;
+    CurrentTurn = 0;
+    InitiativeWinnerFaction = ESkaldFaction::None;
+    bIsAttackerTurn = true;
     AttackerInitialArmyCost = 0;
     for (const FFighter& Fighter : AttackerTeam)
     {
@@ -121,22 +126,36 @@ AFighterPawn* UGridBattleManager::GetActiveFighter() const
 
 void UGridBattleManager::RegisterFighter(AFighterPawn* Fighter, bool bAsAttacker)
 {
-    if (!Fighter) return;
+    if (!Fighter)
+    {
+        return;
+    }
+
+    Fighter->bIsAttacker = bAsAttacker;
+    Fighter->ResetActivationState();
+
     if (!InitiativeOrder.Contains(Fighter))
     {
         InitiativeOrder.Add(Fighter);
     }
-    Fighter->bIsAttacker = bAsAttacker;
 }
 
 void UGridBattleManager::UnregisterFighter(AFighterPawn* Fighter)
 {
+    if (!Fighter)
+    {
+        return;
+    }
+
+    const bool bWasAttacker = Fighter->bIsAttacker;
     InitiativeOrder.Remove(Fighter);
     if (ActiveFighter == Fighter)
     {
         ActiveFighter = nullptr;
         OnActiveFighterChanged.Broadcast(nullptr);
     }
+
+    EvaluateRoundProgress(bWasAttacker);
 }
 
 TArray<FFighterDefinition> UGridBattleManager::GetFightersForFaction(ESkaldFaction Faction) const
@@ -155,163 +174,268 @@ TArray<FFighterDefinition> UGridBattleManager::GetFightersForFaction(ESkaldFacti
 
 void UGridBattleManager::RollInitiative()
 {
-    struct FInitiativeEntry { AFighterPawn* Fighter; int32 Roll; };
-
-    TArray<FInitiativeEntry> Rolls;
-    Rolls.Reserve(InitiativeOrder.Num());
-    for (AFighterPawn* Fighter : InitiativeOrder)
+    if (bBattleConcluded)
     {
-        if (!Fighter) continue;
-        Rolls.Add({ Fighter, Rng.RandRange(1, 20) });
+        return;
     }
 
-    Rolls.Sort([](const FInitiativeEntry& A, const FInitiativeEntry& B)
-    {
-        return A.Roll > B.Roll;
-    });
+    const bool bAttackersPresent = HasLivingFighters(true);
+    const bool bDefendersPresent = HasLivingFighters(false);
 
-    InitiativeOrder.Empty(Rolls.Num());
-    for (const FInitiativeEntry& Entry : Rolls)
+    if (!bAttackersPresent && !bDefendersPresent)
     {
-        InitiativeOrder.Add(Entry.Fighter);
+        InitiativeWinnerFaction = ESkaldFaction::None;
+        bIsAttackerTurn = true;
+        return;
     }
 
-    CurrentTurn = 0;
-    ActiveFighter = InitiativeOrder.Num() > 0 ? InitiativeOrder[0] : nullptr;
-    OnActiveFighterChanged.Broadcast(ActiveFighter);
-    if (ActiveFighter)
+    if (!bAttackersPresent)
     {
-        ActiveFighter->BeginActivation();
+        InitiativeWinnerFaction = DefenderTeam.Num() > 0 ? DefenderTeam[0].Faction : ESkaldFaction::None;
+        bIsAttackerTurn = false;
+        return;
+    }
+
+    if (!bDefendersPresent)
+    {
+        InitiativeWinnerFaction = AttackerTeam.Num() > 0 ? AttackerTeam[0].Faction : ESkaldFaction::None;
+        bIsAttackerTurn = true;
+        return;
+    }
+
+    int32 AttackerRoll = 0;
+    int32 DefenderRoll = 0;
+    int32 Attempts = 0;
+    const int32 MaxAttempts = 10;
+    do
+    {
+        AttackerRoll = Rng.RandRange(1, 20);
+        DefenderRoll = Rng.RandRange(1, 20);
+        ++Attempts;
+    }
+    while (AttackerRoll == DefenderRoll && Attempts < MaxAttempts);
+
+    if (AttackerRoll == DefenderRoll)
+    {
+        // As a fallback, bias ties in favour of the attacker to avoid stalling the round start.
+        ++AttackerRoll;
+    }
+
+    if (AttackerRoll >= DefenderRoll)
+    {
+        bIsAttackerTurn = true;
+        InitiativeWinnerFaction = AttackerTeam.Num() > 0 ? AttackerTeam[0].Faction : ESkaldFaction::None;
+    }
+    else
+    {
+        bIsAttackerTurn = false;
+        InitiativeWinnerFaction = DefenderTeam.Num() > 0 ? DefenderTeam[0].Faction : ESkaldFaction::None;
     }
 }
 
 void UGridBattleManager::StartRound()
-{
-    const int32 EdgeRange = 3;
-
-    if (!bTeamsAssigned)
-    {
-        bTeamsAssigned = true;
-    }
-
-    for (AFighterPawn* Fighter : InitiativeOrder)
-    {
-        if (!Fighter) continue;
-
-        bool bPlaced = false;
-        for (int32 tries = 0; tries < 50 && !bPlaced; ++tries)
-        {
-            FIntPoint Cell;
-            Cell.Y = Rng.RandRange(0, GridSize - 1);
-            Cell.X = Fighter->bIsAttacker
-                ? Rng.RandRange(0, EdgeRange - 1)
-                : Rng.RandRange(GridSize - EdgeRange, GridSize - 1);
-
-            if (UGridOverlayComponent* Grid = Fighter->GetGrid())
-            {
-                if (!Grid->IsOccupied(Cell) && !Grid->IsObscured(Cell))
-                {
-                    Fighter->MoveToCell(Cell);
-                    bPlaced = true;
-                }
-            }
-            else
-            {
-                Fighter->MoveToCell(Cell);
-                bPlaced = true;
-            }
-        }
-
-        Fighter->ActionsRemaining = 0;
-    }
-
-    CurrentTurn = 0;
-    ActiveFighter = InitiativeOrder.Num() > 0 ? InitiativeOrder[0] : nullptr;
-    OnActiveFighterChanged.Broadcast(ActiveFighter);
-    if (ActiveFighter)
-    {
-        ActiveFighter->BeginActivation();
-    }
-}
-
-void UGridBattleManager::AdvanceTurn()
 {
     if (bBattleConcluded)
     {
         return;
     }
 
-    if (ActiveFighter && ActiveFighter->IsAlive() && ActiveFighter->ActionsRemaining > 0)
+    bTeamsAssigned = true;
+
+    ClearInactiveFighters();
+
+    if (!HasLivingFighters(true) || !HasLivingFighters(false))
+    {
+        EndBattle();
+        return;
+    }
+
+    ++CurrentRound;
+
+    for (AFighterPawn* Fighter : InitiativeOrder)
+    {
+        if (Fighter && Fighter->IsAlive())
+        {
+            Fighter->ResetActivationState();
+        }
+    }
+
+    ActiveFighter = nullptr;
+    CurrentTurn = 0;
+    OnActiveFighterChanged.Broadcast(nullptr);
+
+    RollInitiative();
+
+    OnRoundStarted.Broadcast(CurrentRound, InitiativeWinnerFaction);
+}
+
+void UGridBattleManager::AdvanceTurn()
+{
+    FinishActivation(ActiveFighter);
+}
+
+bool UGridBattleManager::CanActivateFighter(AFighterPawn* Fighter) const
+{
+    if (bBattleConcluded || !Fighter)
+    {
+        return false;
+    }
+
+    if (!Fighter->IsAlive() || !InitiativeOrder.Contains(Fighter))
+    {
+        return false;
+    }
+
+    if (ActiveFighter && ActiveFighter != Fighter)
+    {
+        return false;
+    }
+
+    if (Fighter->HasActivatedThisRound())
+    {
+        return false;
+    }
+
+    if (Fighter->bIsAttacker != bIsAttackerTurn)
+    {
+        return false;
+    }
+
+    return true;
+}
+
+bool UGridBattleManager::ActivateFighter(AFighterPawn* Fighter)
+{
+    if (!CanActivateFighter(Fighter))
+    {
+        return false;
+    }
+
+    ActiveFighter = Fighter;
+    CurrentTurn = InitiativeOrder.IndexOfByKey(Fighter);
+    if (ActiveFighter)
+    {
+        ActiveFighter->BeginActivation();
+    }
+    OnActiveFighterChanged.Broadcast(ActiveFighter);
+    return ActiveFighter != nullptr;
+}
+
+void UGridBattleManager::FinishActivation(AFighterPawn* Fighter)
+{
+    if (bBattleConcluded)
     {
         return;
     }
 
-    InitiativeOrder.RemoveAll([](AFighterPawn* Fighter)
+    AFighterPawn* FighterToFinish = Fighter ? Fighter : ActiveFighter;
+    if (!FighterToFinish)
     {
-        return !Fighter || !Fighter->IsAlive();
-    });
+        return;
+    }
 
-    bool bAttackerAlive = false;
-    bool bDefenderAlive = false;
+    const bool bWasAttacker = FighterToFinish->bIsAttacker;
+
+    if (ActiveFighter == FighterToFinish)
+    {
+        ActiveFighter->FinishActivation();
+        ActiveFighter = nullptr;
+        OnActiveFighterChanged.Broadcast(nullptr);
+    }
+    else if (InitiativeOrder.Contains(FighterToFinish))
+    {
+        FighterToFinish->FinishActivation();
+    }
+
+    EvaluateRoundProgress(bWasAttacker);
+}
+
+bool UGridBattleManager::HasLivingFighters(bool bForAttackers) const
+{
+    for (AFighterPawn* Fighter : InitiativeOrder)
+    {
+        if (Fighter && Fighter->IsAlive() && Fighter->bIsAttacker == bForAttackers)
+        {
+            return true;
+        }
+    }
+    return false;
+}
+
+bool UGridBattleManager::HasAvailableFighters(bool bForAttackers) const
+{
     for (AFighterPawn* Fighter : InitiativeOrder)
     {
         if (!Fighter)
         {
             continue;
         }
-        if (Fighter->bIsAttacker)
+
+        if (!Fighter->IsAlive() || Fighter->bIsAttacker != bForAttackers)
         {
-            bAttackerAlive = true;
-        }
-        else
-        {
-            bDefenderAlive = true;
+            continue;
         }
 
-        if (bAttackerAlive && bDefenderAlive)
+        if (!Fighter->HasActivatedThisRound())
         {
-            break;
+            return true;
         }
     }
+    return false;
+}
 
-    if (!bBattleConcluded && (!bAttackerAlive || !bDefenderAlive || InitiativeOrder.Num() == 0))
+void UGridBattleManager::EvaluateRoundProgress(bool bPreviousWasAttacker)
+{
+    if (bBattleConcluded)
+    {
+        return;
+    }
+
+    if (CurrentRound <= 0)
+    {
+        ClearInactiveFighters();
+        return;
+    }
+
+    ClearInactiveFighters();
+
+    if (!HasLivingFighters(true) || !HasLivingFighters(false))
     {
         EndBattle();
         return;
     }
 
-    const int32 NumFighters = InitiativeOrder.Num();
-    if (NumFighters == 0)
+    const bool bOpponentsRemain = HasAvailableFighters(!bPreviousWasAttacker);
+    const bool bCurrentRemain = HasAvailableFighters(bPreviousWasAttacker);
+
+    if (bOpponentsRemain)
     {
-        ActiveFighter = nullptr;
-        OnActiveFighterChanged.Broadcast(ActiveFighter);
+        bIsAttackerTurn = !bPreviousWasAttacker;
         return;
     }
 
-    int32 NextTurnIndex = INDEX_NONE;
-    if (ActiveFighter)
+    if (bCurrentRemain)
     {
-        const int32 ActiveIndex = InitiativeOrder.IndexOfByKey(ActiveFighter);
-        if (ActiveIndex != INDEX_NONE)
-        {
-            NextTurnIndex = (ActiveIndex + 1) % NumFighters;
-        }
+        bIsAttackerTurn = bPreviousWasAttacker;
+        return;
     }
 
-    if (NextTurnIndex == INDEX_NONE)
-    {
-        CurrentTurn = CurrentTurn % NumFighters;
-    }
-    else
-    {
-        CurrentTurn = NextTurnIndex;
-    }
+    StartRound();
+}
 
-    ActiveFighter = InitiativeOrder[CurrentTurn];
-    OnActiveFighterChanged.Broadcast(ActiveFighter);
-    if (ActiveFighter)
+void UGridBattleManager::ClearInactiveFighters()
+{
+    const bool bActiveInvalid = ActiveFighter && (!ActiveFighter->IsAlive() || !InitiativeOrder.Contains(ActiveFighter));
+
+    InitiativeOrder.RemoveAll([](AFighterPawn* Fighter)
     {
-        ActiveFighter->BeginActivation();
+        return !Fighter || !Fighter->IsAlive();
+    });
+
+    if (bActiveInvalid || (ActiveFighter && !InitiativeOrder.Contains(ActiveFighter)))
+    {
+        ActiveFighter = nullptr;
+        OnActiveFighterChanged.Broadcast(nullptr);
     }
 }
 

--- a/Source/Skald/GridBattleManager.h
+++ b/Source/Skald/GridBattleManager.h
@@ -13,6 +13,7 @@ DECLARE_DYNAMIC_MULTICAST_DELEGATE_ThreeParams(
     FOnBattleEnded, ESkaldFaction, WinningFaction, int32, AttackerCasualties, int32, DefenderCasualties);
 
 DECLARE_DYNAMIC_MULTICAST_DELEGATE_OneParam(FOnActiveFighterChanged, AFighterPawn*, NewFighter);
+DECLARE_DYNAMIC_MULTICAST_DELEGATE_TwoParams(FOnRoundStarted, int32, RoundNumber, ESkaldFaction, InitiativeWinner);
 
 /** Statistics for a fighter in grid battle mode. */
 USTRUCT(BlueprintType)
@@ -125,7 +126,7 @@ public:
     UFUNCTION(BlueprintCallable, Category="Battle")
     static bool ResolveAttack(FFighter& Attacker, FFighter& Defender, int32& OutDamage, UPARAM(ref) FRandomStream& RandomStream);
 
-    /** Roll initiative for all fighters participating in the battle. */
+    /** Roll initiative for the next round, determining which side acts first. */
     UFUNCTION(BlueprintCallable, Category="Skald|Battle")
     void RollInitiative();
 
@@ -133,9 +134,21 @@ public:
     UFUNCTION(BlueprintCallable, Category="Skald|Battle")
     void StartRound();
 
-    /** Advance to the next fighter in the initiative order. */
+    /** Finish the currently active fighter's turn and swap sides. */
     UFUNCTION(BlueprintCallable, Category="Battle")
     void AdvanceTurn();
+
+    /** Check whether the specified fighter can activate on the current side. */
+    UFUNCTION(BlueprintCallable, Category="Battle")
+    bool CanActivateFighter(AFighterPawn* Fighter) const;
+
+    /** Attempt to activate the specified fighter for the current side. */
+    UFUNCTION(BlueprintCallable, Category="Battle")
+    bool ActivateFighter(AFighterPawn* Fighter);
+
+    /** Complete the active fighter's activation and rotate the turn. */
+    UFUNCTION(BlueprintCallable, Category="Battle")
+    void FinishActivation(AFighterPawn* Fighter);
 
     /** Conclude the battle and broadcast the results. */
     UFUNCTION(BlueprintCallable, Category="Battle")
@@ -169,6 +182,18 @@ public:
       UFUNCTION(BlueprintCallable, BlueprintPure, Category="Battle")
       AFighterPawn* GetActiveFighter() const;
 
+    /** Return the faction that won the current round's initiative. */
+    UFUNCTION(BlueprintCallable, BlueprintPure, Category="Battle")
+    ESkaldFaction GetInitiativeWinner() const { return InitiativeWinnerFaction; }
+
+    /** True when the attacking side is allowed to activate a fighter. */
+    UFUNCTION(BlueprintCallable, BlueprintPure, Category="Battle")
+    bool IsAttackerTurn() const { return bIsAttackerTurn; }
+
+    /** Current round number, starting at 1 when combat begins. */
+    UFUNCTION(BlueprintCallable, BlueprintPure, Category="Battle")
+    int32 GetCurrentRound() const { return CurrentRound; }
+
     /** Get fighter definitions for the specified faction. */
     UFUNCTION(BlueprintCallable, BlueprintPure, Category="Battle")
     TArray<FFighterDefinition> GetFightersForFaction(ESkaldFaction Faction) const;
@@ -180,6 +205,10 @@ public:
     /** Fired whenever the active fighter changes (including nullptr). */
     UPROPERTY(BlueprintAssignable, Category="Battle|Events")
     FOnActiveFighterChanged OnActiveFighterChanged;
+
+    /** Fired whenever a new round begins. */
+    UPROPERTY(BlueprintAssignable, Category="Battle|Events")
+    FOnRoundStarted OnRoundStarted;
 
     UFUNCTION(BlueprintCallable, Category="Battle")
     void RegisterFighter(AFighterPawn* Fighter, bool bAsAttacker);
@@ -223,7 +252,20 @@ protected:
     UPROPERTY(BlueprintReadOnly, Category="Battle")
     int32 CurrentTurn = 0;
 
+    /** Faction that won the latest initiative roll. */
+    UPROPERTY(BlueprintReadOnly, Category="Battle")
+    ESkaldFaction InitiativeWinnerFaction = ESkaldFaction::None;
+
+    /** True when the attacking side is currently allowed to activate. */
+    UPROPERTY(BlueprintReadOnly, Category="Battle")
+    bool bIsAttackerTurn = true;
+
 private:
+    bool HasLivingFighters(bool bForAttackers) const;
+    bool HasAvailableFighters(bool bForAttackers) const;
+    void EvaluateRoundProgress(bool bPreviousWasAttacker);
+    void ClearInactiveFighters();
+
     // Track both counts and costs separately
     int32 AttackerSurvivorUnitCount = 0;
     int32 DefenderSurvivorUnitCount = 0;

--- a/Source/Skald/Skald_BattleGameMode.cpp
+++ b/Source/Skald/Skald_BattleGameMode.cpp
@@ -1061,7 +1061,6 @@ void ASkald_BattleGameMode::TryLaunchBattle() {
   SpawnFighterSide(AttackerDefs, /*bAsAttacker=*/true);
   SpawnFighterSide(DefenderDefs, /*bAsAttacker=*/false);
 
-  GI->GridBattleManager->RollInitiative();
   GI->GridBattleManager->StartRound();
 
   UE_LOG(LogSkald, Log, TEXT("BattleGM TryLaunchBattle: Battle initialised and round started"));

--- a/Source/Skald/Skald_PlayerController.cpp
+++ b/Source/Skald/Skald_PlayerController.cpp
@@ -11,6 +11,7 @@
 #include "GridBattleManager.h"
 #include "GridOverlayComponent.h"
 #include "InputCoreTypes.h"
+#include "Internationalization/Text.h"
 #include "Kismet/GameplayStatics.h"
 #include "Misc/EngineVersionComparison.h"
 #include "Skald.h"
@@ -616,6 +617,13 @@ void ASkaldPlayerController::InitializeBattleHUD() {
           this, &ASkaldPlayerController::BeginMoveMode);
       BattleHudWidget->OnAttackPressed.AddDynamic(
           this, &ASkaldPlayerController::BeginAttackMode);
+      BattleHudWidget->OnActivatePressed.AddDynamic(
+          this, &ASkaldPlayerController::HandleActivatePressed);
+      BattleHudWidget->OnEndTurnPressed.AddDynamic(
+          this, &ASkaldPlayerController::HandleEndTurnPressed);
+      BattleHudWidget->SetEndTurnVisibility(false);
+      BattleHudWidget->SetActivateEnabled(false);
+      BattleHudWidget->SetEndTurnEnabled(false);
     }
   }
 
@@ -631,13 +639,23 @@ void ASkaldPlayerController::InitializeBattleHUD() {
     GI->GridBattleManager->OnActiveFighterChanged.RemoveAll(this);
     GI->GridBattleManager->OnActiveFighterChanged.AddDynamic(
         this, &ASkaldPlayerController::HandleActiveFighterChanged);
+    GI->GridBattleManager->OnRoundStarted.RemoveAll(this);
+    GI->GridBattleManager->OnRoundStarted.AddDynamic(
+        this, &ASkaldPlayerController::HandleRoundStarted);
     GI->GridBattleManager->OnBattleEnded.RemoveDynamic(
         this, &ASkaldPlayerController::HandleBattleEnded);
     GI->GridBattleManager->OnBattleEnded.AddDynamic(
         this, &ASkaldPlayerController::HandleBattleEnded);
     ActiveFighter = GI->GridBattleManager->GetActiveFighter();
+
+    const int32 CurrentRound = GI->GridBattleManager->GetCurrentRound();
+    if (CurrentRound > 0) {
+      UpdateBattleRoundDisplay(CurrentRound,
+                               GI->GridBattleManager->GetInitiativeWinner());
+    }
   }
 
+  DetermineControlledBattleSide();
   HandleActiveFighterChanged(ActiveFighter);
 }
 
@@ -705,17 +723,21 @@ UGridOverlayComponent *ASkaldPlayerController::FindGridOverlay() const {
 
 void ASkaldPlayerController::HandleActiveFighterChanged(
     AFighterPawn *NewFighter) {
-  if (BattleHudWidget) {
-    BattleHudWidget->BindToFighter(NewFighter);
+  if (NewFighter && NewFighter->IsAlive()) {
+    LockedActiveFighter = NewFighter;
+    SetSelectedFighter(NewFighter, true);
+    if (bBattleHUDReadyToShow && !bBattleHUDVisible) {
+      EnsureBattleHUDVisible();
+    }
+  } else {
+    LockedActiveFighter = nullptr;
   }
-  if (NewFighter && bBattleHUDReadyToShow && !bBattleHUDVisible) {
-    EnsureBattleHUDVisible();
+
+  CancelCommandMode();
+  UpdateBattleHUDButtons();
+  if (!NewFighter) {
+    UpdateBattleHUDSelection();
   }
-  // Clear previous highlights when the turn swaps
-  if (UGridOverlayComponent *Grid = FindGridOverlay()) {
-    Grid->ClearHighlights();
-  }
-  CurrentCommandMode = EBattleCommandMode::None;
 }
 
 void ASkaldPlayerController::DetectBattleMap() {
@@ -1540,6 +1562,11 @@ void ASkaldPlayerController::HandleFighterSelectionLockedIn() {
   // updates even if no pawn has been selected yet.
   InitializeBattleHUD();
 
+  SelectedFighter = nullptr;
+  LockedActiveFighter = nullptr;
+  CancelCommandMode();
+  UpdateBattleHUDButtons();
+
   UWidgetBlueprintLibrary::SetInputMode_GameAndUIEx(
       this, nullptr, EMouseLockMode::DoNotLock, false);
   bShowMouseCursor = true;
@@ -1567,28 +1594,26 @@ void ASkaldPlayerController::SetupInputComponent() {
   if (InputComponent) {
     InputComponent->BindKey(EKeys::LeftMouseButton, IE_Pressed, this,
                             &ASkaldPlayerController::HandleGridClick);
+    InputComponent->BindKey(EKeys::RightMouseButton, IE_Pressed, this,
+                            &ASkaldPlayerController::HandleRightClick);
   }
 }
 
 void ASkaldPlayerController::BeginMoveMode() {
+  if (!LockedActiveFighter)
+    return;
   CurrentCommandMode = EBattleCommandMode::Move;
   if (UGridOverlayComponent *Grid = FindGridOverlay()) {
-    if (USkaldGameInstance *GI = GetGameInstance<USkaldGameInstance>()) {
-      if (GI->GridBattleManager && GI->GridBattleManager->GetActiveFighter()) {
-        Grid->HighlightMovement(GI->GridBattleManager->GetActiveFighter());
-      }
-    }
+    Grid->HighlightMovement(LockedActiveFighter);
   }
 }
 
 void ASkaldPlayerController::BeginAttackMode() {
+  if (!LockedActiveFighter)
+    return;
   CurrentCommandMode = EBattleCommandMode::Attack;
   if (UGridOverlayComponent *Grid = FindGridOverlay()) {
-    if (USkaldGameInstance *GI = GetGameInstance<USkaldGameInstance>()) {
-      if (GI->GridBattleManager && GI->GridBattleManager->GetActiveFighter()) {
-        Grid->HighlightAttack(GI->GridBattleManager->GetActiveFighter());
-      }
-    }
+    Grid->HighlightAttack(LockedActiveFighter);
   }
 }
 
@@ -1609,16 +1634,6 @@ void ASkaldPlayerController::HandleGridClick() {
   }
 
   // Get active fighter
-  AFighterPawn *Active = nullptr;
-  if (USkaldGameInstance *GI = GetGameInstance<USkaldGameInstance>()) {
-    if (GI->GridBattleManager) {
-      Active = GI->GridBattleManager->GetActiveFighter();
-    }
-  }
-  if (!Active || !Active->IsAlive())
-    return;
-
-  // Trace under cursor
   GetHitResultUnderCursor(ECC_Visibility, /*bTraceComplex*/ false, Hit);
 
   UGridOverlayComponent *Grid = FindGridOverlay();
@@ -1627,50 +1642,261 @@ void ASkaldPlayerController::HandleGridClick() {
 
   switch (CurrentCommandMode) {
   case EBattleCommandMode::Move: {
+    if (!LockedActiveFighter) {
+      CancelCommandMode();
+      break;
+    }
     const FVector Impact =
         Hit.bBlockingHit ? Hit.ImpactPoint : FVector::ZeroVector;
     const FIntPoint Cell = Grid->WorldToGrid(Impact);
-    Active->MoveToCell(Cell);
-    Grid->ClearHighlights();
-    if (Active->ActionsRemaining <= 0) {
-      CurrentCommandMode = EBattleCommandMode::None;
-      if (USkaldGameInstance *GI = GetGameInstance<USkaldGameInstance>()) {
-        if (GI->GridBattleManager) {
-          GI->GridBattleManager->AdvanceTurn();
-        }
-      }
-    }
+    LockedActiveFighter->MoveToCell(Cell);
+    CancelCommandMode();
+    UpdateBattleHUDButtons();
     break;
   }
   case EBattleCommandMode::Attack: {
+    if (!LockedActiveFighter) {
+      CancelCommandMode();
+      break;
+    }
     AFighterPawn *TargetPawn = Cast<AFighterPawn>(Hit.GetActor());
-    if (!TargetPawn && Hit.bBlockingHit) {
-      // No pawn? For now require clicking on a pawn to attack.
+    if (TargetPawn && TargetPawn != LockedActiveFighter && TargetPawn->IsAlive() &&
+        !IsFriendlyFighter(TargetPawn)) {
+      LockedActiveFighter->PerformAttack(TargetPawn);
     }
-    if (TargetPawn && TargetPawn != Active && TargetPawn->IsAlive()) {
-      if (TargetPawn->bIsAttacker != Active->bIsAttacker) {
-        Active->PerformAttack(TargetPawn);
-      }
-    }
-    Grid->ClearHighlights();
-    if (Active->ActionsRemaining <= 0) {
-      CurrentCommandMode = EBattleCommandMode::None;
-      if (USkaldGameInstance *GI = GetGameInstance<USkaldGameInstance>()) {
-        if (GI->GridBattleManager) {
-          GI->GridBattleManager->AdvanceTurn();
-        }
-      }
-    }
+    CancelCommandMode();
+    UpdateBattleHUDButtons();
     break;
   }
   default:
     break;
+  }
+
+  if (CurrentCommandMode != EBattleCommandMode::None) {
+    return;
+  }
+
+  AFighterPawn *ClickedPawn = Cast<AFighterPawn>(Hit.GetActor());
+  if (ClickedPawn && ClickedPawn->IsAlive()) {
+    if (LockedActiveFighter && LockedActiveFighter != ClickedPawn) {
+      return;
+    }
+
+    if (IsFriendlyFighter(ClickedPawn)) {
+      SetSelectedFighter(ClickedPawn);
+      UpdateBattleHUDButtons();
+    } else if (!LockedActiveFighter) {
+      ClearSelectedFighter();
+    }
+    return;
+  }
+
+  if (!LockedActiveFighter) {
+    ClearSelectedFighter();
+  }
+}
+
+void ASkaldPlayerController::HandleActivatePressed() {
+  if (!IsLocalController() || !SelectedFighter)
+    return;
+
+  if (SelectedFighter->HasActivatedThisRound()) {
+    NotifyActionError(FString(TEXT("Fighter Already Activated.")));
+    return;
+  }
+
+  if (!IsFriendlyFighter(SelectedFighter)) {
+    NotifyActionError(FString(TEXT("Cannot activate enemy fighter.")));
+    return;
+  }
+
+  if (LockedActiveFighter && LockedActiveFighter != SelectedFighter) {
+    NotifyActionError(FString(TEXT("Another fighter is already active.")));
+    return;
+  }
+
+  if (!CachedGameInstance) {
+    CachedGameInstance = GetGameInstance<USkaldGameInstance>();
+  }
+  if (!CachedGameInstance || !CachedGameInstance->GridBattleManager)
+    return;
+
+  if (!CachedGameInstance->GridBattleManager->CanActivateFighter(SelectedFighter)) {
+    NotifyActionError(FString(TEXT("Cannot activate this fighter right now.")));
+    return;
+  }
+
+  if (CachedGameInstance->GridBattleManager->ActivateFighter(SelectedFighter)) {
+    LockedActiveFighter = SelectedFighter;
+    if (bBattleHUDReadyToShow && !bBattleHUDVisible) {
+      EnsureBattleHUDVisible();
+    }
+    UpdateBattleHUDButtons();
+  }
+}
+
+void ASkaldPlayerController::HandleEndTurnPressed() {
+  if (!LockedActiveFighter)
+    return;
+
+  if (!CachedGameInstance) {
+    CachedGameInstance = GetGameInstance<USkaldGameInstance>();
+  }
+  if (!CachedGameInstance || !CachedGameInstance->GridBattleManager)
+    return;
+
+  CachedGameInstance->GridBattleManager->FinishActivation(LockedActiveFighter);
+  LockedActiveFighter = nullptr;
+  UpdateBattleHUDButtons();
+  CancelCommandMode();
+}
+
+void ASkaldPlayerController::HandleRightClick() {
+  if (!IsLocalController())
+    return;
+
+  if (!bIsBattleMap)
+    return;
+
+  CancelCommandMode();
+  UpdateBattleHUDButtons();
+}
+
+void ASkaldPlayerController::HandleRoundStarted(int32 RoundNumber,
+                                                ESkaldFaction InitiativeWinner) {
+  LockedActiveFighter = nullptr;
+  CancelCommandMode();
+  UpdateBattleRoundDisplay(RoundNumber, InitiativeWinner);
+  UpdateBattleHUDSelection();
+  UpdateBattleHUDButtons();
+}
+
+void ASkaldPlayerController::CancelCommandMode() {
+  CurrentCommandMode = EBattleCommandMode::None;
+  if (UGridOverlayComponent *Grid = FindGridOverlay()) {
+    Grid->ClearHighlights();
+  }
+  if (BattleHudWidget) {
+    BattleHudWidget->ClearCommandPreviews();
+  }
+}
+
+void ASkaldPlayerController::SetSelectedFighter(AFighterPawn *Fighter,
+                                                bool bForce) {
+  if (!bForce && SelectedFighter == Fighter)
+    return;
+
+  SelectedFighter = Fighter;
+  UpdateBattleHUDSelection();
+  UpdateBattleHUDButtons();
+}
+
+void ASkaldPlayerController::ClearSelectedFighter() {
+  if (!SelectedFighter)
+    return;
+
+  SelectedFighter = nullptr;
+  UpdateBattleHUDSelection();
+  UpdateBattleHUDButtons();
+}
+
+void ASkaldPlayerController::UpdateBattleHUDSelection() {
+  if (!BattleHudWidget)
+    return;
+
+  BattleHudWidget->BindToFighter(SelectedFighter);
+  if (SelectedFighter) {
+    BattleHudWidget->SetSelectedFighterName(
+        FText::FromString(SelectedFighter->GetHumanReadableName()));
+  } else {
+    BattleHudWidget->SetSelectedFighterName(FText::GetEmpty());
+  }
+}
+
+void ASkaldPlayerController::UpdateBattleHUDButtons() {
+  if (!BattleHudWidget)
+    return;
+
+  bool bCanActivate = false;
+  if (SelectedFighter && !LockedActiveFighter && IsFriendlyFighter(SelectedFighter)) {
+    if (!CachedGameInstance) {
+      CachedGameInstance = GetGameInstance<USkaldGameInstance>();
+    }
+    if (CachedGameInstance && CachedGameInstance->GridBattleManager) {
+      bCanActivate =
+          CachedGameInstance->GridBattleManager->CanActivateFighter(SelectedFighter);
+    }
+  }
+
+  BattleHudWidget->SetActivateEnabled(bCanActivate);
+  const bool bEndTurnVisible = LockedActiveFighter != nullptr;
+  BattleHudWidget->SetEndTurnVisibility(bEndTurnVisible);
+  BattleHudWidget->SetEndTurnEnabled(bEndTurnVisible);
+}
+
+void ASkaldPlayerController::UpdateBattleRoundDisplay(
+    int32 RoundNumber, ESkaldFaction InitiativeWinner) {
+  if (!BattleHudWidget)
+    return;
+
+  const FText RoundText = FText::Format(
+      NSLOCTEXT("Skald", "BattleRound", "Round {0}"), FText::AsNumber(RoundNumber));
+
+  FText InitiativeText = NSLOCTEXT("Skald", "BattleInitiativeNone",
+                                   "Initiative: None");
+  if (InitiativeWinner != ESkaldFaction::None) {
+    if (const UEnum *FactionEnum = StaticEnum<ESkaldFaction>()) {
+      const FText WinnerText =
+          FactionEnum->GetDisplayNameTextByValue(static_cast<int64>(InitiativeWinner));
+      InitiativeText = FText::Format(
+          NSLOCTEXT("Skald", "BattleInitiative", "Initiative: {0}"),
+          WinnerText);
+    }
+  }
+
+  BattleHudWidget->SetRoundInfo(RoundText, InitiativeText);
+}
+
+bool ASkaldPlayerController::IsFriendlyFighter(const AFighterPawn *Fighter) const {
+  if (!Fighter)
+    return false;
+
+  return Fighter->bIsAttacker ? bControlsAttackerSide : bControlsDefenderSide;
+}
+
+void ASkaldPlayerController::DetermineControlledBattleSide() {
+  bControlsAttackerSide = false;
+  bControlsDefenderSide = false;
+
+  const ASkaldPlayerState *PS = GetPlayerState<ASkaldPlayerState>();
+  if (!PS)
+    return;
+
+  if (!CachedGameInstance) {
+    CachedGameInstance = GetGameInstance<USkaldGameInstance>();
+  }
+  if (!CachedGameInstance)
+    return;
+
+  const FS_BattlePayload &Battle = CachedGameInstance->PendingBattle;
+  const int32 PlayerID = PS->GetPlayerId();
+  if (PlayerID == Battle.AttackerPlayerID) {
+    bControlsAttackerSide = true;
+  }
+  if (PlayerID == Battle.DefenderPlayerID) {
+    bControlsDefenderSide = true;
   }
 }
 
 void ASkaldPlayerController::HandleBattleEnded(ESkaldFaction WinningFaction,
                                                int32 AttackerCasualties,
                                                int32 DefenderCasualties) {
+  CancelCommandMode();
+  SelectedFighter = nullptr;
+  LockedActiveFighter = nullptr;
+  bControlsAttackerSide = false;
+  bControlsDefenderSide = false;
+
   if (BattleHudWidget) {
     BattleHudWidget->RemoveFromParent();
     BattleHudWidget = nullptr;

--- a/Source/Skald/Skald_PlayerController.h
+++ b/Source/Skald/Skald_PlayerController.h
@@ -197,6 +197,15 @@ protected:
   UFUNCTION()
   void HandleGridClick();
 
+  UFUNCTION()
+  void HandleActivatePressed();
+
+  UFUNCTION()
+  void HandleEndTurnPressed();
+
+  UFUNCTION()
+  void HandleRightClick();
+
 public:
   /** Handle HUD attack submissions.
    *  Bound to USkaldMainHUDWidget::OnAttackRequested in the HUD.
@@ -267,6 +276,9 @@ public:
 
   UFUNCTION()
   void HandleActiveFighterChanged(AFighterPawn *NewFighter);
+
+  UFUNCTION()
+  void HandleRoundStarted(int32 RoundNumber, ESkaldFaction InitiativeWinner);
 
   /** Server-side processing of an attack request. */
   UFUNCTION(Server, Reliable)
@@ -383,4 +395,22 @@ private:
   /** Create the fighter selection widget if we are on a battle map and it is
    * not already shown. */
   void InitializeFighterSelectionIfNeeded();
+
+  void CancelCommandMode();
+  void SetSelectedFighter(AFighterPawn *Fighter, bool bForce = false);
+  void ClearSelectedFighter();
+  void UpdateBattleHUDSelection();
+  void UpdateBattleHUDButtons();
+  void UpdateBattleRoundDisplay(int32 RoundNumber, ESkaldFaction InitiativeWinner);
+  bool IsFriendlyFighter(const AFighterPawn *Fighter) const;
+  void DetermineControlledBattleSide();
+
+  UPROPERTY()
+  TObjectPtr<AFighterPawn> SelectedFighter;
+
+  UPROPERTY()
+  TObjectPtr<AFighterPawn> LockedActiveFighter;
+
+  bool bControlsAttackerSide = false;
+  bool bControlsDefenderSide = false;
 };

--- a/Source/Skald/UI/BattleHUDWidget.cpp
+++ b/Source/Skald/UI/BattleHUDWidget.cpp
@@ -17,6 +17,14 @@ void UBattleHUDWidget::NativeConstruct() {
     AttackButton->OnClicked.AddDynamic(this,
                                        &UBattleHUDWidget::HandleAttackPressed);
   }
+  if (ActivateButton) {
+    ActivateButton->OnClicked.AddDynamic(
+        this, &UBattleHUDWidget::HandleActivatePressed);
+  }
+  if (EndTurnButton) {
+    EndTurnButton->OnClicked.AddDynamic(
+        this, &UBattleHUDWidget::HandleEndTurnPressed);
+  }
 }
 
 void UBattleHUDWidget::RefreshStats() { UpdateStatPanel(); }
@@ -31,6 +39,10 @@ void UBattleHUDWidget::BindToFighter(AFighterPawn *Fighter) {
     BoundFighter->OnHealthChanged.AddDynamic(
         this, &UBattleHUDWidget::HandleHealthChanged);
     UpdateStatPanel();
+    if (FighterNameText) {
+      FighterNameText->SetText(
+          FText::FromString(BoundFighter->GetHumanReadableName()));
+    }
   } else {
     if (HealthText) {
       HealthText->SetText(FText::GetEmpty());
@@ -52,6 +64,9 @@ void UBattleHUDWidget::BindToFighter(AFighterPawn *Fighter) {
     }
     if (AttackDiceText) {
       AttackDiceText->SetText(FText::GetEmpty());
+    }
+    if (FighterNameText) {
+      FighterNameText->SetText(FText::GetEmpty());
     }
   }
 }
@@ -90,6 +105,16 @@ void UBattleHUDWidget::HandleAttackPressed() {
   }
 }
 
+void UBattleHUDWidget::HandleActivatePressed() {
+  OnActivatePressed.Broadcast();
+  ClearCommandPreviews();
+}
+
+void UBattleHUDWidget::HandleEndTurnPressed() {
+  OnEndTurnPressed.Broadcast();
+  ClearCommandPreviews();
+}
+
 void UBattleHUDWidget::HandleHealthChanged(int32 NewHealth) {
   if (HealthText) {
     HealthText->SetText(FText::AsNumber(NewHealth));
@@ -120,6 +145,49 @@ void UBattleHUDWidget::UpdateStatPanel() {
   }
   if (AttackDiceText) {
     AttackDiceText->SetText(FText::AsNumber(BoundFighter->Stats.AttackDice));
+  }
+}
+
+void UBattleHUDWidget::SetRoundInfo(const FText &RoundLabel,
+                                    const FText &InitiativeLabel) {
+  if (RoundText) {
+    RoundText->SetText(RoundLabel);
+  }
+  if (InitiativeText) {
+    InitiativeText->SetText(InitiativeLabel);
+  }
+}
+
+void UBattleHUDWidget::SetSelectedFighterName(const FText &Name) {
+  if (FighterNameText) {
+    FighterNameText->SetText(Name);
+  }
+}
+
+void UBattleHUDWidget::SetActivateEnabled(bool bEnabled) {
+  if (ActivateButton) {
+    ActivateButton->SetIsEnabled(bEnabled);
+  }
+}
+
+void UBattleHUDWidget::SetEndTurnEnabled(bool bEnabled) {
+  if (EndTurnButton) {
+    EndTurnButton->SetIsEnabled(bEnabled);
+  }
+}
+
+void UBattleHUDWidget::SetEndTurnVisibility(bool bVisible) {
+  if (EndTurnButton) {
+    EndTurnButton->SetVisibility(
+        bVisible ? ESlateVisibility::Visible : ESlateVisibility::Collapsed);
+  }
+}
+
+void UBattleHUDWidget::ClearCommandPreviews() {
+  bMoveSelected = false;
+  bAttackSelected = false;
+  if (UGridOverlayComponent *Grid = FindGridOverlay()) {
+    Grid->ClearHighlights();
   }
 }
 

--- a/Source/Skald/UI/BattleHUDWidget.h
+++ b/Source/Skald/UI/BattleHUDWidget.h
@@ -36,6 +36,16 @@ public:
   UPROPERTY(BlueprintAssignable, Category = "Skald|Battle|Events")
   FOnAttackPressed OnAttackPressed;
 
+  /** Delegate fired when the Activate button is pressed. */
+  DECLARE_DYNAMIC_MULTICAST_DELEGATE(FOnActivatePressed);
+  UPROPERTY(BlueprintAssignable, Category = "Skald|Battle|Events")
+  FOnActivatePressed OnActivatePressed;
+
+  /** Delegate fired when the End Turn button is pressed. */
+  DECLARE_DYNAMIC_MULTICAST_DELEGATE(FOnEndTurnPressed);
+  UPROPERTY(BlueprintAssignable, Category = "Skald|Battle|Events")
+  FOnEndTurnPressed OnEndTurnPressed;
+
   /** Move action button bound from the blueprint. */
   UPROPERTY(BlueprintReadOnly, meta = (BindWidget))
   UButton *MoveButton;
@@ -43,6 +53,14 @@ public:
   /** Attack action button bound from the blueprint. */
   UPROPERTY(BlueprintReadOnly, meta = (BindWidget))
   UButton *AttackButton;
+
+  /** Activate action button bound from the blueprint. */
+  UPROPERTY(BlueprintReadOnly, meta = (BindWidgetOptional))
+  UButton *ActivateButton;
+
+  /** End turn button bound from the blueprint. */
+  UPROPERTY(BlueprintReadOnly, meta = (BindWidgetOptional))
+  UButton *EndTurnButton;
 
   /** Text displaying current health. */
   UPROPERTY(BlueprintReadOnly, meta = (BindWidget))
@@ -72,6 +90,36 @@ public:
   UPROPERTY(BlueprintReadOnly, meta = (BindWidget))
   UTextBlock *AttackDiceText;
 
+  /** Text displaying the fighter's name. */
+  UPROPERTY(BlueprintReadOnly, meta = (BindWidgetOptional))
+  UTextBlock *FighterNameText;
+
+  /** Text displaying the current round. */
+  UPROPERTY(BlueprintReadOnly, meta = (BindWidgetOptional))
+  UTextBlock *RoundText;
+
+  /** Text displaying initiative winner. */
+  UPROPERTY(BlueprintReadOnly, meta = (BindWidgetOptional))
+  UTextBlock *InitiativeText;
+
+  /** Update the round and initiative labels. */
+  void SetRoundInfo(const FText &RoundLabel, const FText &InitiativeLabel);
+
+  /** Update the fighter name label. */
+  void SetSelectedFighterName(const FText &Name);
+
+  /** Enable or disable the Activate button. */
+  void SetActivateEnabled(bool bEnabled);
+
+  /** Enable or disable the End Turn button. */
+  void SetEndTurnEnabled(bool bEnabled);
+
+  /** Toggle visibility for the End Turn button. */
+  void SetEndTurnVisibility(bool bVisible);
+
+  /** Clear any preview highlights tracked by the widget. */
+  void ClearCommandPreviews();
+
 private:
   /** Callback when MoveButton is pressed. */
   UFUNCTION()
@@ -80,6 +128,14 @@ private:
   /** Callback when AttackButton is pressed. */
   UFUNCTION()
   void HandleAttackPressed();
+
+  /** Callback when ActivateButton is pressed. */
+  UFUNCTION()
+  void HandleActivatePressed();
+
+  /** Callback when EndTurnButton is pressed. */
+  UFUNCTION()
+  void HandleEndTurnPressed();
 
   /** Update all stat text panels from the bound fighter. */
   void UpdateStatPanel();

--- a/docs/grid-battle-followup-tasks.md
+++ b/docs/grid-battle-followup-tasks.md
@@ -28,3 +28,33 @@
 ## Battle conclusion UI hooks
 - Extend the HUD/controller battle widgets to listen for `UGridBattleManager::OnBattleEnded` and present a victory/defeat banner (or modal) that differentiates attacker vs. defender outcomes.
 - Tear down or hide battle-specific UI when the delegate fires and re-enable world-map widgets after the travel back to the overworld completes, preventing stuck buttons when the level transitions.
+
+## Existing battle-map functionality to leverage
+- `UGridOverlayComponent::HighlightMovement` and `HighlightAttack` already compute legal movement and attack targets from a fighter's stats, so the upcoming UI workflow can reuse them without new pathfinding code.
+- `AFighterPawn::MoveToCell` handles grid occupancy, world-space alignment, and respects the fighter's movement stat when walking to a highlighted tile. `AFighterPawn::PerformAttack` likewise performs the die rolls and damage application against a target pawn.
+- `ASkaldPlayerController::BeginMoveMode` and `BeginAttackMode` are wired to the battle HUD buttons and call into the overlay highlight helpers today. The activation flow can keep these entry points while tightening when they are available.
+
+## Round tracking and initiative messaging
+- Rework `UGridBattleManager` so rounds advance when both sides have activated every surviving fighter instead of chaining `AdvanceTurn`. Store the `CurrentRound`, expose it through an accessor, and broadcast a new `OnRoundStarted` delegate (or similar) that includes the side that won initiative.
+- Roll initiative for attacker versus defender at the start of each round, keep the winning side in a replicated/accessible field, and use it to seed which team is allowed to activate first. Emit an announcement string for the HUD when the roll occurs.
+- Make `ASkaldPlayerController` (or the battle HUD) listen for the new round delegate and update on-screen text with the round number and initiative winner.
+
+## Fighter activation and action economy
+- Extend `AFighterPawn` with replicated fields that track whether it has activated this round and how many actions remain (exactly two per activation). Update `BeginActivation` to set those values, add a `ResetActivationState` helper, and expose a getter the controller can query before sending commands.
+- Adjust `MoveToCell` and `PerformAttack` so each call consumes one action, rejects attempts when the pawn is out of actions, and stops invoking `GridBattleManager::AdvanceTurn` automatically. The explicit End Turn button will now advance play instead of moves doing it implicitly.
+- Ensure deactivation (e.g., a fighter dies mid-turn) clears grid occupancy, marks the pawn as no longer active, and notifies the manager so the owning side can pick a replacement.
+
+## Side turn sequencing and round reset
+- Replace the per-pawn `AdvanceTurn` loop in `UGridBattleManager` with side-based bookkeeping: maintain lists of living attacker and defender pawns plus a set of which ones have activated this round. Provide helpers such as `CanActivateFighter`, `ActivateFighter`, and `FinishActivation` so the controller can drive the flow.
+- When a side ends its activation, swap to the opposing side only if they still have unactivated fighters. If the opponent is empty, keep the turn with the current side until they exhaust their roster. As soon as both sides are marked done, increment `CurrentRound`, clear the per-fighter flags, reset their action points, roll initiative again, and broadcast the round start event.
+- Update any remaining references to `AdvanceTurn` (player controller, pawns, or UI) to call the new activation/finish helpers so the sequencing stays consistent across server and clients.
+
+## Battle HUD commands and indicators
+- Add BindWidget properties for an Activate button, an End Turn button, and text blocks that show the current round/initiative string plus the selected fighter's name in `UBattleHUDWidget`. Expose delegates for the new buttons so the player controller can subscribe in the same way it already listens to Move/Attack.
+- Update `BindToFighter` to refresh the fighter name and stat panel whenever the player clicks a different pawn, and clear the panel when selection goes away. The End Turn button should remain hidden or disabled until a fighter is activated.
+- Implement helper methods on the widget for setting the round/initiative text, toggling the End Turn button's visibility, and clearing any move/attack highlight state when right-click cancels a command.
+
+## Player-controller activation flow and input handling
+- Store the currently selected fighter and the fighter that has been activated this turn inside `ASkaldPlayerController`. Modify `HandleGridClick` so left-click selects friendly pawns when no command mode is active, clears selection on empty tiles (unless an activation is locked in), and only issues move/attack orders to the active fighter.
+- Bind the HUD's new Activate and End Turn delegates. When Activate fires, validate ownership, call the manager's `ActivateFighter`, and surface a warning such as "Fighter Already Activated." through `NotifyActionError` if the pawn is no longer eligible. End Turn should inform the manager that the side is ready to rotate or start the next round.
+- Add a right-click binding that cancels the current Move/Attack mode, clears grid highlights, and returns the controller to selection mode without consuming actions. This should respect the "selection locked while activated" rule from the design.


### PR DESCRIPTION
## Summary
- track per-round activation state on fighters so movement and attacks spend from two explicit actions
- overhaul the grid battle manager to manage initiative rolls, side turns, round resets, and activation helpers for the UI
- refresh the player battle HUD/controller wiring with activate/end-turn controls, selection locking, right-click cancel, and round/initiative text updates

## Testing
- not run (Unreal Engine project)


------
https://chatgpt.com/codex/tasks/task_e_68d403c7ed1883249405350f62b69659