### PR TITLE
Fix unsupported blueprint property for spawned grid obstacles

### DIFF
--- a/Source/Skald/GridOverlayActor.h
+++ b/Source/Skald/GridOverlayActor.h
@@ -78,7 +78,7 @@ protected:
 
 private:
   /** Track obstacle actors spawned by this overlay. */
-  UPROPERTY(Transient, BlueprintReadOnly, Category = "Grid|Obstacles", meta = (AllowPrivateAccess = "true"))
+  UPROPERTY(Transient, Category = "Grid|Obstacles", meta = (AllowPrivateAccess = "true"))
   TArray<TObjectPtr<AGridObstacleActor>> SpawnedObstacleActors;
 
   /** Grid cells that currently contain spawned obstacles. */


### PR DESCRIPTION
## Summary
- remove BlueprintReadOnly flag from the spawned obstacle tracking array so it is no longer exposed to blueprints
- keep the runtime tracking array transient while avoiding unsupported blueprint types

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d65b39fea08324956ba6ea26a8403e