### PR TITLE
Ensure army placement end phase runs on the server

### DIFF
--- a/Source/Skald/Skald_PlayerController.cpp
+++ b/Source/Skald/Skald_PlayerController.cpp
@@ -857,6 +857,19 @@ void ASkaldPlayerController::EndTurn() {
 }
 
 void ASkaldPlayerController::EndPhase() {
+  if (!HasAuthority()) {
+    ServerEndPhase();
+    return;
+  }
+
+  HandleEndPhaseInternal();
+}
+
+void ASkaldPlayerController::ServerEndPhase_Implementation() {
+  HandleEndPhaseInternal();
+}
+
+void ASkaldPlayerController::HandleEndPhaseInternal() {
   if (!EnsureTurnManager(TEXT("EndPhase"))) {
     return;
   }

--- a/Source/Skald/Skald_PlayerController.h
+++ b/Source/Skald/Skald_PlayerController.h
@@ -52,6 +52,10 @@ public:
   UFUNCTION(BlueprintCallable, Category = "Turn")
   void EndPhase();
 
+  /** Request the server to end the current phase for this controller. */
+  UFUNCTION(Server, Reliable)
+  void ServerEndPhase();
+
   /** Set the turn manager responsible for sequencing play. */
   UFUNCTION(BlueprintCallable, Category = "Turn")
   void SetTurnManager(ATurnManager *Manager);
@@ -182,6 +186,9 @@ protected:
 
   UFUNCTION()
   void HandlePostLoadMap(UWorld *LoadedWorld);
+
+  /** Shared implementation for ending the current phase on the server. */
+  void HandleEndPhaseInternal();
 
   FDelegateHandle PostLoadMapHandle;
 


### PR DESCRIPTION
## Summary
- add a server RPC for ending the current phase from the player controller
- route the end phase button through the server so army placement advances correctly

## Testing
- not run (not provided)

------
https://chatgpt.com/codex/tasks/task_e_68d46002e68c83249445b80faaf39fb8