### PR TITLE
Track fighter actions in battle HUD

### DIFF
--- a/Source/Skald/FighterPawn.cpp
+++ b/Source/Skald/FighterPawn.cpp
@@ -89,6 +89,8 @@ void AFighterPawn::BeginPlay() {
   OnHealthChanged.AddDynamic(this, &AFighterPawn::UpdateHealthDisplay);
   OnHealthChanged.Broadcast(Stats.Health);
 
+  BroadcastActionsRemaining();
+
   UpdateMeshOffset();
 
   if (UGridOverlayComponent *Grid = GetGrid()) {
@@ -117,17 +119,23 @@ void AFighterPawn::BeginActivation() {
   ActionsRemaining = ActionsPerActivation;
   bIsCurrentlyActive = true;
   bHasActivatedThisRound = true;
+
+  BroadcastActionsRemaining();
 }
 
 void AFighterPawn::ResetActivationState() {
   ActionsRemaining = 0;
   bHasActivatedThisRound = false;
   bIsCurrentlyActive = false;
+
+  BroadcastActionsRemaining();
 }
 
 void AFighterPawn::FinishActivation() {
   ActionsRemaining = 0;
   bIsCurrentlyActive = false;
+
+  BroadcastActionsRemaining();
 }
 
 UGridOverlayComponent *AFighterPawn::GetGrid() {
@@ -188,6 +196,8 @@ void AFighterPawn::MoveToCell(FIntPoint TargetCell) {
   }
   SetActorLocation(NewLocation);
   ActionsRemaining = FMath::Max(0, ActionsRemaining - 1);
+
+  BroadcastActionsRemaining();
 
   if (Grid) {
     Grid->SetOccupied(TargetCell, true);
@@ -266,6 +276,8 @@ void AFighterPawn::PerformAttack(AFighterPawn *Target) {
   }
   ActionsRemaining = FMath::Max(0, ActionsRemaining - 1);
 
+  BroadcastActionsRemaining();
+
   if (Grid) {
     Grid->ClearHighlights();
   }
@@ -319,4 +331,10 @@ void AFighterPawn::OnRep_Stats(const FFighterStats &OldStats) {
   } else if (!OnHealthChanged.IsBound()) {
     UpdateHealthDisplay(Stats.Health);
   }
+}
+
+void AFighterPawn::OnRep_ActionsRemaining() { BroadcastActionsRemaining(); }
+
+void AFighterPawn::BroadcastActionsRemaining() {
+  OnActionsChanged.Broadcast(ActionsRemaining);
 }

--- a/Source/Skald/FighterPawn.h
+++ b/Source/Skald/FighterPawn.h
@@ -11,6 +11,8 @@ class UGridOverlayComponent;
 class UCapsuleComponent;
 
 DECLARE_DYNAMIC_MULTICAST_DELEGATE_OneParam(FOnHealthChanged, int32, NewHealth);
+DECLARE_DYNAMIC_MULTICAST_DELEGATE_OneParam(FOnActionsChanged, int32,
+                                            NewActionsRemaining);
 
 /** Pawn representing a fighter in grid battles. */
 UCLASS()
@@ -63,7 +65,8 @@ public:
   bool bIsAttacker = false;
 
   /** Actions remaining for the current activation. */
-  UPROPERTY(BlueprintReadOnly, Replicated, Category = "Fighter")
+  UPROPERTY(BlueprintReadOnly, ReplicatedUsing = OnRep_ActionsRemaining,
+            Category = "Fighter")
   int32 ActionsRemaining;
 
   /** True once the fighter has activated during the current round. */
@@ -99,6 +102,10 @@ public:
   UPROPERTY(BlueprintAssignable, Category = "Fighter|Events")
   FOnHealthChanged OnHealthChanged;
 
+  /** Event broadcast when actions remaining changes. */
+  UPROPERTY(BlueprintAssignable, Category = "Fighter|Events")
+  FOnActionsChanged OnActionsChanged;
+
 protected:
   /** Clear grid occupancy when the fighter is destroyed. */
   virtual void Destroyed() override;
@@ -111,12 +118,17 @@ private:
   /** Respond when the fighter stats replicate to clients. */
   UFUNCTION()
   void OnRep_Stats(const FFighterStats &OldStats);
+  UFUNCTION()
+  void OnRep_ActionsRemaining();
 
   /** Retrieve or create a damage widget from the pool. */
   UUserWidget *GetDamageWidgetFromPool();
 
   /** Align the visible mesh with the collision capsule. */
   void UpdateMeshOffset();
+
+  /** Helper to broadcast the current actions remaining value. */
+  void BroadcastActionsRemaining();
 
   /** Pool of reusable damage widgets to avoid repeated allocations. */
   UPROPERTY()

--- a/Source/Skald/UI/BattleHUDWidget.cpp
+++ b/Source/Skald/UI/BattleHUDWidget.cpp
@@ -33,11 +33,15 @@ void UBattleHUDWidget::BindToFighter(AFighterPawn *Fighter) {
   if (BoundFighter) {
     BoundFighter->OnHealthChanged.RemoveDynamic(
         this, &UBattleHUDWidget::HandleHealthChanged);
+    BoundFighter->OnActionsChanged.RemoveDynamic(
+        this, &UBattleHUDWidget::HandleActionsChanged);
   }
   BoundFighter = Fighter;
   if (BoundFighter) {
     BoundFighter->OnHealthChanged.AddDynamic(
         this, &UBattleHUDWidget::HandleHealthChanged);
+    BoundFighter->OnActionsChanged.AddDynamic(
+        this, &UBattleHUDWidget::HandleActionsChanged);
     UpdateStatPanel();
     if (FighterNameText) {
       FighterNameText->SetText(
@@ -52,6 +56,9 @@ void UBattleHUDWidget::BindToFighter(AFighterPawn *Fighter) {
     }
     if (MoveText) {
       MoveText->SetText(FText::GetEmpty());
+    }
+    if (ActionsText) {
+      ActionsText->SetText(FText::GetEmpty());
     }
     if (StrengthText) {
       StrengthText->SetText(FText::GetEmpty());
@@ -121,6 +128,12 @@ void UBattleHUDWidget::HandleHealthChanged(int32 NewHealth) {
   }
 }
 
+void UBattleHUDWidget::HandleActionsChanged(int32 NewActions) {
+  if (ActionsText) {
+    ActionsText->SetText(FText::AsNumber(NewActions));
+  }
+}
+
 void UBattleHUDWidget::UpdateStatPanel() {
   if (!BoundFighter) {
     return;
@@ -133,6 +146,9 @@ void UBattleHUDWidget::UpdateStatPanel() {
   }
   if (MoveText) {
     MoveText->SetText(FText::AsNumber(BoundFighter->Stats.Movement));
+  }
+  if (ActionsText) {
+    ActionsText->SetText(FText::AsNumber(BoundFighter->ActionsRemaining));
   }
   if (StrengthText) {
     StrengthText->SetText(FText::AsNumber(BoundFighter->Stats.Strength));

--- a/Source/Skald/UI/BattleHUDWidget.h
+++ b/Source/Skald/UI/BattleHUDWidget.h
@@ -74,6 +74,10 @@ public:
   UPROPERTY(BlueprintReadOnly, meta = (BindWidget))
   UTextBlock *MoveText;
 
+  /** Text displaying remaining actions. */
+  UPROPERTY(BlueprintReadOnly, meta = (BindWidgetOptional))
+  UTextBlock *ActionsText;
+
   /** Text displaying strength value. */
   UPROPERTY(BlueprintReadOnly, meta = (BindWidget))
   UTextBlock *StrengthText;
@@ -150,6 +154,10 @@ private:
   /** Respond to health changes from the fighter. */
   UFUNCTION()
   void HandleHealthChanged(int32 NewHealth);
+
+  /** Respond to action count changes from the fighter. */
+  UFUNCTION()
+  void HandleActionsChanged(int32 NewActions);
 
   /** Find the grid overlay component in the world. */
   UGridOverlayComponent *FindGridOverlay() const;


### PR DESCRIPTION
## Summary
- add a multicast event that keeps the fighter's replicated actions remaining in sync
- update the battle HUD widget to display remaining actions and react to changes

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d5a956fd2483249cffb50eb8a33215