### PR TITLE
Implement battle turn automation for AI controllers

### DIFF
--- a/Source/Skald/Skald_AIController.cpp
+++ b/Source/Skald/Skald_AIController.cpp
@@ -1,16 +1,23 @@
 #include "Skald_AIController.h"
 #include "AIController.h"
+#include "Algo/Sort.h"
 #include "Engine/World.h"
+#include "EngineUtils.h"
+#include "FighterPawn.h"
 #include "GameFramework/Controller.h"
+#include "GridBattleManager.h"
+#include "GridOverlayComponent.h"
 #include "Kismet/GameplayStatics.h"
 #include "Skald.h"
 #include "SkaldLogging.h"
 #include "Skald_BattleGameMode.h"
+#include "Skald_GameInstance.h"
 #include "Skald_GameMode.h"
 #include "Skald_PlayerState.h"
 #include "Skald_TurnManager.h"
 #include "SkaldTypes.h"
 #include "Territory.h"
+#include "TimerManager.h"
 #include "WorldMap.h"
 #include <limits>
 
@@ -27,6 +34,8 @@ void ASkaldAIController::BeginPlay() {
       BattleGM->OnControllerReady(this);
     }
   }
+
+  SetupBattleAutomation();
 }
 
 void ASkaldAIController::StartTurn() { MakeAIDecision(); }
@@ -170,5 +179,394 @@ void ASkaldAIController::MakeAIDecision() {
   }
 
   EndTurn();
