### PR TITLE
Add random obstacle spawning to grid overlay actor

### DIFF
--- a/Source/Skald/GridOverlayActor.cpp
+++ b/Source/Skald/GridOverlayActor.cpp
@@ -1,6 +1,14 @@
 #include "GridOverlayActor.h"
 #include "Components/SceneComponent.h"
+#include "Engine/EngineTypes.h"
+#include "Engine/World.h"
+#include "GridObstacleActor.h"
 #include "GridOverlayComponent.h"
+#include "CollisionQueryParams.h"
+
+namespace {
+constexpr float kSmallHeightEpsilon = 0.01f;
+}
 
 AGridOverlayActor::AGridOverlayActor() {
   PrimaryActorTick.bCanEverTick = false;
@@ -16,6 +24,143 @@ void AGridOverlayActor::BeginPlay() {
     GridComponent->ApplyRandomizedOrigin();
   }
 
+  SpawnRandomObstacles();
+
   Super::BeginPlay();
+}
+
+void AGridOverlayActor::SpawnRandomObstacles() {
+  if (!bSpawnRandomObstacles) {
+    return;
+  }
+
+  if (!GridComponent) {
+    return;
+  }
+
+  UWorld *World = GetWorld();
+  if (!World) {
+    return;
+  }
+
+  const EWorldType::Type WorldType = World->WorldType;
+  const bool bIsEditorPreviewWorld =
+      (WorldType == EWorldType::Editor || WorldType == EWorldType::EditorPreview ||
+       WorldType == EWorldType::Inactive);
+
+  if (bObstaclesSpawned && !bIsEditorPreviewWorld) {
+    return;
+  }
+
+  if (!HasAuthority() && !bIsEditorPreviewWorld) {
+    return;
+  }
+
+  if (bIsEditorPreviewWorld && SpawnedObstacleActors.Num() > 0) {
+    ClearSpawnedObstacles();
+  }
+
+  const int32 GridWidth = GridComponent->GetWidth();
+  const int32 GridHeight = GridComponent->GetHeight();
+  if (GridWidth <= 0 || GridHeight <= 0) {
+    return;
+  }
+
+  if (ObstacleCandidates.Num() == 0) {
+    return;
+  }
+
+  const int32 MaxCells = GridWidth * GridHeight;
+  const int32 ClampedMin = FMath::Clamp(MinObstacleCount, 0, MaxCells);
+  const int32 ClampedMax = FMath::Clamp(MaxObstacleCount, ClampedMin, MaxCells);
+  if (ClampedMax <= 0) {
+    return;
+  }
+
+  FRandomStream RandomStream;
+  if (bOverrideObstacleSpawnSeed) {
+    RandomStream.Initialize(ObstacleSpawnSeed);
+  } else {
+    RandomStream.GenerateNewSeed();
+  }
+
+  const int32 ObstaclesToSpawn = RandomStream.RandRange(ClampedMin, ClampedMax);
+  if (ObstaclesToSpawn <= 0) {
+    return;
+  }
+
+  SpawnedObstacleActors.Reset();
+  SpawnedObstacleCells.Empty();
+
+  const float ClampedMinHeightOffset = FMath::Min(MinObstacleHeightOffset, MaxObstacleHeightOffset);
+  const float ClampedMaxHeightOffset = FMath::Max(MinObstacleHeightOffset, MaxObstacleHeightOffset);
+
+  TSet<FIntPoint> CandidateCells;
+  CandidateCells.Reserve(ObstaclesToSpawn);
+
+  const int32 MaxIterations = ObstaclesToSpawn * 10;
+  int32 IterationCount = 0;
+  while (CandidateCells.Num() < ObstaclesToSpawn && IterationCount < MaxIterations) {
+    IterationCount++;
+
+    const int32 CellX = RandomStream.RandRange(0, GridWidth - 1);
+    const int32 CellY = RandomStream.RandRange(0, GridHeight - 1);
+    const FIntPoint Cell(CellX, CellY);
+
+    if (!GridComponent->IsCellInBounds(Cell)) {
+      continue;
+    }
+
+    CandidateCells.Add(Cell);
+  }
+
+  for (const FIntPoint &Cell : CandidateCells) {
+    const int32 ClassIndex = RandomStream.RandRange(0, ObstacleCandidates.Num() - 1);
+    const TSubclassOf<AGridObstacleActor> ObstacleClass = ObstacleCandidates[ClassIndex];
+    if (!ObstacleClass) {
+      continue;
+    }
+
+    const FVector CellLocation = GridComponent->GridToWorld(Cell);
+    const FVector TraceOffset = FVector::UpVector * FMath::Max(ObstacleTraceHeight, kSmallHeightEpsilon);
+    const FVector TraceStart = CellLocation + TraceOffset;
+    const FVector TraceEnd = CellLocation - TraceOffset;
+
+    FHitResult HitResult;
+    FCollisionQueryParams QueryParams(SCENE_QUERY_STAT(SpawnRandomObstacles), false, this);
+    const bool bHitGround = World->LineTraceSingleByChannel(HitResult, TraceStart, TraceEnd, ECC_WorldStatic, QueryParams);
+
+    FVector SpawnLocation = bHitGround ? HitResult.Location : CellLocation;
+    const float HeightOffset = RandomStream.FRandRange(ClampedMinHeightOffset, ClampedMaxHeightOffset);
+    SpawnLocation.Z += HeightOffset;
+
+    const FRotator SpawnRotation = bHitGround ? HitResult.Normal.Rotation() : FRotator::ZeroRotator;
+
+    FActorSpawnParameters SpawnParams;
+    SpawnParams.Owner = this;
+    SpawnParams.SpawnCollisionHandlingOverride = ESpawnActorCollisionHandlingMethod::AdjustIfPossibleButAlwaysSpawn;
+
+    if (AGridObstacleActor *SpawnedActor = World->SpawnActor<AGridObstacleActor>(ObstacleClass, SpawnLocation, SpawnRotation, SpawnParams)) {
+      SpawnedObstacleActors.Add(SpawnedActor);
+      SpawnedObstacleCells.Add(Cell);
+    }
+  }
+
+  bObstaclesSpawned = SpawnedObstacleActors.Num() > 0 && !bIsEditorPreviewWorld;
+}
+
+void AGridOverlayActor::ClearSpawnedObstacles() {
+  for (const TWeakObjectPtr<AGridObstacleActor> &ObstaclePtr : SpawnedObstacleActors) {
+    if (ObstaclePtr.IsValid()) {
+      AGridObstacleActor *Obstacle = ObstaclePtr.Get();
+      if (Obstacle && Obstacle->IsValidLowLevelFast()) {
+        Obstacle->Destroy();
+      }
+    }
+  }
+
+  SpawnedObstacleActors.Reset();
+  SpawnedObstacleCells.Empty();
+  bObstaclesSpawned = false;
 }
 

