### PR TITLE
Handle post-battle travel per net mode

### DIFF
--- a/Source/Skald/Skald_TurnManager.cpp
+++ b/Source/Skald/Skald_TurnManager.cpp
@@ -118,15 +118,11 @@ void ATurnManager::HandleGridBattleEnded(ESkaldFaction /*WinningFaction*/, int32
       World->ServerTravel(ListenTarget);
       break;
     }
-    case NM_Client: {
-      if (APlayerController *PC = World->GetFirstPlayerController()) {
-        PC->ClientTravel(ReturnMapName, TRAVEL_Absolute);
-      } else {
-        const FName LevelName(*ReturnMapName);
-        UGameplayStatics::OpenLevel(World, LevelName, /*bAbsolute=*/true);
-      }
+    case NM_Client:
+      // Clients should wait for the server's travel notification instead of
+      // loading the map locally with an incomplete URL. The pending server
+      // travel initiated above will automatically move connected clients.
       break;
-    }
     default:
       World->ServerTravel(ReturnMapName);
       break;

--- a/Source/Skald/Skald_TurnManager.cpp
+++ b/Source/Skald/Skald_TurnManager.cpp
@@ -101,8 +101,36 @@ void ATurnManager::HandleGridBattleEnded(ESkaldFaction /*WinningFaction*/, int32
   }
 
   if (UWorld *World = GetWorld()) {
-    // Travel back to the overworld after the tactical battle ends
-    World->ServerTravel(ReturnMapName);
+    const ENetMode NetMode = World->GetNetMode();
+
+    switch (NetMode) {
+    case NM_Standalone: {
+      const FName LevelName(*ReturnMapName);
+      UGameplayStatics::OpenLevel(World, LevelName, /*bAbsolute=*/true);
+      break;
+    }
+    case NM_DedicatedServer:
+    case NM_ListenServer: {
+      FString ListenTarget = ReturnMapName;
+      if (!ListenTarget.Contains(TEXT("?listen"))) {
+        ListenTarget.Append(TEXT("?listen"));
+      }
+      World->ServerTravel(ListenTarget);
+      break;
+    }
+    case NM_Client: {
+      if (APlayerController *PC = World->GetFirstPlayerController()) {
+        PC->ClientTravel(ReturnMapName, TRAVEL_Absolute);
+      } else {
+        const FName LevelName(*ReturnMapName);
+        UGameplayStatics::OpenLevel(World, LevelName, /*bAbsolute=*/true);
+      }
+      break;
+    }
+    default:
+      World->ServerTravel(ReturnMapName);
+      break;
+    }
   }
 }
 


### PR DESCRIPTION
## Summary
- update HandleGridBattleEnded to branch on network mode when returning to the overworld
- use OpenLevel for standalone or fallback client travel while appending ?listen for servers

## Testing
- not run (multiplayer session unavailable in CI environment)

------
https://chatgpt.com/codex/tasks/task_e_68d94c3f36588324996afe369975b51c