### PR TITLE
Fix deploy button visibility when starting army placement

### DIFF
--- a/Source/Skald/UI/SkaldMainHUDWidget.cpp
+++ b/Source/Skald/UI/SkaldMainHUDWidget.cpp
@@ -210,8 +210,13 @@ void USkaldMainHUDWidget::UpdateTerritoryInfo(const FString &TerritoryName,
   BP_SetTerritoryPanel(TerritoryName, OwnerName, ArmyCount);
 
   // Keep Deploy button visibility in sync with current selection ownership.
-  const bool bIsMyTurn = (CurrentPlayerID != -1 &&
-                          LocalPlayerID != -1 &&
+  if (LocalPlayerID == -1) {
+    const int32 ResolvedLocalId = ResolveLocalPlayerId();
+    if (ResolvedLocalId != -1) {
+      LocalPlayerID = ResolvedLocalId;
+    }
+  }
+  const bool bIsMyTurn = (CurrentPlayerID != -1 && LocalPlayerID != -1 &&
                           CurrentPlayerID == LocalPlayerID);
 
   if (DeployButton && (CurrentPhase == ETurnPhase::Reinforcement ||
@@ -584,8 +589,16 @@ void USkaldMainHUDWidget::OnTerritoryClickedUI(ATerritory *Territory) {
              CurrentPhase == ETurnPhase::ArmyPlacement) {
     SelectedSourceID = Territory->TerritoryID;
     if (DeployButton) {
-      const bool bIsMyTurn = (CurrentPlayerID != -1 && LocalPlayerID != -1 &&
-                              CurrentPlayerID == LocalPlayerID);
+      int32 EffectiveLocalPlayerId = LocalPlayerID;
+      if (EffectiveLocalPlayerId == -1) {
+        EffectiveLocalPlayerId = ResolveLocalPlayerId();
+        if (EffectiveLocalPlayerId != -1) {
+          LocalPlayerID = EffectiveLocalPlayerId;
+        }
+      }
+      const bool bIsMyTurn =
+          (CurrentPlayerID != -1 && EffectiveLocalPlayerId != -1 &&
+           CurrentPlayerID == EffectiveLocalPlayerId);
       const bool bShouldShowDeploy = bIsMyTurn && bOwnedByLocal;
       DeployButton->SetVisibility(
           bShouldShowDeploy ? ESlateVisibility::Visible


### PR DESCRIPTION
## Summary
- resolve the local player id opportunistically before checking turn ownership when updating territory info
- ensure territory clicks also resolve and cache the local player id before toggling the deploy button

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d5a04893d88324a352ae0a41f077e1