### PR TITLE
Ensure AI controllers register for battle setup

### DIFF
--- a/Source/Skald/Skald_AIController.cpp
+++ b/Source/Skald/Skald_AIController.cpp
@@ -29,6 +29,15 @@ void ASkaldAIController::BeginPlay() {
   Super::BeginPlay();
 
   SetupBattleAutomation();
+
+  if (HasAuthority()) {
+    if (UWorld *World = GetWorld()) {
+      if (ASkald_BattleGameMode *BattleGameMode =
+              World->GetAuthGameMode<ASkald_BattleGameMode>()) {
+        BattleGameMode->OnAIControllerReady(this);
+      }
+    }
+  }
 }
 
 void ASkaldAIController::StartTurn() { MakeAIDecision(); }


### PR DESCRIPTION
## Summary
- notify the battle game mode when an AI controller begins play so it gets registered for battle setup
- call `OnAIControllerReady` when the controller has authority, ensuring both participants are available before launching the battle

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d4c9d104b08324a431c13726fa035d