### PR TITLE
Add randomised placement support to grid overlay component

### DIFF
--- a/Source/Skald/GridOverlayActor.cpp
+++ b/Source/Skald/GridOverlayActor.cpp
@@ -11,3 +11,11 @@ AGridOverlayActor::AGridOverlayActor() {
   GridComponent = CreateDefaultSubobject<UGridOverlayComponent>(TEXT("GridOverlay"));
 }
 
+void AGridOverlayActor::BeginPlay() {
+  if (GridComponent) {
+    GridComponent->ApplyRandomizedOrigin();
+  }
+
+  Super::BeginPlay();
+}
+

--- a/Source/Skald/GridOverlayActor.h
+++ b/Source/Skald/GridOverlayActor.h
@@ -18,6 +18,8 @@ public:
   AGridOverlayActor();
 
 protected:
+  virtual void BeginPlay() override;
+
   /** Root component used to anchor the grid overlay. */
   UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "Grid")
   USceneComponent *SceneRoot = nullptr;

--- a/Source/Skald/GridOverlayComponent.cpp
+++ b/Source/Skald/GridOverlayComponent.cpp
@@ -1,4 +1,5 @@
 #include "GridOverlayComponent.h"
+#include "CollisionQueryParams.h"
 #include "Containers/Queue.h"
 #include "DrawDebugHelpers.h"
 #include "Engine/EngineTypes.h"
