### PR TITLE
Add fighter removal and sort fighter entries by cost

### DIFF
--- a/Source/Skald/UI/FighterSelectionWidget.cpp
+++ b/Source/Skald/UI/FighterSelectionWidget.cpp
@@ -30,6 +30,10 @@ void UFighterEntryWidget::NativeConstruct() {
     SelectButton->OnClicked.AddDynamic(this,
                                        &UFighterEntryWidget::HandleClicked);
   }
+  if (RemoveButton) {
+    RemoveButton->OnClicked.AddDynamic(this,
+                                       &UFighterEntryWidget::HandleRemoveClicked);
+  }
 }
 
 void UFighterEntryWidget::Init(const FFighterDefinition &InFighter,
@@ -75,6 +79,12 @@ void UFighterEntryWidget::Init(const FFighterDefinition &InFighter,
 void UFighterEntryWidget::HandleClicked() {
   if (Owner) {
     Owner->ChooseFighter(Fighter);
+  }
+}
+
+void UFighterEntryWidget::HandleRemoveClicked() {
+  if (Owner) {
+    Owner->RemoveFighter(Fighter);
   }
 }
 
@@ -134,6 +144,11 @@ void UFighterSelectionWidget::PopulateFighterList() {
     UE_LOG(LogSkaldUI, Warning, TEXT("[FighterSelection] AvailableFighters is EMPTY."));
   }
 
+  AvailableFighters.Sort([](const FFighterDefinition& A, const FFighterDefinition& B)
+  {
+    return A.Stats.ArmyCost < B.Stats.ArmyCost;
+  });
+
   int32 Added = 0;
   for (const FFighterDefinition &Fighter : AvailableFighters) {
     if (UFighterEntryWidget *Entry =
@@ -160,6 +175,27 @@ bool UFighterSelectionWidget::ChooseFighter(const FFighterDefinition &Fighter) {
   CurrentCost += Fighter.Stats.ArmyCost;
   OnFighterChosen.Broadcast(Fighter);
   UpdateCostDisplay();
+  RefreshEntryAffordability();
+  return true;
+}
+
+bool UFighterSelectionWidget::RemoveFighter(const FFighterDefinition &Fighter)
+{
+  const int32 Index = ChosenFighters.IndexOfByPredicate(
+      [&Fighter](const FFighterDefinition& Candidate)
+      {
+        return Candidate.Id == Fighter.Id;
+      });
+
+  if (Index == INDEX_NONE)
+  {
+    return false;
+  }
+
+  CurrentCost -= ChosenFighters[Index].Stats.ArmyCost;
+  ChosenFighters.RemoveAt(Index);
+  UpdateCostDisplay();
+  RefreshEntryAffordability();
   return true;
 }
 
@@ -211,5 +247,25 @@ void UFighterSelectionWidget::UpdateCostDisplay() {
     Args.Add(TEXT("Max"), MaxCost);
     CostDisplayText->SetText(
         FText::Format(FText::FromString("{Cur} / {Max}"), Args));
+  }
+}
+
+void UFighterSelectionWidget::RefreshEntryAffordability()
+{
+  if (!FighterList)
+  {
+    return;
+  }
+
+  const int32 NumChildren = FighterList->GetChildrenCount();
+  for (int32 ChildIdx = 0; ChildIdx < NumChildren; ++ChildIdx)
+  {
+    if (UFighterEntryWidget* Entry = Cast<UFighterEntryWidget>(FighterList->GetChildAt(ChildIdx)))
+    {
+      if (Entry->SelectButton)
+      {
+        Entry->SelectButton->SetIsEnabled(CanAfford(Entry->Fighter));
+      }
+    }
   }
 }

--- a/Source/Skald/UI/FighterSelectionWidget.h
+++ b/Source/Skald/UI/FighterSelectionWidget.h
@@ -29,6 +29,10 @@ public:
   UPROPERTY(BlueprintReadOnly, meta = (BindWidgetOptional))
   UButton *SelectButton;
 
+  /** Button bound from the blueprint used to remove this fighter. */
+  UPROPERTY(BlueprintReadOnly, meta = (BindWidgetOptional))
+  UButton *RemoveButton;
+
   /** Name text bound from the blueprint. */
   UPROPERTY(BlueprintReadOnly, meta = (BindWidgetOptional))
   UTextBlock *NameText;
@@ -73,6 +77,10 @@ private:
   /** Callback for SelectButton. */
   UFUNCTION()
   void HandleClicked();
+
+  /** Callback for RemoveButton. */
+  UFUNCTION()
+  void HandleRemoveClicked();
 
   /** Owning selection widget. */
   UPROPERTY()
@@ -144,6 +152,10 @@ public:
   UFUNCTION(BlueprintCallable, Category = "Skald|Fighter")
   bool ChooseFighter(const FFighterDefinition &Fighter);
 
+  /** Attempt to remove a fighter, returns true if removed. */
+  UFUNCTION(BlueprintCallable, Category = "Skald|Fighter")
+  bool RemoveFighter(const FFighterDefinition &Fighter);
+
   /** Lock in the current selection. */
   UFUNCTION(BlueprintCallable, Category = "Skald|Fighter")
   void LockIn();
@@ -178,4 +190,6 @@ private:
   void HandleLockInClicked();
 
   void GatherSelectedFighters(TArray<FFighterDefinition> &OutFighters) const;
+
+  void RefreshEntryAffordability();
 };


### PR DESCRIPTION
## Summary
- add a bound remove button to fighter entries so players can deselect fighters and refund their cost
- expose removal handling on the selection widget and refresh entry button states after selections change
- sort available fighters by army cost before creating entry widgets so cheaper units appear first

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d5cf03fe2c8324a0e68b44fa14826a