### PR TITLE
Add decal-based grid highlights

### DIFF
--- a/Source/Skald/GridOverlayComponent.cpp
+++ b/Source/Skald/GridOverlayComponent.cpp
@@ -6,6 +6,8 @@
 #include "Engine/World.h"
 #include "FighterPawn.h"
 #include "GridObstacleComponent.h"
+#include "Components/DecalComponent.h"
+#include "Materials/MaterialInstanceDynamic.h"
 #include "Components/InstancedStaticMeshComponent.h"
 #include "Components/SceneComponent.h"
 #include "GameFramework/Actor.h"
@@ -173,7 +175,9 @@ void UGridOverlayComponent::OnRegister() {
   RefreshOriginFromOwner();
 
   EnsureBaseGridComponentSetup();
-  EnsureHighlightComponentSetup();
+  if (!bUseDecalHighlights) {
+    EnsureHighlightComponentSetup();
+  }
 }
 
 void UGridOverlayComponent::BeginPlay() {
@@ -449,6 +453,109 @@ void UGridOverlayComponent::ApplyHighlightColor(int32 InstanceIndex,
   HighlightMeshComponent->SetCustomDataValue(InstanceIndex, 3, Color.A, true);
 }
 
+UMaterialInterface *UGridOverlayComponent::GetHighlightDecalMaterial() const {
+  if (HighlightDecalMaterial) {
+    return HighlightDecalMaterial;
+  }
+
+  return HighlightMaterial;
+}
+
+void UGridOverlayComponent::HighlightCellWithDecal(const FIntPoint &GridCoord,
+                                                   const FColor &Color) {
+  AActor *Owner = GetOwner();
+  if (!Owner) {
+    return;
+  }
+
+  UMaterialInterface *BaseMaterial = GetHighlightDecalMaterial();
+  if (!BaseMaterial) {
+    return;
+  }
+
+  UDecalComponent *Decal = nullptr;
+  if (TWeakObjectPtr<UDecalComponent> *Existing = HighlightedDecals.Find(GridCoord)) {
+    Decal = Existing->Get();
+    if (!Decal) {
+      HighlightedDecals.Remove(GridCoord);
+      HighlightedDecalMaterials.Remove(GridCoord);
+    }
+  }
+
+  if (!Decal) {
+    Decal = NewObject<UDecalComponent>(Owner);
+    if (!Decal) {
+      return;
+    }
+
+    Decal->CreationMethod = EComponentCreationMethod::Instance;
+    Decal->SetMobility(EComponentMobility::Movable);
+    Decal->FadeScreenSize = HighlightDecalFadeScreenSize;
+    Owner->AddOwnedComponent(Decal);
+    Owner->AddInstanceComponent(Decal);
+
+    if (USceneComponent *Root = Owner->GetRootComponent()) {
+      Decal->AttachToComponent(Root, FAttachmentTransformRules::KeepWorldTransform);
+    }
+
+    Decal->RegisterComponent();
+    HighlightedDecals.Add(GridCoord, Decal);
+  }
+
+  UMaterialInstanceDynamic *DynamicMaterial = nullptr;
+  if (TWeakObjectPtr<UMaterialInstanceDynamic> *ExistingMaterial =
+          HighlightedDecalMaterials.Find(GridCoord)) {
+    DynamicMaterial = ExistingMaterial->Get();
+    if (!DynamicMaterial) {
+      HighlightedDecalMaterials.Remove(GridCoord);
+    }
+  }
+
+  if (!DynamicMaterial) {
+    DynamicMaterial = UMaterialInstanceDynamic::Create(BaseMaterial, this);
+
+    if (DynamicMaterial) {
+      HighlightedDecalMaterials.Add(GridCoord, DynamicMaterial);
+    }
+  }
+
+  if (DynamicMaterial) {
+    Decal->SetDecalMaterial(DynamicMaterial);
+  } else {
+    Decal->SetDecalMaterial(BaseMaterial);
+  }
+
+  const int32 ArrayIndex = Index(GridCoord);
+  const FQuat CellRotation =
+      CellRotations.IsValidIndex(ArrayIndex) ? CellRotations[ArrayIndex]
+                                             : FQuat::Identity;
+  const FVector CellNormal = CellRotation.RotateVector(FVector::UpVector).GetSafeNormal();
+  const FVector CellTangent =
+      CellRotation.RotateVector(FVector::ForwardVector).GetSafeNormal();
+  const FVector WorldCenter = GridToWorld(GridCoord);
+  FVector DecalLocation =
+      WorldCenter + CellNormal * (HighlightHeightOffset + HighlightDecalProjectionDepth * 0.5f);
+  const FRotationMatrix DecalBasis = FRotationMatrix::MakeFromXZ(-CellNormal, CellTangent);
+  const FRotator DecalRotation = DecalBasis.Rotator();
+
+  const float EffectiveCellSize = FMath::Max(CellSize, KINDA_SMALL_NUMBER);
+  const float HalfSize = 0.5f * EffectiveCellSize * HighlightDecalSizeMultiplier;
+  Decal->DecalSize = FVector(HighlightDecalProjectionDepth, HalfSize, HalfSize);
+  Decal->FadeScreenSize = HighlightDecalFadeScreenSize;
+  Decal->SetWorldLocationAndRotation(DecalLocation, DecalRotation);
+
+  if (HighlightDecalLifeSpan > 0.f && HighlightDecalFadeDuration > 0.f) {
+    Decal->SetFadeOut(HighlightDecalLifeSpan, HighlightDecalFadeDuration, true);
+  } else {
+    Decal->ResetFade();
+  }
+
+  if (DynamicMaterial) {
+    DynamicMaterial->SetVectorParameterValue(HighlightDecalColorParameter,
+                                             FLinearColor(Color));
+  }
+}
+
 void UGridOverlayComponent::ApplyBaseGridColor(int32 InstanceIndex,
                                                const FLinearColor &Color) {
   if (!BaseGridMeshComponent || BaseGridMeshComponent->NumCustomDataFloats < 4 ||
@@ -559,6 +666,11 @@ void UGridOverlayComponent::HighlightCell(const FIntPoint &GridCoord,
     return;
   }
 
+  if (bUseDecalHighlights) {
+    HighlightCellWithDecal(GridCoord, Color);
+    return;
+  }
+
   if (!EnsureHighlightComponentSetup()) {
     return;
   }
@@ -607,6 +719,16 @@ void UGridOverlayComponent::ClearHighlights() {
   if (HighlightMeshComponent) {
     HighlightMeshComponent->ClearInstances();
   }
+
+  if (HighlightedDecals.Num() > 0) {
+    for (auto It = HighlightedDecals.CreateIterator(); It; ++It) {
+      if (UDecalComponent *Decal = It.Value().Get()) {
+        Decal->DestroyComponent();
+      }
+    }
+    HighlightedDecals.Empty();
+  }
+  HighlightedDecalMaterials.Empty();
 
 #if WITH_EDITOR
   if (GetWorld() && bFlushAllPersistentOnClear) {

--- a/Source/Skald/GridOverlayComponent.h
+++ b/Source/Skald/GridOverlayComponent.h
@@ -9,8 +9,10 @@ class AFighterPawn;
 class UGridObstacleComponent;
 struct FHitResult;
 class UInstancedStaticMeshComponent;
+class UDecalComponent;
 class UMaterialInterface;
 class UStaticMesh;
+class UMaterialInstanceDynamic;
 
 USTRUCT()
 struct FPendingGridOccupancyUpdate {
@@ -162,6 +164,43 @@ public:
   UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category = "Grid|Highlight")
   UMaterialInterface *HighlightMaterial = nullptr;
 
+  /** If true, highlights will spawn decals instead of instanced meshes. */
+  UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Grid|Highlight|Decal")
+  bool bUseDecalHighlights = false;
+
+  /** Material applied to highlight decals (must use the Deferred Decal domain). */
+  UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category = "Grid|Highlight|Decal")
+  UMaterialInterface *HighlightDecalMaterial = nullptr;
+
+  /** Name of the vector parameter driven by highlight colours on the decal material. */
+  UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category = "Grid|Highlight|Decal")
+  FName HighlightDecalColorParameter = TEXT("TintColor");
+
+  /** Depth of the decal projection along the surface normal. */
+  UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Grid|Highlight|Decal",
+            meta = (ClampMin = "0.0"))
+  float HighlightDecalProjectionDepth = 32.f;
+
+  /** Multiplier applied to the XY footprint of the decal relative to the cell size. */
+  UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Grid|Highlight|Decal",
+            meta = (ClampMin = "0.01"))
+  float HighlightDecalSizeMultiplier = 1.0f;
+
+  /** Screen size threshold at which decals begin to fade out. */
+  UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Grid|Highlight|Decal",
+            meta = (ClampMin = "0.0"))
+  float HighlightDecalFadeScreenSize = 0.01f;
+
+  /** Delay before decals automatically fade out (0 to disable automatic fade). */
+  UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Grid|Highlight|Decal",
+            meta = (ClampMin = "0.0"))
+  float HighlightDecalLifeSpan = 0.f;
+
+  /** Duration of the fade once it begins (used when LifeSpan is greater than zero). */
+  UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Grid|Highlight|Decal",
+            meta = (ClampMin = "0.0"))
+  float HighlightDecalFadeDuration = 0.25f;
+
   /** Vertical offset applied to highlight instances. */
   UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Grid|Highlight")
   float HighlightHeightOffset = 2.f;
