### PR TITLE
Fix battle side determination after player id updates

### DIFF
--- a/Source/Skald/Skald_PlayerController.cpp
+++ b/Source/Skald/Skald_PlayerController.cpp
@@ -1984,6 +1984,11 @@ void ASkaldPlayerController::DetermineControlledBattleSide() {
   }
 }
 
+void ASkaldPlayerController::HandlePlayerIdUpdated() {
+  DetermineControlledBattleSide();
+  UpdateBattleHUDButtons();
+}
+
 void ASkaldPlayerController::HandleBattleEnded(ESkaldFaction WinningFaction,
                                                int32 AttackerCasualties,
                                                int32 DefenderCasualties) {

--- a/Source/Skald/Skald_PlayerController.h
+++ b/Source/Skald/Skald_PlayerController.h
@@ -210,6 +210,9 @@ protected:
   UFUNCTION()
   void HandleEndTurnPressed();
 
+  /** Respond when our PlayerState receives an updated PlayerId. */
+  void HandlePlayerIdUpdated();
+
   UFUNCTION()
   void HandleRightClick();
 

--- a/Source/Skald/Skald_PlayerState.cpp
+++ b/Source/Skald/Skald_PlayerState.cpp
@@ -108,6 +108,7 @@ void ASkaldPlayerState::OnRep_PlayerId() {
           HUD->SyncPhaseButtons(HUD->CurrentPlayerID == HUD->LocalPlayerID);
         }
       }
+      SkaldPC->HandlePlayerIdUpdated();
     }
   }
 


### PR DESCRIPTION
## Summary
- Recalculate the human-controlled battle side whenever the PlayerState replicates a new PlayerId
- Update battle HUD button states after the PlayerId refresh so the End Turn button becomes available

## Testing
- Not run (Unreal Engine automation not available in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68d47fbd526c83249092d84db608f52d