### PR TITLE
Add attack roll sequencing delays and HUD indicators

### DIFF
--- a/Source/Skald/FighterPawn.cpp
+++ b/Source/Skald/FighterPawn.cpp
@@ -125,6 +125,8 @@ void AFighterPawn::BeginActivation() {
 }
 
 void AFighterPawn::ResetActivationState() {
+  CleanupPendingAttack();
+
   ActionsRemaining = 0;
   bHasActivatedThisRound = false;
   bIsCurrentlyActive = false;
@@ -133,6 +135,8 @@ void AFighterPawn::ResetActivationState() {
 }
 
 void AFighterPawn::FinishActivation() {
+  CleanupPendingAttack();
+
   ActionsRemaining = 0;
   bIsCurrentlyActive = false;
 
@@ -209,8 +213,8 @@ void AFighterPawn::MoveToCell(FIntPoint TargetCell) {
 }
 
 void AFighterPawn::PerformAttack(AFighterPawn *Target) {
-  if (!bIsCurrentlyActive || ActionsRemaining <= 0 || !Target ||
-      !Target->IsAlive()) {
+  if (bAttackSequenceInProgress || !bIsCurrentlyActive || ActionsRemaining <= 0 ||
+      !Target || !Target->IsAlive()) {
     return;
   }
 
@@ -225,72 +229,116 @@ void AFighterPawn::PerformAttack(AFighterPawn *Target) {
     return;
   }
 
-  FRandomStream *RandomStream = nullptr;
-  if (UWorld *World = GetWorld()) {
-    if (USkaldGameInstance *GameInstance =
-            Cast<USkaldGameInstance>(World->GetGameInstance())) {
-      RandomStream = &GameInstance->CombatRandomStream;
-    }
-  }
-  if (!RandomStream) {
-    return;
-  }
-
   const int32 RequiredRoll =
       Stats.Strength > Target->Stats.Defence
           ? 3
           : (Stats.Strength < Target->Stats.Defence ? 5 : 4);
 
-  for (int32 i = 0; i < Stats.AttackDice && Target->IsAlive(); ++i) {
-    const int32 Roll = RandomStream->RandRange(1, 6);
-    int32 DamageThisDie = 0;
+  PendingAttackTarget = Target;
+  PendingAttackRequiredRoll = RequiredRoll;
+  PendingAttackDiceRemaining = FMath::Max(Stats.AttackDice, 0);
+  bAttackSequenceInProgress = PendingAttackDiceRemaining > 0;
 
-    if (Roll == 6) {
-      DamageThisDie = Stats.AttackDamage + 3; // crit
-    } else if (Roll >= RequiredRoll) {
-      DamageThisDie = Stats.AttackDamage;
-    }
+  if (!bAttackSequenceInProgress) {
+    FinalizePendingAttack(Target);
+    return;
+  }
 
-    const bool bHit = DamageThisDie > 0;
-    if (USkaldGameInstance *GI = Cast<USkaldGameInstance>(GetGameInstance())) {
-      if (UGridBattleManager *BattleManager = GI->GridBattleManager) {
-        BattleManager->ReportAttackRoll(this, Target, Roll, bHit, DamageThisDie);
+  ResolvePendingAttackRoll();
+}
+
+void AFighterPawn::ResolvePendingAttackRoll() {
+  UWorld *World = GetWorld();
+  if (!World) {
+    CleanupPendingAttack();
+    return;
+  }
+
+  AFighterPawn *Target = PendingAttackTarget.Get();
+  if (!Target || !Target->IsAlive()) {
+    FinalizePendingAttack(Target);
+    return;
+  }
+
+  USkaldGameInstance *GameInstance =
+      Cast<USkaldGameInstance>(World->GetGameInstance());
+  if (!GameInstance) {
+    CleanupPendingAttack();
+    return;
+  }
+
+  const int32 Roll = GameInstance->CombatRandomStream.RandRange(1, 6);
+  int32 DamageThisDie = 0;
+
+  if (Roll == 6) {
+    DamageThisDie = Stats.AttackDamage + 3; // crit
+  } else if (Roll >= PendingAttackRequiredRoll) {
+    DamageThisDie = Stats.AttackDamage;
+  }
+
+  const bool bHit = DamageThisDie > 0;
+  if (UGridBattleManager *BattleManager = GameInstance->GridBattleManager) {
+    BattleManager->ReportAttackRoll(this, Target, Roll, bHit, DamageThisDie);
+  }
+
+  if (DamageThisDie > 0) {
+    Target->Stats.Health =
+        FMath::Max(0, Target->Stats.Health - DamageThisDie);
+
+    if (UUserWidget *DamageWidget = GetDamageWidgetFromPool()) {
+      if (UTextBlock *Text = Cast<UTextBlock>(
+              DamageWidget->GetWidgetFromName(TEXT("DamageText")))) {
+        Text->SetText(FText::AsNumber(DamageThisDie));
       }
-    }
-
-    if (DamageThisDie > 0) {
-      Target->Stats.Health =
-          FMath::Max(0, Target->Stats.Health - DamageThisDie);
-
-      if (UUserWidget *DamageWidget = GetDamageWidgetFromPool()) {
-        if (UTextBlock *Text = Cast<UTextBlock>(
-                DamageWidget->GetWidgetFromName(TEXT("DamageText")))) {
-          Text->SetText(FText::AsNumber(DamageThisDie));
-        }
-        DamageWidget->AddToViewport();
-        if (UWorld *World = GetWorld()) {
-          FTimerHandle Timer;
-          World->GetTimerManager().SetTimer(
-              Timer, FTimerDelegate::CreateLambda([DamageWidget]() {
-                DamageWidget->RemoveFromParent();
-              }),
-              1.f, false);
-        }
-      }
+      DamageWidget->AddToViewport();
+      FTimerHandle LocalTimer;
+      World->GetTimerManager().SetTimer(
+          LocalTimer, FTimerDelegate::CreateLambda([DamageWidget]() {
+            DamageWidget->RemoveFromParent();
+          }),
+          1.f, false);
     }
   }
 
-  Target->OnHealthChanged.Broadcast(Target->Stats.Health);
-  if (!Target->IsAlive()) {
-    Target->Destroy();
+  --PendingAttackDiceRemaining;
+
+  if (PendingAttackDiceRemaining > 0 && Target->IsAlive()) {
+    World->GetTimerManager().SetTimer(AttackRollTimerHandle, this,
+                                      &AFighterPawn::ResolvePendingAttackRoll,
+                                      1.f, false);
+  } else {
+    FinalizePendingAttack(Target);
   }
+}
+
+void AFighterPawn::FinalizePendingAttack(AFighterPawn *Target) {
+  if (Target) {
+    Target->OnHealthChanged.Broadcast(Target->Stats.Health);
+    if (!Target->IsAlive()) {
+      Target->Destroy();
+    }
+  }
+
   ActionsRemaining = FMath::Max(0, ActionsRemaining - 1);
 
   BroadcastActionsRemaining();
 
-  if (Grid) {
+  if (UGridOverlayComponent *Grid = GetGrid()) {
     Grid->ClearHighlights();
   }
+
+  CleanupPendingAttack();
+}
+
+void AFighterPawn::CleanupPendingAttack() {
+  if (UWorld *World = GetWorld()) {
+    World->GetTimerManager().ClearTimer(AttackRollTimerHandle);
+  }
+
+  PendingAttackTarget = nullptr;
+  PendingAttackDiceRemaining = 0;
+  PendingAttackRequiredRoll = 0;
+  bAttackSequenceInProgress = false;
 }
 
 void AFighterPawn::UpdateMeshOffset() {

--- a/Source/Skald/FighterPawn.h
+++ b/Source/Skald/FighterPawn.h
@@ -5,6 +5,7 @@
 #include "CoreMinimal.h"
 #include "GameFramework/Pawn.h"
 #include "GridBattleManager.h"
+#include "TimerManager.h"
 #include "FighterPawn.generated.h"
 
 class UGridOverlayComponent;
@@ -127,6 +128,15 @@ private:
   /** Retrieve or create a damage widget from the pool. */
   UUserWidget *GetDamageWidgetFromPool();
 
+  /** Resolve the next pending attack roll when sequencing dice. */
+  void ResolvePendingAttackRoll();
+
+  /** Finalize an attack once all dice have been processed. */
+  void FinalizePendingAttack(AFighterPawn *Target);
+
+  /** Clear any in-progress attack sequencing state. */
+  void CleanupPendingAttack();
+
   /** Align the visible mesh with the collision capsule. */
   void UpdateMeshOffset();
 
@@ -136,6 +146,21 @@ private:
   /** Pool of reusable damage widgets to avoid repeated allocations. */
   UPROPERTY()
   TArray<UUserWidget *> DamageWidgetPool;
+
+  /** Timer used to delay sequential attack dice rolls. */
+  FTimerHandle AttackRollTimerHandle;
+
+  /** Target currently being attacked while sequencing dice. */
+  TWeakObjectPtr<AFighterPawn> PendingAttackTarget;
+
+  /** Remaining dice to resolve for the pending attack. */
+  int32 PendingAttackDiceRemaining = 0;
+
+  /** Required roll threshold cached for the pending attack. */
+  int32 PendingAttackRequiredRoll = 0;
+
+  /** True while the fighter is sequencing attack dice rolls. */
+  bool bAttackSequenceInProgress = false;
 
   /** Current cell occupied by the fighter. */
   UPROPERTY(Replicated)

--- a/Source/Skald/Skald_PlayerController.cpp
+++ b/Source/Skald/Skald_PlayerController.cpp
@@ -675,6 +675,10 @@ void ASkaldPlayerController::InitializeBattleHUD() {
         this, &ASkaldPlayerController::HandleBattleEnded);
     GI->GridBattleManager->OnBattleEnded.AddDynamic(
         this, &ASkaldPlayerController::HandleBattleEnded);
+    GI->GridBattleManager->OnAttackResolved.RemoveDynamic(
+        this, &ASkaldPlayerController::HandleAttackResolved);
+    GI->GridBattleManager->OnAttackResolved.AddDynamic(
+        this, &ASkaldPlayerController::HandleAttackResolved);
     ActiveFighter = GI->GridBattleManager->GetActiveFighter();
 
     const int32 CurrentRound = GI->GridBattleManager->GetCurrentRound();
@@ -1949,6 +1953,21 @@ void ASkaldPlayerController::HandleEndTurnPressed() {
   LockedActiveFighter = nullptr;
   UpdateBattleHUDButtons();
   CancelCommandMode();
+}
+
+void ASkaldPlayerController::HandleAttackResolved(AFighterPawn *Attacker,
+                                                  AFighterPawn *Defender,
+                                                  int32 Roll, bool bHit,
+                                                  int32 Damage) {
+  if (!IsLocalController() || !BattleHudWidget) {
+    return;
+  }
+
+  if (!Attacker || !Defender) {
+    return;
+  }
+
+  BattleHudWidget->ShowAttackRollResult(bHit, Damage);
 }
 
 void ASkaldPlayerController::HandleRightClick() {

--- a/Source/Skald/Skald_PlayerController.h
+++ b/Source/Skald/Skald_PlayerController.h
@@ -215,6 +215,10 @@ protected:
   UFUNCTION()
   void HandleEndTurnPressed();
 
+  UFUNCTION()
+  void HandleAttackResolved(AFighterPawn *Attacker, AFighterPawn *Defender,
+                            int32 Roll, bool bHit, int32 Damage);
+
   /** Respond when our PlayerState receives an updated PlayerId. */
   void HandlePlayerIdUpdated();
 

--- a/Source/Skald/UI/BattleHUDWidget.cpp
+++ b/Source/Skald/UI/BattleHUDWidget.cpp
@@ -5,6 +5,7 @@
 #include "EngineUtils.h"
 #include "FighterPawn.h"
 #include "GridOverlayComponent.h"
+#include "Styling/SlateColor.h"
 
 void UBattleHUDWidget::NativeConstruct() {
   Super::NativeConstruct();
@@ -25,6 +26,8 @@ void UBattleHUDWidget::NativeConstruct() {
     EndTurnButton->OnClicked.AddDynamic(
         this, &UBattleHUDWidget::HandleEndTurnPressed);
   }
+
+  ClearAttackRollResult();
 }
 
 void UBattleHUDWidget::RefreshStats() { UpdateStatPanel(); }
@@ -210,6 +213,42 @@ void UBattleHUDWidget::ClearCommandPreviews() {
   bAttackSelected = false;
   if (UGridOverlayComponent *Grid = FindGridOverlay()) {
     Grid->ClearHighlights();
+  }
+}
+
+void UBattleHUDWidget::ShowAttackRollResult(bool bHit, int32 Damage) {
+  if (!AttackRollResultText) {
+    return;
+  }
+
+  const bool bValidHit = bHit && Damage > 0;
+  const FText DisplayText =
+      bValidHit ? FText::AsNumber(Damage)
+                : NSLOCTEXT("Skald", "BattleAttackMiss", "Miss");
+  const FSlateColor DisplayColor = bValidHit
+                                        ? FSlateColor(FLinearColor(0.85f, 0.1f, 0.1f))
+                                        : FSlateColor(FLinearColor(0.6f, 0.6f, 0.6f));
+
+  AttackRollResultText->SetText(DisplayText);
+  AttackRollResultText->SetColorAndOpacity(DisplayColor);
+  AttackRollResultText->SetVisibility(ESlateVisibility::HitTestInvisible);
+
+  if (UWorld *World = GetWorld()) {
+    World->GetTimerManager().ClearTimer(AttackResultTimerHandle);
+    World->GetTimerManager().SetTimer(AttackResultTimerHandle, this,
+                                      &UBattleHUDWidget::ClearAttackRollResult,
+                                      1.f, false);
+  }
+}
+
+void UBattleHUDWidget::ClearAttackRollResult() {
+  if (AttackRollResultText) {
+    AttackRollResultText->SetText(FText::GetEmpty());
+    AttackRollResultText->SetVisibility(ESlateVisibility::Collapsed);
+  }
+
+  if (UWorld *World = GetWorld()) {
+    World->GetTimerManager().ClearTimer(AttackResultTimerHandle);
   }
 }
 

--- a/Source/Skald/UI/BattleHUDWidget.h
+++ b/Source/Skald/UI/BattleHUDWidget.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "Blueprint/UserWidget.h"
+#include "TimerManager.h"
 #include "BattleHUDWidget.generated.h"
 
 class UButton;
@@ -110,6 +111,10 @@ public:
   UPROPERTY(BlueprintReadOnly, meta = (BindWidgetOptional))
   UTextBlock *PlayersTurnText;
 
+  /** Text displaying the most recent attack roll result. */
+  UPROPERTY(BlueprintReadOnly, meta = (BindWidgetOptional))
+  UTextBlock *AttackRollResultText;
+
   /** Update the round and initiative labels. */
   void SetRoundInfo(const FText &RoundLabel, const FText &InitiativeLabel);
 
@@ -130,6 +135,9 @@ public:
 
   /** Clear any preview highlights tracked by the widget. */
   void ClearCommandPreviews();
+
+  /** Display the outcome of an attack roll for a short duration. */
+  void ShowAttackRollResult(bool bHit, int32 Damage);
 
 private:
   /** Callback when MoveButton is pressed. */
@@ -162,6 +170,10 @@ private:
   /** Find the grid overlay component in the world. */
   UGridOverlayComponent *FindGridOverlay() const;
 
+  /** Clear the current attack roll indicator. */
+  UFUNCTION()
+  void ClearAttackRollResult();
+
   /** Whether movement preview is currently shown. */
   bool bMoveSelected = false;
 
@@ -171,5 +183,8 @@ private:
   /** Fighter currently bound to the HUD. */
   UPROPERTY()
   AFighterPawn *BoundFighter;
+
+  /** Timer used to hide the attack roll indicator after a delay. */
+  FTimerHandle AttackResultTimerHandle;
 };
 


### PR DESCRIPTION
## Summary
- stagger fighter attack dice resolution so each roll is processed once per second
- surface attack roll results on the battle HUD with temporary hit/miss text
- hook the player controller to forward attack events to the HUD indicator

## Testing
- not run (Unreal build tools unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68d6f7cb97d48324b886cec145a69149