### PR TITLE
Gate automatic activation endings behind AI control

### DIFF
--- a/Source/Skald/GridBattleManager.cpp
+++ b/Source/Skald/GridBattleManager.cpp
@@ -3,6 +3,7 @@
 #include "FighterPawn.h"
 #include "GridOverlayComponent.h"
 #include "SkaldLogging.h"
+#include "Skald_GameInstance.h"
 #include "UObject/UnrealType.h"
 
 namespace
@@ -327,7 +328,7 @@ void UGridBattleManager::StartRound()
 void UGridBattleManager::AdvanceTurn()
 {
     UE_LOG(LogSkaldBattle, Verbose, TEXT("[Battle] AdvanceTurn called. Active fighter: %s"), *DescribeFighter(ActiveFighter));
-    FinishActivation(ActiveFighter);
+    FinishActivation(ActiveFighter, EGridActivationFinishReason::Auto);
 }
 
 bool UGridBattleManager::CanActivateFighter(AFighterPawn* Fighter) const
@@ -391,7 +392,7 @@ bool UGridBattleManager::ActivateFighter(AFighterPawn* Fighter)
     return ActiveFighter != nullptr;
 }
 
-void UGridBattleManager::FinishActivation(AFighterPawn* Fighter)
+void UGridBattleManager::FinishActivation(AFighterPawn* Fighter, EGridActivationFinishReason Reason)
 {
     if (bBattleConcluded)
     {
@@ -407,6 +408,13 @@ void UGridBattleManager::FinishActivation(AFighterPawn* Fighter)
     }
 
     const bool bWasAttacker = FighterToFinish->bIsAttacker;
+
+    if (Reason == EGridActivationFinishReason::Auto && !IsSideAIControlled(bWasAttacker))
+    {
+        UE_LOG(LogSkaldBattle, Verbose, TEXT("[Battle] Ignoring automatic FinishActivation for human-controlled %s"),
+            bWasAttacker ? TEXT("attackers") : TEXT("defenders"));
+        return;
+    }
 
     if (ActiveFighter == FighterToFinish)
     {
@@ -526,6 +534,19 @@ void UGridBattleManager::ClearInactiveFighters()
     {
         UE_LOG(LogSkaldBattle, Log, TEXT("[Battle] Cleared %d inactive fighters from initiative order"), Removed);
     }
+}
+
+bool UGridBattleManager::IsSideAIControlled(bool bForAttackers) const
+{
+    if (const UWorld* World = GetWorld())
+    {
+        if (const USkaldGameInstance* GameInstance = World->GetGameInstance<USkaldGameInstance>())
+        {
+            const FS_BattlePayload& Battle = GameInstance->PendingBattle;
+            return bForAttackers ? Battle.bAttackerIsAI : Battle.bDefenderIsAI;
+        }
+    }
+    return false;
 }
 
 void UGridBattleManager::EndBattle()

--- a/Source/Skald/GridBattleManager.h
+++ b/Source/Skald/GridBattleManager.h
@@ -104,7 +104,14 @@ struct FFighter
  * described in the design. It focuses on dice rolling and turn order
  * logic, leaving visuals and detailed rules to Blueprints or future
  * work.
- */
+*/
+UENUM()
+enum class EGridActivationFinishReason : uint8
+{
+    Manual,
+    Auto
+};
+
 UCLASS(Blueprintable)
 class SKALD_API UGridBattleManager : public UObject
 {
@@ -148,7 +155,7 @@ public:
 
     /** Complete the active fighter's activation and rotate the turn. */
     UFUNCTION(BlueprintCallable, Category="Battle")
-    void FinishActivation(AFighterPawn* Fighter);
+    void FinishActivation(AFighterPawn* Fighter, EGridActivationFinishReason Reason = EGridActivationFinishReason::Auto);
 
     /** Conclude the battle and broadcast the results. */
     UFUNCTION(BlueprintCallable, Category="Battle")
@@ -263,6 +270,7 @@ protected:
 private:
     bool HasLivingFighters(bool bForAttackers) const;
     bool HasAvailableFighters(bool bForAttackers) const;
+    bool IsSideAIControlled(bool bForAttackers) const;
     void EvaluateRoundProgress(bool bPreviousWasAttacker);
     void ClearInactiveFighters();
 

--- a/Source/Skald/Skald_AIController.cpp
+++ b/Source/Skald/Skald_AIController.cpp
@@ -507,7 +507,7 @@ void ASkaldAIController::ExecuteActivationForFighter(AFighterPawn *Fighter) {
   }
 
   if (CachedBattleManager.IsValid()) {
-    CachedBattleManager->FinishActivation(Fighter);
+    CachedBattleManager->FinishActivation(Fighter, EGridActivationFinishReason::Auto);
   }
 }
 

--- a/Source/Skald/Skald_PlayerController.cpp
+++ b/Source/Skald/Skald_PlayerController.cpp
@@ -1839,7 +1839,8 @@ void ASkaldPlayerController::HandleEndTurnPressed() {
          TEXT("[BattleHUD] Finishing activation for %s (Round=%d, AttackerTurn=%s)"),
          *LockedActiveFighter->GetHumanReadableName(), RoundNumber,
          bAttackerTurn ? TEXT("true") : TEXT("false"));
-  CachedGameInstance->GridBattleManager->FinishActivation(LockedActiveFighter);
+  CachedGameInstance->GridBattleManager->FinishActivation(
+      LockedActiveFighter, EGridActivationFinishReason::Manual);
   LockedActiveFighter = nullptr;
   UpdateBattleHUDButtons();
   CancelCommandMode();


### PR DESCRIPTION
## Summary
- add an EGridActivationFinishReason enum to the grid battle manager so automatic end-of-activation calls can be distinguished from manual ones
- block automatic FinishActivation calls for human-controlled sides by consulting the pending battle metadata from the game instance
- update the player and AI controllers to pass the appropriate reason when they finish an activation

## Testing
- not run (project has no automated tests)


------
https://chatgpt.com/codex/tasks/task_e_68d481d45e1883248e62813cff16a1fe