### PR TITLE
Guard automation tests behind WITH_AUTOMATION_TESTS

### DIFF
--- a/Source/Skald/Tests/AIDecisionFlowTest.cpp
+++ b/Source/Skald/Tests/AIDecisionFlowTest.cpp
@@ -1,3 +1,4 @@
+#if WITH_AUTOMATION_TESTS
 #include "Misc/AutomationTest.h"
 #include "Tests/AutomationEditorCommon.h"
 #include "Engine/World.h"
@@ -81,3 +82,4 @@ bool FSkaldAIDecisionFlowTest::RunTest(const FString& Parameters)
 
     return true;
 }
+#endif // WITH_AUTOMATION_TESTS

--- a/Source/Skald/Tests/ArmyPlacementInitiativeTest.cpp
+++ b/Source/Skald/Tests/ArmyPlacementInitiativeTest.cpp
@@ -1,3 +1,4 @@
+#if WITH_AUTOMATION_TESTS
 #include "Misc/AutomationTest.h"
 #include "Skald_AIController.h"
 #include "Skald_GameMode.h"
@@ -446,3 +447,4 @@ bool FInitializeWorldSingleInitiativeRollTest::RunTest(const FString &Parameters
 
   return true;
 }
+#endif // WITH_AUTOMATION_TESTS

--- a/Source/Skald/Tests/BattleResolutionSyncTest.cpp
+++ b/Source/Skald/Tests/BattleResolutionSyncTest.cpp
@@ -1,3 +1,4 @@
+#if WITH_AUTOMATION_TESTS
 #include "BattleResolutionSyncTest.h"
 
 #include "Misc/AutomationTest.h"
@@ -61,3 +62,4 @@ bool FSkaldBattleResolutionSyncTest::RunTest(const FString& Parameters) {
 
   return true;
 }
+#endif // WITH_AUTOMATION_TESTS

--- a/Source/Skald/Tests/BattleResolutionSyncTest.h
+++ b/Source/Skald/Tests/BattleResolutionSyncTest.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#if WITH_AUTOMATION_TESTS
 #include "CoreMinimal.h"
 #include "BattleResolutionSyncTest.generated.h"
 
@@ -20,4 +21,6 @@ public:
         bBroadcasted = true;
     }
 };
+
+#endif // WITH_AUTOMATION_TESTS
 

--- a/Source/Skald/Tests/CapitalAttackRequirementTest.cpp
+++ b/Source/Skald/Tests/CapitalAttackRequirementTest.cpp
@@ -1,3 +1,4 @@
+#if WITH_AUTOMATION_TESTS
 #include "Misc/AutomationTest.h"
 #include "SkaldTypes.h"
 
@@ -10,3 +11,4 @@ bool FSkaldCapitalAttackRequirementTest::RunTest(const FString& Parameters)
     TestTrue(TEXT("Capital attack meeting requirement is valid"), SkaldHelpers::MeetsCapitalAttackRequirement(true, SkaldConstants::CapitalAttackArmyRequirement));
     return true;
 }
+#endif // WITH_AUTOMATION_TESTS

--- a/Source/Skald/Tests/DeploySelectionCachingTest.cpp
+++ b/Source/Skald/Tests/DeploySelectionCachingTest.cpp
@@ -1,3 +1,4 @@
+#if WITH_AUTOMATION_TESTS
 #include "DeploySelectionCachingTest.h"
 
 #include "Misc/AutomationTest.h"
@@ -68,4 +69,4 @@ bool FSkaldDeploySelectionCachingTest::RunTest(const FString& Parameters)
 
     return true;
 }
-
+#endif // WITH_AUTOMATION_TESTS

--- a/Source/Skald/Tests/DeploySelectionCachingTest.h
+++ b/Source/Skald/Tests/DeploySelectionCachingTest.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#if WITH_AUTOMATION_TESTS
 #include "CoreMinimal.h"
 #include "UI/SkaldMainHUDWidget.h"
 #include "DeploySelectionCachingTest.generated.h"
@@ -19,4 +20,6 @@ public:
 
     UDeployWidget* GetActiveDeployWidget() const { return ActiveDeployWidget; }
 };
+
+#endif // WITH_AUTOMATION_TESTS
 

--- a/Source/Skald/Tests/DeployUnitsReplicationTest.cpp
+++ b/Source/Skald/Tests/DeployUnitsReplicationTest.cpp
@@ -1,3 +1,4 @@
+#if WITH_AUTOMATION_TESTS
 #include "DeployUnitsReplicationTest.h"
 
 #include "Misc/AutomationTest.h"
@@ -68,4 +69,4 @@ bool FSkaldDeployReplicationTest::RunTest(const FString& Parameters)
 
     return true;
 }
-
+#endif // WITH_AUTOMATION_TESTS

--- a/Source/Skald/Tests/DeployUnitsReplicationTest.h
+++ b/Source/Skald/Tests/DeployUnitsReplicationTest.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#if WITH_AUTOMATION_TESTS
 #include "CoreMinimal.h"
 #include "Skald_PlayerController.h"
 #include "UI/SkaldMainHUDWidget.h"
