### PR TITLE
Reset initiative rolls before new match initialization

### DIFF
--- a/Source/Skald/Skald_GameMode.cpp
+++ b/Source/Skald/Skald_GameMode.cpp
@@ -878,6 +878,18 @@ void ASkaldGameMode::TryInitializeWorldAndStart() {
   }
 
   if (!bWorldInitialized && bReadyToStart) {
+    // New matches may reuse existing player states carrying initiative rolls
+    // from the previous session. Clear any stored values so InitializeWorld can
+    // assign fresh rolls for the upcoming match while still preserving rerolls
+    // within the same initialization sequence.
+    for (APlayerState *PSBase : GS->PlayerArray) {
+      if (ASkaldPlayerState *PS = Cast<ASkaldPlayerState>(PSBase)) {
+        if (PS->InitiativeRoll > 0) {
+          PS->InitiativeRoll = 0;
+        }
+      }
+    }
+
     UE_LOG(LogSkald, Log,
            TEXT("TryInitializeWorldAndStart: Initializing world"));
     if (InitializeWorld()) {


### PR DESCRIPTION
## Summary
- reset player initiative rolls before initializing a new match so reused player states don't carry over past results
- keep the guard that preserves initiative when InitializeWorld is called repeatedly in the same match

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d4753d76bc8324b36a939995bc76bb