### PR TITLE
Update listen server HUD after player ID reassignment

### DIFF
--- a/Source/Skald/Skald_GameMode.cpp
+++ b/Source/Skald/Skald_GameMode.cpp
@@ -813,6 +813,13 @@ void ASkaldGameMode::TryInitializeWorldAndStart() {
       if (PlayerDataArray.IsValidIndex(i)) {
         PlayerDataArray[i].PlayerID = NewPlayerId;
       }
+      if (ASkaldPlayerController *OwningController =
+              Cast<ASkaldPlayerController>(PS->GetOwner())) {
+        if (USkaldMainHUDWidget *HUD = OwningController->GetHUDWidget()) {
+          HUD->LocalPlayerID = NewPlayerId;
+          HUD->SyncPhaseButtons(HUD->CurrentPlayerID == HUD->LocalPlayerID);
+        }
+      }
     }
   }
 


### PR DESCRIPTION
## Summary
- update listen-server HUD widgets as soon as player IDs are reassigned so local buttons refresh immediately

## Testing
- not run (Unreal Engine PIE not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68d591a307e48324b88c35e4e2b7bd18