### PR TITLE
Rotate fighter pawns toward their actions

### DIFF
--- a/Source/Skald/FighterPawn.cpp
+++ b/Source/Skald/FighterPawn.cpp
@@ -221,6 +221,7 @@ void AFighterPawn::MoveToCell(FIntPoint TargetCell) {
     NewLocation = Grid->GridToWorld(TargetCell);
     NewLocation.Z += GetSimpleCollisionHalfHeight();
   }
+  FaceTowardsLocation(NewLocation);
   SetActorLocation(NewLocation);
   ActionsRemaining = FMath::Max(0, ActionsRemaining - 1);
 
@@ -309,6 +310,8 @@ void AFighterPawn::PerformAttack(AFighterPawn *Target) {
   ActionsRemaining = FMath::Max(0, ActionsRemaining - 1);
 
   BroadcastActionsRemaining();
+
+  FaceTowardsLocation(Target->GetActorLocation());
 
   if (Grid) {
     Grid->ClearHighlights();
@@ -504,4 +507,13 @@ void AFighterPawn::OnRep_ActionsRemaining() { BroadcastActionsRemaining(); }
 
 void AFighterPawn::BroadcastActionsRemaining() {
   OnActionsChanged.Broadcast(ActionsRemaining);
+}
+
+void AFighterPawn::FaceTowardsLocation(const FVector &TargetLocation) {
+  FVector Direction = TargetLocation - GetActorLocation();
+  Direction.Z = 0.f;
+  if (!Direction.IsNearlyZero()) {
+    const FRotator LookRotation = Direction.Rotation();
+    SetActorRotation(FRotator(0.f, LookRotation.Yaw, 0.f));
+  }
 }

--- a/Source/Skald/FighterPawn.h
+++ b/Source/Skald/FighterPawn.h
@@ -141,6 +141,9 @@ private:
   /** Helper to broadcast the current actions remaining value. */
   void BroadcastActionsRemaining();
 
+  /** Rotate the fighter to face a world-space location. */
+  void FaceTowardsLocation(const FVector &TargetLocation);
+
   /** Data describing a single queued attack roll. */
   struct FQueuedAttackRoll {
     int32 RollValue = 1;


### PR DESCRIPTION
## Summary
- rotate fighter pawns to face their destination cells when moving
- make pawns turn toward their targets when performing attacks
- add a shared helper for orienting a fighter toward a world location

## Testing
- not run (Unreal project)


------
https://chatgpt.com/codex/tasks/task_e_68d94cdc4a3c8324a51cf660b027c3f9