### PR TITLE
Add authority validation to ServerEndPhase

### DIFF
--- a/Source/Skald/Skald_PlayerController.cpp
+++ b/Source/Skald/Skald_PlayerController.cpp
@@ -874,6 +874,31 @@ void ASkaldPlayerController::HandleEndPhaseInternal() {
     return;
   }
 
+  if (HasAuthority()) {
+    ASkaldPlayerState *PS = GetPlayerState<ASkaldPlayerState>();
+    if (!PS) {
+      UE_LOG(LogSkald, Warning,
+             TEXT("HandleEndPhaseInternal: %s has no PlayerState; rejecting."),
+             *GetName());
+      return;
+    }
+
+    if (ASkaldGameState *GS = GetWorld()->GetGameState<ASkaldGameState>()) {
+      const int32 MyIndex = GS->PlayerArray.IndexOfByKey(PS);
+      if (MyIndex == INDEX_NONE || GS->CurrentTurnIndex != MyIndex) {
+        UE_LOG(LogSkald, Warning,
+               TEXT("HandleEndPhaseInternal: %s attempted to end phase out of turn."),
+               *GetName());
+        return;
+      }
+    } else {
+      UE_LOG(LogSkald, Warning,
+             TEXT("HandleEndPhaseInternal: %s missing GameState; rejecting."),
+             *GetName());
+      return;
+    }
+  }
+
   ETurnPhase Phase = TurnManager->GetCurrentPhase();
   if (Phase == ETurnPhase::ArmyPlacement) {
     if (ASkaldPlayerState *PS = GetPlayerState<ASkaldPlayerState>()) {


### PR DESCRIPTION
## Summary
- require the server-side EndPhase handler to confirm the caller controls the active turn before advancing the phase
- log and reject end-phase requests from controllers lacking a player state or active turn ownership

## Testing
- not run (logic change only)


------
https://chatgpt.com/codex/tasks/task_e_68d4621e87f883249e87ada90120df4f