@@ -13,6 +14,8 @@ public:
     int32 LastUnits = -1;
     virtual void UpdateDeployableUnits(int32 UnitsRemaining) override { LastUnits = UnitsRemaining; }
 };
+
+#endif // WITH_AUTOMATION_TESTS
 
 /** Player controller with accessible HUD setter for tests. */
 UCLASS()

--- a/Source/Skald/Tests/DeployUnitsValidationTest.cpp
+++ b/Source/Skald/Tests/DeployUnitsValidationTest.cpp
@@ -1,3 +1,4 @@
+#if WITH_AUTOMATION_TESTS
 #include "PlayerControllerValidationTest.h"
 
 #include "Misc/AutomationTest.h"
@@ -67,4 +68,4 @@ bool FSkaldDeployUnitsValidationFeedbackTest::RunTest(const FString&)
 
     return true;
 }
-
+#endif // WITH_AUTOMATION_TESTS

--- a/Source/Skald/Tests/DeployableUnitsCalculationTest.cpp
+++ b/Source/Skald/Tests/DeployableUnitsCalculationTest.cpp
@@ -1,3 +1,4 @@
+#if WITH_AUTOMATION_TESTS
 
 #include "Misc/AutomationTest.h"
 #include "Tests/AutomationEditorCommon.h"
@@ -67,3 +68,4 @@ bool FSkaldDeployableUnitsCalculationTest::RunTest(const FString& Parameters) {
 
   return true;
 }
+#endif // WITH_AUTOMATION_TESTS

--- a/Source/Skald/Tests/FullTurnFlowTest.cpp
+++ b/Source/Skald/Tests/FullTurnFlowTest.cpp
@@ -1,3 +1,4 @@
+#if WITH_AUTOMATION_TESTS
 #include "Components/TextBlock.h"
 #include "Misc/AutomationTest.h"
 #include "Skald_PlayerController.h"
@@ -122,3 +123,4 @@ bool FSkaldFullTurnFlowTest::RunTest(const FString &Parameters) {
 
   return true;
 }
+#endif // WITH_AUTOMATION_TESTS

--- a/Source/Skald/Tests/PlayerControllerLockInMovementTest.cpp
+++ b/Source/Skald/Tests/PlayerControllerLockInMovementTest.cpp
@@ -1,3 +1,4 @@
+#if WITH_AUTOMATION_TESTS
 #include "ChoosePlayerWidget.h"
 #include "Misc/AutomationTest.h"
 #include "Skald_PlayerController.h"
@@ -44,4 +45,4 @@ bool FSkaldPlayerControllerLockInMovementTest::RunTest(const FString &)
 
     return true;
 }
-
+#endif // WITH_AUTOMATION_TESTS

--- a/Source/Skald/Tests/PlayerControllerValidationTest.cpp
+++ b/Source/Skald/Tests/PlayerControllerValidationTest.cpp
@@ -1,3 +1,4 @@
+#if WITH_AUTOMATION_TESTS
 #include "PlayerControllerValidationTest.h"
 
 #include "Misc/AutomationTest.h"
@@ -46,3 +47,4 @@ bool FSkaldPlayerControllerValidationFeedbackTest::RunTest(const FString &)
 
     return true;
 }
+#endif // WITH_AUTOMATION_TESTS

--- a/Source/Skald/Tests/PlayerControllerValidationTest.h
+++ b/Source/Skald/Tests/PlayerControllerValidationTest.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#if WITH_AUTOMATION_TESTS
 #include "CoreMinimal.h"
 #include "Skald_PlayerController.h"
 #include "UI/SkaldMainHUDWidget.h"
@@ -13,6 +14,8 @@ public:
     FString LastError;
     virtual void ShowErrorMessage(const FString& Message) override;
 };
+
+#endif // WITH_AUTOMATION_TESTS
 
 UCLASS()
 class ATestPlayerController : public ASkaldPlayerController

--- a/Source/Skald/Tests/ReinforcementResourceTest.cpp
+++ b/Source/Skald/Tests/ReinforcementResourceTest.cpp
@@ -1,3 +1,4 @@
+#if WITH_AUTOMATION_TESTS
 #include "Misc/AutomationTest.h"
 #include "Tests/AutomationEditorCommon.h"
 #include "Skald_TurnManager.h"
@@ -54,3 +55,4 @@ bool FSkaldReinforcementResourceTest::RunTest(const FString& Parameters) {
 
   return true;
 }
+#endif // WITH_AUTOMATION_TESTS

--- a/Source/Skald/Tests/ResolveAttackClampTest.cpp
+++ b/Source/Skald/Tests/ResolveAttackClampTest.cpp
@@ -1,3 +1,4 @@
+#if WITH_AUTOMATION_TESTS
 #include "Misc/AutomationTest.h"
 #include "GridBattleManager.h"
 
@@ -18,3 +19,4 @@ bool FSkaldResolveAttackClampTest::RunTest(const FString& Parameters) {
   TestEqual(TEXT("Defender health clamped"), Defender.Stats.Health, 0);
   return true;
 }
