### PR TITLE
Guard PlayerControllerValidationTest definitions with automation flag

### DIFF
--- a/Source/Skald/Tests/PlayerControllerValidationTest.h
+++ b/Source/Skald/Tests/PlayerControllerValidationTest.h
@@ -15,8 +15,6 @@ public:
     virtual void ShowErrorMessage(const FString& Message) override;
 };
 
-#endif // WITH_AUTOMATION_TESTS
-
 UCLASS()
 class ATestPlayerController : public ASkaldPlayerController
 {
@@ -24,4 +22,6 @@ class ATestPlayerController : public ASkaldPlayerController
 public:
     void SetHUD(USkaldMainHUDWidget* InHUD);
 };
+
+#endif // WITH_AUTOMATION_TESTS
 


### PR DESCRIPTION
## Summary
- wrap the automation test HUD and player controller definitions in PlayerControllerValidationTest.h with WITH_AUTOMATION_TESTS so no UCLASS declarations remain when tests are disabled

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d9eac98fec8324a84ae28c055d435b