### PR TITLE
Show delayed dice roll feedback during attacks

### DIFF
--- a/Source/Skald/FighterPawn.cpp
+++ b/Source/Skald/FighterPawn.cpp
@@ -238,6 +238,21 @@ void AFighterPawn::PerformAttack(AFighterPawn *Target) {
     return;
   }
 
+  if (PendingAttackTarget.IsValid() || PendingAttackRolls.Num() > 0) {
+    if (UWorld *World = GetWorld()) {
+      if (USkaldGameInstance *GameInstance =
+              Cast<USkaldGameInstance>(World->GetGameInstance())) {
+        if (UGridBattleManager *BattleManager =
+                GameInstance->GridBattleManager) {
+          BattleManager->ReportAttackRejected(
+              this, Target,
+              NSLOCTEXT("SkaldBattle", "AttackInProgress", "Attack in progress."));
+        }
+      }
+    }
+    return;
+  }
+
   const int32 Distance = FMath::Abs(Target->CurrentCell.X - CurrentCell.X) +
                          FMath::Abs(Target->CurrentCell.Y - CurrentCell.Y);
   if (Distance > Stats.AttackRange) {

--- a/Source/Skald/FighterPawn.cpp
+++ b/Source/Skald/FighterPawn.cpp
@@ -55,6 +55,12 @@ AFighterPawn::AFighterPawn() {
     DamageFloatWidgetTemplate = DamageWidgetFinder.Class;
   }
 
+  static ConstructorHelpers::FClassFinder<UUserWidget> MissWidgetFinder(
+      TEXT("/Game/Blueprints/UI/WBP_Misses"));
+  if (MissWidgetFinder.Succeeded()) {
+    MissWidgetTemplate = MissWidgetFinder.Class;
+  }
+
   ActionsRemaining = 0;
   bHasActivatedThisRound = false;
   bIsCurrentlyActive = false;
@@ -173,6 +179,24 @@ UUserWidget *AFighterPawn::GetDamageWidgetFromPool() {
   return nullptr;
 }
 
+UUserWidget *AFighterPawn::GetMissWidgetFromPool() {
+  for (UUserWidget *Widget : MissWidgetPool) {
+    if (Widget && !Widget->IsInViewport()) {
+      return Widget;
+    }
+  }
+  if (MissWidgetTemplate) {
+    if (UWorld *World = GetWorld()) {
+      if (UUserWidget *NewWidget =
+              CreateWidget<UUserWidget>(World, MissWidgetTemplate)) {
+        MissWidgetPool.Add(NewWidget);
+        return NewWidget;
+      }
+    }
+  }
+  return nullptr;
+}
+
 void AFighterPawn::MoveToCell(FIntPoint TargetCell) {
   if (!bIsCurrentlyActive || ActionsRemaining <= 0) {
     return;
@@ -241,7 +265,11 @@ void AFighterPawn::PerformAttack(AFighterPawn *Target) {
           ? 3
           : (Stats.Strength < Target->Stats.Defence ? 5 : 4);
 
-  for (int32 i = 0; i < Stats.AttackDice && Target->IsAlive(); ++i) {
+  TArray<FQueuedAttackRoll> QueuedRolls;
+  QueuedRolls.Reserve(Stats.AttackDice);
+
+  int32 SimulatedHealth = Target->Stats.Health;
+  for (int32 i = 0; i < Stats.AttackDice && SimulatedHealth > 0; ++i) {
     const int32 Roll = RandomStream->RandRange(1, 6);
     int32 DamageThisDie = 0;
 
@@ -251,39 +279,18 @@ void AFighterPawn::PerformAttack(AFighterPawn *Target) {
       DamageThisDie = Stats.AttackDamage;
     }
 
-    const bool bHit = DamageThisDie > 0;
-    if (USkaldGameInstance *GI = Cast<USkaldGameInstance>(GetGameInstance())) {
-      if (UGridBattleManager *BattleManager = GI->GridBattleManager) {
-        BattleManager->ReportAttackRoll(this, Target, Roll, bHit, DamageThisDie);
-      }
-    }
-
     if (DamageThisDie > 0) {
-      Target->Stats.Health =
-          FMath::Max(0, Target->Stats.Health - DamageThisDie);
-
-      if (UUserWidget *DamageWidget = GetDamageWidgetFromPool()) {
-        if (UTextBlock *Text = Cast<UTextBlock>(
-                DamageWidget->GetWidgetFromName(TEXT("DamageText")))) {
-          Text->SetText(FText::AsNumber(DamageThisDie));
-        }
-        DamageWidget->AddToViewport();
-        if (UWorld *World = GetWorld()) {
-          FTimerHandle Timer;
-          World->GetTimerManager().SetTimer(
-              Timer, FTimerDelegate::CreateLambda([DamageWidget]() {
-                DamageWidget->RemoveFromParent();
-              }),
-              1.f, false);
-        }
-      }
+      SimulatedHealth = FMath::Max(0, SimulatedHealth - DamageThisDie);
     }
+
+    FQueuedAttackRoll &NewRoll = QueuedRolls.Emplace_GetRef();
+    NewRoll.RollValue = Roll;
+    NewRoll.Damage = DamageThisDie;
+    NewRoll.bHit = DamageThisDie > 0;
   }
 
-  Target->OnHealthChanged.Broadcast(Target->Stats.Health);
-  if (!Target->IsAlive()) {
-    Target->Destroy();
-  }
+  StartQueuedAttack(Target, MoveTemp(QueuedRolls));
+
   ActionsRemaining = FMath::Max(0, ActionsRemaining - 1);
 
   BroadcastActionsRemaining();
@@ -291,6 +298,141 @@ void AFighterPawn::PerformAttack(AFighterPawn *Target) {
   if (Grid) {
     Grid->ClearHighlights();
   }
+}
+
+void AFighterPawn::StartQueuedAttack(AFighterPawn *Target,
+                                     TArray<FQueuedAttackRoll> &&Rolls) {
+  if (UWorld *World = GetWorld()) {
+    World->GetTimerManager().ClearTimer(AttackRollTimerHandle);
+  }
+
+  PendingAttackRolls = MoveTemp(Rolls);
+  PendingAttackRollIndex = 0;
+  PendingAttackTarget = Target;
+  bPendingAttackTargetDied = false;
+  bHasProcessedPendingRoll = false;
+
+  if (PendingAttackRolls.Num() == 0) {
+    FinalizeQueuedAttack();
+    return;
+  }
+
+  if (UWorld *World = GetWorld()) {
+    World->GetTimerManager().SetTimer(AttackRollTimerHandle, this,
+                                      &AFighterPawn::ResolveNextAttackRoll, 1.f,
+                                      false);
+  } else {
+    ResolveNextAttackRoll();
+  }
+}
+
+void AFighterPawn::ResolveNextAttackRoll() {
+  if (UWorld *World = GetWorld()) {
+    World->GetTimerManager().ClearTimer(AttackRollTimerHandle);
+  }
+
+  if (!PendingAttackRolls.IsValidIndex(PendingAttackRollIndex)) {
+    FinalizeQueuedAttack();
+    return;
+  }
+
+  AFighterPawn *Target = PendingAttackTarget.Get();
+  if (!Target) {
+    FinalizeQueuedAttack();
+    return;
+  }
+
+  const FQueuedAttackRoll Roll = PendingAttackRolls[PendingAttackRollIndex];
+  bHasProcessedPendingRoll = true;
+
+  if (USkaldGameInstance *GI = Cast<USkaldGameInstance>(GetGameInstance())) {
+    if (UGridBattleManager *BattleManager = GI->GridBattleManager) {
+      BattleManager->ReportAttackRoll(this, Target, Roll.RollValue, Roll.bHit,
+                                      Roll.Damage);
+    }
+  }
+
+  if (Roll.bHit) {
+    Target->Stats.Health =
+        FMath::Max(0, Target->Stats.Health - Roll.Damage);
+    if (Target->Stats.Health <= 0) {
+      bPendingAttackTargetDied = true;
+    }
+
+    if (UUserWidget *DamageWidget = GetDamageWidgetFromPool()) {
+      if (UTextBlock *Text = Cast<UTextBlock>(
+              DamageWidget->GetWidgetFromName(TEXT("DamageText")))) {
+        Text->SetText(FText::AsNumber(Roll.Damage));
+      }
+      DamageWidget->AddToViewport();
+      if (UWorld *WorldPtr = GetWorld()) {
+        FTimerHandle Timer;
+        WorldPtr->GetTimerManager().SetTimer(
+            Timer, FTimerDelegate::CreateLambda([DamageWidget]() {
+              DamageWidget->RemoveFromParent();
+            }),
+            1.f, false);
+      }
+    }
+  } else {
+    if (UUserWidget *MissWidget = GetMissWidgetFromPool()) {
+      if (UTextBlock *MissText =
+              Cast<UTextBlock>(MissWidget->GetWidgetFromName(TEXT("Missed")))) {
+        MissText->SetText(NSLOCTEXT("Skald", "BattleAttackMiss", "Missed"));
+      }
+      MissWidget->AddToViewport();
+      if (UWorld *WorldPtr = GetWorld()) {
+        FTimerHandle Timer;
+        WorldPtr->GetTimerManager().SetTimer(
+            Timer, FTimerDelegate::CreateLambda([MissWidget]() {
+              MissWidget->RemoveFromParent();
+            }),
+            1.f, false);
+      }
+    }
+  }
+
+  Target->OnHealthChanged.Broadcast(Target->Stats.Health);
+
+  ++PendingAttackRollIndex;
+
+  const bool bHasMoreRolls =
+      PendingAttackRolls.IsValidIndex(PendingAttackRollIndex);
+  const bool bTargetAlive = Target->IsAlive();
+
+  if (bHasMoreRolls && bTargetAlive) {
+    if (UWorld *WorldPtr = GetWorld()) {
+      WorldPtr->GetTimerManager().SetTimer(
+          AttackRollTimerHandle, this, &AFighterPawn::ResolveNextAttackRoll,
+          1.f, false);
+    } else {
+      ResolveNextAttackRoll();
+    }
+  } else {
+    FinalizeQueuedAttack();
+  }
+}
+
+void AFighterPawn::FinalizeQueuedAttack() {
+  if (UWorld *World = GetWorld()) {
+    World->GetTimerManager().ClearTimer(AttackRollTimerHandle);
+  }
+
+  AFighterPawn *Target = PendingAttackTarget.Get();
+  if (Target) {
+    if (!bPendingAttackTargetDied && !bHasProcessedPendingRoll) {
+      Target->OnHealthChanged.Broadcast(Target->Stats.Health);
+    }
+    if (!Target->IsAlive() && !Target->IsPendingKill()) {
+      Target->Destroy();
+    }
+  }
+
+  PendingAttackRolls.Reset();
+  PendingAttackRollIndex = 0;
+  PendingAttackTarget = nullptr;
+  bPendingAttackTargetDied = false;
+  bHasProcessedPendingRoll = false;
 }
 
 void AFighterPawn::UpdateMeshOffset() {

--- a/Source/Skald/FighterPawn.h
+++ b/Source/Skald/FighterPawn.h
@@ -5,6 +5,7 @@
 #include "CoreMinimal.h"
 #include "GameFramework/Pawn.h"
 #include "GridBattleManager.h"
+#include "TimerManager.h"
 #include "FighterPawn.generated.h"
 
 class UGridOverlayComponent;
@@ -101,6 +102,10 @@ public:
   UPROPERTY(EditDefaultsOnly, BlueprintReadWrite, Category = "Fighter|UI")
   TSubclassOf<UUserWidget> DamageFloatWidgetTemplate;
 
+  /** Widget class used for optional miss indicators. */
+  UPROPERTY(EditDefaultsOnly, BlueprintReadWrite, Category = "Fighter|UI")
+  TSubclassOf<UUserWidget> MissWidgetTemplate;
+
   /** Event broadcast when health changes. */
   UPROPERTY(BlueprintAssignable, Category = "Fighter|Events")
   FOnHealthChanged OnHealthChanged;
@@ -127,15 +132,57 @@ private:
   /** Retrieve or create a damage widget from the pool. */
   UUserWidget *GetDamageWidgetFromPool();
 
+  /** Retrieve or create a miss widget from the pool. */
+  UUserWidget *GetMissWidgetFromPool();
+
   /** Align the visible mesh with the collision capsule. */
   void UpdateMeshOffset();
 
   /** Helper to broadcast the current actions remaining value. */
   void BroadcastActionsRemaining();
 
+  /** Data describing a single queued attack roll. */
+  struct FQueuedAttackRoll {
+    int32 RollValue = 1;
+    int32 Damage = 0;
+    bool bHit = false;
+  };
+
+  /** Begin resolving queued attack rolls with a delay between each. */
+  void StartQueuedAttack(AFighterPawn *Target,
+                         TArray<FQueuedAttackRoll> &&Rolls);
+
+  /** Apply the next queued attack roll, showing the appropriate widget. */
+  void ResolveNextAttackRoll();
+
+  /** Finalise any pending attack resolution and clean up timers/state. */
+  void FinalizeQueuedAttack();
+
   /** Pool of reusable damage widgets to avoid repeated allocations. */
   UPROPERTY()
   TArray<UUserWidget *> DamageWidgetPool;
+
+  /** Pool of reusable miss widgets to avoid repeated allocations. */
+  UPROPERTY()
+  TArray<UUserWidget *> MissWidgetPool;
+
+  /** Pending attack rolls awaiting delayed resolution. */
+  TArray<FQueuedAttackRoll> PendingAttackRolls;
+
+  /** Index of the next pending attack roll to resolve. */
+  int32 PendingAttackRollIndex = 0;
+
+  /** Target currently receiving delayed attack rolls. */
+  TWeakObjectPtr<AFighterPawn> PendingAttackTarget;
+
+  /** Whether the pending attack target has been reduced to zero health. */
+  bool bPendingAttackTargetDied = false;
+
+  /** Timer driving delayed attack roll resolution. */
+  FTimerHandle AttackRollTimerHandle;
+
+  /** Tracks whether any pending attack roll has been processed. */
+  bool bHasProcessedPendingRoll = false;
 
   /** Current cell occupied by the fighter. */
   UPROPERTY(Replicated)

--- a/Source/Skald/GridBattleManager.cpp
+++ b/Source/Skald/GridBattleManager.cpp
@@ -353,6 +353,20 @@ void UGridBattleManager::ReportAttackRoll(AFighterPawn* Attacker, AFighterPawn* 
     OnAttackResolved.Broadcast(Attacker, Defender, Roll, bHit, Damage);
 }
 
+void UGridBattleManager::ReportAttackRejected(AFighterPawn* Attacker, AFighterPawn* Defender, const FText& Reason)
+{
+    if (!Attacker)
+    {
+        return;
+    }
+
+    const FString ReasonString = Reason.ToString();
+    UE_LOG(LogSkaldBattle, Verbose, TEXT("[Battle] Attack rejected: %s -> %s | %s"),
+        *DescribeFighter(Attacker), *DescribeFighter(Defender), ReasonString.IsEmpty() ? TEXT("<No Reason>") : *ReasonString);
+
+    OnAttackRejected.Broadcast(Attacker, Defender, Reason);
+}
+
 bool UGridBattleManager::CanActivateFighter(AFighterPawn* Fighter) const
 {
     if (bBattleConcluded || !Fighter)

--- a/Source/Skald/GridBattleManager.h
+++ b/Source/Skald/GridBattleManager.h
@@ -14,6 +14,8 @@ DECLARE_DYNAMIC_MULTICAST_DELEGATE_ThreeParams(
     FOnBattleEnded, ESkaldFaction, WinningFaction, int32, AttackerCasualties, int32, DefenderCasualties);
 DECLARE_DYNAMIC_MULTICAST_DELEGATE_FiveParams(
     FOnAttackResolved, AFighterPawn*, Attacker, AFighterPawn*, Defender, int32, Roll, bool, bHit, int32, Damage);
+DECLARE_DYNAMIC_MULTICAST_DELEGATE_ThreeParams(
+    FOnAttackRejected, AFighterPawn*, Attacker, AFighterPawn*, Defender, const FText&, Reason);
 
 DECLARE_DYNAMIC_MULTICAST_DELEGATE_OneParam(FOnActiveFighterChanged, AFighterPawn*, NewFighter);
 DECLARE_DYNAMIC_MULTICAST_DELEGATE_TwoParams(FOnRoundStarted, int32, RoundNumber, ESkaldFaction, InitiativeWinner);
@@ -220,6 +222,10 @@ public:
     UPROPERTY(BlueprintAssignable, Category="Battle|Events")
     FOnAttackResolved OnAttackResolved;
 
+    /** Fired when an attack command is rejected. */
+    UPROPERTY(BlueprintAssignable, Category="Battle|Events")
+    FOnAttackRejected OnAttackRejected;
+
     /** Fired whenever the active fighter changes (including nullptr). */
     UPROPERTY(BlueprintAssignable, Category="Battle|Events")
     FOnActiveFighterChanged OnActiveFighterChanged;
@@ -235,6 +241,7 @@ public:
     void UnregisterFighter(AFighterPawn* Fighter);
 
     void ReportAttackRoll(AFighterPawn* Attacker, AFighterPawn* Defender, int32 Roll, bool bHit, int32 Damage);
+    void ReportAttackRejected(AFighterPawn* Attacker, AFighterPawn* Defender, const FText& Reason);
 
     /** Table containing fighter definitions. */
     UPROPERTY(EditDefaultsOnly, Category="Data")

--- a/Source/Skald/Skald_PlayerController.cpp
+++ b/Source/Skald/Skald_PlayerController.cpp
@@ -675,6 +675,9 @@ void ASkaldPlayerController::InitializeBattleHUD() {
         this, &ASkaldPlayerController::HandleBattleEnded);
     GI->GridBattleManager->OnBattleEnded.AddDynamic(
         this, &ASkaldPlayerController::HandleBattleEnded);
+    GI->GridBattleManager->OnAttackResolved.RemoveAll(this);
+    GI->GridBattleManager->OnAttackResolved.AddDynamic(
+        this, &ASkaldPlayerController::HandleAttackResolved);
     ActiveFighter = GI->GridBattleManager->GetActiveFighter();
 
     const int32 CurrentRound = GI->GridBattleManager->GetCurrentRound();
@@ -2140,6 +2143,17 @@ void ASkaldPlayerController::UpdateBattlePlayersTurnDisplay() {
                                            "{0}'s Turn"),
                                  FText::FromString(PlayerName));
   BattleHudWidget->SetPlayersTurnLabel(Label);
+}
+
+void ASkaldPlayerController::HandleAttackResolved(AFighterPawn *Attacker,
+                                                  AFighterPawn *Defender,
+                                                  int32 Roll, bool bHit,
+                                                  int32 Damage) {
+  if (!BattleHudWidget) {
+    return;
+  }
+
+  BattleHudWidget->ShowDiceRoll(Roll);
 }
 
 bool ASkaldPlayerController::IsFriendlyFighter(const AFighterPawn *Fighter) const {

--- a/Source/Skald/Skald_PlayerController.cpp
+++ b/Source/Skald/Skald_PlayerController.cpp
@@ -678,6 +678,9 @@ void ASkaldPlayerController::InitializeBattleHUD() {
     GI->GridBattleManager->OnAttackResolved.RemoveAll(this);
     GI->GridBattleManager->OnAttackResolved.AddDynamic(
         this, &ASkaldPlayerController::HandleAttackResolved);
+    GI->GridBattleManager->OnAttackRejected.RemoveAll(this);
+    GI->GridBattleManager->OnAttackRejected.AddDynamic(
+        this, &ASkaldPlayerController::HandleAttackRejected);
     ActiveFighter = GI->GridBattleManager->GetActiveFighter();
 
     const int32 CurrentRound = GI->GridBattleManager->GetCurrentRound();
@@ -2154,6 +2157,21 @@ void ASkaldPlayerController::HandleAttackResolved(AFighterPawn *Attacker,
   }
 
   BattleHudWidget->ShowDiceRoll(Roll);
+}
+
+void ASkaldPlayerController::HandleAttackRejected(AFighterPawn *Attacker,
+                                                  AFighterPawn *Defender,
+                                                  const FText &Reason) {
+  if (!IsFriendlyFighter(Attacker)) {
+    return;
+  }
+
+  const FString ReasonString = Reason.ToString();
+  if (ReasonString.IsEmpty()) {
+    return;
+  }
+
+  NotifyActionError(ReasonString);
 }
 
 bool ASkaldPlayerController::IsFriendlyFighter(const AFighterPawn *Fighter) const {

--- a/Source/Skald/Skald_PlayerController.h
+++ b/Source/Skald/Skald_PlayerController.h
@@ -421,6 +421,9 @@ private:
   void UpdateBattleHUDButtons();
   void UpdateBattleRoundDisplay(int32 RoundNumber, ESkaldFaction InitiativeWinner);
   void UpdateBattlePlayersTurnDisplay();
+  UFUNCTION()
+  void HandleAttackResolved(AFighterPawn *Attacker, AFighterPawn *Defender,
+                            int32 Roll, bool bHit, int32 Damage);
   bool IsFriendlyFighter(const AFighterPawn *Fighter) const;
   void DetermineControlledBattleSide();
 

--- a/Source/Skald/Skald_PlayerController.h
+++ b/Source/Skald/Skald_PlayerController.h
@@ -424,6 +424,9 @@ private:
   UFUNCTION()
   void HandleAttackResolved(AFighterPawn *Attacker, AFighterPawn *Defender,
                             int32 Roll, bool bHit, int32 Damage);
+  UFUNCTION()
+  void HandleAttackRejected(AFighterPawn *Attacker, AFighterPawn *Defender,
+                            const FText &Reason);
   bool IsFriendlyFighter(const AFighterPawn *Fighter) const;
   void DetermineControlledBattleSide();
 

--- a/Source/Skald/UI/BattleHUDWidget.cpp
+++ b/Source/Skald/UI/BattleHUDWidget.cpp
@@ -1,10 +1,13 @@
 #include "UI/BattleHUDWidget.h"
 #include "Components/Button.h"
+#include "Components/Image.h"
 #include "Components/TextBlock.h"
 #include "Engine/World.h"
 #include "EngineUtils.h"
 #include "FighterPawn.h"
 #include "GridOverlayComponent.h"
+#include "TimerManager.h"
+#include "Engine/Texture2D.h"
 
 void UBattleHUDWidget::NativeConstruct() {
   Super::NativeConstruct();
@@ -24,6 +27,10 @@ void UBattleHUDWidget::NativeConstruct() {
   if (EndTurnButton) {
     EndTurnButton->OnClicked.AddDynamic(
         this, &UBattleHUDWidget::HandleEndTurnPressed);
+  }
+
+  if (DiceRollerImage) {
+    DiceRollerImage->SetVisibility(ESlateVisibility::Collapsed);
   }
 }
 
@@ -205,6 +212,32 @@ void UBattleHUDWidget::SetEndTurnVisibility(bool bVisible) {
   }
 }
 
+void UBattleHUDWidget::ShowDiceRoll(int32 RollValue) {
+  if (!DiceRollerImage) {
+    return;
+  }
+
+  UTexture2D *Texture = nullptr;
+  const int32 Index = RollValue - 1;
+  if (DiceFaceTextures.IsValidIndex(Index)) {
+    Texture = DiceFaceTextures[Index];
+  }
+
+  if (Texture) {
+    DiceRollerImage->SetBrushFromTexture(Texture, true);
+    DiceRollerImage->SetVisibility(ESlateVisibility::HitTestInvisible);
+  } else {
+    DiceRollerImage->SetVisibility(ESlateVisibility::Collapsed);
+  }
+
+  if (UWorld *World = GetWorld()) {
+    World->GetTimerManager().ClearTimer(DiceRollerHideTimer);
+    World->GetTimerManager().SetTimer(
+        DiceRollerHideTimer, this, &UBattleHUDWidget::HideDiceRoller, 1.f,
+        false);
+  }
+}
+
 void UBattleHUDWidget::ClearCommandPreviews() {
   bMoveSelected = false;
   bAttackSelected = false;
@@ -223,4 +256,11 @@ UGridOverlayComponent *UBattleHUDWidget::FindGridOverlay() const {
     }
   }
   return nullptr;
+}
+
+void UBattleHUDWidget::HideDiceRoller() {
+  if (!DiceRollerImage) {
+    return;
+  }
+  DiceRollerImage->SetVisibility(ESlateVisibility::Collapsed);
 }

--- a/Source/Skald/UI/BattleHUDWidget.h
+++ b/Source/Skald/UI/BattleHUDWidget.h
@@ -1,12 +1,15 @@
 #pragma once
 
 #include "Blueprint/UserWidget.h"
+#include "TimerManager.h"
 #include "BattleHUDWidget.generated.h"
 
 class UButton;
+class UImage;
 class UTextBlock;
 class AFighterPawn;
 class UGridOverlayComponent;
+class UTexture2D;
 
 /**
  * HUD widget displayed during grid battles.
@@ -110,6 +113,17 @@ public:
   UPROPERTY(BlueprintReadOnly, meta = (BindWidgetOptional))
   UTextBlock *PlayersTurnText;
 
+  /** Image used to display a temporary dice roll result. */
+  UPROPERTY(BlueprintReadOnly, meta = (BindWidgetOptional))
+  UImage *DiceRollerImage;
+
+  /** Textures representing dice faces, indexed from 1 to 6. */
+  UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "Skald|Battle|Dice")
+  TArray<TObjectPtr<UTexture2D>> DiceFaceTextures;
+
+  /** Display a dice face corresponding to the supplied roll value. */
+  void ShowDiceRoll(int32 RollValue);
+
   /** Update the round and initiative labels. */
   void SetRoundInfo(const FText &RoundLabel, const FText &InitiativeLabel);
 
@@ -162,6 +176,9 @@ private:
   /** Find the grid overlay component in the world. */
   UGridOverlayComponent *FindGridOverlay() const;
 
+  /** Hide the dice roller image after the timer elapses. */
+  void HideDiceRoller();
+
   /** Whether movement preview is currently shown. */
   bool bMoveSelected = false;
 
@@ -171,5 +188,8 @@ private:
   /** Fighter currently bound to the HUD. */
   UPROPERTY()
   AFighterPawn *BoundFighter;
+
+  /** Timer managing dice roll visibility. */
+  FTimerHandle DiceRollerHideTimer;
 };
 


### PR DESCRIPTION
## Summary
- queue fighter attack rolls so each die resolves once per second while spawning damage or miss widgets
- add a configurable dice roller image to the battle HUD that displays the rolled face for one second
- hook the player controller to attack resolution events to trigger the HUD dice feedback

## Testing
- Not run (Unreal project)


------
https://chatgpt.com/codex/tasks/task_e_68d70524f270832489f6c8141247ad4d