### PR TITLE
Add fighter portrait support to entry widgets

### DIFF
--- a/Source/Skald/GridBattleManager.h
+++ b/Source/Skald/GridBattleManager.h
@@ -5,6 +5,7 @@
 #include "Engine/DataTable.h"
 #include "GameFramework/Actor.h"
 #include "SkaldTypes.h"
+#include "Engine/Texture2D.h"
 #include "GridBattleManager.generated.h"
 
 class AFighterPawn; // MUST be before the delegates
@@ -68,6 +69,7 @@ struct FFighterDefinition : public FTableRowBase
         , MeshClass(nullptr)
         , Faction(ESkaldFaction::None)
         , Stats()
+        , Portrait(nullptr)
     {
     }
 
@@ -82,6 +84,9 @@ struct FFighterDefinition : public FTableRowBase
 
     UPROPERTY(EditAnywhere, BlueprintReadOnly, Category="Fighter")
     FFighterStats Stats;
+
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="Fighter")
+    TSoftObjectPtr<UTexture2D> Portrait;
 };
 
 USTRUCT(BlueprintType)

--- a/Source/Skald/UI/FighterSelectionWidget.cpp
+++ b/Source/Skald/UI/FighterSelectionWidget.cpp
@@ -1,8 +1,10 @@
 #include "UI/FighterSelectionWidget.h"
 
 #include "Components/Button.h"
+#include "Components/Image.h"
 #include "Components/ScrollBox.h"
 #include "Components/TextBlock.h"
+#include "Engine/Texture2D.h"
 #include "SkaldLogging.h"
 #include "Skald_PlayerController.h"
 
@@ -68,6 +70,28 @@ void UFighterEntryWidget::Init(const FFighterDefinition &InFighter,
     CostText->SetText(FText::AsNumber(Fighter.Stats.ArmyCost));
   }
 
+  if (PortraitImage)
+  {
+      UTexture2D* PortraitTexture = nullptr;
+      if (Fighter.Portrait.IsValid())
+      {
+          PortraitTexture = Fighter.Portrait.Get();
+      }
+      else if (!Fighter.Portrait.IsNull())
+      {
+          PortraitTexture = Fighter.Portrait.LoadSynchronous();
+      }
+
+      if (PortraitTexture)
+      {
+          PortraitImage->SetBrushFromTexture(PortraitTexture);
+      }
+      else
+      {
+          PortraitImage->SetBrushFromTexture(nullptr);
+      }
+  }
+
   // Disable selection if fighter cannot be afforded.
   if (SelectButton && Owner)
   {
@@ -86,6 +110,16 @@ void UFighterEntryWidget::HandleRemoveClicked() {
   if (Owner) {
     Owner->RemoveFighter(Fighter);
   }
+}
+
+UTexture2D* UFighterEntryWidget::GetPortraitTexture() const
+{
+    if (Fighter.Portrait.IsValid())
+    {
+        return Fighter.Portrait.Get();
+    }
+
+    return nullptr;
 }
 
 void UFighterSelectionWidget::SetAvailableFighters(const TArray<FFighterDefinition>& InFighters)

--- a/Source/Skald/UI/FighterSelectionWidget.h
+++ b/Source/Skald/UI/FighterSelectionWidget.h
@@ -5,6 +5,8 @@
 #include "FighterSelectionWidget.generated.h"
 
 class UButton;
+class UTexture2D;
+class UImage;
 class UScrollBox;
 class UTextBlock;
 class UFighterSelectionWidget; // forward declare for entry widget
@@ -36,6 +38,10 @@ public:
   /** Name text bound from the blueprint. */
   UPROPERTY(BlueprintReadOnly, meta = (BindWidgetOptional))
   UTextBlock *NameText;
+
+  /** Portrait image bound from the blueprint. */
+  UPROPERTY(BlueprintReadOnly, meta = (BindWidgetOptional))
+  UImage *PortraitImage;
 
   /** Strength display text. */
   UPROPERTY(BlueprintReadOnly, meta = (BindWidgetOptional))
@@ -72,6 +78,10 @@ public:
   /** Fighter definition represented by this entry. */
   UPROPERTY(BlueprintReadOnly, Category = "Skald|Fighter")
   FFighterDefinition Fighter;
+
+  /** Returns the portrait texture for this fighter, if loaded. */
+  UFUNCTION(BlueprintCallable, BlueprintPure, Category = "Skald|Fighter")
+  UTexture2D *GetPortraitTexture() const;
 
 private:
   /** Callback for SelectButton. */


### PR DESCRIPTION
## Summary
- add a portrait reference to fighter definitions
- expose portrait image widgets and load textures for fighter entries

## Testing
- not run (N/A)

## Additional Notes
- the fighter entry widget blueprint and fighter data table need their new portrait fields wired up in the editor


------
https://chatgpt.com/codex/tasks/task_e_68d652f54c1c83248c51a9145ee9edd2