### PR TITLE
Set fighter UI defaults

### DIFF
--- a/Source/Skald/FighterPawn.cpp
+++ b/Source/Skald/FighterPawn.cpp
@@ -10,6 +10,7 @@
 #include "Net/UnrealNetwork.h"
 #include "Skald_GameInstance.h"
 #include "TimerManager.h"
+#include "UObject/ConstructorHelpers.h"
 
 namespace
 {
@@ -37,6 +38,19 @@ AFighterPawn::AFighterPawn() {
 
   HealthWidget = CreateDefaultSubobject<UWidgetComponent>(TEXT("HealthWidget"));
   HealthWidget->SetupAttachment(DisplayMesh);
+  HealthWidget->SetTwoSided(true);
+
+  static ConstructorHelpers::FClassFinder<UUserWidget> HealthWidgetFinder(
+      TEXT("/Game/Blueprints/UI/WBP_FighterHealth"));
+  if (HealthWidgetFinder.Succeeded()) {
+    HealthWidgetTemplate = HealthWidgetFinder.Class;
+  }
+
+  static ConstructorHelpers::FClassFinder<UUserWidget> DamageWidgetFinder(
+      TEXT("/Game/Blueprints/UI/WBP_DamageFloat"));
+  if (DamageWidgetFinder.Succeeded()) {
+    DamageFloatWidgetTemplate = DamageWidgetFinder.Class;
+  }
 
   ActionsRemaining = 0;
   bHasActivatedThisRound = false;


### PR DESCRIPTION
## Summary
- load the fighter health and damage widget blueprints by default
- enable two-sided rendering on the fighter health widget component so it shows from all angles

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d4a512e07083248d99fbb919fe19e5