### PR TITLE
Make Skald player controller battle callbacks virtual

### DIFF
--- a/Source/Skald/Skald_PlayerController.h
+++ b/Source/Skald/Skald_PlayerController.h
@@ -271,14 +271,16 @@ public:
 
   /** React to the end of a battle. */
   UFUNCTION()
-  void HandleBattleEnded(ESkaldFaction WinningFaction, int32 AttackerCasualties,
-                         int32 DefenderCasualties);
+  virtual void HandleBattleEnded(ESkaldFaction WinningFaction,
+                                 int32 AttackerCasualties,
+                                 int32 DefenderCasualties);
 
   UFUNCTION()
-  void HandleActiveFighterChanged(AFighterPawn *NewFighter);
+  virtual void HandleActiveFighterChanged(AFighterPawn *NewFighter);
 
   UFUNCTION()
-  void HandleRoundStarted(int32 RoundNumber, ESkaldFaction InitiativeWinner);
+  virtual void HandleRoundStarted(int32 RoundNumber,
+                                  ESkaldFaction InitiativeWinner);
 
   /** Server-side processing of an attack request. */
   UFUNCTION(Server, Reliable)


### PR DESCRIPTION
## Summary
- make ASkaldPlayerController's battle event handlers virtual so AI subclasses can override them

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d44b7f2d348324b04eb585e2d155c3