@@ -276,6 +315,14 @@ protected:
   UPROPERTY(Transient)
   TMap<FIntPoint, int32> HighlightedInstances;
 
+  /** Map grid coordinates to spawned highlight decals when decal mode is active. */
+  UPROPERTY(Transient)
+  TMap<FIntPoint, TWeakObjectPtr<UDecalComponent>> HighlightedDecals;
+
+  /** Dynamic materials created for active decal highlights. */
+  UPROPERTY(Transient)
+  TMap<FIntPoint, TWeakObjectPtr<UMaterialInstanceDynamic>> HighlightedDecalMaterials;
+
   /** Mapping of grid cell index to persistent grid instance index. */
   UPROPERTY(Transient)
   TArray<int32> BaseGridInstanceIndices;
@@ -323,6 +370,12 @@ protected:
 
   /** Apply highlight color as per-instance custom data. */
   void ApplyHighlightColor(int32 InstanceIndex, const FLinearColor &Color);
+
+  /** Highlight a cell using a spawned decal component. */
+  void HighlightCellWithDecal(const FIntPoint &GridCoord, const FColor &Color);
+
+  /** Resolve the material that should be used for decal highlights. */
+  UMaterialInterface *GetHighlightDecalMaterial() const;
 
   /** Ensure the instanced highlight component exists and belongs to the owner. */
   bool EnsureHighlightMeshComponentExists();

