### PR TITLE
Add decal rendering option for base grid overlay

### DIFF
--- a/Source/Skald/GridOverlayComponent.cpp
+++ b/Source/Skald/GridOverlayComponent.cpp
@@ -176,7 +176,11 @@ void UGridOverlayComponent::OnRegister() {
 
   RefreshOriginFromOwner();
 
-  EnsureBaseGridComponentSetup();
+  if (bUseDecalBaseGrid) {
+    ClearBaseGridDecals();
+  } else {
+    EnsureBaseGridComponentSetup();
+  }
   if (!bUseDecalHighlights) {
     EnsureHighlightComponentSetup();
   }
@@ -193,7 +197,12 @@ void UGridOverlayComponent::BeginPlay() {
   DynamicOccupiedCells.Init(false, TotalCells);
   CellHeights.Init(Origin.Z, TotalCells);
   CellRotations.Init(FQuat::Identity, TotalCells);
-  BaseGridInstanceIndices.Init(INDEX_NONE, TotalCells);
+  if (bUseDecalBaseGrid) {
+    BaseGridInstanceIndices.Empty();
+    ClearBaseGridDecals();
+  } else {
+    BaseGridInstanceIndices.Init(INDEX_NONE, TotalCells);
+  }
 
   SampleEnvironmentAtOrigin();
 
@@ -423,6 +432,10 @@ bool UGridOverlayComponent::EnsureHighlightComponentSetup() {
 }
 
 bool UGridOverlayComponent::EnsureBaseGridComponentSetup() {
+  if (bUseDecalBaseGrid) {
+    return false;
+  }
+
   if (!bDrawBaseGrid) {
     return false;
   }
@@ -624,6 +637,41 @@ void UGridOverlayComponent::HighlightCellWithDecal(const FIntPoint &GridCoord,
   }
 }
 
+UMaterialInterface *UGridOverlayComponent::GetBaseGridDecalMaterial() const {
+  if (BaseGridDecalMaterial) {
+    return BaseGridDecalMaterial;
+  }
+
+  if (HighlightDecalMaterial) {
+    return HighlightDecalMaterial;
+  }
+
+  return nullptr;
+}
+
+void UGridOverlayComponent::ClearBaseGridDecals() {
+  for (TWeakObjectPtr<UDecalComponent> &DecalPtr : BaseGridDecalComponents) {
+    if (UDecalComponent *Decal = DecalPtr.Get()) {
+      Decal->DestroyComponent();
+    }
+  }
+
+  BaseGridDecalComponents.Empty();
+  BaseGridDecalMaterials.Empty();
+}
+
+void UGridOverlayComponent::ApplyBaseGridDecalColor(int32 CellIndex,
+                                                    const FLinearColor &Color) {
+  if (!BaseGridDecalMaterials.IsValidIndex(CellIndex)) {
+    return;
+  }
+
+  if (UMaterialInstanceDynamic *DynamicMaterial =
+          BaseGridDecalMaterials[CellIndex].Get()) {
+    DynamicMaterial->SetVectorParameterValue(BaseGridDecalColorParameter, Color);
+  }
+}
+
 void UGridOverlayComponent::ApplyBaseGridColor(int32 InstanceIndex,
                                                const FLinearColor &Color) {
   if (!BaseGridMeshComponent || BaseGridMeshComponent->NumCustomDataFloats < 4 ||
@@ -659,12 +707,17 @@ FLinearColor UGridOverlayComponent::GetBaseGridColor(int32 CellIndex) const {
 }
 
 void UGridOverlayComponent::UpdateBaseGridVisual(const FIntPoint &GridCoord) {
-  if (!BaseGridMeshComponent || !IsValidGrid(GridCoord)) {
+  if (!IsValidGrid(GridCoord)) {
     return;
   }
 
   const int32 ArrayIndex = Index(GridCoord);
-  if (!BaseGridInstanceIndices.IsValidIndex(ArrayIndex)) {
+  if (bUseDecalBaseGrid) {
+    ApplyBaseGridDecalColor(ArrayIndex, GetBaseGridColor(ArrayIndex));
+    return;
+  }
+
+  if (!BaseGridMeshComponent || !BaseGridInstanceIndices.IsValidIndex(ArrayIndex)) {
     return;
   }
 
@@ -678,21 +731,129 @@ void UGridOverlayComponent::UpdateBaseGridVisual(const FIntPoint &GridCoord) {
 
 void UGridOverlayComponent::RebuildBaseGridInstances() {
   if (!bDrawBaseGrid) {
-    if (BaseGridMeshComponent) {
+    if (bUseDecalBaseGrid) {
+      ClearBaseGridDecals();
+    } else if (BaseGridMeshComponent) {
       BaseGridMeshComponent->ClearInstances();
     }
     BaseGridInstanceIndices.Empty();
     return;
   }
 
-  if (!EnsureBaseGridComponentSetup()) {
+  const int32 TotalCells = Width * Height;
+  if (TotalCells <= 0) {
+    if (bUseDecalBaseGrid) {
+      ClearBaseGridDecals();
+    } else if (BaseGridMeshComponent) {
+      BaseGridMeshComponent->ClearInstances();
+    }
+    BaseGridInstanceIndices.Empty();
     return;
   }
 
-  const int32 TotalCells = Width * Height;
-  if (TotalCells <= 0) {
-    BaseGridMeshComponent->ClearInstances();
-    BaseGridInstanceIndices.Empty();
+  if (bUseDecalBaseGrid) {
+    UMaterialInterface *DecalMaterial = GetBaseGridDecalMaterial();
+    if (!DecalMaterial) {
+      UE_LOG(LogTemp, Warning,
+             TEXT("GridOverlayComponent %s is configured to use decal base grid but no decal material is set."),
+             *GetNameSafe(GetOwner()));
+      ClearBaseGridDecals();
+      return;
+    }
+
+    ClearBaseGridDecals();
+    BaseGridDecalComponents.SetNum(TotalCells);
+    BaseGridDecalMaterials.SetNum(TotalCells);
+
+    AActor *Owner = GetOwner();
+    if (!Owner) {
+      return;
+    }
+
+    USceneComponent *Root = Owner->GetRootComponent();
+    const float EffectiveCellSize = FMath::Max(CellSize, KINDA_SMALL_NUMBER);
+    const float HalfSize = 0.5f * EffectiveCellSize * BaseGridDecalSizeMultiplier;
+
+    for (int32 Y = 0; Y < Height; ++Y) {
+      for (int32 X = 0; X < Width; ++X) {
+        const FIntPoint Cell(X, Y);
+        const int32 ArrayIndex = Index(Cell);
+
+        UDecalComponent *Decal = nullptr;
+        if (BaseGridDecalComponents.IsValidIndex(ArrayIndex)) {
+          Decal = BaseGridDecalComponents[ArrayIndex].Get();
+        }
+
+        if (!Decal) {
+          Decal = NewObject<UDecalComponent>(Owner);
+          if (!Decal) {
+            continue;
+          }
+
+          Decal->CreationMethod = EComponentCreationMethod::Instance;
+          Decal->SetMobility(EComponentMobility::Movable);
+          Decal->FadeScreenSize = BaseGridDecalFadeScreenSize;
+          Owner->AddOwnedComponent(Decal);
+          Owner->AddInstanceComponent(Decal);
+
+          if (Root) {
+            Decal->AttachToComponent(Root, FAttachmentTransformRules::KeepWorldTransform);
+          }
+
+          Decal->RegisterComponent();
+          BaseGridDecalComponents[ArrayIndex] = Decal;
+        }
+
+        UMaterialInstanceDynamic *DynamicMaterial = nullptr;
+        if (BaseGridDecalMaterials.IsValidIndex(ArrayIndex)) {
+          DynamicMaterial = BaseGridDecalMaterials[ArrayIndex].Get();
+        }
+
+        if (!DynamicMaterial) {
+          DynamicMaterial = UMaterialInstanceDynamic::Create(DecalMaterial, this);
+          if (DynamicMaterial) {
+            BaseGridDecalMaterials[ArrayIndex] = DynamicMaterial;
+          }
+        }
+
+        if (DynamicMaterial) {
+          Decal->SetDecalMaterial(DynamicMaterial);
+        } else {
+          Decal->SetDecalMaterial(DecalMaterial);
+        }
+
+        const FQuat CellRotation =
+            CellRotations.IsValidIndex(ArrayIndex) ? CellRotations[ArrayIndex]
+                                                   : FQuat::Identity;
+        const FVector CellNormal =
+            CellRotation.RotateVector(FVector::UpVector).GetSafeNormal();
+        const FVector CellTangent =
+            CellRotation.RotateVector(FVector::ForwardVector).GetSafeNormal();
+        const FVector WorldCenter = GridToWorld(Cell);
+        const FVector DecalLocation =
+            WorldCenter +
+            CellNormal * (GridHeightOffset + BaseGridDecalProjectionDepth * 0.5f);
+        const auto DecalBasis =
+            UE::Math::TRotationMatrix<double>::MakeFromXZ(-CellNormal, CellTangent);
+        const FQuat DecalQuat = DecalBasis.ToQuat();
+        const FRotator DecalRotation = DecalQuat.Rotator();
+
+        Decal->DecalSize =
+            FVector(BaseGridDecalProjectionDepth, HalfSize, HalfSize);
+        Decal->FadeScreenSize = BaseGridDecalFadeScreenSize;
+        Decal->SetWorldLocationAndRotation(DecalLocation, DecalRotation);
+        Decal->SetFadeOut(0.f, 0.f, false);
+
+        ApplyBaseGridDecalColor(ArrayIndex, GetBaseGridColor(ArrayIndex));
+      }
+    }
+
+    return;
+  }
+
+  ClearBaseGridDecals();
+
+  if (!EnsureBaseGridComponentSetup()) {
     return;
   }
 

--- a/Source/Skald/GridOverlayComponent.h
+++ b/Source/Skald/GridOverlayComponent.h
@@ -218,6 +218,33 @@ public:
   UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Grid|Display")
   bool bDrawBaseGrid = true;
 
+  /** If true, the persistent grid will spawn decals instead of instanced meshes. */
+  UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Grid|Display|Decal")
+  bool bUseDecalBaseGrid = false;
+
+  /** Material applied to base grid decals (must use the Deferred Decal domain). */
+  UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category = "Grid|Display|Decal")
+  UMaterialInterface *BaseGridDecalMaterial = nullptr;
+
+  /** Name of the vector parameter driven by base grid colours on the decal material. */
+  UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category = "Grid|Display|Decal")
+  FName BaseGridDecalColorParameter = TEXT("TintColor");
+
+  /** Depth of the decal projection along the surface normal for the base grid. */
+  UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Grid|Display|Decal",
+            meta = (ClampMin = "0.0"))
+  float BaseGridDecalProjectionDepth = 32.f;
+
+  /** Multiplier applied to the XY footprint of base grid decals relative to the cell size. */
+  UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Grid|Display|Decal",
+            meta = (ClampMin = "0.01"))
+  float BaseGridDecalSizeMultiplier = 1.0f;
+
+  /** Screen size threshold at which base grid decals begin to fade out. */
+  UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Grid|Display|Decal",
+            meta = (ClampMin = "0.0"))
+  float BaseGridDecalFadeScreenSize = 0.01f;
+
   /** Vertical offset applied to the persistent grid overlay. */
   UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Grid|Display")
   float GridHeightOffset = 0.f;
@@ -312,6 +339,14 @@ protected:
   UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "Grid|Display")
   UInstancedStaticMeshComponent *BaseGridMeshComponent = nullptr;
 
+  /** Spawned decal components used when the base grid renders as decals. */
+  UPROPERTY(Transient)
+  TArray<TWeakObjectPtr<UDecalComponent>> BaseGridDecalComponents;
+
+  /** Dynamic materials created for base grid decals to support colour changes. */
+  UPROPERTY(Transient)
+  TArray<TWeakObjectPtr<UMaterialInstanceDynamic>> BaseGridDecalMaterials;
+
   /** Map grid coordinates to highlight instance indices for updates. */
   UPROPERTY(Transient)
   TMap<FIntPoint, int32> HighlightedInstances;
@@ -377,6 +412,15 @@ protected:
 
   /** Highlight a cell using a spawned decal component. */
   void HighlightCellWithDecal(const FIntPoint &GridCoord, const FColor &Color);
+
+  /** Resolve the material that should be used for base grid decals. */
+  UMaterialInterface *GetBaseGridDecalMaterial() const;
+
+  /** Destroy any existing base grid decals and clear cached references. */
+  void ClearBaseGridDecals();
+
+  /** Apply colour data to a base grid decal material instance. */
+  void ApplyBaseGridDecalColor(int32 CellIndex, const FLinearColor &Color);
 
   /** Resolve the material that should be used for decal highlights. */
   UMaterialInterface *GetHighlightDecalMaterial() const;


### PR DESCRIPTION
## Summary
- add configuration options to let the persistent grid overlay spawn decals instead of instanced meshes
- manage decal components and dynamic materials so cell colours update consistently with occupancy changes
- update runtime setup paths to rebuild decals or instanced meshes depending on the chosen mode

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d99504bb38832488086cbd2d6315f8