### PR TITLE
Improve grid click handling and fighter lookup

### DIFF
--- a/Source/Skald/FighterPawn.cpp
+++ b/Source/Skald/FighterPawn.cpp
@@ -152,6 +152,8 @@ UGridOverlayComponent *AFighterPawn::GetGrid() {
   return CachedGrid;
 }
 
+FIntPoint AFighterPawn::GetCurrentCell() const { return CurrentCell; }
+
 UUserWidget *AFighterPawn::GetDamageWidgetFromPool() {
   for (UUserWidget *Widget : DamageWidgetPool) {
     if (Widget && !Widget->IsInViewport()) {

--- a/Source/Skald/FighterPawn.h
+++ b/Source/Skald/FighterPawn.h
@@ -54,6 +54,9 @@ public:
   /** Get the grid overlay component, caching the result. */
   UGridOverlayComponent *GetGrid();
 
+  /** Retrieve the grid cell currently occupied by this fighter. */
+  FIntPoint GetCurrentCell() const;
+
   /** Statistics describing this fighter. */
   UPROPERTY(BlueprintReadWrite, EditAnywhere, ReplicatedUsing = OnRep_Stats,
             Category = "Fighter")

--- a/Source/Skald/Skald_PlayerController.cpp
+++ b/Source/Skald/Skald_PlayerController.cpp
@@ -718,6 +718,19 @@ UGridOverlayComponent *ASkaldPlayerController::FindGridOverlay() const {
   return nullptr;
 }
 
+AFighterPawn *ASkaldPlayerController::FindFighterAtCell(
+    const FIntPoint &Cell) const {
+  if (UWorld *World = GetWorld()) {
+    for (TActorIterator<AFighterPawn> It(World); It; ++It) {
+      AFighterPawn *Fighter = *It;
+      if (Fighter && Fighter->GetCurrentCell() == Cell) {
+        return Fighter;
+      }
+    }
+  }
+  return nullptr;
+}
+
 void ASkaldPlayerController::HandleActiveFighterChanged(
     AFighterPawn *NewFighter) {
   if (NewFighter && NewFighter->IsAlive()) {
@@ -1653,6 +1666,10 @@ void ASkaldPlayerController::HandleGridClick() {
   if (!IsLocalController())
     return;
 
+  if (UWidgetBlueprintLibrary::IsCursorOverInteractableWidget()) {
+    return;
+  }
+
   // Non-battle map handling
   FHitResult Hit;
   if (!bIsBattleMap) {
@@ -1666,11 +1683,21 @@ void ASkaldPlayerController::HandleGridClick() {
   }
 
   // Get active fighter
-  GetHitResultUnderCursor(ECC_Visibility, /*bTraceComplex*/ false, Hit);
+  if (!GetHitResultUnderCursor(ECC_Visibility, /*bTraceComplex*/ false, Hit)) {
+    return;
+  }
 
   UGridOverlayComponent *Grid = FindGridOverlay();
   if (!Grid)
     return;
+
+  const FVector WorldLocation = Hit.bBlockingHit ? Hit.ImpactPoint : Hit.Location;
+  const FIntPoint Cell = Grid->WorldToGrid(WorldLocation);
+  if (!Grid->IsCellInBounds(Cell)) {
+    return;
+  }
+
+  AFighterPawn *CellFighter = FindFighterAtCell(Cell);
 
   switch (CurrentCommandMode) {
   case EBattleCommandMode::Move: {
@@ -1682,9 +1709,6 @@ void ASkaldPlayerController::HandleGridClick() {
       CancelCommandMode();
       break;
     }
-    const FVector Impact =
-        Hit.bBlockingHit ? Hit.ImpactPoint : FVector::ZeroVector;
-    const FIntPoint Cell = Grid->WorldToGrid(Impact);
     LockedActiveFighter->MoveToCell(Cell);
     CancelCommandMode();
     UpdateBattleHUDButtons();
@@ -1699,7 +1723,7 @@ void ASkaldPlayerController::HandleGridClick() {
       CancelCommandMode();
       break;
     }
-    AFighterPawn *TargetPawn = Cast<AFighterPawn>(Hit.GetActor());
+    AFighterPawn *TargetPawn = CellFighter;
     if (TargetPawn && TargetPawn != LockedActiveFighter && TargetPawn->IsAlive() &&
         !IsFriendlyFighter(TargetPawn)) {
       LockedActiveFighter->PerformAttack(TargetPawn);
@@ -1716,14 +1740,13 @@ void ASkaldPlayerController::HandleGridClick() {
     return;
   }
 
-  AFighterPawn *ClickedPawn = Cast<AFighterPawn>(Hit.GetActor());
-  if (ClickedPawn && ClickedPawn->IsAlive()) {
-    if (LockedActiveFighter && LockedActiveFighter != ClickedPawn) {
+  if (CellFighter && CellFighter->IsAlive()) {
+    if (LockedActiveFighter && LockedActiveFighter != CellFighter) {
       return;
     }
 
-    if (IsFriendlyFighter(ClickedPawn)) {
-      SetSelectedFighter(ClickedPawn);
+    if (IsFriendlyFighter(CellFighter)) {
+      SetSelectedFighter(CellFighter);
       UpdateBattleHUDButtons();
     } else if (!LockedActiveFighter) {
       ClearSelectedFighter();

--- a/Source/Skald/Skald_PlayerController.h
+++ b/Source/Skald/Skald_PlayerController.h
@@ -206,6 +206,9 @@ protected:
   UFUNCTION()
   void HandleGridClick();
 
+  /** Find a fighter occupying the specified grid cell. */
+  AFighterPawn *FindFighterAtCell(const FIntPoint &Cell) const;
+
   UFUNCTION()
   void HandleActivatePressed();
 


### PR DESCRIPTION
## Summary
- prevent grid clicks from firing when the cursor is over HUD widgets or outside the grid bounds
- derive clicked cells from the grid overlay and resolve occupants via a helper lookup
- expose a fighter cell accessor so controllers can locate pawns without relying on trace actors

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d5ac66e4f08324b78c9ba37820bfb1