### PR TITLE
Fix HUD turn message when initiative winner is the local player

### DIFF
--- a/Source/Skald/UI/SkaldMainHUDWidget.cpp
+++ b/Source/Skald/UI/SkaldMainHUDWidget.cpp
@@ -78,6 +78,11 @@ void USkaldMainHUDWidget::NativeConstruct() {
            TEXT("SkaldMainHUDWidget could not find GameInstance."));
   }
 
+  const int32 ResolvedLocalId = ResolveLocalPlayerId();
+  if (ResolvedLocalId != -1) {
+    LocalPlayerID = ResolvedLocalId;
+  }
+
   if (AttackButton) {
     AttackButton->OnClicked.AddDynamic(
         this, &USkaldMainHUDWidget::BeginAttackSelection);
@@ -593,16 +598,25 @@ void USkaldMainHUDWidget::SetUseSiegeForNextAttack(bool bEnable) {
   bUseSiegeForNextAttack = bEnable;
 }
 
+int32 USkaldMainHUDWidget::ResolveLocalPlayerId() const {
+  if (const APlayerController *PC = GetOwningPlayer()) {
+    if (const ASkaldPlayerState *LocalPS =
+            PC->GetPlayerState<ASkaldPlayerState>()) {
+      return LocalPS->GetPlayerId();
+    }
+  }
+  return -1;
+}
+
 void USkaldMainHUDWidget::HandlePlayersUpdated() {
   if (!GameState) {
     return;
   }
 
   int32 NewLocalPlayerId = LocalPlayerID;
-  if (APlayerController *PC = GetOwningPlayer()) {
-    if (ASkaldPlayerState *LocalPS = PC->GetPlayerState<ASkaldPlayerState>()) {
-      NewLocalPlayerId = LocalPS->GetPlayerId();
-    }
+  const int32 ResolvedLocalId = ResolveLocalPlayerId();
+  if (ResolvedLocalId != -1) {
+    NewLocalPlayerId = ResolvedLocalId;
   }
 
   TArray<FS_PlayerData> Players;
@@ -650,6 +664,12 @@ void USkaldMainHUDWidget::HandleTurnIndexChanged(int32 /*NewTurnIndex*/) {
   BP_SetTurnText(TurnNumber, CurrentPlayerID);
 
   // Update buttons for the new player and show a brief turn message.
+  if (LocalPlayerID == -1) {
+    const int32 ResolvedLocalId = ResolveLocalPlayerId();
+    if (ResolvedLocalId != -1) {
+      LocalPlayerID = ResolvedLocalId;
+    }
+  }
   const bool bIsMyTurn = (CurrentPlayerID == LocalPlayerID);
   SyncPhaseButtons(bIsMyTurn);
   ShowTurnMessage(bIsMyTurn);

--- a/Source/Skald/UI/SkaldMainHUDWidget.h
+++ b/Source/Skald/UI/SkaldMainHUDWidget.h
@@ -338,4 +338,6 @@ protected:
   /** GS -> HUD: react to turn index changes (client + server). */
   UFUNCTION()
   void HandleTurnIndexChanged(int32 NewTurnIndex);
+
+  int32 ResolveLocalPlayerId() const;
 };


### PR DESCRIPTION
## Summary
- resolve the local player id when the HUD is constructed so the first turn announcement uses the correct controller
- reuse the same helper during player list and turn index updates to keep the cached id in sync before showing turn banners

## Testing
- ./Build/validate.sh *(fails: UnrealBuildTool/UnrealEditor not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d550c237608324bc906c3c47aa8edd