--- a/docs/GridHighlightDecals.md
+++ b/docs/GridHighlightDecals.md
@@ -1,0 +1,24 @@
+# Grid Highlight Decal Setup
+
+The grid overlay component can now spawn decals for highlighted tiles. This lets the highlight conform to uneven terrain instead of relying on a flat instanced mesh. Use the steps below to configure the feature inside the editor.
+
+## 1. Author a decal material
+
+1. Create a new material that uses the **Deferred Decal** material domain. Existing grid materials are almost certainly set to the *Surface* domain so they cannot be reused directly; copy their node graph into the new material if you want the same look.
+2. Set the **Decal Blend Mode** to `Translucent` (or another mode that suits your art style).
+3. Add a `VectorParameter` node named **`TintColor`** (this matches the default parameter name expected by the component) and feed it into the decal's base/opacity inputs as required.
+4. Expose any other parameters you need (mask textures, emissive, roughness, etc.).
+5. Save the material and, if desired, create a material instance for runtime tweaking.
+
+> **Tip:** If you want to share textures with the existing grid highlight, right-click the original material and choose **Create Material Instance**, then use that instance as the texture source inside your decal material. The domain still needs to be `Deferred Decal` for decals to render.
+
+## 2. Configure the grid overlay component
+
+1. Select the actor that owns `UGridOverlayComponent` (e.g. the grid overlay actor in your battle map).
+2. In the **Grid | Highlight | Decal** category:
+   - Enable **Use Decal Highlights**.
+   - Assign your new decal material (or material instance) to **Highlight Decal Material**.
+   - Adjust **Decal Projection Depth**, **Size Multiplier**, **Fade Screen Size**, **Life Span**, and **Fade Duration** to taste. Leave **Life Span** at `0` for persistent highlights that clear only when the component tells them to.
+3. (Optional) Set **Highlight Decal Color Parameter** if your material expects a different vector parameter name for tinting.
+
+Once configured, calling any of the existing highlight helpers (`HighlightCell`, `HighlightMovement`, `HighlightAttack`, `HighlightSelection`) will spawn decals instead of instanced meshes. Call `ClearHighlights` to remove any active decals when they are no longer needed.


### PR DESCRIPTION
## Summary
- add configuration switches that let the grid overlay spawn decals instead of instanced meshes
- implement decal spawning, reuse, and cleanup while keeping the existing mesh workflow available
- document how to author a compatible decal material and enable the new option

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d6d9bb44348324a46f4f0ee4596293