+#endif // WITH_AUTOMATION_TESTS

--- a/Source/Skald/Tests/SkaldMainHUDWidgetTest.cpp
+++ b/Source/Skald/Tests/SkaldMainHUDWidgetTest.cpp
@@ -1,3 +1,4 @@
+#if WITH_AUTOMATION_TESTS
 #include "Misc/AutomationTest.h"
 #include "UI/SkaldMainHUDWidget.h"
 #include "UObject/Class.h"
@@ -13,3 +14,4 @@ bool FSkaldMainHUDWidgetBindingsTest::RunTest(const FString& Parameters)
     TestNotNull(TEXT("EndPhaseButton property should exist"), WidgetClass->FindPropertyByName(GET_MEMBER_NAME_CHECKED(USkaldMainHUDWidget, EndPhaseButton)));
     return true;
 }
+#endif // WITH_AUTOMATION_TESTS

--- a/Source/Skald/Tests/TerritoryMoveTest.cpp
+++ b/Source/Skald/Tests/TerritoryMoveTest.cpp
@@ -1,3 +1,4 @@
+#if WITH_AUTOMATION_TESTS
 #include "Misc/AutomationTest.h"
 #include "Tests/AutomationEditorCommon.h"
 #include "Territory.h"
@@ -115,3 +116,4 @@ bool FSkaldTerritoryMoveInvalidTest::RunTest(const FString& Parameters)
 
     return true;
 }
+#endif // WITH_AUTOMATION_TESTS

--- a/Source/Skald/Tests/TerritorySelectionTest.cpp
+++ b/Source/Skald/Tests/TerritorySelectionTest.cpp
@@ -1,3 +1,4 @@
+#if WITH_AUTOMATION_TESTS
 #include "TerritorySelectionTest.h"
 
 #include "Engine/GameInstance.h"
@@ -61,3 +62,4 @@ bool FTerritorySelectionFlowTest::RunTest(const FString &Parameters) {
   World->GetGameInstance()->RemoveLocalPlayer(LocalPlayer);
   return true;
 }
+#endif // WITH_AUTOMATION_TESTS

--- a/Source/Skald/Tests/TerritorySelectionTest.h
+++ b/Source/Skald/Tests/TerritorySelectionTest.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#if WITH_AUTOMATION_TESTS
 #include "CoreMinimal.h"
 #include "Skald_PlayerController.h"
 #include "TerritorySelectionTest.generated.h"
@@ -15,4 +16,6 @@ public:
         Super::ServerSelectTerritory_Implementation(TerritoryID);
     }
 };
+
+#endif // WITH_AUTOMATION_TESTS
 

--- a/Source/Skald/Tests/TurnManagerTest.cpp
+++ b/Source/Skald/Tests/TurnManagerTest.cpp
@@ -1,3 +1,4 @@
+#if WITH_AUTOMATION_TESTS
 #include "Misc/AutomationTest.h"
 #include "Tests/AutomationEditorCommon.h"
 #include "Skald_TurnManager.h"
@@ -84,3 +85,4 @@ bool FSkaldTurnManagerInitiativeTest::RunTest(const FString& Parameters) {
 
   return true;
 }
+#endif // WITH_AUTOMATION_TESTS

--- a/Source/Skald/Tests/WorldMapDefaultTableTest.cpp
+++ b/Source/Skald/Tests/WorldMapDefaultTableTest.cpp
@@ -1,3 +1,4 @@
+#if WITH_AUTOMATION_TESTS
 #include "Misc/AutomationTest.h"
 #include "WorldMap.h"
 #include "Tests/AutomationEditorCommon.h"
@@ -24,3 +25,4 @@ bool FWorldMapDefaultTableTest::RunTest(const FString& Parameters)
     TestNull(TEXT("TerritoryTable should be unset"), Map->TerritoryTable);
     return true;
 }
+#endif // WITH_AUTOMATION_TESTS

--- a/Source/Skald/Tests/WorldMapFindPathTest.cpp
+++ b/Source/Skald/Tests/WorldMapFindPathTest.cpp
@@ -1,3 +1,4 @@
+#if WITH_AUTOMATION_TESTS
 #include "Misc/AutomationTest.h"
 #include "Tests/AutomationEditorCommon.h"
 #include "WorldMap.h"
@@ -82,3 +83,4 @@ bool FWorldMapFindPathBlockedTest::RunTest(const FString& Parameters) {
 
   return true;
 }
+#endif // WITH_AUTOMATION_TESTS


### PR DESCRIPTION
## Summary
- wrap all Skald automation test sources in WITH_AUTOMATION_TESTS so they compile only when automation support is enabled
- guard test-only headers, including DeploySelectionCachingTest, to prevent UHT from processing them in non-test builds

## Testing
- ./Engine/Build/BatchFiles/Build.sh SkaldEditor Linux Development -project="$(pwd)/Skald.uproject" *(fails: No such file or directory)*
- ./Engine/Build/BatchFiles/Build.sh Skald Linux Shipping -project="$(pwd)/Skald.uproject" *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68d9e174b4808324b0e33b1ce3b7c23f