### PR TITLE
Allow clients to refresh randomized grid origin

### DIFF
--- a/Source/Skald/GridOverlayComponent.cpp
+++ b/Source/Skald/GridOverlayComponent.cpp
@@ -31,7 +31,12 @@ void UGridOverlayComponent::ApplyRandomizedOrigin() {
   }
 
   AActor *Owner = GetOwner();
-  if (!Owner || !Owner->HasAuthority()) {
+  if (!Owner) {
+    return;
+  }
+
+  if (!Owner->HasAuthority()) {
+    RefreshOriginFromOwner(true);
     return;
   }
 


### PR DESCRIPTION
## Summary
- allow ApplyRandomizedOrigin to refresh the cached origin on clients without authority
- keep the random placement logic server-side while marking the placement as completed for clients

## Testing
- not run (UE-specific tests not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68d64deb53d083249e560655c191320d