### PR TITLE
Clear dynamic occupancy when refreshing grid

### DIFF
--- a/Source/Skald/GridOverlayComponent.cpp
+++ b/Source/Skald/GridOverlayComponent.cpp
@@ -230,9 +230,7 @@ void UGridOverlayComponent::RefreshGridDataFromOrigin() {
   ObscuredCells.Init(false, TotalCells);
   CellHeights.Init(Origin.Z, TotalCells);
 
-  if (DynamicOccupiedCells.Num() != TotalCells) {
-    DynamicOccupiedCells.SetNum(TotalCells);
-  }
+  DynamicOccupiedCells.Init(false, TotalCells);
 
   SampleEnvironmentAtOrigin();
 


### PR DESCRIPTION
## Summary
- clear dynamic occupancy entries when refreshing the grid origin so stale occupancy is not retained

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d653f1af9c8324accbe39cd9ee96c1