### PR TITLE
Ensure deploy button is interactable during placement phases

### DIFF
--- a/Source/Skald/UI/SkaldMainHUDWidget.cpp
+++ b/Source/Skald/UI/SkaldMainHUDWidget.cpp
@@ -583,8 +583,14 @@ void USkaldMainHUDWidget::OnTerritoryClickedUI(ATerritory *Territory) {
   } else if (CurrentPhase == ETurnPhase::Reinforcement ||
              CurrentPhase == ETurnPhase::ArmyPlacement) {
     SelectedSourceID = Territory->TerritoryID;
-    if (bOwnedByLocal && DeployButton) {
-      DeployButton->SetVisibility(ESlateVisibility::Visible);
+    if (DeployButton) {
+      const bool bIsMyTurn = (CurrentPlayerID != -1 && LocalPlayerID != -1 &&
+                              CurrentPlayerID == LocalPlayerID);
+      const bool bShouldShowDeploy = bIsMyTurn && bOwnedByLocal;
+      DeployButton->SetVisibility(
+          bShouldShowDeploy ? ESlateVisibility::Visible
+                            : ESlateVisibility::Collapsed);
+      DeployButton->SetIsEnabled(bShouldShowDeploy);
     }
   } else if (CurrentPhase == ETurnPhase::Engineering && bOwnedByLocal &&
              Territory->bIsCapital) {


### PR DESCRIPTION
## Summary
- update the HUD's territory click handling to respect turn ownership when showing the deploy button
- re-enable the deploy button whenever it is made visible so it can be clicked during reinforcement and army placement

## Testing
- not run (Unreal Engine build not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68d57383dd388324bdb69dc8f79960d0