### PR TITLE
Fix highlight decal build errors

### DIFF
--- a/Source/Skald/GridOverlayComponent.cpp
+++ b/Source/Skald/GridOverlayComponent.cpp
@@ -598,7 +598,7 @@ void UGridOverlayComponent::HighlightCellWithDecal(const FIntPoint &GridCoord,
   const FVector WorldCenter = GridToWorld(GridCoord);
   FVector DecalLocation =
       WorldCenter + CellNormal * (HighlightHeightOffset + HighlightDecalProjectionDepth * 0.5f);
-  const FRotationMatrix DecalBasis = FRotationMatrix::MakeFromXZ(-CellNormal, CellTangent);
+  const FMatrix DecalBasis = FRotationMatrix::MakeFromXZ(-CellNormal, CellTangent);
   const FRotator DecalRotation = DecalBasis.Rotator();
 
   const float EffectiveCellSize = FMath::Max(CellSize, KINDA_SMALL_NUMBER);
@@ -611,7 +611,7 @@ void UGridOverlayComponent::HighlightCellWithDecal(const FIntPoint &GridCoord,
     Decal->SetFadeOut(HighlightDecalLifeSpan, HighlightDecalFadeDuration, false);
     ScheduleDecalRemoval(GridCoord, Decal);
   } else {
-    Decal->ResetFade();
+    Decal->SetFadeOut(0.f, 0.f, false);
     ClearDecalRemovalTimer(GridCoord);
   }
 


### PR DESCRIPTION
## Summary
- use the generic matrix returned by MakeFromXZ when deriving decal rotation
- replace the removed ResetFade call with a SetFadeOut configuration to clear fading state

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d715c38888832489950bd1999d6fe5