### PR TITLE
Replicate grid origin randomization to clients

### DIFF
--- a/Source/Skald/GridOverlayActor.cpp
+++ b/Source/Skald/GridOverlayActor.cpp
@@ -5,6 +5,7 @@
 #include "GridObstacleActor.h"
 #include "GridOverlayComponent.h"
 #include "CollisionQueryParams.h"
+#include "Net/UnrealNetwork.h"
 
 namespace {
 constexpr float kSmallHeightEpsilon = 0.01f;
@@ -21,6 +22,20 @@ AGridOverlayActor::AGridOverlayActor() {
   GridComponent = CreateDefaultSubobject<UGridOverlayComponent>(TEXT("GridOverlay"));
 }
 
+void AGridOverlayActor::BeginPlay() {
+  if (HasAuthority()) {
+    if (GridComponent) {
+      GridComponent->ApplyRandomizedOrigin();
+    }
+
+    ReplicatedGridOrigin = GetActorLocation();
+  }
+
+  SpawnRandomObstacles();
+
+  Super::BeginPlay();
+}
+
 void AGridOverlayActor::OnRep_ReplicatedMovement() {
   Super::OnRep_ReplicatedMovement();
 
@@ -29,14 +44,20 @@ void AGridOverlayActor::OnRep_ReplicatedMovement() {
   }
 }
 
-void AGridOverlayActor::BeginPlay() {
+void AGridOverlayActor::GetLifetimeReplicatedProps(
+    TArray<FLifetimeProperty> &OutLifetimeProps) const {
+  Super::GetLifetimeReplicatedProps(OutLifetimeProps);
+
+  DOREPLIFETIME(AGridOverlayActor, ReplicatedGridOrigin);
+}
+
+void AGridOverlayActor::OnRep_RandomizedGridOrigin() {
+  SetActorLocation(ReplicatedGridOrigin, false, nullptr,
+                   ETeleportType::TeleportPhysics);
+
   if (GridComponent) {
-    GridComponent->ApplyRandomizedOrigin();
+    GridComponent->RefreshOriginFromOwner(true);
   }
-
-  SpawnRandomObstacles();
-
-  Super::BeginPlay();
 }
 
 void AGridOverlayActor::SpawnRandomObstacles() {

--- a/Source/Skald/GridOverlayActor.h
+++ b/Source/Skald/GridOverlayActor.h
@@ -31,6 +31,9 @@ protected:
 
   virtual void OnRep_ReplicatedMovement() override;
 
+  virtual void GetLifetimeReplicatedProps(
+      TArray<FLifetimeProperty> &OutLifetimeProps) const override;
+
   /** Root component used to anchor the grid overlay. */
   UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "Grid")
   USceneComponent *SceneRoot = nullptr;
@@ -85,5 +88,12 @@ private:
 
   /** True once random obstacles have been spawned at runtime. */
   bool bObstaclesSpawned = false;
+
+  /** Authoritative grid origin applied after randomisation and shared with clients. */
+  UPROPERTY(ReplicatedUsing = OnRep_RandomizedGridOrigin)
+  FVector_NetQuantize ReplicatedGridOrigin = FVector::ZeroVector;
+
+  UFUNCTION()
+  void OnRep_RandomizedGridOrigin();
 };
 


### PR DESCRIPTION
## Summary
- replicate the randomized grid origin so that clients receive the authoritative transform
- refresh the grid component when the replicated origin arrives to keep visuals in sync

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d64c88bcd88324b9796fc8cdf111d5