### PR TITLE
Fix grid overlay randomization for replicated actors

### DIFF
--- a/Source/Skald/GridOverlayActor.cpp
+++ b/Source/Skald/GridOverlayActor.cpp
@@ -12,6 +12,8 @@ constexpr float kSmallHeightEpsilon = 0.01f;
 
 AGridOverlayActor::AGridOverlayActor() {
   PrimaryActorTick.bCanEverTick = false;
+  bReplicates = true;
+  SetReplicateMovement(true);
 
   SceneRoot = CreateDefaultSubobject<USceneComponent>(TEXT("Root"));
   SetRootComponent(SceneRoot);
@@ -22,11 +24,24 @@ AGridOverlayActor::AGridOverlayActor() {
 void AGridOverlayActor::BeginPlay() {
   if (GridComponent) {
     GridComponent->ApplyRandomizedOrigin();
+    SyncGridOriginWithActorTransform();
   }
 
   SpawnRandomObstacles();
 
   Super::BeginPlay();
+}
+
+void AGridOverlayActor::OnRep_ReplicatedMovement() {
+  Super::OnRep_ReplicatedMovement();
+
+  SyncGridOriginWithActorTransform();
+}
+
+void AGridOverlayActor::SyncGridOriginWithActorTransform() {
+  if (GridComponent) {
+    GridComponent->RefreshOriginFromOwner();
+  }
 }
 
 void AGridOverlayActor::SpawnRandomObstacles() {

--- a/Source/Skald/GridOverlayActor.h
+++ b/Source/Skald/GridOverlayActor.h
@@ -28,6 +28,9 @@ public:
 
 protected:
   virtual void BeginPlay() override;
+  virtual void OnRep_ReplicatedMovement() override;
+
+  void SyncGridOriginWithActorTransform();
 
   /** Root component used to anchor the grid overlay. */
   UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "Grid")

--- a/Source/Skald/GridOverlayComponent.cpp
+++ b/Source/Skald/GridOverlayComponent.cpp
@@ -71,6 +71,15 @@ void UGridOverlayComponent::ApplyRandomizedOrigin() {
   bHasRandomizedPlacement = true;
 }
 
+void UGridOverlayComponent::RefreshOriginFromOwner() {
+  if (AActor *Owner = GetOwner()) {
+    Origin = Owner->GetActorLocation();
+    if (bRandomizePlacement) {
+      bHasRandomizedPlacement = true;
+    }
+  }
+}
+
 bool UGridOverlayComponent::EnsureInstancedMeshComponent(
     UInstancedStaticMeshComponent *&Component, FName ComponentName) {
   AActor *Owner = GetOwner();

--- a/Source/Skald/GridOverlayComponent.h
+++ b/Source/Skald/GridOverlayComponent.h
@@ -73,6 +73,9 @@ public:
   UFUNCTION(BlueprintCallable, Category = "Grid")
   void ApplyRandomizedOrigin();
 
+  UFUNCTION(BlueprintCallable, Category = "Grid")
+  void RefreshOriginFromOwner();
+
   /** Convert a world location to grid coordinates. */
   UFUNCTION(BlueprintCallable, BlueprintPure, Category = "Grid")
   FIntPoint WorldToGrid(const FVector &WorldLocation) const;


### PR DESCRIPTION
## Summary
- enable grid overlay actors to replicate their transforms after randomizing placement
- synchronize the grid component origin with the replicated actor position on clients

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d6488e4d5c832482a7583ae5a04e35