### PR TITLE
Ensure battle HUD becomes visible once battle begins

### DIFF
--- a/Source/Skald/Skald_PlayerController.cpp
+++ b/Source/Skald/Skald_PlayerController.cpp
@@ -789,7 +789,6 @@ void ASkaldPlayerController::DetectBattleMap() {
   if (bIsBattleMap) {
     HideOverworldHUDForBattle();
     if (CachedGameInstance && CachedGameInstance->GridBattleManager &&
-        CachedGameInstance->GridBattleManager->GetActiveFighter() &&
         bBattleHUDReadyToShow) {
       EnsureBattleHUDVisible();
     }
@@ -1581,10 +1580,7 @@ void ASkaldPlayerController::HandleFighterSelectionLockedIn() {
   }
   if (CachedGameInstance && CachedGameInstance->GridBattleManager &&
       !bBattleHUDVisible) {
-    if (AFighterPawn *ActiveFighter =
-            CachedGameInstance->GridBattleManager->GetActiveFighter()) {
-      EnsureBattleHUDVisible();
-    }
+    EnsureBattleHUDVisible();
   }
 }
 


### PR DESCRIPTION
## Summary
- show the battle HUD when the battle map is detected and the controller is ready, even if no fighter is active yet
- ensure the HUD becomes visible immediately after the player locks in their selection so they can activate fighters

## Testing
- not run (Unreal build tooling unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68d425cc5f2c8324ad696c4c533ddba6