### PR TITLE
Fix build failures caused by missing includes and shadowed variable names

### DIFF
--- a/Source/Skald/GridOverlayActor.cpp
+++ b/Source/Skald/GridOverlayActor.cpp
@@ -5,6 +5,7 @@
 #include "GridObstacleActor.h"
 #include "GridOverlayComponent.h"
 #include "CollisionQueryParams.h"
+#include "Engine/HitResult.h"
 
 namespace {
 constexpr float kSmallHeightEpsilon = 0.01f;

--- a/Source/Skald/Skald_BattleGameMode.cpp
+++ b/Source/Skald/Skald_BattleGameMode.cpp
@@ -895,8 +895,8 @@ bool ASkald_BattleGameMode::RelocateControllersNearBattleGrid(
       BaseLocation.X += (static_cast<float>(Width) * CellSize) * 0.5f;
       BaseLocation.Y += (static_cast<float>(Height) * CellSize) * 0.5f;
       bHasLocation = true;
-    } else if (AActor *Owner = Grid->GetOwner()) {
-      BaseLocation = Owner->GetActorLocation();
+    } else if (AActor *OwnerActor = Grid->GetOwner()) {
+      BaseLocation = OwnerActor->GetActorLocation();
       bHasLocation = true;
     }
   }
@@ -1122,13 +1122,15 @@ void ASkald_BattleGameMode::TryLaunchBattle() {
 
   TArray<AController *> ControllersToRelocate;
   if (AttackerPS) {
-    if (AController *Owner = Cast<AController>(AttackerPS->GetOwner())) {
-      ControllersToRelocate.AddUnique(Owner);
+    if (AController *OwnerController =
+            Cast<AController>(AttackerPS->GetOwner())) {
+      ControllersToRelocate.AddUnique(OwnerController);
     }
   }
   if (DefenderPS) {
-    if (AController *Owner = Cast<AController>(DefenderPS->GetOwner())) {
-      ControllersToRelocate.AddUnique(Owner);
+    if (AController *OwnerController =
+            Cast<AController>(DefenderPS->GetOwner())) {
+      ControllersToRelocate.AddUnique(OwnerController);
     }
   }
 


### PR DESCRIPTION
## Summary
- include the engine hit result header so FHitResult is defined during grid overlay compilation
- rename local variables that shadow AActor::Owner when relocating controllers for battles

## Testing
- not run (development environment does not support Unreal Engine build)


------
https://chatgpt.com/codex/tasks/task_e_68d65fe86ab88324935d8c1d39436b89