### PR TITLE
Prevent controlling enemy fighters through HUD commands

### DIFF
--- a/Source/Skald/Skald_PlayerController.cpp
+++ b/Source/Skald/Skald_PlayerController.cpp
@@ -1600,7 +1600,7 @@ void ASkaldPlayerController::SetupInputComponent() {
 }
 
 void ASkaldPlayerController::BeginMoveMode() {
-  if (!LockedActiveFighter)
+  if (!LockedActiveFighter || !IsFriendlyFighter(LockedActiveFighter))
     return;
   CurrentCommandMode = EBattleCommandMode::Move;
   if (UGridOverlayComponent *Grid = FindGridOverlay()) {
@@ -1609,7 +1609,7 @@ void ASkaldPlayerController::BeginMoveMode() {
 }
 
 void ASkaldPlayerController::BeginAttackMode() {
-  if (!LockedActiveFighter)
+  if (!LockedActiveFighter || !IsFriendlyFighter(LockedActiveFighter))
     return;
   CurrentCommandMode = EBattleCommandMode::Attack;
   if (UGridOverlayComponent *Grid = FindGridOverlay()) {
@@ -1646,6 +1646,10 @@ void ASkaldPlayerController::HandleGridClick() {
       CancelCommandMode();
       break;
     }
+    if (!IsFriendlyFighter(LockedActiveFighter)) {
+      CancelCommandMode();
+      break;
+    }
     const FVector Impact =
         Hit.bBlockingHit ? Hit.ImpactPoint : FVector::ZeroVector;
     const FIntPoint Cell = Grid->WorldToGrid(Impact);
@@ -1656,6 +1660,10 @@ void ASkaldPlayerController::HandleGridClick() {
   }
   case EBattleCommandMode::Attack: {
     if (!LockedActiveFighter) {
+      CancelCommandMode();
+      break;
+    }
+    if (!IsFriendlyFighter(LockedActiveFighter)) {
       CancelCommandMode();
       break;
     }


### PR DESCRIPTION
## Summary
- prevent BeginMoveMode and BeginAttackMode from activating when the locked fighter is not on the player's side
- cancel queued move/attack commands if the active fighter is unfriendly so enemy units can no longer be moved from the local controller

## Testing
- not run (Unreal project – no automated tests available in container)


------
https://chatgpt.com/codex/tasks/task_e_68d4172e4df48324bab26662393a9c42