### PR TITLE
Adjust grid overlay placement timing

### DIFF
--- a/Source/Skald/GridOverlayActor.cpp
+++ b/Source/Skald/GridOverlayActor.cpp
@@ -21,6 +21,15 @@ AGridOverlayActor::AGridOverlayActor() {
   GridComponent = CreateDefaultSubobject<UGridOverlayComponent>(TEXT("GridOverlay"));
 }
 
+void AGridOverlayActor::OnConstruction(const FTransform &Transform) {
+  Super::OnConstruction(Transform);
+
+  if (GridComponent) {
+    GridComponent->ApplyRandomizedOrigin();
+    GridComponent->RefreshOriginFromOwner(true);
+  }
+}
+
 void AGridOverlayActor::OnRep_ReplicatedMovement() {
   Super::OnRep_ReplicatedMovement();
 
@@ -30,10 +39,6 @@ void AGridOverlayActor::OnRep_ReplicatedMovement() {
 }
 
 void AGridOverlayActor::BeginPlay() {
-  if (GridComponent) {
-    GridComponent->ApplyRandomizedOrigin();
-  }
-
   SpawnRandomObstacles();
 
   Super::BeginPlay();

--- a/Source/Skald/GridOverlayActor.h
+++ b/Source/Skald/GridOverlayActor.h
@@ -27,6 +27,7 @@ public:
   void ClearSpawnedObstacles();
 
 protected:
+  virtual void OnConstruction(const FTransform &Transform) override;
   virtual void BeginPlay() override;
 
   virtual void OnRep_ReplicatedMovement() override;

--- a/Source/Skald/GridOverlayComponent.cpp
+++ b/Source/Skald/GridOverlayComponent.cpp
@@ -77,9 +77,14 @@ void UGridOverlayComponent::ApplyRandomizedOrigin() {
 
 void UGridOverlayComponent::RefreshOriginFromOwner(bool bMarkPlacementRandomized) {
   if (AActor *Owner = GetOwner()) {
-    Origin = Owner->GetActorLocation();
+    const FVector NewOrigin = Owner->GetActorLocation();
+    const bool bOriginChanged = !Origin.Equals(NewOrigin, KINDA_SMALL_NUMBER);
+    Origin = NewOrigin;
     if (bMarkPlacementRandomized && bRandomizePlacement) {
       bHasRandomizedPlacement = true;
+    }
+    if (bHasInitializedGrid && bOriginChanged) {
+      RefreshGridDataFromOrigin();
     }
   }
 }
@@ -173,9 +178,7 @@ void UGridOverlayComponent::OnRegister() {
 void UGridOverlayComponent::BeginPlay() {
   Super::BeginPlay();
 
-  if (AActor *Owner = GetOwner()) {
-    Origin = Owner->GetActorLocation();
-  }
+  RefreshOriginFromOwner(false);
 
   const int32 TotalCells = Width * Height;
   Cells.Init(false, TotalCells);
@@ -184,25 +187,7 @@ void UGridOverlayComponent::BeginPlay() {
   CellHeights.Init(Origin.Z, TotalCells);
   BaseGridInstanceIndices.Init(INDEX_NONE, TotalCells);
 
-  if (UWorld *World = GetWorld()) {
-    for (int32 Y = 0; Y < Height; ++Y) {
-      for (int32 X = 0; X < Width; ++X) {
-        const int32 Idx = Index(FIntPoint(X, Y));
-        FVector Start = Origin + FVector((X + 0.5f) * CellSize,
-                                         (Y + 0.5f) * CellSize, 10000.f);
-        FVector End = Start - FVector(0.f, 0.f, 20000.f);
-        FHitResult Hit;
-        if (World->LineTraceSingleByChannel(Hit, Start, End, ECC_WorldStatic)) {
-          CellHeights[Idx] = Hit.Location.Z;
-          if (Cast<ULandscapeComponent>(Hit.GetComponent())) {
-            HandleLandscapeHit(Hit, FIntPoint(X, Y), Idx);
-          }
-        } else {
-          CellHeights[Idx] = Origin.Z;
-        }
-      }
-    }
-  }
+  SampleEnvironmentAtOrigin();
 
   bHasInitializedGrid = true;
 
@@ -226,6 +211,69 @@ void UGridOverlayComponent::BeginPlay() {
     PendingOccupancyUpdates.Empty();
     for (const FPendingGridOccupancyUpdate &Update : OccupancyToApply) {
       SetOccupied(Update.GridCoord, Update.bOccupied);
+    }
+  }
+}
+
+void UGridOverlayComponent::RefreshGridDataFromOrigin() {
+  const int32 TotalCells = Width * Height;
+  if (TotalCells <= 0) {
+    Cells.Empty();
+    ObscuredCells.Empty();
+    CellHeights.Empty();
+    DynamicOccupiedCells.Empty();
+    RebuildBaseGridInstances();
+    return;
+  }
+
+  Cells.Init(false, TotalCells);
+  ObscuredCells.Init(false, TotalCells);
+  CellHeights.Init(Origin.Z, TotalCells);
+
+  if (DynamicOccupiedCells.Num() != TotalCells) {
+    DynamicOccupiedCells.SetNum(TotalCells);
+  }
+
+  SampleEnvironmentAtOrigin();
+
+  for (int32 Index = Obstacles.Num() - 1; Index >= 0; --Index) {
+    UGridObstacleComponent *Obstacle = Obstacles[Index];
+    if (!IsValid(Obstacle)) {
+      Obstacles.RemoveAtSwap(Index);
+      continue;
+    }
+
+    ApplyObstacleToGrid(Obstacle);
+  }
+
+  RebuildBaseGridInstances();
+}
+
+void UGridOverlayComponent::SampleEnvironmentAtOrigin() {
+  if (Width <= 0 || Height <= 0) {
+    return;
+  }
+
+  UWorld *World = GetWorld();
+  if (!World) {
+    return;
+  }
+
+  for (int32 Y = 0; Y < Height; ++Y) {
+    for (int32 X = 0; X < Width; ++X) {
+      const int32 Idx = Index(FIntPoint(X, Y));
+      FVector Start = Origin +
+                      FVector((X + 0.5f) * CellSize, (Y + 0.5f) * CellSize, 10000.f);
+      FVector End = Start - FVector(0.f, 0.f, 20000.f);
+      FHitResult Hit;
+      if (World->LineTraceSingleByChannel(Hit, Start, End, ECC_WorldStatic)) {
+        CellHeights[Idx] = Hit.Location.Z;
+        if (Cast<ULandscapeComponent>(Hit.GetComponent())) {
+          HandleLandscapeHit(Hit, FIntPoint(X, Y), Idx);
+        }
+      } else {
+        CellHeights[Idx] = Origin.Z;
+      }
     }
   }
 }
@@ -557,6 +605,14 @@ void UGridOverlayComponent::RegisterObstacle(UGridObstacleComponent *Obstacle) {
   }
 
   Obstacles.AddUnique(Obstacle);
+  ApplyObstacleToGrid(Obstacle);
+}
+
+void UGridOverlayComponent::ApplyObstacleToGrid(UGridObstacleComponent *Obstacle) {
+  if (!Obstacle || !bHasInitializedGrid) {
+    return;
+  }
+
   if (AActor *Owner = Obstacle->GetOwner()) {
     const FBox Bounds = Owner->GetComponentsBoundingBox(true);
     const FIntPoint Min = WorldToGrid(Bounds.Min);

--- a/Source/Skald/GridOverlayComponent.h
+++ b/Source/Skald/GridOverlayComponent.h
@@ -305,6 +305,15 @@ protected:
   void HandleLandscapeHit(const FHitResult &Hit, const FIntPoint &Cell,
                           int32 CellIndex);
 
+  /** Resample height/occupancy information around the current origin. */
+  void RefreshGridDataFromOrigin();
+
+  /** Trace the world to populate per-cell height and slope information. */
+  void SampleEnvironmentAtOrigin();
+
+  /** Apply a registered obstacle's footprint to the cached grid data. */
+  void ApplyObstacleToGrid(class UGridObstacleComponent *Obstacle);
+
   /** Ensure the instanced highlight component is ready for use. */
   bool EnsureHighlightComponentSetup();
 


### PR DESCRIPTION
## Summary
- Move randomized grid placement into the actor's construction step so the component sees the final origin before BeginPlay.
- Refresh the grid component's cached origin and resample terrain data whenever the owner relocates, sharing the existing sampling logic.
- Reapply registered obstacles after resampling to keep occupancy information consistent.

## Testing
- Not run (not requested).


------
https://chatgpt.com/codex/tasks/task_e_68d6509df6148324a4921d9f95b11123