### PR TITLE
Show current battle turn in HUD

### DIFF
--- a/Source/Skald/Skald_PlayerController.cpp
+++ b/Source/Skald/Skald_PlayerController.cpp
@@ -735,6 +735,7 @@ void ASkaldPlayerController::HandleActiveFighterChanged(
 
   CancelCommandMode();
   UpdateBattleHUDButtons();
+  UpdateBattlePlayersTurnDisplay();
   if (!NewFighter) {
     UpdateBattleHUDSelection();
   }
@@ -1862,6 +1863,7 @@ void ASkaldPlayerController::HandleRoundStarted(int32 RoundNumber,
   LockedActiveFighter = nullptr;
   CancelCommandMode();
   UpdateBattleRoundDisplay(RoundNumber, InitiativeWinner);
+  UpdateBattlePlayersTurnDisplay();
   UpdateBattleHUDSelection();
   UpdateBattleHUDButtons();
 }
@@ -1952,6 +1954,61 @@ void ASkaldPlayerController::UpdateBattleRoundDisplay(
   }
 
   BattleHudWidget->SetRoundInfo(RoundText, InitiativeText);
+}
+
+void ASkaldPlayerController::UpdateBattlePlayersTurnDisplay() {
+  if (!BattleHudWidget)
+    return;
+
+  USkaldGameInstance *GI = CachedGameInstance;
+  if (!GI) {
+    GI = GetGameInstance<USkaldGameInstance>();
+    CachedGameInstance = GI;
+  }
+
+  if (!GI) {
+    BattleHudWidget->SetPlayersTurnLabel(FText::GetEmpty());
+    return;
+  }
+
+  bool bAttackerTurn = true;
+  if (GI->GridBattleManager) {
+    bAttackerTurn = GI->GridBattleManager->IsAttackerTurn();
+  } else if (LockedActiveFighter) {
+    bAttackerTurn = LockedActiveFighter->bIsAttacker;
+  }
+
+  const FS_BattlePayload &Battle = GI->PendingBattle;
+  FString PlayerName =
+      bAttackerTurn ? Battle.AttackerDisplayName : Battle.DefenderDisplayName;
+  const int32 PlayerId =
+      bAttackerTurn ? Battle.AttackerPlayerID : Battle.DefenderPlayerID;
+
+  if (PlayerName.IsEmpty()) {
+    ASkaldGameState *GameState = CachedGameState;
+    if (!GameState && GetWorld()) {
+      GameState = GetWorld()->GetGameState<ASkaldGameState>();
+      CachedGameState = GameState;
+    }
+    if (GameState) {
+      if (ASkaldPlayerState *PS = GameState->GetPlayerById(PlayerId)) {
+        PlayerName =
+            ResolvePlayerName(PS, TEXT("BattleHUD_PlayerTurnDisplay"));
+      }
+    }
+  }
+
+  if (PlayerName.IsEmpty()) {
+    PlayerName = bAttackerTurn ? TEXT("Attackers") : TEXT("Defenders");
+  }
+
+  const FText Label = PlayerName.IsEmpty()
+                           ? FText::GetEmpty()
+                           : FText::Format(
+                                 NSLOCTEXT("Skald", "BattlePlayersTurnLabel",
+                                           "{0}'s Turn"),
+                                 FText::FromString(PlayerName));
+  BattleHudWidget->SetPlayersTurnLabel(Label);
 }
 
 bool ASkaldPlayerController::IsFriendlyFighter(const AFighterPawn *Fighter) const {

--- a/Source/Skald/Skald_PlayerController.h
+++ b/Source/Skald/Skald_PlayerController.h
@@ -416,6 +416,7 @@ private:
   void UpdateBattleHUDSelection();
   void UpdateBattleHUDButtons();
   void UpdateBattleRoundDisplay(int32 RoundNumber, ESkaldFaction InitiativeWinner);
+  void UpdateBattlePlayersTurnDisplay();
   bool IsFriendlyFighter(const AFighterPawn *Fighter) const;
   void DetermineControlledBattleSide();
 

--- a/Source/Skald/UI/BattleHUDWidget.cpp
+++ b/Source/Skald/UI/BattleHUDWidget.cpp
@@ -158,6 +158,12 @@ void UBattleHUDWidget::SetRoundInfo(const FText &RoundLabel,
   }
 }
 
+void UBattleHUDWidget::SetPlayersTurnLabel(const FText &PlayerLabel) {
+  if (PlayersTurnText) {
+    PlayersTurnText->SetText(PlayerLabel);
+  }
+}
+
 void UBattleHUDWidget::SetSelectedFighterName(const FText &Name) {
   if (FighterNameText) {
     FighterNameText->SetText(Name);

--- a/Source/Skald/UI/BattleHUDWidget.h
+++ b/Source/Skald/UI/BattleHUDWidget.h
@@ -102,8 +102,15 @@ public:
   UPROPERTY(BlueprintReadOnly, meta = (BindWidgetOptional))
   UTextBlock *InitiativeText;
 
+  /** Text displaying whose turn is currently active. */
+  UPROPERTY(BlueprintReadOnly, meta = (BindWidgetOptional))
+  UTextBlock *PlayersTurnText;
+
   /** Update the round and initiative labels. */
   void SetRoundInfo(const FText &RoundLabel, const FText &InitiativeLabel);
+
+  /** Update the label that shows whose turn is active. */
+  void SetPlayersTurnLabel(const FText &PlayerLabel);
 
   /** Update the fighter name label. */
   void SetSelectedFighterName(const FText &Name);


### PR DESCRIPTION
## Summary
- add an optional PlayersTurn text binding and setter on the battle HUD widget
- update the player controller to derive the active side's display name and refresh the PlayersTurn label as turns advance

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d495705f908324b301b351110de0eb