### PR TITLE
Fix AI controller ready callback signature

### DIFF
--- a/Source/Skald/Skald_BattleGameMode.cpp
+++ b/Source/Skald/Skald_BattleGameMode.cpp
@@ -1093,7 +1093,7 @@ void ASkald_BattleGameMode::PostLogin(APlayerController *NewPlayer) {
   OnControllerReady(NewPlayer);
 }
 
-void ASkald_BattleGameMode::OnAIControllerReady(AAIController *Controller) {
+void ASkald_BattleGameMode::OnAIControllerReady(ASkaldAIController *Controller) {
   OnControllerReady(Controller);
 }
 

--- a/Source/Skald/Skald_BattleGameMode.h
+++ b/Source/Skald/Skald_BattleGameMode.h
@@ -38,7 +38,7 @@ protected:
 
 public:
   // Called by the AI controller when it’s ready (BeginPlay)
-  void OnAIControllerReady(AAIController *Controller);
+  void OnAIControllerReady(class ASkaldAIController *Controller);
 
   UFUNCTION(BlueprintCallable)
   void OnControllerReady(AController *Controller);


### PR DESCRIPTION
## Summary
- update `ASkald_BattleGameMode::OnAIControllerReady` to accept the concrete AI controller type now derived from `ASkaldPlayerController`
- forward the ready notification using the corrected pointer type so the build succeeds

## Testing
- not run (Unreal Engine build tooling not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68d54093cd9483249cee3dbb6cc03614