### PR TITLE
Fix current turn tracking to respect initiative order

### DIFF
--- a/Source/Skald/Skald_GameState.cpp
+++ b/Source/Skald/Skald_GameState.cpp
@@ -61,7 +61,12 @@ void ASkaldGameState::RemovePlayerState(APlayerState* PlayerState)
 
 ASkaldPlayerState* ASkaldGameState::GetCurrentPlayer() const
 {
-    return Players.IsValidIndex(CurrentTurnIndex) ? Players[CurrentTurnIndex] : nullptr;
+    if (!PlayerArray.IsValidIndex(CurrentTurnIndex))
+    {
+        return nullptr;
+    }
+
+    return Cast<ASkaldPlayerState>(PlayerArray[CurrentTurnIndex]);
 }
 
 ASkaldPlayerState* ASkaldGameState::GetPlayerById(int32 PlayerID) const
@@ -106,14 +111,16 @@ void ASkaldGameState::OnRep_BattleSummary()
 
 void ASkaldGameState::ClampTurnIndex()
 {
-    if (Players.Num() == 0)
+    const int32 PlayerCount = PlayerArray.Num();
+    if (PlayerCount == 0)
     {
         CurrentTurnIndex = 0;
         return;
     }
-    if (CurrentTurnIndex < 0 || CurrentTurnIndex >= Players.Num())
+
+    if (CurrentTurnIndex < 0 || CurrentTurnIndex >= PlayerCount)
     {
-        CurrentTurnIndex = FMath::Clamp(CurrentTurnIndex, 0, FMath::Max(0, Players.Num() - 1));
+        CurrentTurnIndex = FMath::Clamp(CurrentTurnIndex, 0, FMath::Max(0, PlayerCount - 1));
     }
 }
 

--- a/Source/Skald/UI/SkaldMainHUDWidget.cpp
+++ b/Source/Skald/UI/SkaldMainHUDWidget.cpp
@@ -675,7 +675,7 @@ void USkaldMainHUDWidget::HandleTurnIndexChanged(int32 /*NewTurnIndex*/) {
       NewPlayerID = PS->GetPlayerId();
     }
 
-    const int32 PlayerCount = GameState->Players.Num();
+    const int32 PlayerCount = GameState->PlayerArray.Num();
     if (PlayerCount > 0) {
       NewTurnNumber = GameState->CurrentTurnIndex / PlayerCount + 1;
     }


### PR DESCRIPTION
## Summary
- look up the active turn player from the authoritative PlayerArray instead of the replicated Players list so initiative order is respected on clients
- clamp CurrentTurnIndex using the PlayerArray length and align HUD turn number calculations to the same source

## Testing
- ./Build/validate.sh *(fails: UnrealEditor not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d5d0b0c898832494c3a1fa7486ecbf