### PR TITLE
Implement smooth fighter movement

### DIFF
--- a/Source/Skald/FighterPawn.cpp
+++ b/Source/Skald/FighterPawn.cpp
@@ -18,7 +18,8 @@ constexpr int32 ActionsPerActivation = 2;
 }
 
 AFighterPawn::AFighterPawn() {
-  PrimaryActorTick.bCanEverTick = false;
+  PrimaryActorTick.bCanEverTick = true;
+  PrimaryActorTick.bStartWithTickEnabled = true;
 
   bReplicates = true;
   SetReplicateMovement(true);
@@ -108,6 +109,8 @@ void AFighterPawn::BeginPlay() {
     Grid->SetOccupied(CurrentCell, true);
   }
 
+  MovementTargetLocation = GetActorLocation();
+
   if (UWorld *World = GetWorld()) {
     if (USkaldGameInstance *GI =
             Cast<USkaldGameInstance>(World->GetGameInstance())) {
@@ -115,6 +118,30 @@ void AFighterPawn::BeginPlay() {
         GI->GridBattleManager->RegisterFighter(this, bIsAttacker);
       }
     }
+  }
+}
+
+void AFighterPawn::Tick(float DeltaSeconds) {
+  Super::Tick(DeltaSeconds);
+
+  if (!bIsMoving) {
+    return;
+  }
+
+  const FVector CurrentLocation = GetActorLocation();
+  const float EffectiveSpeed = FMath::Max(MovementSpeed, KINDA_SMALL_NUMBER);
+  const FVector NextLocation =
+      FMath::VInterpConstantTo(CurrentLocation, MovementTargetLocation, DeltaSeconds,
+                               EffectiveSpeed);
+  SetActorLocation(NextLocation);
+
+  const float EffectiveTolerance =
+      FMath::Max(MovementStopTolerance, KINDA_SMALL_NUMBER);
+  if (FVector::DistSquared(NextLocation, MovementTargetLocation) <=
+      FMath::Square(EffectiveTolerance)) {
+    SetActorLocation(MovementTargetLocation);
+    bIsMoving = false;
+    MovementTargetLocation = GetActorLocation();
   }
 }
 
@@ -231,9 +258,22 @@ void AFighterPawn::MoveToCell(FIntPoint TargetCell) {
     NewLocation = Grid->GridToWorld(TargetCell);
     NewLocation.Z += GetSimpleCollisionHalfHeight();
   }
+  MovementTargetLocation = NewLocation;
   FaceTowardsCells(PreviousCell, TargetCell);
   FaceTowardsLocation(NewLocation);
-  SetActorLocation(NewLocation);
+
+  const float EffectiveTolerance =
+      FMath::Max(MovementStopTolerance, KINDA_SMALL_NUMBER);
+  const bool bAlreadyAtTarget =
+      GetActorLocation().Equals(MovementTargetLocation, EffectiveTolerance);
+
+  if (MovementSpeed <= KINDA_SMALL_NUMBER || bAlreadyAtTarget) {
+    SetActorLocation(MovementTargetLocation);
+    bIsMoving = false;
+    MovementTargetLocation = GetActorLocation();
+  } else {
+    bIsMoving = true;
+  }
   ActionsRemaining = FMath::Max(0, ActionsRemaining - 1);
 
   BroadcastActionsRemaining();

--- a/Source/Skald/FighterPawn.h
+++ b/Source/Skald/FighterPawn.h
@@ -23,6 +23,7 @@ class SKALD_API AFighterPawn : public APawn {
 public:
   AFighterPawn();
 
+  virtual void Tick(float DeltaSeconds) override;
   virtual void OnConstruction(const FTransform &Transform) override;
   virtual void BeginPlay() override;
   virtual void GetLifetimeReplicatedProps(
@@ -43,6 +44,16 @@ public:
   /** Move to the specified grid cell if actions remain. */
   UFUNCTION(BlueprintCallable, Category = "Fighter")
   void MoveToCell(FIntPoint TargetCell);
+
+  /** Units per second used when travelling between grid cells. */
+  UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Fighter|Movement",
+            meta = (ClampMin = "0.0"))
+  float MovementSpeed = 600.f;
+
+  /** Distance threshold for snapping to the target cell during movement. */
+  UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Fighter|Movement",
+            meta = (ClampMin = "0.0"))
+  float MovementStopTolerance = 1.f;
 
   /** Perform an attack against another fighter. */
   UFUNCTION(BlueprintCallable, Category = "Fighter")
@@ -196,6 +207,12 @@ private:
 
   /** Cached grid overlay component. */
   UGridOverlayComponent *CachedGrid = nullptr;
+
+  /** True while the fighter is interpolating towards a grid cell. */
+  bool bIsMoving = false;
+
+  /** World-space destination for the current interpolated move. */
+  FVector MovementTargetLocation = FVector::ZeroVector;
 
 public:
   /** Returns true if the fighter has already activated this round. */


### PR DESCRIPTION
## Summary
- enable ticking on fighter pawns and expose movement speed/tolerance properties
- interpolate pawn location each tick toward the stored grid destination
- update MoveToCell to drive interpolation while preserving action bookkeeping

## Testing
- Not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d9e623650883249e1ca175084dad11