### PR TITLE
Highlight clicked battle cells and show enemy HUD info

### DIFF
--- a/Source/Skald/Skald_PlayerController.cpp
+++ b/Source/Skald/Skald_PlayerController.cpp
@@ -1823,6 +1823,8 @@ void ASkaldPlayerController::HandleGridClick() {
     break;
   }
 
+  HighlightClickedCell(Grid, Cell);
+
   if (CurrentCommandMode != EBattleCommandMode::None) {
     return;
   }
@@ -1832,12 +1834,7 @@ void ASkaldPlayerController::HandleGridClick() {
       return;
     }
 
-    if (IsFriendlyFighter(CellFighter)) {
-      SetSelectedFighter(CellFighter);
-      UpdateBattleHUDButtons();
-    } else if (!LockedActiveFighter) {
-      ClearSelectedFighter();
-    }
+    SetSelectedFighter(CellFighter);
     return;
   }
 
@@ -1983,6 +1980,33 @@ void ASkaldPlayerController::CancelCommandMode() {
   if (BattleHudWidget) {
     BattleHudWidget->ClearCommandPreviews();
   }
+}
+
+void ASkaldPlayerController::HighlightClickedCell(UGridOverlayComponent *Grid,
+                                                  const FIntPoint &Cell) {
+  if (!Grid || !Grid->IsCellInBounds(Cell)) {
+    return;
+  }
+
+  bool bRestoredCommandHighlights = false;
+  if (CurrentCommandMode == EBattleCommandMode::Move) {
+    if (LockedActiveFighter && IsFriendlyFighter(LockedActiveFighter)) {
+      Grid->HighlightMovement(LockedActiveFighter);
+      bRestoredCommandHighlights = true;
+    }
+  } else if (CurrentCommandMode == EBattleCommandMode::Attack) {
+    if (LockedActiveFighter && IsFriendlyFighter(LockedActiveFighter)) {
+      Grid->HighlightAttack(LockedActiveFighter);
+      bRestoredCommandHighlights = true;
+    }
+  }
+
+  if (!bRestoredCommandHighlights) {
+    Grid->ClearHighlights();
+  }
+
+  Grid->HighlightCell(Cell, Grid->SelectionHighlightColor.ToFColor(true), 0.f,
+                      false);
 }
 
 void ASkaldPlayerController::SetSelectedFighter(AFighterPawn *Fighter,

--- a/Source/Skald/Skald_PlayerController.h
+++ b/Source/Skald/Skald_PlayerController.h
@@ -414,6 +414,7 @@ private:
   void InitializeFighterSelectionIfNeeded();
 
   void CancelCommandMode();
+  void HighlightClickedCell(UGridOverlayComponent *Grid, const FIntPoint &Cell);
   void SetSelectedFighter(AFighterPawn *Fighter, bool bForce = false);
   void ClearSelectedFighter();
   void UpdateBattleHUDSelection();


### PR DESCRIPTION
## Summary
- highlight clicked battle-map grid cells while keeping command highlights intact
- allow enemy fighters to be selected so their details appear in the battle HUD

## Testing
- not run (not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68d63298eb1c8324950068c6c8935525