### PR TITLE
Fix AI fighter activation timing

### DIFF
--- a/Source/Skald/GridBattleManager.cpp
+++ b/Source/Skald/GridBattleManager.cpp
@@ -416,11 +416,12 @@ void UGridBattleManager::FinishActivation(AFighterPawn* Fighter, EGridActivation
         return;
     }
 
-    if (ActiveFighter == FighterToFinish)
+    const bool bWasActiveFighter = ActiveFighter == FighterToFinish;
+
+    if (bWasActiveFighter)
     {
         ActiveFighter->FinishActivation();
         ActiveFighter = nullptr;
-        OnActiveFighterChanged.Broadcast(nullptr);
         UE_LOG(LogSkaldBattle, Log, TEXT("[Battle] Fighter finished activation: %s"), *DescribeFighter(FighterToFinish));
     }
     else if (InitiativeOrder.Contains(FighterToFinish))
@@ -430,6 +431,11 @@ void UGridBattleManager::FinishActivation(AFighterPawn* Fighter, EGridActivation
     }
 
     EvaluateRoundProgress(bWasAttacker);
+
+    if (bWasActiveFighter)
+    {
+        OnActiveFighterChanged.Broadcast(nullptr);
+    }
 }
 
 bool UGridBattleManager::HasLivingFighters(bool bForAttackers) const


### PR DESCRIPTION
## Summary
- ensure the active fighter cleared notification fires after turn state updates so AI controllers can claim the next fighter

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d4947244a48324bf92b888ba147978