### PR TITLE
Remove unused damage die stat and configure crit damage

### DIFF
--- a/Content/DataTables/FighterTable.csv
+++ b/Content/DataTables/FighterTable.csv
@@ -1,4 +1,4 @@
-Id,MeshClass,Faction,Stats.Health,Stats.Defence,Stats.Strength,Stats.AttackDice,Stats.AttackRange,Stats.Movement,Stats.DamageDie,Stats.AttackDamage,Stats.ArmyCost
-HumanSoldier,,Human,10,5,5,1,1,5,6,1,1
-OrcGrunt,,Orc,12,4,6,1,1,5,8,1,1
-SkeletonWarrior,,Undead,8,3,4,1,1,5,6,1,1
+Id,MeshClass,Faction,Stats.Health,Stats.Defence,Stats.Strength,Stats.AttackDice,Stats.AttackRange,Stats.Movement,Stats.AttackDamage,Stats.CriticalBonusDamage,Stats.ArmyCost
+HumanSoldier,,Human,10,5,5,1,1,5,1,3,1
+OrcGrunt,,Orc,12,4,6,1,1,5,1,3,1
+SkeletonWarrior,,Undead,8,3,4,1,1,5,1,3,1

--- a/Source/Skald/FighterPawn.cpp
+++ b/Source/Skald/FighterPawn.cpp
@@ -289,7 +289,7 @@ void AFighterPawn::PerformAttack(AFighterPawn *Target) {
     int32 DamageThisDie = 0;
 
     if (Roll == 6) {
-      DamageThisDie = Stats.AttackDamage + 3; // crit
+      DamageThisDie = Stats.AttackDamage + Stats.CriticalBonusDamage; // crit
     } else if (Roll >= RequiredRoll) {
       DamageThisDie = Stats.AttackDamage;
     }

--- a/Source/Skald/GridBattleManager.cpp
+++ b/Source/Skald/GridBattleManager.cpp
@@ -110,7 +110,7 @@ bool UGridBattleManager::ResolveAttack(FFighter& Attacker, FFighter& Defender, i
         int32 Roll = RandomStream.RandRange(1, 6);
         if (Roll == 6)
         {
-            int32 Damage = Attacker.Stats.AttackDamage + 3;
+            int32 Damage = Attacker.Stats.AttackDamage + Attacker.Stats.CriticalBonusDamage;
             Defender.Stats.Health -= Damage;
             Defender.Stats.Health = FMath::Max(Defender.Stats.Health, 0);
             OutDamage += Damage;

--- a/Source/Skald/GridBattleManager.h
+++ b/Source/Skald/GridBattleManager.h
@@ -47,13 +47,13 @@ struct FFighterStats
     UPROPERTY(BlueprintReadWrite, EditAnywhere, Category="Stats")
     int32 Movement = 1;
 
-    /** Sides of the damage dice rolled on a successful hit. */
-    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category="Stats")
-    int32 DamageDie = 6;
-
     /** Damage dealt on a successful hit. */
     UPROPERTY(BlueprintReadWrite, EditAnywhere, Category="Stats")
     int32 AttackDamage = 1;
+
+    /** Additional damage dealt when scoring a critical hit. */
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category="Stats")
+    int32 CriticalBonusDamage = 3;
 
     /** Cost to include this fighter in an army. */
     UPROPERTY(BlueprintReadWrite, EditAnywhere, Category="Stats")


### PR DESCRIPTION
## Summary
- remove the unused damage die column from the fighter data table
- add a configurable critical bonus damage stat and apply it during battle resolution and previews

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d710cdb860832498a2a6ade8d6f89c