### PR TITLE
Fix build regressions in FighterPawn and grid overlay decal setup

### DIFF
--- a/Source/Skald/FighterPawn.cpp
+++ b/Source/Skald/FighterPawn.cpp
@@ -438,7 +438,7 @@ void AFighterPawn::FinalizeQueuedAttack() {
     if (!bPendingAttackTargetDied && !bHasProcessedPendingRoll) {
       Target->OnHealthChanged.Broadcast(Target->Stats.Health);
     }
-    if (!Target->IsAlive() && !Target->IsPendingKill()) {
+    if (!Target->IsAlive() && !Target->IsActorBeingDestroyed()) {
       Target->Destroy();
     }
   }

--- a/Source/Skald/GridOverlayComponent.cpp
+++ b/Source/Skald/GridOverlayComponent.cpp
@@ -601,7 +601,7 @@ void UGridOverlayComponent::HighlightCellWithDecal(const FIntPoint &GridCoord,
       WorldCenter + CellNormal * (HighlightHeightOffset + HighlightDecalProjectionDepth * 0.5f);
   const auto DecalBasis =
       UE::Math::TRotationMatrix<double>::MakeFromXZ(-CellNormal, CellTangent);
-  const FQuat DecalQuat = UE::Math::TQuat<double>::MakeFromRotationMatrix(DecalBasis);
+  const FQuat DecalQuat = DecalBasis.ToQuat();
   const FRotator DecalRotation = DecalQuat.Rotator();
 
   const float EffectiveCellSize = FMath::Max(CellSize, KINDA_SMALL_NUMBER);


### PR DESCRIPTION
## Summary
- replace the deprecated IsPendingKill() usage with IsActorBeingDestroyed() before destroying defeated fighters
- derive decal rotation from the rotation matrix via ToQuat() to avoid calling removed MakeFromRotationMatrix

## Testing
- Not run (Unreal build environment unavailable in container)

------
https://chatgpt.com/codex/tasks/task_e_68d71fb01fe0832482d1ccd8c80354a9