### PR TITLE
Fix UPROPERTY category warning

### DIFF
--- a/Source/Skald/GridOverlayActor.h
+++ b/Source/Skald/GridOverlayActor.h
@@ -78,7 +78,7 @@ protected:
 
 private:
   /** Track obstacle actors spawned by this overlay. */
-  UPROPERTY(Transient, Category = "Grid|Obstacles", meta = (AllowPrivateAccess = "true"))
+  UPROPERTY(Transient, meta = (AllowPrivateAccess = "true"))
   TArray<TObjectPtr<AGridObstacleActor>> SpawnedObstacleActors;
 
   /** Grid cells that currently contain spawned obstacles. */


### PR DESCRIPTION
## Summary
- remove the category metadata from the private transient obstacle array to satisfy Unreal Header Tool warnings

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d65e9f486483248a2ae3de8cdad506