### PR TITLE
Ensure AI advances battle turns and broadcast attack rolls

### DIFF
--- a/Source/Skald/FighterPawn.cpp
+++ b/Source/Skald/FighterPawn.cpp
@@ -238,6 +238,13 @@ void AFighterPawn::PerformAttack(AFighterPawn *Target) {
       DamageThisDie = Stats.AttackDamage;
     }
 
+    const bool bHit = DamageThisDie > 0;
+    if (USkaldGameInstance *GI = Cast<USkaldGameInstance>(GetGameInstance())) {
+      if (UGridBattleManager *BattleManager = GI->GridBattleManager) {
+        BattleManager->ReportAttackRoll(this, Target, Roll, bHit, DamageThisDie);
+      }
+    }
+
     if (DamageThisDie > 0) {
       Target->Stats.Health =
           FMath::Max(0, Target->Stats.Health - DamageThisDie);

--- a/Source/Skald/GridBattleManager.cpp
+++ b/Source/Skald/GridBattleManager.cpp
@@ -329,7 +329,28 @@ void UGridBattleManager::StartRound()
 void UGridBattleManager::AdvanceTurn()
 {
     UE_LOG(LogSkaldBattle, Verbose, TEXT("[Battle] AdvanceTurn called. Active fighter: %s"), *DescribeFighter(ActiveFighter));
-    FinishActivation(ActiveFighter, EGridActivationFinishReason::Auto);
+    if (ActiveFighter)
+    {
+        FinishActivation(ActiveFighter, EGridActivationFinishReason::Auto);
+        return;
+    }
+
+    const bool bPreviousWasAttacker = bIsAttackerTurn;
+    EvaluateRoundProgress(bPreviousWasAttacker);
+    OnActiveFighterChanged.Broadcast(nullptr);
+}
+
+void UGridBattleManager::ReportAttackRoll(AFighterPawn* Attacker, AFighterPawn* Defender, int32 Roll, bool bHit, int32 Damage)
+{
+    if (!Attacker || !Defender)
+    {
+        return;
+    }
+
+    UE_LOG(LogSkaldBattle, Log, TEXT("[Battle] Attack roll: %s -> %s | Roll=%d Result=%s Damage=%d"),
+        *DescribeFighter(Attacker), *DescribeFighter(Defender), Roll, bHit ? TEXT("Hit") : TEXT("Miss"), Damage);
+
+    OnAttackResolved.Broadcast(Attacker, Defender, Roll, bHit, Damage);
 }
 
 bool UGridBattleManager::CanActivateFighter(AFighterPawn* Fighter) const

--- a/Source/Skald/GridBattleManager.h
+++ b/Source/Skald/GridBattleManager.h
@@ -11,6 +11,8 @@ class AFighterPawn; // MUST be before the delegates
 
 DECLARE_DYNAMIC_MULTICAST_DELEGATE_ThreeParams(
     FOnBattleEnded, ESkaldFaction, WinningFaction, int32, AttackerCasualties, int32, DefenderCasualties);
+DECLARE_DYNAMIC_MULTICAST_DELEGATE_FiveParams(
+    FOnAttackResolved, AFighterPawn*, Attacker, AFighterPawn*, Defender, int32, Roll, bool, bHit, int32, Damage);
 
 DECLARE_DYNAMIC_MULTICAST_DELEGATE_OneParam(FOnActiveFighterChanged, AFighterPawn*, NewFighter);
 DECLARE_DYNAMIC_MULTICAST_DELEGATE_TwoParams(FOnRoundStarted, int32, RoundNumber, ESkaldFaction, InitiativeWinner);
@@ -209,6 +211,10 @@ public:
     UPROPERTY(BlueprintAssignable, Category="Battle|Events")
     FOnBattleEnded OnBattleEnded;
 
+    /** Fired whenever an individual attack roll resolves. */
+    UPROPERTY(BlueprintAssignable, Category="Battle|Events")
+    FOnAttackResolved OnAttackResolved;
+
     /** Fired whenever the active fighter changes (including nullptr). */
     UPROPERTY(BlueprintAssignable, Category="Battle|Events")
     FOnActiveFighterChanged OnActiveFighterChanged;
@@ -222,6 +228,8 @@ public:
 
     UFUNCTION(BlueprintCallable, Category="Battle")
     void UnregisterFighter(AFighterPawn* Fighter);
+
+    void ReportAttackRoll(AFighterPawn* Attacker, AFighterPawn* Defender, int32 Roll, bool bHit, int32 Damage);
 
     /** Table containing fighter definitions. */
     UPROPERTY(EditDefaultsOnly, Category="Data")

--- a/Source/Skald/Skald_AIController.cpp
+++ b/Source/Skald/Skald_AIController.cpp
@@ -545,6 +545,7 @@ void ASkaldAIController::TryActivateNextFighter() {
   const bool bAttackerTurn = CachedBattleManager->IsAttackerTurn();
   AFighterPawn *NextFighter = FindNextFriendlyFighter(bAttackerTurn);
   if (!NextFighter) {
+    CachedBattleManager->AdvanceTurn();
     return;
   }
 


### PR DESCRIPTION
## Summary
- ensure the battle manager can progress turns even when no fighter is active and report each attack roll
- update the AI controller to end its turn when it has no fighters left to activate
- forward attack roll information from fighters so UI or logs can display hit or miss results

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68d5a8d68af88324a890d6631dd87b48