### PR TITLE
Fix const Cell reassignment in HandleGridClick attack branch

### DIFF
--- a/Source/Skald/Skald_PlayerController.cpp
+++ b/Source/Skald/Skald_PlayerController.cpp
@@ -1813,7 +1813,6 @@ void ASkaldPlayerController::HandleGridClick() {
 
     if (IsValidEnemyTarget(TargetPawn)) {
       CellFighter = TargetPawn;
-      Cell = TargetCell;
       LockedActiveFighter->PerformAttack(TargetPawn);
     }
     CancelCommandMode();


### PR DESCRIPTION
## Summary
- remove the redundant reassignment to `Cell` in the attack command handling to keep the variable immutable

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d5bba50a2883249cfb1af143ff28ae