+}
+
+void ASkaldAIController::EndPlay(const EEndPlayReason::Type EndPlayReason) {
+  TeardownBattleAutomation();
+  Super::EndPlay(EndPlayReason);
+}
+
+void ASkaldAIController::SetupBattleAutomation() {
+  if (CachedBattleManager.IsValid()) {
+    return;
+  }
+
+  USkaldGameInstance *GameInstance = GetGameInstance<USkaldGameInstance>();
+  if (!GameInstance || !GameInstance->GridBattleManager) {
+    if (UWorld *World = GetWorld()) {
+      if (!World->GetTimerManager().IsTimerActive(BattleAutomationPollHandle)) {
+        World->GetTimerManager().SetTimer(
+            BattleAutomationPollHandle, this,
+            &ASkaldAIController::SetupBattleAutomation, 0.5f, false);
+      }
+    }
+    return;
+  }
+
+  if (UWorld *World = GetWorld()) {
+    World->GetTimerManager().ClearTimer(BattleAutomationPollHandle);
+  }
+
+  CachedBattleManager = GameInstance->GridBattleManager;
+  if (!CachedBattleManager.IsValid()) {
+    return;
+  }
+
+  CachedBattleManager->OnActiveFighterChanged.AddDynamic(
+      this, &ASkaldAIController::HandleActiveFighterChanged);
+  CachedBattleManager->OnRoundStarted.AddDynamic(
+      this, &ASkaldAIController::HandleRoundStarted);
+  CachedBattleManager->OnBattleEnded.AddDynamic(
+      this, &ASkaldAIController::HandleBattleEnded);
+
+  DetermineControlledBattleSide();
+  TryActivateNextFighter();
+}
+
+void ASkaldAIController::TeardownBattleAutomation() {
+  if (UWorld *World = GetWorld()) {
+    World->GetTimerManager().ClearTimer(BattleAutomationPollHandle);
+  }
+
+  if (CachedBattleManager.IsValid()) {
+    CachedBattleManager->OnActiveFighterChanged.RemoveDynamic(
+        this, &ASkaldAIController::HandleActiveFighterChanged);
+    CachedBattleManager->OnRoundStarted.RemoveDynamic(
+        this, &ASkaldAIController::HandleRoundStarted);
+    CachedBattleManager->OnBattleEnded.RemoveDynamic(
+        this, &ASkaldAIController::HandleBattleEnded);
+  }
+
+  CachedBattleManager.Reset();
+  bAIControlsAttackerSide = false;
+  bAIControlsDefenderSide = false;
+}
+
+void ASkaldAIController::DetermineControlledBattleSide() {
+  bAIControlsAttackerSide = false;
+  bAIControlsDefenderSide = false;
+
+  const ASkaldPlayerState *PS = GetPlayerState<ASkaldPlayerState>();
+  if (!PS) {
+    return;
+  }
+
+  const USkaldGameInstance *GameInstance = GetGameInstance<USkaldGameInstance>();
+  if (!GameInstance) {
+    return;
+  }
+
+  const FS_BattlePayload &Battle = GameInstance->PendingBattle;
+  const int32 PlayerId = PS->GetPlayerId();
+
+  if (PlayerId == Battle.AttackerPlayerID && PlayerId > 0) {
+    bAIControlsAttackerSide = true;
+  }
+  if (PlayerId == Battle.DefenderPlayerID && PlayerId > 0) {
+    bAIControlsDefenderSide = true;
+  }
+}
+
+bool ASkaldAIController::ControlsFighter(const AFighterPawn *Fighter) const {
+  if (!Fighter) {
+    return false;
+  }
+  return Fighter->bIsAttacker ? bAIControlsAttackerSide
+                              : bAIControlsDefenderSide;
+}
+
+bool ASkaldAIController::IsMyTurn() const {
+  if (!CachedBattleManager.IsValid()) {
+    return false;
+  }
+  const bool bAttackerTurn = CachedBattleManager->IsAttackerTurn();
+  return (bAttackerTurn && bAIControlsAttackerSide) ||
+         (!bAttackerTurn && bAIControlsDefenderSide);
+}
+
+int32 ASkaldAIController::ComputeManhattanDistance(UGridOverlayComponent *Grid,
+                                                   const AFighterPawn *A,
+                                                   const AFighterPawn *B) const {
+  if (!Grid || !A || !B) {
+    return TNumericLimits<int32>::Max();
+  }
+
+  const FIntPoint CellA = Grid->WorldToGrid(A->GetActorLocation());
+  const FIntPoint CellB = Grid->WorldToGrid(B->GetActorLocation());
+  if (!Grid->IsValidGrid(CellA) || !Grid->IsValidGrid(CellB)) {
+    return TNumericLimits<int32>::Max();
+  }
+
+  return FMath::Abs(CellA.X - CellB.X) + FMath::Abs(CellA.Y - CellB.Y);
+}
+
+AFighterPawn *ASkaldAIController::FindNearestEnemy(AFighterPawn *Fighter) const {
+  if (!Fighter) {
+    return nullptr;
+  }
+
+  UGridOverlayComponent *Grid = Fighter->GetGrid();
+  if (!Grid) {
+    return nullptr;
+  }
+
+  UWorld *World = GetWorld();
+  if (!World) {
+    return nullptr;
+  }
+
+  AFighterPawn *BestEnemy = nullptr;
+  int32 BestDistance = TNumericLimits<int32>::Max();
+
+  const FIntPoint StartCell = Grid->WorldToGrid(Fighter->GetActorLocation());
+  if (!Grid->IsValidGrid(StartCell)) {
+    return nullptr;
+  }
+
+  for (TActorIterator<AFighterPawn> It(World); It; ++It) {
+    AFighterPawn *Candidate = *It;
+    if (!Candidate || Candidate == Fighter || !Candidate->IsAlive()) {
+      continue;
+    }
+    if (ControlsFighter(Candidate)) {
+      continue;
+    }
+
+    const int32 Distance = ComputeManhattanDistance(Grid, Fighter, Candidate);
+    if (Distance < BestDistance) {
+      BestDistance = Distance;
+      BestEnemy = Candidate;
+    }
+  }
+
+  return BestEnemy;
+}
+
+AFighterPawn *ASkaldAIController::FindNextFriendlyFighter(bool bExpectAttacker) const {
+  UWorld *World = GetWorld();
+  if (!World) {
+    return nullptr;
+  }
+
+  AFighterPawn *BestFighter = nullptr;
+  int32 BestDistance = TNumericLimits<int32>::Max();
+
+  for (TActorIterator<AFighterPawn> It(World); It; ++It) {
+    AFighterPawn *Candidate = *It;
+    if (!Candidate || !Candidate->IsAlive()) {
+      continue;
+    }
+    if (Candidate->bIsAttacker != bExpectAttacker) {
+      continue;
+    }
+    if (!ControlsFighter(Candidate) || Candidate->HasActivatedThisRound()) {
+      continue;
+    }
+
+    UGridOverlayComponent *Grid = Candidate->GetGrid();
+    const int32 Distance = ComputeManhattanDistance(
+        Grid, Candidate, FindNearestEnemy(Candidate));
+    if (Distance < BestDistance || !BestFighter) {
+      BestDistance = Distance;
+      BestFighter = Candidate;
+    }
+  }
+
+  return BestFighter;
+}
+
+bool ASkaldAIController::TryAttackNearestEnemy(AFighterPawn *Fighter) {
+  if (!Fighter || Fighter->ActionsRemaining <= 0) {
+    return false;
+  }
+
+  UGridOverlayComponent *Grid = Fighter->GetGrid();
+  if (!Grid) {
+    return false;
+  }
+
+  AFighterPawn *Target = FindNearestEnemy(Fighter);
+  if (!Target) {
+    return false;
+  }
+
+  const FIntPoint SelfCell = Grid->WorldToGrid(Fighter->GetActorLocation());
+  const FIntPoint TargetCell = Grid->WorldToGrid(Target->GetActorLocation());
+  if (!Grid->IsValidGrid(SelfCell) || !Grid->IsValidGrid(TargetCell)) {
+    return false;
+  }
+
+  const int32 Distance = FMath::Abs(SelfCell.X - TargetCell.X) +
+                         FMath::Abs(SelfCell.Y - TargetCell.Y);
+  if (Distance > Fighter->Stats.AttackRange) {
+    return false;
+  }
+
+  if (!Grid->HasLineOfSight(SelfCell, TargetCell)) {
+    return false;
+  }
+
+  const int32 ActionsBefore = Fighter->ActionsRemaining;
+  Fighter->PerformAttack(Target);
+  return Fighter->ActionsRemaining < ActionsBefore;
+}
+
+bool ASkaldAIController::TryMoveTowardsNearestEnemy(AFighterPawn *Fighter) {
+  if (!Fighter || Fighter->ActionsRemaining <= 0 || Fighter->Stats.Movement <= 0) {
+    return false;
+  }
+
+  UGridOverlayComponent *Grid = Fighter->GetGrid();
+  if (!Grid) {
+    return false;
+  }
+
+  AFighterPawn *Enemy = FindNearestEnemy(Fighter);
+  if (!Enemy) {
+    return false;
+  }
+
+  const FIntPoint StartCell = Grid->WorldToGrid(Fighter->GetActorLocation());
+  const FIntPoint EnemyCell = Grid->WorldToGrid(Enemy->GetActorLocation());
+  if (!Grid->IsValidGrid(StartCell) || !Grid->IsValidGrid(EnemyCell)) {
+    return false;
+  }
+
+  FIntPoint Current = StartCell;
+  int32 CurrentDistance = FMath::Abs(EnemyCell.X - Current.X) +
+                          FMath::Abs(EnemyCell.Y - Current.Y);
+
+  const int32 MaxSteps = Fighter->Stats.Movement;
+  for (int32 Step = 0; Step < MaxSteps; ++Step) {
+    TArray<FIntPoint> Directions = {FIntPoint(1, 0), FIntPoint(-1, 0),
+                                    FIntPoint(0, 1), FIntPoint(0, -1)};
+    Directions.Sort([&](const FIntPoint &A, const FIntPoint &B) {
+      const FIntPoint PosA = Current + A;
+      const FIntPoint PosB = Current + B;
+      const int32 DistA =
+          FMath::Abs(EnemyCell.X - PosA.X) + FMath::Abs(EnemyCell.Y - PosA.Y);
+      const int32 DistB =
+          FMath::Abs(EnemyCell.X - PosB.X) + FMath::Abs(EnemyCell.Y - PosB.Y);
+      return DistA < DistB;
+    });
+
+    bool bMovedThisStep = false;
+    for (const FIntPoint &Dir : Directions) {
+      const FIntPoint Candidate = Current + Dir;
+      if (!Grid->IsValidGrid(Candidate) || Grid->IsOccupied(Candidate) ||
+          Grid->IsObscured(Candidate)) {
+        continue;
+      }
+
+      const int32 CandidateDistance = FMath::Abs(EnemyCell.X - Candidate.X) +
+                                      FMath::Abs(EnemyCell.Y - Candidate.Y);
+      if (CandidateDistance >= CurrentDistance) {
+        continue;
+      }
+
+      Current = Candidate;
+      CurrentDistance = CandidateDistance;
+      bMovedThisStep = true;
+      break;
+    }
+
+    if (!bMovedThisStep) {
+      break;
+    }
+  }
+
+  if (Current == StartCell) {
+    return false;
+  }
+
+  const int32 ActionsBefore = Fighter->ActionsRemaining;
+  Fighter->MoveToCell(Current);
+  return Fighter->ActionsRemaining < ActionsBefore;
+}
+
+void ASkaldAIController::ExecuteActivationForFighter(AFighterPawn *Fighter) {
+  if (!Fighter || !CachedBattleManager.IsValid()) {
+    return;
+  }
+
+  int32 SafetyCounter = 0;
+  while (Fighter->IsAlive() && Fighter->bIsCurrentlyActive &&
+         Fighter->ActionsRemaining > 0 && SafetyCounter < 8) {
+    bool bActionTaken = false;
+    if (TryAttackNearestEnemy(Fighter)) {
+      bActionTaken = true;
+    } else if (TryMoveTowardsNearestEnemy(Fighter)) {
+      bActionTaken = true;
+    }
+
+    if (!bActionTaken) {
+      break;
+    }
+
+    ++SafetyCounter;
+  }
+
+  if (CachedBattleManager.IsValid()) {
+    CachedBattleManager->FinishActivation(Fighter);
+  }
+}
+
+void ASkaldAIController::TryActivateNextFighter() {
+  if (!CachedBattleManager.IsValid()) {
+    SetupBattleAutomation();
+    return;
+  }
+
+  if (CachedBattleManager->GetActiveFighter()) {
+    return;
+  }
+
+  if (!IsMyTurn()) {
+    return;
+  }
+
+  const bool bAttackerTurn = CachedBattleManager->IsAttackerTurn();
+  AFighterPawn *NextFighter = FindNextFriendlyFighter(bAttackerTurn);
+  if (!NextFighter) {
+    return;
+  }
+
+  if (!CachedBattleManager->CanActivateFighter(NextFighter)) {
+    return;
+  }
+
+  CachedBattleManager->ActivateFighter(NextFighter);
+}
+
+void ASkaldAIController::HandleActiveFighterChanged(AFighterPawn *NewFighter) {
+  if (bProcessingActivation) {
+    return;
+  }
+
+  if (NewFighter) {
+    if (!ControlsFighter(NewFighter)) {
+      return;
+    }
+
+    bProcessingActivation = true;
+    ExecuteActivationForFighter(NewFighter);
+    bProcessingActivation = false;
+    TryActivateNextFighter();
+    return;
+  }
+
+  TryActivateNextFighter();
+}
+
+void ASkaldAIController::HandleRoundStarted(int32 /*RoundNumber*/,
+                                            ESkaldFaction /*InitiativeWinner*/) {
+  DetermineControlledBattleSide();
+  TryActivateNextFighter();
+}
+
+void ASkaldAIController::HandleBattleEnded(ESkaldFaction /*WinningFaction*/,
+                                           int32 /*AttackerCasualties*/,
+                                           int32 /*DefenderCasualties*/) {
+  TeardownBattleAutomation();
 }
 

