### PR TITLE
Reset grid when clearing spawned obstacles

### DIFF
--- a/Source/Skald/GridOverlayActor.cpp
+++ b/Source/Skald/GridOverlayActor.cpp
@@ -160,6 +160,12 @@ void AGridOverlayActor::SpawnRandomObstacles() {
 }
 
 void AGridOverlayActor::ClearSpawnedObstacles() {
+  if (GridComponent && SpawnedObstacleCells.Num() > 0) {
+    for (const FIntPoint &Cell : SpawnedObstacleCells) {
+      GridComponent->ClearStaticObstacleAtCell(Cell);
+    }
+  }
+
   for (const TWeakObjectPtr<AGridObstacleActor> &ObstaclePtr : SpawnedObstacleActors) {
     if (ObstaclePtr.IsValid()) {
       AGridObstacleActor *Obstacle = ObstaclePtr.Get();

--- a/Source/Skald/GridOverlayComponent.cpp
+++ b/Source/Skald/GridOverlayComponent.cpp
@@ -584,6 +584,23 @@ void UGridOverlayComponent::RegisterObstacle(UGridObstacleComponent *Obstacle) {
   }
 }
 
+void UGridOverlayComponent::ClearStaticObstacleAtCell(
+    const FIntPoint &GridCoord) {
+  if (!bHasInitializedGrid || !IsValidGrid(GridCoord)) {
+    return;
+  }
+
+  const int32 Idx = Index(GridCoord);
+  if (Cells.IsValidIndex(Idx)) {
+    Cells[Idx] = false;
+  }
+  if (ObscuredCells.IsValidIndex(Idx)) {
+    ObscuredCells[Idx] = false;
+  }
+
+  UpdateBaseGridVisual(GridCoord);
+}
+
 void UGridOverlayComponent::HandleLandscapeHit(const FHitResult &Hit,
                                                const FIntPoint &Cell,
                                                int32 CellIndex) {

--- a/Source/Skald/GridOverlayComponent.h
+++ b/Source/Skald/GridOverlayComponent.h
@@ -134,9 +134,12 @@ public:
   UFUNCTION(BlueprintCallable, Category = "Grid")
   void RebuildGridVisuals();
 
-    /** Register an obstacle component so it can affect grid behaviour. */
-    UFUNCTION(BlueprintCallable, Category = "Grid")
-    void RegisterObstacle(UGridObstacleComponent *Obstacle);
+  /** Register an obstacle component so it can affect grid behaviour. */
+  UFUNCTION(BlueprintCallable, Category = "Grid")
+  void RegisterObstacle(UGridObstacleComponent *Obstacle);
+
+  /** Clear any static obstacle state associated with the given cell. */
+  void ClearStaticObstacleAtCell(const FIntPoint &GridCoord);
 
   /** If true, ClearHighlights() will FlushPersistentDebugLines for the entire world. */
   UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="Grid|Debug")


### PR DESCRIPTION
## Summary
- clear static grid occupancy for cells associated with spawned obstacles
- add helper on the grid overlay component so cells are marked free when actors are destroyed

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d649bad9a483248419a03eb8b4d662