### PR TITLE
Fix automation access to army placement helpers

### DIFF
--- a/Source/Skald/Skald_GameMode.h
+++ b/Source/Skald/Skald_GameMode.h
@@ -18,6 +18,7 @@ class USkaldSaveGame;
 class FArmyPlacementInitiativeOrderTest;
 class FAIArmyPlacementAutoAdvanceTest;
 #endif // WITH_AUTOMATION_TESTS
+struct FSkaldGameModeAutomationAccessor;
 
 DECLARE_DYNAMIC_MULTICAST_DELEGATE_OneParam(FSkaldGameOver, ASkaldPlayerState *,
                                             Winner);
@@ -35,6 +36,7 @@ class SKALD_API ASkaldGameMode : public AGameModeBase {
   friend class FAIArmyPlacementAutoAdvanceTest;
   friend class FInitializeWorldSingleInitiativeRollTest;
 #endif // WITH_AUTOMATION_TESTS
+  friend struct FSkaldGameModeAutomationAccessor;
 
 public:
   ASkaldGameMode();

--- a/Source/Skald/Tests/ArmyPlacementInitiativeTest.cpp
+++ b/Source/Skald/Tests/ArmyPlacementInitiativeTest.cpp
@@ -11,6 +11,20 @@
 #include "WorldMap.h"
 
 namespace {
+struct FSkaldGameModeAutomationAccessor {
+  static void BeginArmyPlacementPhase(ASkaldGameMode *GameMode) {
+    if (GameMode) {
+      GameMode->BeginArmyPlacementPhase();
+    }
+  }
+
+  static void HandleArmyPlacementFailsafe(ASkaldGameMode *GameMode) {
+    if (GameMode) {
+      GameMode->HandleArmyPlacementFailsafe();
+    }
+  }
+};
+
 void SetObjectProperty(UObject *Target, const TCHAR *PropertyName, UObject *Value) {
   if (!Target) {
     return;
@@ -120,7 +134,7 @@ bool FArmyPlacementInitiativeOrderTest::RunTest(const FString &Parameters) {
   TurnManager->RegisterController(ControllerA);
   TurnManager->RegisterController(ControllerB);
 
-  GameMode->BeginArmyPlacementPhase();
+  FSkaldGameModeAutomationAccessor::BeginArmyPlacementPhase(GameMode);
 
   const int32 IndexA = GameState->PlayerArray.IndexOfByKey(StateA);
   const int32 IndexB = GameState->PlayerArray.IndexOfByKey(StateB);
@@ -220,7 +234,7 @@ bool FAIArmyPlacementAutoAdvanceTest::RunTest(const FString &Parameters) {
   TurnManager->RegisterController(AIController);
   TurnManager->RegisterController(HumanController);
 
-  GameMode->BeginArmyPlacementPhase();
+  FSkaldGameModeAutomationAccessor::BeginArmyPlacementPhase(GameMode);
 
   const int32 HumanIndex = GameState->PlayerArray.IndexOfByKey(HumanState);
   TestTrue(TEXT("Human player index valid"), HumanIndex != INDEX_NONE);
@@ -314,7 +328,7 @@ bool FAIArmyPlacementFailsafeRespectsHumanTest::RunTest(
   TurnManager->RegisterController(AIController);
   TurnManager->RegisterController(HumanController);
 
-  GameMode->BeginArmyPlacementPhase();
+  FSkaldGameModeAutomationAccessor::BeginArmyPlacementPhase(GameMode);
 
   const int32 HumanIndex = GameState->PlayerArray.IndexOfByKey(HumanState);
   TestTrue(TEXT("Human player index valid"), HumanIndex != INDEX_NONE);
@@ -323,7 +337,7 @@ bool FAIArmyPlacementFailsafeRespectsHumanTest::RunTest(
   TestEqual(TEXT("Army placement phase active"), TurnManager->GetCurrentPhase(),
             ETurnPhase::ArmyPlacement);
 
-  GameMode->HandleArmyPlacementFailsafe();
+  FSkaldGameModeAutomationAccessor::HandleArmyPlacementFailsafe(GameMode);
 
   TestEqual(TEXT("Failsafe does not skip human"), GameState->CurrentTurnIndex,
             HumanIndex);

--- a/Source/Skald/Tests/ArmyPlacementInitiativeTest.cpp
+++ b/Source/Skald/Tests/ArmyPlacementInitiativeTest.cpp
@@ -10,7 +10,6 @@
 #include "UObject/UnrealType.h"
 #include "WorldMap.h"
 
-namespace {
 struct FSkaldGameModeAutomationAccessor {
   static void BeginArmyPlacementPhase(ASkaldGameMode *GameMode) {
     if (GameMode) {
@@ -25,6 +24,7 @@ struct FSkaldGameModeAutomationAccessor {
   }
 };
 
+namespace {
 void SetObjectProperty(UObject *Target, const TCHAR *PropertyName, UObject *Value) {
   if (!Target) {
     return;


### PR DESCRIPTION
## Summary
- add a dedicated automation accessor for SkaldGameMode army placement helpers
- update automation tests to call the accessor instead of protected members directly

## Testing
- not run (automation-only change)


------
https://chatgpt.com/codex/tasks/task_e_68d4bea8612c8324adf1189e5c0d8aa6