### PR TITLE
Ensure fighter pawns face movement and attack directions

### DIFF
--- a/Source/Skald/FighterPawn.cpp
+++ b/Source/Skald/FighterPawn.cpp
@@ -219,6 +219,8 @@ void AFighterPawn::MoveToCell(FIntPoint TargetCell) {
     return;
   }
 
+  const FIntPoint PreviousCell = CurrentCell;
+
   if (Grid) {
     Grid->SetOccupied(CurrentCell, false);
   }
@@ -229,6 +231,7 @@ void AFighterPawn::MoveToCell(FIntPoint TargetCell) {
     NewLocation = Grid->GridToWorld(TargetCell);
     NewLocation.Z += GetSimpleCollisionHalfHeight();
   }
+  FaceTowardsCells(PreviousCell, TargetCell);
   FaceTowardsLocation(NewLocation);
   SetActorLocation(NewLocation);
   ActionsRemaining = FMath::Max(0, ActionsRemaining - 1);
@@ -319,6 +322,7 @@ void AFighterPawn::PerformAttack(AFighterPawn *Target) {
 
   BroadcastActionsRemaining();
 
+  FaceTowardsCells(CurrentCell, Target->CurrentCell);
   FaceTowardsLocation(Target->GetActorLocation());
 
   if (Grid) {
@@ -519,6 +523,30 @@ void AFighterPawn::BroadcastActionsRemaining() {
 
 void AFighterPawn::FaceTowardsLocation(const FVector &TargetLocation) {
   FVector Direction = TargetLocation - GetActorLocation();
+  Direction.Z = 0.f;
+  if (!Direction.IsNearlyZero()) {
+    const FRotator LookRotation = Direction.Rotation();
+    SetActorRotation(FRotator(0.f, LookRotation.Yaw, 0.f));
+  }
+}
+
+void AFighterPawn::FaceTowardsCells(const FIntPoint &FromCell,
+                                    const FIntPoint &ToCell) {
+  if (FromCell == ToCell) {
+    return;
+  }
+
+  FVector FromLocation(static_cast<double>(FromCell.X),
+                       static_cast<double>(FromCell.Y), 0.0);
+  FVector TargetLocation(static_cast<double>(ToCell.X),
+                         static_cast<double>(ToCell.Y), 0.0);
+
+  if (UGridOverlayComponent *Grid = GetGrid()) {
+    FromLocation = Grid->GridToWorld(FromCell);
+    TargetLocation = Grid->GridToWorld(ToCell);
+  }
+
+  FVector Direction = TargetLocation - FromLocation;
   Direction.Z = 0.f;
   if (!Direction.IsNearlyZero()) {
     const FRotator LookRotation = Direction.Rotation();

--- a/Source/Skald/FighterPawn.h
+++ b/Source/Skald/FighterPawn.h
@@ -144,6 +144,9 @@ private:
   /** Rotate the fighter to face a world-space location. */
   void FaceTowardsLocation(const FVector &TargetLocation);
 
+  /** Rotate the fighter to face from one grid cell towards another. */
+  void FaceTowardsCells(const FIntPoint &FromCell, const FIntPoint &ToCell);
+
   /** Data describing a single queued attack roll. */
   struct FQueuedAttackRoll {
     int32 RollValue = 1;


### PR DESCRIPTION
## Summary
- rotate fighter pawns toward their movement and attack destinations using grid-aware yaw calculations
- add a helper that derives facing direction from source and target grid cells to keep visuals aligned in battle mode

## Testing
- not run (Unreal Engine project)


------
https://chatgpt.com/codex/tasks/task_e_68d9e43ce5a8832498e22322baa5bc86