### PR TITLE
Allow player state to trigger controller ID refresh

### DIFF
--- a/Source/Skald/Skald_PlayerController.h
+++ b/Source/Skald/Skald_PlayerController.h
@@ -37,6 +37,8 @@ class SKALD_API ASkaldPlayerController : public APlayerController {
 
   /** Allow the game mode to trigger binding once the world map exists. */
   friend class ASkaldGameMode;
+  /** Allow the player state to notify us when its player ID changes. */
+  friend class ASkaldPlayerState;
 
 public:
   ASkaldPlayerController();


### PR DESCRIPTION
## Summary
- allow the player state to notify the player controller when its player id changes by granting friend access

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d4836590188324bd82782ba8353455