### PR TITLE
Prevent duplicate initiative rolls during overworld setup

### DIFF
--- a/Source/Skald/Skald_GameMode.cpp
+++ b/Source/Skald/Skald_GameMode.cpp
@@ -1321,9 +1321,16 @@ bool ASkaldGameMode::InitializeWorld() {
   // Shuffle territories before assignment
   Algo::RandomShuffle(WorldMap->Territories);
 
-  // Roll initiative and sort players accordingly
+  // Roll initiative and sort players accordingly. Preserve existing rolls so
+  // the initiative winner from the initial match start remains the leader even
+  // if InitializeWorld is triggered again (for example due to late HUD
+  // initialisation callbacks).
   for (APlayerState *PSBase : GS->PlayerArray) {
     if (ASkaldPlayerState *PS = Cast<ASkaldPlayerState>(PSBase)) {
+      if (PS->InitiativeRoll > 0) {
+        continue;
+      }
+
       if (USkaldGameInstance *GI = GetGameInstance<USkaldGameInstance>()) {
         PS->InitiativeRoll = GI->CombatRandomStream.RandRange(1, 6);
       } else {

--- a/Source/Skald/Tests/ArmyPlacementInitiativeTest.cpp
+++ b/Source/Skald/Tests/ArmyPlacementInitiativeTest.cpp
@@ -244,3 +244,95 @@ bool FAIArmyPlacementAutoAdvanceTest::RunTest(const FString &Parameters) {
 
   return true;
 }
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FInitializeWorldSingleInitiativeRollTest,
+                                 "Skald.Turn.ArmyPlacement.SingleInitiativeRoll",
+                                 EAutomationTestFlags::EditorContext |
+                                     EAutomationTestFlags::EngineFilter)
+
+bool FInitializeWorldSingleInitiativeRollTest::RunTest(const FString &Parameters) {
+  UWorld *World = FAutomationEditorCommonUtils::CreateNewMap();
+  TestNotNull(TEXT("World created"), World);
+  if (!World) {
+    return false;
+  }
+
+  ASkaldGameMode *GameMode = World->SpawnActor<ASkaldGameMode>();
+  AWorldMap *Map = World->SpawnActor<AWorldMap>();
+  ATurnManager *TurnManager = World->SpawnActor<ATurnManager>();
+  ATerritory *TerritoryA = World->SpawnActor<ATerritory>();
+  ATerritory *TerritoryB = World->SpawnActor<ATerritory>();
+  ASkaldPlayerController *ControllerA = World->SpawnActor<ASkaldPlayerController>();
+  ASkaldPlayerController *ControllerB = World->SpawnActor<ASkaldPlayerController>();
+  ASkaldPlayerState *StateA = World->SpawnActor<ASkaldPlayerState>();
+  ASkaldPlayerState *StateB = World->SpawnActor<ASkaldPlayerState>();
+
+  TestNotNull(TEXT("GameMode"), GameMode);
+  TestNotNull(TEXT("WorldMap"), Map);
+  TestNotNull(TEXT("TurnManager"), TurnManager);
+  TestNotNull(TEXT("TerritoryA"), TerritoryA);
+  TestNotNull(TEXT("TerritoryB"), TerritoryB);
+  TestNotNull(TEXT("ControllerA"), ControllerA);
+  TestNotNull(TEXT("ControllerB"), ControllerB);
+  TestNotNull(TEXT("StateA"), StateA);
+  TestNotNull(TEXT("StateB"), StateB);
+  if (!GameMode || !Map || !TurnManager || !TerritoryA || !TerritoryB ||
+      !ControllerA || !ControllerB || !StateA || !StateB) {
+    return false;
+  }
+
+  AttachGameModeToWorld(World, GameMode);
+  GameMode->InitGameState();
+  ASkaldGameState *GameState = GameMode->GetGameState<ASkaldGameState>();
+  TestNotNull(TEXT("GameState initialised"), GameState);
+  if (!GameState) {
+    return false;
+  }
+
+  ConfigureController(ControllerA, StateA, 1, TEXT("PlayerA"), 0);
+  ConfigureController(ControllerB, StateB, 2, TEXT("PlayerB"), 0);
+  GameState->AddPlayerState(StateA);
+  GameState->AddPlayerState(StateB);
+
+  TerritoryA->TerritoryID = 1;
+  TerritoryB->TerritoryID = 2;
+  Map->Territories = {TerritoryA, TerritoryB};
+
+  SetObjectProperty(GameMode, TEXT("TurnManager"), TurnManager);
+  SetObjectProperty(GameMode, TEXT("WorldMap"), Map);
+  SetObjectProperty(TurnManager, TEXT("CachedWorldMap"), Map);
+
+  const bool bFirstInit = GameMode->InitializeWorld();
+  TestTrue(TEXT("Initial world initialisation succeeded"), bFirstInit);
+  if (!bFirstInit) {
+    return false;
+  }
+
+  TMap<ASkaldPlayerState *, int32> InitialRolls;
+  for (APlayerState *PSBase : GameState->PlayerArray) {
+    if (ASkaldPlayerState *PS = Cast<ASkaldPlayerState>(PSBase)) {
+      TestTrue(TEXT("Initial initiative roll assigned"), PS->InitiativeRoll > 0);
+      InitialRolls.Add(PS, PS->InitiativeRoll);
+    }
+  }
+  TestTrue(TEXT("Captured initiative rolls for all players"),
+           InitialRolls.Num() == GameState->PlayerArray.Num());
+  if (InitialRolls.Num() != GameState->PlayerArray.Num()) {
+    return false;
+  }
+
+  const bool bSecondInit = GameMode->InitializeWorld();
+  TestTrue(TEXT("Second world initialisation succeeded"), bSecondInit);
+  if (!bSecondInit) {
+    return false;
+  }
+
+  for (const auto &Pair : InitialRolls) {
+    ASkaldPlayerState *PS = Pair.Key;
+    const int32 ExpectedRoll = Pair.Value;
+    TestEqual(TEXT("Initiative roll preserved"), PS->InitiativeRoll,
+              ExpectedRoll);
+  }
+
+  return true;
+}


### PR DESCRIPTION
## Summary
- preserve existing initiative rolls when InitializeWorld is invoked again so the original match leader stays in front
- add an automation test that verifies InitializeWorld does not reroll initiative after the first pass

## Testing
- not run (Unreal automation tests unavailable in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68d46ff5605483249eb3a213fec01754