### PR TITLE
Allow initiative test to access InitializeWorld

### DIFF
--- a/Source/Skald/Skald_GameMode.h
+++ b/Source/Skald/Skald_GameMode.h
@@ -33,6 +33,7 @@ class SKALD_API ASkaldGameMode : public AGameModeBase {
   // Allow automation tests to drive protected game flow entry points.
   friend class FArmyPlacementInitiativeOrderTest;
   friend class FAIArmyPlacementAutoAdvanceTest;
+  friend class FInitializeWorldSingleInitiativeRollTest;
 #endif // WITH_AUTOMATION_TESTS
 
 public:


### PR DESCRIPTION
## Summary
- expose the automation test that verifies repeated world initialization to ASkaldGameMode's protected API by declaring it as a friend class

## Testing
- not run (header-only change)


------
https://chatgpt.com/codex/tasks/task_e_68d47847f0148324a44940379e6d04d9