### PR TITLE
Stop auto-advancing deployment phase from deploy widget

### DIFF
--- a/Source/Skald/UI/DeployWidget.cpp
+++ b/Source/Skald/UI/DeployWidget.cpp
@@ -1,7 +1,6 @@
 #include "UI/DeployWidget.h"
 #include "Components/Button.h"
 #include "Components/SpinBox.h"
-#include "Skald_GameMode.h"
 #include "Skald_PlayerController.h"
 #include "Skald_PlayerState.h"
 #include "SkaldTypes.h"
@@ -68,20 +67,6 @@ void UDeployWidget::HandleAccept() {
     const int32 Remaining = PlayerState->DeployableUnits - Selected;
     if (Remaining <= 0 && OwningHUD->DeployButton) {
       OwningHUD->DeployButton->SetVisibility(ESlateVisibility::Collapsed);
-      bool bHandled = false;
-      if (ASkaldGameMode *GM =
-              OwningHUD->GetWorld()->GetAuthGameMode<ASkaldGameMode>()) {
-        if (TurnManager &&
-            TurnManager->GetCurrentPhase() == ETurnPhase::ArmyPlacement) {
-          GM->AdvanceArmyPlacement();
-          bHandled = true;
-        }
-      }
-      if (!bHandled) {
-        if (TurnManager) {
-          TurnManager->AdvancePhase();
-        }
-      }
     }
   }
 


### PR DESCRIPTION
## Summary
- stop the deploy widget from auto-advancing the turn phase when players finish placing units
- leave the deploy button collapse behaviour so the UI still reflects depleted unit pools
- drop the unused Skald_GameMode include

## Testing
- `UnrealEditor /workspace/Skald_TurnBasedStrategy_Code/Skald.uproject -ExecCmds="Automation RunTests Skald.Turn.ArmyPlacement.InitiativeOrder+Skald.Turn.ArmyPlacement.AIAutoAdvance+Skald.Turn.ArmyPlacement.FailsafeRespectsHuman;Quit" -unattended -nop4` *(fails: UnrealEditor not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d5c3e4c2cc832487f1ad912a2f9ca2