### PR TITLE
Fix grid overlay random origin replication

### DIFF
--- a/Source/Skald/GridOverlayActor.cpp
+++ b/Source/Skald/GridOverlayActor.cpp
@@ -12,11 +12,21 @@ constexpr float kSmallHeightEpsilon = 0.01f;
 
 AGridOverlayActor::AGridOverlayActor() {
   PrimaryActorTick.bCanEverTick = false;
+  bReplicates = true;
+  SetReplicateMovement(true);
 
   SceneRoot = CreateDefaultSubobject<USceneComponent>(TEXT("Root"));
   SetRootComponent(SceneRoot);
 
   GridComponent = CreateDefaultSubobject<UGridOverlayComponent>(TEXT("GridOverlay"));
+}
+
+void AGridOverlayActor::OnRep_ReplicatedMovement() {
+  Super::OnRep_ReplicatedMovement();
+
+  if (GridComponent) {
+    GridComponent->RefreshOriginFromOwner(true);
+  }
 }
 
 void AGridOverlayActor::BeginPlay() {

--- a/Source/Skald/GridOverlayActor.h
+++ b/Source/Skald/GridOverlayActor.h
@@ -29,6 +29,8 @@ public:
 protected:
   virtual void BeginPlay() override;
 
+  virtual void OnRep_ReplicatedMovement() override;
+
   /** Root component used to anchor the grid overlay. */
   UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "Grid")
   USceneComponent *SceneRoot = nullptr;

--- a/Source/Skald/GridOverlayComponent.cpp
+++ b/Source/Skald/GridOverlayComponent.cpp
@@ -67,8 +67,16 @@ void UGridOverlayComponent::ApplyRandomizedOrigin() {
   }
 
   Owner->SetActorLocation(TargetLocation, false, nullptr, ETeleportType::TeleportPhysics);
-  Origin = TargetLocation;
-  bHasRandomizedPlacement = true;
+  RefreshOriginFromOwner(true);
+}
+
+void UGridOverlayComponent::RefreshOriginFromOwner(bool bMarkPlacementRandomized) {
+  if (AActor *Owner = GetOwner()) {
+    Origin = Owner->GetActorLocation();
+    if (bMarkPlacementRandomized && bRandomizePlacement) {
+      bHasRandomizedPlacement = true;
+    }
+  }
 }
 
 bool UGridOverlayComponent::EnsureInstancedMeshComponent(
@@ -151,9 +159,7 @@ void UGridOverlayComponent::ConfigureInstancedComponent(
 void UGridOverlayComponent::OnRegister() {
   Super::OnRegister();
 
-  if (AActor *Owner = GetOwner()) {
-    Origin = Owner->GetActorLocation();
-  }
+  RefreshOriginFromOwner();
 
   EnsureBaseGridComponentSetup();
   EnsureHighlightComponentSetup();

--- a/Source/Skald/GridOverlayComponent.h
+++ b/Source/Skald/GridOverlayComponent.h
@@ -73,6 +73,10 @@ public:
   UFUNCTION(BlueprintCallable, Category = "Grid")
   void ApplyRandomizedOrigin();
 
+  /** Update the cached origin from the owning actor's transform. */
+  UFUNCTION(BlueprintCallable, Category = "Grid")
+  void RefreshOriginFromOwner(bool bMarkPlacementRandomized = false);
+
   /** Convert a world location to grid coordinates. */
   UFUNCTION(BlueprintCallable, BlueprintPure, Category = "Grid")
   FIntPoint WorldToGrid(const FVector &WorldLocation) const;


### PR DESCRIPTION
## Summary
- enable network replication on the grid overlay actor so randomized placement updates reach clients
- allow the grid overlay component to refresh its cached origin when the owning actor's transform changes

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d6488a0d1083248ce8aa4434ed01ae