### PR TITLE
Replicate fighter current cell to clients

### DIFF
--- a/Source/Skald/FighterPawn.cpp
+++ b/Source/Skald/FighterPawn.cpp
@@ -72,6 +72,7 @@ void AFighterPawn::GetLifetimeReplicatedProps(
   DOREPLIFETIME(AFighterPawn, ActionsRemaining);
   DOREPLIFETIME(AFighterPawn, bHasActivatedThisRound);
   DOREPLIFETIME(AFighterPawn, bIsCurrentlyActive);
+  DOREPLIFETIME(AFighterPawn, CurrentCell);
 }
 
 void AFighterPawn::OnConstruction(const FTransform &Transform) {

--- a/Source/Skald/FighterPawn.h
+++ b/Source/Skald/FighterPawn.h
@@ -138,6 +138,7 @@ private:
   TArray<UUserWidget *> DamageWidgetPool;
 
   /** Current cell occupied by the fighter. */
+  UPROPERTY(Replicated)
   FIntPoint CurrentCell;
 
   /** Cached grid overlay component. */


### PR DESCRIPTION
## Summary
- replicate the fighter pawn's CurrentCell property to keep remote clients updated
- include the cell property in lifetime replication to support multiplayer selection logic

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d5b2195ff483249bf93d158cb84f98