@@ -14,6 +15,60 @@
 
 UGridOverlayComponent::UGridOverlayComponent() {
   PrimaryComponentTick.bCanEverTick = false;
+}
+
+int32 UGridOverlayComponent::GetWidth() const { return Width; }
+
+int32 UGridOverlayComponent::GetHeight() const { return Height; }
+
+float UGridOverlayComponent::GetCellSize() const { return CellSize; }
+
+FVector UGridOverlayComponent::GetOrigin() const { return Origin; }
+
+void UGridOverlayComponent::ApplyRandomizedOrigin() {
+  if (bHasRandomizedPlacement || !bRandomizePlacement) {
+    return;
+  }
+
+  AActor *Owner = GetOwner();
+  if (!Owner || !Owner->HasAuthority()) {
+    return;
+  }
+
+  const FVector BaseLocation = Owner->GetActorLocation();
+  FVector TargetLocation = BaseLocation;
+
+  if (RandomPlacementBounds.HasArea()) {
+    const float MinX = FMath::Min(RandomPlacementBounds.Min.X, RandomPlacementBounds.Max.X);
+    const float MaxX = FMath::Max(RandomPlacementBounds.Min.X, RandomPlacementBounds.Max.X);
+    const float MinY = FMath::Min(RandomPlacementBounds.Min.Y, RandomPlacementBounds.Max.Y);
+    const float MaxY = FMath::Max(RandomPlacementBounds.Min.Y, RandomPlacementBounds.Max.Y);
+    const float RandomX = FMath::FRandRange(MinX, MaxX);
+    const float RandomY = FMath::FRandRange(MinY, MaxY);
+    TargetLocation.X = BaseLocation.X + RandomX;
+    TargetLocation.Y = BaseLocation.Y + RandomY;
+  } else if (RandomPlacementRadius > KINDA_SMALL_NUMBER) {
+    const float Angle = FMath::FRandRange(0.f, 2.f * PI);
+    const float Distance = RandomPlacementRadius * FMath::Sqrt(FMath::FRand());
+    TargetLocation.X = BaseLocation.X + FMath::Cos(Angle) * Distance;
+    TargetLocation.Y = BaseLocation.Y + FMath::Sin(Angle) * Distance;
+  }
+
+  if (PlacementTraceHeight > KINDA_SMALL_NUMBER) {
+    if (UWorld *World = GetWorld()) {
+      const FVector Start = TargetLocation + FVector(0.f, 0.f, PlacementTraceHeight);
+      const FVector End = TargetLocation - FVector(0.f, 0.f, PlacementTraceHeight);
+      FHitResult Hit;
+      FCollisionQueryParams Params(SCENE_QUERY_STAT(GridOverlayPlacementTrace), false, Owner);
+      if (World->LineTraceSingleByChannel(Hit, Start, End, ECC_WorldStatic, Params)) {
+        TargetLocation.Z = Hit.Location.Z;
+      }
+    }
+  }
+
+  Owner->SetActorLocation(TargetLocation, false, nullptr, ETeleportType::TeleportPhysics);
+  Origin = TargetLocation;
+  bHasRandomizedPlacement = true;
 }
 
 bool UGridOverlayComponent::EnsureInstancedMeshComponent(

--- a/Source/Skald/GridOverlayComponent.h
+++ b/Source/Skald/GridOverlayComponent.h
@@ -28,6 +28,22 @@ struct FPendingGridOccupancyUpdate {
   bool bOccupied = false;
 };
 
+USTRUCT(BlueprintType)
+struct FGridPlacementBounds {
+  GENERATED_BODY()
+
+  UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Grid|Placement")
+  FVector2D Min = FVector2D::ZeroVector;
+
+  UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Grid|Placement")
+  FVector2D Max = FVector2D::ZeroVector;
+
+  bool HasArea() const {
+    return (FMath::Abs(Max.X - Min.X) > KINDA_SMALL_NUMBER) ||
+           (FMath::Abs(Max.Y - Min.Y) > KINDA_SMALL_NUMBER);
+  }
+};
+
 /**
  * Component that tracks grid cell occupancy and provides world/grid conversion.
  * Designed to be attached to the battle map floor actor.
@@ -41,6 +57,21 @@ public:
 
   virtual void OnRegister() override;
   virtual void BeginPlay() override;
+
+  UFUNCTION(BlueprintCallable, BlueprintPure, Category = "Grid")
+  int32 GetWidth() const;
+
+  UFUNCTION(BlueprintCallable, BlueprintPure, Category = "Grid")
+  int32 GetHeight() const;
+
+  UFUNCTION(BlueprintCallable, BlueprintPure, Category = "Grid")
+  float GetCellSize() const;
+
+  UFUNCTION(BlueprintCallable, BlueprintPure, Category = "Grid")
+  FVector GetOrigin() const;
+
+  UFUNCTION(BlueprintCallable, Category = "Grid")
+  void ApplyRandomizedOrigin();
 
   /** Convert a world location to grid coordinates. */
   UFUNCTION(BlueprintCallable, BlueprintPure, Category = "Grid")
@@ -173,6 +204,25 @@ public:
   FLinearColor AttackHighlightColor = FLinearColor(1.f, 0.1f, 0.1f, 0.85f);
 
 protected:
+  /** Randomise the placement of the grid around the actor's starting point. */
+  UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Grid|Placement")
+  bool bRandomizePlacement = false;
+
+  /** Bounds in local XY around the actor used for placement randomisation. */
+  UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Grid|Placement",
+            meta = (EditCondition = "bRandomizePlacement"))
+  FGridPlacementBounds RandomPlacementBounds;
+
+  /** Fallback placement radius when bounds are not provided. */
+  UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Grid|Placement",
+            meta = (EditCondition = "bRandomizePlacement", ClampMin = "0.0"))
+  float RandomPlacementRadius = 0.f;
+
+  /** Height of the placement trace used to find the ground. */
+  UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Grid|Placement",
+            meta = (EditCondition = "bRandomizePlacement", ClampMin = "0.0"))
+  float PlacementTraceHeight = 0.f;
+
   /** Width of the grid in cells. */
   UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Grid")
   int32 Width = UGridBattleManager::GridSize;
@@ -199,6 +249,9 @@ protected:
   /** Cached world-space Z for each grid cell. */
   UPROPERTY()
   TArray<float> CellHeights;
+
+  /** Guard to ensure placement randomisation is only applied once. */
+  bool bHasRandomizedPlacement = false;
 
   /** Instanced mesh component used to render highlight quads. */
   UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "Grid|Highlight")


### PR DESCRIPTION
## Summary
- add configurable placement randomisation settings and read-only accessors to the grid overlay component
- implement ApplyRandomizedOrigin to relocate the grid actor using optional bounds and ground traces
- ensure the grid overlay actor triggers randomisation before base BeginPlay so sampling uses the new position

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d6425546a48324bc7f8f9af9b103ae