### PR TITLE
Fix blueprint unsupported obstacle array

### DIFF
--- a/Source/Skald/GridOverlayActor.cpp
+++ b/Source/Skald/GridOverlayActor.cpp
@@ -171,10 +171,9 @@ void AGridOverlayActor::ClearSpawnedObstacles() {
     }
   }
 
-  for (const TWeakObjectPtr<AGridObstacleActor> &ObstaclePtr : SpawnedObstacleActors) {
-    if (ObstaclePtr.IsValid()) {
-      AGridObstacleActor *Obstacle = ObstaclePtr.Get();
-      if (Obstacle && Obstacle->IsValidLowLevelFast()) {
+  for (const TObjectPtr<AGridObstacleActor> &ObstaclePtr : SpawnedObstacleActors) {
+    if (AGridObstacleActor *Obstacle = ObstaclePtr.Get()) {
+      if (Obstacle->IsValidLowLevelFast()) {
         Obstacle->Destroy();
       }
     }

--- a/Source/Skald/GridOverlayActor.h
+++ b/Source/Skald/GridOverlayActor.h
@@ -79,7 +79,7 @@ protected:
 private:
   /** Track obstacle actors spawned by this overlay. */
   UPROPERTY(Transient, BlueprintReadOnly, Category = "Grid|Obstacles", meta = (AllowPrivateAccess = "true"))
-  TArray<TWeakObjectPtr<AGridObstacleActor>> SpawnedObstacleActors;
+  TArray<TObjectPtr<AGridObstacleActor>> SpawnedObstacleActors;
 
   /** Grid cells that currently contain spawned obstacles. */
   TSet<FIntPoint> SpawnedObstacleCells;


### PR DESCRIPTION
## Summary
- replace the blueprint-exposed obstacle pointer array with TObjectPtr so the type is blueprint compatible
- update obstacle cleanup loop to iterate over the new pointer type

## Testing
- not run (editor build only change)


------
https://chatgpt.com/codex/tasks/task_e_68d6580334908324b2b3e58af0aaac07