### PR TITLE
Fix cursor interactable widget check

### DIFF
--- a/Source/Skald/Skald_PlayerController.cpp
+++ b/Source/Skald/Skald_PlayerController.cpp
@@ -32,6 +32,11 @@
 #include "UObject/ConstructorHelpers.h"
 #include "WorldMap.h"
 
+#include "Framework/Application/SlateApplication.h"
+#include "Layout/WidgetPath.h"
+#include "Widgets/SWidget.h"
+#include "Widgets/SWindow.h"
+
 // Portable include for FCoreUObjectDelegates across UE versions
 #if __has_include("UObject/CoreUObjectDelegates.h")
     #include "UObject/CoreUObjectDelegates.h"
@@ -51,6 +56,32 @@ FString ResolvePlayerName(const ASkaldPlayerState *PlayerState,
   }
 
   return PlayerState->GetResolvedPlayerName(Context);
+}
+
+bool IsCursorOverInteractableSlateWidget() {
+  if (!FSlateApplication::IsInitialized()) {
+    return false;
+  }
+
+  FSlateApplication &SlateApp = FSlateApplication::Get();
+  const FVector2D CursorPos = SlateApp.GetCursorPos();
+
+  TArray<TSharedRef<SWindow>> Windows = SlateApp.GetInteractiveTopLevelWindows();
+  if (Windows.Num() == 0) {
+    return false;
+  }
+
+  const FWidgetPath WidgetPath =
+      SlateApp.LocateWindowUnderMouse(CursorPos, Windows);
+
+  for (int32 Index = WidgetPath.Widgets.Num() - 1; Index >= 0; --Index) {
+    const FArrangedWidget &ArrangedWidget = WidgetPath.Widgets[Index];
+    if (ArrangedWidget.Widget->IsInteractable()) {
+      return true;
+    }
+  }
+
+  return false;
 }
 }
 
@@ -1666,7 +1697,7 @@ void ASkaldPlayerController::HandleGridClick() {
   if (!IsLocalController())
     return;
 
-  if (UWidgetBlueprintLibrary::IsCursorOverInteractableWidget()) {
+  if (IsCursorOverInteractableSlateWidget()) {
     return;
   }
 


### PR DESCRIPTION
## Summary
- add a Slate-based helper to detect when the cursor is over an interactable widget
- replace the removed UWidgetBlueprintLibrary::IsCursorOverInteractableWidget usage with the new helper to keep grid clicks from firing while hovering UI

## Testing
- not run (native build environment not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68d5b4661f488324b714d2da814b4394