--- a/Source/Skald/Skald_AIController.h
+++ b/Source/Skald/Skald_AIController.h
@@ -2,7 +2,12 @@
 
 #include "CoreMinimal.h"
 #include "Skald_PlayerController.h"
+#include "TimerManager.h"
 #include "Skald_AIController.generated.h"
+
+class AFighterPawn;
+class UGridBattleManager;
+class UGridOverlayComponent;
 
 /**
  * Controller handling AI turn logic.
@@ -18,5 +23,50 @@ public:
   /** Execute the AI's decision making for the current turn. */
   UFUNCTION(BlueprintCallable, Category = "Turn")
   void MakeAIDecision();
+
+protected:
+  virtual void EndPlay(const EEndPlayReason::Type EndPlayReason) override;
+
+private:
+  void SetupBattleAutomation();
+  void TeardownBattleAutomation();
+
+  void DetermineControlledBattleSide();
+  bool ControlsFighter(const AFighterPawn *Fighter) const;
+  bool IsMyTurn() const;
+
+  AFighterPawn *FindNextFriendlyFighter(bool bExpectAttacker) const;
+  AFighterPawn *FindNearestEnemy(AFighterPawn *Fighter) const;
+  bool TryAttackNearestEnemy(AFighterPawn *Fighter);
+  bool TryMoveTowardsNearestEnemy(AFighterPawn *Fighter);
+  void ExecuteActivationForFighter(AFighterPawn *Fighter);
+  void TryActivateNextFighter();
+
+  int32 ComputeManhattanDistance(UGridOverlayComponent *Grid,
+                                 const AFighterPawn *A,
+                                 const AFighterPawn *B) const;
+
+  UFUNCTION()
+  void HandleActiveFighterChanged(AFighterPawn *NewFighter);
+
+  UFUNCTION()
+  void HandleRoundStarted(int32 RoundNumber, ESkaldFaction InitiativeWinner);
+
+  UFUNCTION()
+  void HandleBattleEnded(ESkaldFaction WinningFaction, int32 AttackerCasualties,
+                         int32 DefenderCasualties);
+
+  /** Cached reference to the battle manager when grid combat is active. */
+  TWeakObjectPtr<UGridBattleManager> CachedBattleManager;
+
+  /** Tracks which side of the battle this AI controls. */
+  bool bAIControlsAttackerSide = false;
+  bool bAIControlsDefenderSide = false;
+
+  /** Prevents recursive handling when resolving an activation. */
+  bool bProcessingActivation = false;
+
+  /** Timer used to retry battle automation binding while the manager spawns. */
+  FTimerHandle BattleAutomationPollHandle;
 };
 


### PR DESCRIPTION
## Summary
- bind AI controllers to the grid battle manager so they automatically activate eligible fighters on their side
- drive simple battle turns by moving toward the nearest enemy, attacking when possible, and finishing activations to keep rounds flowing

## Testing
- not run (Unreal build pipeline unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68d42da324ec83249c9fd8b14ce00258