### PR TITLE
Update fighter miss widget default blueprint

### DIFF
--- a/Source/Skald/FighterPawn.cpp
+++ b/Source/Skald/FighterPawn.cpp
@@ -57,7 +57,7 @@ AFighterPawn::AFighterPawn() {
   }
 
   static ConstructorHelpers::FClassFinder<UUserWidget> MissWidgetFinder(
-      TEXT("/Game/Blueprints/UI/WBP_Misses"));
+      TEXT("/Game/Blueprints/UI/WBP_MissWidget"));
   if (MissWidgetFinder.Succeeded()) {
     MissWidgetTemplate = MissWidgetFinder.Class;
   }


### PR DESCRIPTION
## Summary
- update the fighter pawn miss widget template to use the WBP_MissWidget blueprint

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d9e9aba34c8324ae66d7ecf359f02a