### PR TITLE
Keep active fighters highlighted until turn ends

### DIFF
--- a/Source/Skald/FighterPawn.cpp
+++ b/Source/Skald/FighterPawn.cpp
@@ -128,6 +128,10 @@ void AFighterPawn::BeginActivation() {
   bHasActivatedThisRound = true;
 
   BroadcastActionsRemaining();
+
+  if (UGridOverlayComponent *Grid = GetGrid()) {
+    Grid->HighlightSelection(this);
+  }
 }
 
 void AFighterPawn::ResetActivationState() {
@@ -143,6 +147,10 @@ void AFighterPawn::FinishActivation() {
   bIsCurrentlyActive = false;
 
   BroadcastActionsRemaining();
+
+  if (UGridOverlayComponent *Grid = GetGrid()) {
+    Grid->ClearSelectionHighlight();
+  }
 }
 
 UGridOverlayComponent *AFighterPawn::GetGrid() {

--- a/Source/Skald/GridOverlayComponent.cpp
+++ b/Source/Skald/GridOverlayComponent.cpp
@@ -936,14 +936,20 @@ void UGridOverlayComponent::HighlightCell(const FIntPoint &GridCoord,
 
 void UGridOverlayComponent::HighlightSelection(AFighterPawn *Fighter) {
   if (!Fighter) {
+    ClearSelectionHighlight();
     return;
   }
 
-  const FIntPoint Cell = WorldToGrid(Fighter->GetActorLocation());
-  HighlightCell(Cell, SelectionHighlightColor.ToFColor(true), 0.f, false);
+  PersistentlyHighlightedFighter = Fighter;
+  ClearHighlights(true);
 }
 
-void UGridOverlayComponent::ClearHighlights() {
+void UGridOverlayComponent::ClearSelectionHighlight() {
+  PersistentlyHighlightedFighter.Reset();
+  ClearHighlights(false);
+}
+
+void UGridOverlayComponent::ClearHighlights(bool bMaintainPersistentSelection) {
   HighlightedInstances.Empty();
   if (HighlightMeshComponent) {
     HighlightMeshComponent->ClearInstances();
@@ -970,11 +976,34 @@ void UGridOverlayComponent::ClearHighlights() {
     HighlightedDecalRemovalTimers.Empty();
   }
 
+  if (!bMaintainPersistentSelection) {
+    PersistentlyHighlightedFighter.Reset();
+  }
+
 #if WITH_EDITOR
   if (GetWorld() && bFlushAllPersistentOnClear) {
     FlushPersistentDebugLines(GetWorld());
   }
 #endif
+
+  if (bMaintainPersistentSelection) {
+    RefreshPersistentSelectionHighlight();
+  }
+}
+
+void UGridOverlayComponent::RefreshPersistentSelectionHighlight() {
+  if (!PersistentlyHighlightedFighter.IsValid()) {
+    return;
+  }
+
+  AFighterPawn *Fighter = PersistentlyHighlightedFighter.Get();
+  if (!Fighter) {
+    PersistentlyHighlightedFighter.Reset();
+    return;
+  }
+
+  const FIntPoint Cell = WorldToGrid(Fighter->GetActorLocation());
+  HighlightCell(Cell, SelectionHighlightColor.ToFColor(true), 0.f, false);
 }
 
 void UGridOverlayComponent::RegisterObstacle(UGridObstacleComponent *Obstacle) {

--- a/Source/Skald/GridOverlayComponent.h
+++ b/Source/Skald/GridOverlayComponent.h
@@ -129,9 +129,13 @@ public:
   UFUNCTION(BlueprintCallable, Category = "Grid")
   void HighlightSelection(AFighterPawn *Fighter);
 
+  /** Clear any selection highlight that should persist across commands. */
+  UFUNCTION(BlueprintCallable, Category = "Grid")
+  void ClearSelectionHighlight();
+
   /** Remove any persistent highlights. */
   UFUNCTION(BlueprintCallable, Category = "Grid")
-  void ClearHighlights();
+  void ClearHighlights(bool bMaintainPersistentSelection = true);
 
   /** Rebuild the persistent grid overlay instances. */
   UFUNCTION(BlueprintCallable, Category = "Grid")
@@ -359,6 +363,10 @@ protected:
   UPROPERTY(Transient)
   TMap<FIntPoint, TWeakObjectPtr<UMaterialInstanceDynamic>> HighlightedDecalMaterials;
 
+  /** Fighter whose current cell should remain highlighted until cleared. */
+  UPROPERTY(Transient)
+  TWeakObjectPtr<AFighterPawn> PersistentlyHighlightedFighter;
+
   /** Timers that remove decal components once their fade completes. */
   TMap<FIntPoint, FTimerHandle> HighlightedDecalRemovalTimers;
 
@@ -409,6 +417,9 @@ protected:
 
   /** Apply highlight color as per-instance custom data. */
   void ApplyHighlightColor(int32 InstanceIndex, const FLinearColor &Color);
+
+  /** Reapply the persistent selection highlight if one is set. */
+  void RefreshPersistentSelectionHighlight();
 
   /** Highlight a cell using a spawned decal component. */
   void HighlightCellWithDecal(const FIntPoint &GridCoord, const FColor &Color);

--- a/Source/Skald/Skald_PlayerController.cpp
+++ b/Source/Skald/Skald_PlayerController.cpp
@@ -787,6 +787,14 @@ void ASkaldPlayerController::HandleActiveFighterChanged(
   if (!NewFighter) {
     UpdateBattleHUDSelection();
   }
+
+  if (UGridOverlayComponent *Grid = FindGridOverlay()) {
+    if (NewFighter && NewFighter->IsAlive()) {
+      Grid->HighlightSelection(NewFighter);
+    } else {
+      Grid->ClearSelectionHighlight();
+    }
+  }
 }
 
 void ASkaldPlayerController::DetectBattleMap() {


### PR DESCRIPTION
## Summary
- add persistent selection tracking to the grid overlay so a fighter's cell stays highlighted between commands
- highlight fighters when they activate and clear the selection highlight when they finish
- ensure the player controller re-applies the persistent highlight whenever the active fighter changes

## Testing
- not run (not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68d9c291c1f88324b6e21d65e5be03ca