--- a/Source/Skald/GridOverlayActor.h
+++ b/Source/Skald/GridOverlayActor.h
@@ -6,6 +6,7 @@
 
 class UGridOverlayComponent;
 class USceneComponent;
+class AGridObstacleActor;
 
 /**
  * Actor wrapper that exposes the grid overlay component directly in the level.
@@ -17,6 +18,14 @@ class SKALD_API AGridOverlayActor : public AActor {
 public:
   AGridOverlayActor();
 
+  /** Spawn random obstacles across the grid using the configured settings. */
+  UFUNCTION(BlueprintCallable, CallInEditor, Category = "Grid|Obstacles")
+  void SpawnRandomObstacles();
+
+  /** Destroy and clear any spawned obstacle actors. */
+  UFUNCTION(BlueprintCallable, CallInEditor, Category = "Grid|Obstacles")
+  void ClearSpawnedObstacles();
+
 protected:
   virtual void BeginPlay() override;
 
@@ -27,5 +36,52 @@ protected:
   /** Grid overlay component responsible for sampling and rendering the grid. */
   UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "Grid")
   UGridOverlayComponent *GridComponent = nullptr;
+
+  /** Whether random obstacles should be spawned across the grid. */
+  UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "Grid|Obstacles")
+  bool bSpawnRandomObstacles = false;
+
+  /** Minimum number of random obstacles to spawn. */
+  UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "Grid|Obstacles", meta = (EditCondition = "bSpawnRandomObstacles", ClampMin = "0"))
+  int32 MinObstacleCount = 0;
+
+  /** Maximum number of random obstacles to spawn. */
+  UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "Grid|Obstacles", meta = (EditCondition = "bSpawnRandomObstacles", ClampMin = "0"))
+  int32 MaxObstacleCount = 0;
+
+  /** Candidate obstacle classes that can be spawned. */
+  UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "Grid|Obstacles", meta = (EditCondition = "bSpawnRandomObstacles"))
+  TArray<TSubclassOf<AGridObstacleActor>> ObstacleCandidates;
+
+  /** Optional deterministic seed override for obstacle placement. */
+  UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "Grid|Obstacles", meta = (EditCondition = "bSpawnRandomObstacles"))
+  bool bOverrideObstacleSpawnSeed = false;
+
+  /** Seed used when deterministic obstacle placement is desired. */
+  UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "Grid|Obstacles", meta = (EditCondition = "bSpawnRandomObstacles && bOverrideObstacleSpawnSeed"))
+  int32 ObstacleSpawnSeed = 1337;
+
+  /** Height used when tracing down to find a ground placement for an obstacle. */
+  UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "Grid|Obstacles", meta = (EditCondition = "bSpawnRandomObstacles", ClampMin = "0.0"))
+  float ObstacleTraceHeight = 2000.f;
+
+  /** Minimum vertical offset applied to spawned obstacles. */
+  UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "Grid|Obstacles", meta = (EditCondition = "bSpawnRandomObstacles"))
+  float MinObstacleHeightOffset = 0.f;
+
+  /** Maximum vertical offset applied to spawned obstacles. */
+  UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "Grid|Obstacles", meta = (EditCondition = "bSpawnRandomObstacles"))
+  float MaxObstacleHeightOffset = 0.f;
+
+private:
+  /** Track obstacle actors spawned by this overlay. */
+  UPROPERTY(Transient, BlueprintReadOnly, Category = "Grid|Obstacles", meta = (AllowPrivateAccess = "true"))
+  TArray<TWeakObjectPtr<AGridObstacleActor>> SpawnedObstacleActors;
+
+  /** Grid cells that currently contain spawned obstacles. */
+  TSet<FIntPoint> SpawnedObstacleCells;
+
+  /** True once random obstacles have been spawned at runtime. */
+  bool bObstaclesSpawned = false;
 };
 


### PR DESCRIPTION
## Summary
- add obstacle spawning configuration to `AGridOverlayActor`
- implement random obstacle placement with deterministic seeding and ground traces
- expose spawn/clear utilities and ensure runtime initialization occurs before grid sampling

## Testing
- not run (engine build not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68d6468279408324aae1654fbe03dab8