### PR TITLE
Show dice board background with roller

### DIFF
--- a/Source/Skald/UI/BattleHUDWidget.cpp
+++ b/Source/Skald/UI/BattleHUDWidget.cpp
@@ -226,8 +226,14 @@ void UBattleHUDWidget::ShowDiceRoll(int32 RollValue) {
   if (Texture) {
     DiceRollerImage->SetBrushFromTexture(Texture, true);
     DiceRollerImage->SetVisibility(ESlateVisibility::HitTestInvisible);
+    if (DiceBoardImage) {
+      DiceBoardImage->SetVisibility(ESlateVisibility::HitTestInvisible);
+    }
   } else {
     DiceRollerImage->SetVisibility(ESlateVisibility::Collapsed);
+    if (DiceBoardImage) {
+      DiceBoardImage->SetVisibility(ESlateVisibility::Collapsed);
+    }
   }
 
   if (UWorld *World = GetWorld()) {
@@ -263,4 +269,7 @@ void UBattleHUDWidget::HideDiceRoller() {
     return;
   }
   DiceRollerImage->SetVisibility(ESlateVisibility::Collapsed);
+  if (DiceBoardImage) {
+    DiceBoardImage->SetVisibility(ESlateVisibility::Collapsed);
+  }
 }

--- a/Source/Skald/UI/BattleHUDWidget.h
+++ b/Source/Skald/UI/BattleHUDWidget.h
@@ -117,6 +117,10 @@ public:
   UPROPERTY(BlueprintReadOnly, meta = (BindWidgetOptional))
   UImage *DiceRollerImage;
 
+  /** Background image shown behind the dice roller when active. */
+  UPROPERTY(BlueprintReadOnly, meta = (BindWidgetOptional))
+  UImage *DiceBoardImage;
+
   /** Textures representing dice faces, indexed from 1 to 6. */
   UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "Skald|Battle|Dice")
   TArray<TObjectPtr<UTexture2D>> DiceFaceTextures;


### PR DESCRIPTION
## Summary
- add a bindable DiceBoardImage to the battle HUD widget
- ensure the dice board background appears and hides with the dice roller

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d99fe21e388324969eb6d726a1d9fd