### PR TITLE
Restrict end turn to friendly active fighters

### DIFF
--- a/Source/Skald/Skald_PlayerController.cpp
+++ b/Source/Skald/Skald_PlayerController.cpp
@@ -1739,6 +1739,9 @@ void ASkaldPlayerController::HandleEndTurnPressed() {
   if (!LockedActiveFighter)
     return;
 
+  if (!IsFriendlyFighter(LockedActiveFighter))
+    return;
+
   if (!CachedGameInstance) {
     CachedGameInstance = GetGameInstance<USkaldGameInstance>();
   }
@@ -1829,9 +1832,11 @@ void ASkaldPlayerController::UpdateBattleHUDButtons() {
   }
 
   BattleHudWidget->SetActivateEnabled(bCanActivate);
-  const bool bEndTurnVisible = LockedActiveFighter != nullptr;
-  BattleHudWidget->SetEndTurnVisibility(bEndTurnVisible);
-  BattleHudWidget->SetEndTurnEnabled(bEndTurnVisible);
+  const bool bHasActiveFighter = LockedActiveFighter != nullptr;
+  const bool bHasFriendlyActive =
+      LockedActiveFighter && IsFriendlyFighter(LockedActiveFighter);
+  BattleHudWidget->SetEndTurnVisibility(bHasActiveFighter);
+  BattleHudWidget->SetEndTurnEnabled(bHasFriendlyActive);
 }
 
 void ASkaldPlayerController::UpdateBattleRoundDisplay(


### PR DESCRIPTION
## Summary
- prevent player controllers from ending activation for enemy fighters
- only enable the end turn button when the active fighter is friendly to the controller

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d413c8d9648324b157bb3829ceb67a