### PR TITLE
Adjust fighter health widget transform

### DIFF
--- a/Source/Skald/FighterPawn.cpp
+++ b/Source/Skald/FighterPawn.cpp
@@ -39,6 +39,9 @@ AFighterPawn::AFighterPawn() {
   HealthWidget = CreateDefaultSubobject<UWidgetComponent>(TEXT("HealthWidget"));
   HealthWidget->SetupAttachment(DisplayMesh);
   HealthWidget->SetTwoSided(true);
+  HealthWidget->SetRelativeLocation(FVector(0.f, 0.f, 400.f));
+  HealthWidget->SetRelativeRotation(FRotator(0.f, 90.f, 0.f));
+  HealthWidget->SetRelativeScale3D(FVector(1.f));
 
   static ConstructorHelpers::FClassFinder<UUserWidget> HealthWidgetFinder(
       TEXT("/Game/Blueprints/UI/WBP_FighterHealth"));


### PR DESCRIPTION
## Summary
- position the fighter health widget 400 units above the mesh and rotate it to face sideways while keeping the default scale

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d4b94fb6e88324b2eb0f16d62e62eb