### PR TITLE
Add fighter footprint options for large pawns

### DIFF
--- a/Source/Skald/FighterPawn.cpp
+++ b/Source/Skald/FighterPawn.cpp
@@ -225,6 +225,134 @@ bool AFighterPawn::OccupiesCell(const FIntPoint &Cell) const {
   return OccupiedCells.Contains(Cell);
 }
 
+int32 AFighterPawn::GetFootprintDistanceToCell(const FIntPoint &Cell,
+                                               FIntPoint *OutClosestCell) const {
+  const TArray<FIntPoint> OccupiedCells = GetOccupiedCells();
+  int32 BestDistance = TNumericLimits<int32>::Max();
+  FIntPoint BestCell = CurrentCell;
+
+  for (const FIntPoint &SelfCell : OccupiedCells) {
+    const int32 Distance = FMath::Abs(SelfCell.X - Cell.X) +
+                           FMath::Abs(SelfCell.Y - Cell.Y);
+    if (Distance < BestDistance) {
+      BestDistance = Distance;
+      BestCell = SelfCell;
+      if (Distance == 0) {
+        break;
+      }
+    }
+  }
+
+  if (OutClosestCell) {
+    *OutClosestCell = BestCell;
+  }
+
+  return BestDistance;
+}
+
+int32 AFighterPawn::GetFootprintDistanceToFighter(
+    const AFighterPawn *Other, FIntPoint *OutSelfCell,
+    FIntPoint *OutOtherCell) const {
+  if (!Other) {
+    if (OutSelfCell) {
+      *OutSelfCell = CurrentCell;
+    }
+    if (OutOtherCell) {
+      *OutOtherCell = FIntPoint::ZeroValue;
+    }
+    return TNumericLimits<int32>::Max();
+  }
+
+  const TArray<FIntPoint> SelfCells = GetOccupiedCells();
+  const TArray<FIntPoint> OtherCells = Other->GetOccupiedCells();
+
+  int32 BestDistance = TNumericLimits<int32>::Max();
+  FIntPoint BestSelf = CurrentCell;
+  FIntPoint BestOther = Other->GetCurrentCell();
+
+  for (const FIntPoint &SelfCell : SelfCells) {
+    for (const FIntPoint &OtherCell : OtherCells) {
+      const int32 Distance = FMath::Abs(SelfCell.X - OtherCell.X) +
+                             FMath::Abs(SelfCell.Y - OtherCell.Y);
+      if (Distance < BestDistance) {
+        BestDistance = Distance;
+        BestSelf = SelfCell;
+        BestOther = OtherCell;
+        if (Distance == 0) {
+          break;
+        }
+      }
+    }
+    if (BestDistance == 0) {
+      break;
+    }
+  }
+
+  if (OutSelfCell) {
+    *OutSelfCell = BestSelf;
+  }
+  if (OutOtherCell) {
+    *OutOtherCell = BestOther;
+  }
+
+  return BestDistance;
+}
+
+bool AFighterPawn::HasLineOfSightToFighter(
+    const AFighterPawn *Other, int32 Range, UGridOverlayComponent *Grid,
+    FIntPoint *OutSelfCell, FIntPoint *OutOtherCell) const {
+  if (!Grid || !Other) {
+    return false;
+  }
+
+  const TArray<FIntPoint> SelfCells = GetOccupiedCells();
+  const TArray<FIntPoint> OtherCells = Other->GetOccupiedCells();
+
+  bool bFoundLine = false;
+  int32 BestDistance = TNumericLimits<int32>::Max();
+  FIntPoint BestSelf = CurrentCell;
+  FIntPoint BestOther = Other->GetCurrentCell();
+
+  for (const FIntPoint &SelfCell : SelfCells) {
+    for (const FIntPoint &OtherCell : OtherCells) {
+      const int32 Distance = FMath::Abs(SelfCell.X - OtherCell.X) +
+                             FMath::Abs(SelfCell.Y - OtherCell.Y);
+      if (Distance > Range) {
+        continue;
+      }
+      if (!Grid->HasLineOfSight(SelfCell, OtherCell)) {
+        continue;
+      }
+
+      if (!bFoundLine || Distance < BestDistance) {
+        BestDistance = Distance;
+        BestSelf = SelfCell;
+        BestOther = OtherCell;
+        bFoundLine = true;
+        if (BestDistance == 0) {
+          break;
+        }
+      }
+    }
+    if (BestDistance == 0) {
+      break;
+    }
+  }
+
+  if (!bFoundLine) {
+    return false;
+  }
+
+  if (OutSelfCell) {
+    *OutSelfCell = BestSelf;
+  }
+  if (OutOtherCell) {
+    *OutOtherCell = BestOther;
+  }
+
+  return true;
+}
+
 void AFighterPawn::ApplyFootprintScale() {
   if (DisplayMesh) {
     const float Scale =
@@ -391,14 +519,18 @@ void AFighterPawn::PerformAttack(AFighterPawn *Target) {
     return;
   }
 
-  const int32 Distance = FMath::Abs(Target->CurrentCell.X - CurrentCell.X) +
-                         FMath::Abs(Target->CurrentCell.Y - CurrentCell.Y);
+  FIntPoint ClosestSelfCell = CurrentCell;
+  FIntPoint ClosestTargetCell = Target->GetCurrentCell();
+  const int32 Distance =
+      GetFootprintDistanceToFighter(Target, &ClosestSelfCell, &ClosestTargetCell);
   if (Distance > Stats.AttackRange) {
     return;
   }
 
   UGridOverlayComponent *Grid = GetGrid();
-  if (Grid && !Grid->HasLineOfSight(CurrentCell, Target->CurrentCell)) {
+  if (Grid &&
+      !HasLineOfSightToFighter(Target, Stats.AttackRange, Grid, &ClosestSelfCell,
+                               &ClosestTargetCell)) {
     return;
   }
 

--- a/Source/Skald/FighterPawn.cpp
+++ b/Source/Skald/FighterPawn.cpp
@@ -67,6 +67,7 @@ AFighterPawn::AFighterPawn() {
   bIsCurrentlyActive = false;
   CurrentCell = FIntPoint::ZeroValue;
 
+  ApplyFootprintScale();
   UpdateMeshOffset();
 }
 
@@ -79,12 +80,15 @@ void AFighterPawn::GetLifetimeReplicatedProps(
   DOREPLIFETIME(AFighterPawn, ActionsRemaining);
   DOREPLIFETIME(AFighterPawn, bHasActivatedThisRound);
   DOREPLIFETIME(AFighterPawn, bIsCurrentlyActive);
+  DOREPLIFETIME(AFighterPawn, GridFootprint);
   DOREPLIFETIME(AFighterPawn, CurrentCell);
 }
 
 void AFighterPawn::OnConstruction(const FTransform &Transform) {
   Super::OnConstruction(Transform);
+  ApplyFootprintScale();
   UpdateMeshOffset();
+  AlignToCurrentCell();
 }
 
 void AFighterPawn::BeginPlay() {
@@ -103,10 +107,12 @@ void AFighterPawn::BeginPlay() {
 
   if (UGridOverlayComponent *Grid = GetGrid()) {
     CurrentCell = Grid->WorldToGrid(GetActorLocation());
-    FVector AlignedLocation = Grid->GridToWorld(CurrentCell);
-    AlignedLocation.Z += GetSimpleCollisionHalfHeight();
-    SetActorLocation(AlignedLocation);
-    Grid->SetOccupied(CurrentCell, true);
+    AlignToCurrentCell();
+
+    const TArray<FIntPoint> OccupiedCells = GetOccupiedCells();
+    for (const FIntPoint &Cell : OccupiedCells) {
+      Grid->SetOccupied(Cell, true);
+    }
   }
 
   MovementTargetLocation = GetActorLocation();
@@ -180,7 +186,7 @@ void AFighterPawn::FinishActivation() {
   }
 }
 
-UGridOverlayComponent *AFighterPawn::GetGrid() {
+UGridOverlayComponent *AFighterPawn::GetGrid() const {
   if (!CachedGrid) {
     if (UWorld *World = GetWorld()) {
       for (TActorIterator<AActor> It(World); It; ++It) {
@@ -195,6 +201,66 @@ UGridOverlayComponent *AFighterPawn::GetGrid() {
 }
 
 FIntPoint AFighterPawn::GetCurrentCell() const { return CurrentCell; }
+
+int32 AFighterPawn::GetFootprintSideLength() const {
+  return GridFootprint == EFighterPawnFootprint::FourCells ? 2 : 1;
+}
+
+TArray<FIntPoint> AFighterPawn::GetOccupiedCells(const FIntPoint &Anchor) const {
+  const int32 SideLength = GetFootprintSideLength();
+  TArray<FIntPoint> Cells;
+  Cells.Reserve(SideLength * SideLength);
+
+  for (int32 Y = 0; Y < SideLength; ++Y) {
+    for (int32 X = 0; X < SideLength; ++X) {
+      Cells.Add(Anchor + FIntPoint(X, Y));
+    }
+  }
+
+  return Cells;
+}
+
+bool AFighterPawn::OccupiesCell(const FIntPoint &Cell) const {
+  const TArray<FIntPoint> OccupiedCells = GetOccupiedCells();
+  return OccupiedCells.Contains(Cell);
+}
+
+void AFighterPawn::ApplyFootprintScale() {
+  if (DisplayMesh) {
+    const float Scale =
+        GridFootprint == EFighterPawnFootprint::FourCells ? 2.f : 1.f;
+    DisplayMesh->SetRelativeScale3D(FVector(Scale));
+  }
+}
+
+FVector AFighterPawn::GetAlignedWorldLocation(const FIntPoint &Anchor) const {
+  if (UGridOverlayComponent *Grid = GetGrid()) {
+    const TArray<FIntPoint> Cells = GetOccupiedCells(Anchor);
+    FVector AccumulatedLocation = FVector::ZeroVector;
+    int32 CellCount = 0;
+
+    for (const FIntPoint &Cell : Cells) {
+      AccumulatedLocation += Grid->GridToWorld(Cell);
+      ++CellCount;
+    }
+
+    if (CellCount > 0) {
+      AccumulatedLocation /= static_cast<float>(CellCount);
+      AccumulatedLocation.Z += GetSimpleCollisionHalfHeight();
+      return AccumulatedLocation;
+    }
+  }
+
+  return GetActorLocation();
+}
+
+void AFighterPawn::AlignToCurrentCell() {
+  if (UGridOverlayComponent *Grid = GetGrid()) {
+    const FVector AlignedLocation = GetAlignedWorldLocation(CurrentCell);
+    SetActorLocation(AlignedLocation);
+    MovementTargetLocation = AlignedLocation;
+  }
+}
 
 UUserWidget *AFighterPawn::GetDamageWidgetFromPool() {
   for (UUserWidget *Widget : DamageWidgetPool) {
@@ -242,22 +308,40 @@ void AFighterPawn::MoveToCell(FIntPoint TargetCell) {
     return;
   }
   UGridOverlayComponent *Grid = GetGrid();
-  if (Grid && Grid->IsObscured(TargetCell)) {
-    return;
-  }
-
   const FIntPoint PreviousCell = CurrentCell;
 
+  TArray<FIntPoint> PreviousCells;
+  TArray<FIntPoint> TargetCells;
+
   if (Grid) {
-    Grid->SetOccupied(CurrentCell, false);
+    PreviousCells = GetOccupiedCells();
+    TargetCells = GetOccupiedCells(TargetCell);
+
+    bool bCanOccupyTarget = true;
+    for (const FIntPoint &Cell : TargetCells) {
+      if (!Grid->IsCellInBounds(Cell) || Grid->IsObscured(Cell)) {
+        bCanOccupyTarget = false;
+        break;
+      }
+      const bool bCellPreviouslyOccupied = PreviousCells.Contains(Cell);
+      if (!bCellPreviouslyOccupied && Grid->IsOccupied(Cell)) {
+        bCanOccupyTarget = false;
+        break;
+      }
+    }
+
+    if (!bCanOccupyTarget) {
+      return;
+    }
+
+    for (const FIntPoint &Cell : PreviousCells) {
+      Grid->SetOccupied(Cell, false);
+    }
   }
 
   CurrentCell = TargetCell;
-  FVector NewLocation = GetActorLocation();
-  if (Grid) {
-    NewLocation = Grid->GridToWorld(TargetCell);
-    NewLocation.Z += GetSimpleCollisionHalfHeight();
-  }
+  FVector NewLocation = Grid ? GetAlignedWorldLocation(TargetCell)
+                             : GetActorLocation();
   MovementTargetLocation = NewLocation;
   FaceTowardsCells(PreviousCell, TargetCell);
   FaceTowardsLocation(NewLocation);
@@ -279,7 +363,9 @@ void AFighterPawn::MoveToCell(FIntPoint TargetCell) {
   BroadcastActionsRemaining();
 
   if (Grid) {
-    Grid->SetOccupied(TargetCell, true);
+    for (const FIntPoint &Cell : TargetCells) {
+      Grid->SetOccupied(Cell, true);
+    }
     Grid->ClearHighlights();
   }
 }
@@ -529,7 +615,10 @@ void AFighterPawn::UpdateHealthDisplay(int32 NewHealth) {
 void AFighterPawn::Destroyed() {
   FinishActivation();
   if (UGridOverlayComponent *Grid = GetGrid()) {
-    Grid->SetOccupied(CurrentCell, false);
+    const TArray<FIntPoint> OccupiedCells = GetOccupiedCells();
+    for (const FIntPoint &Cell : OccupiedCells) {
+      Grid->SetOccupied(Cell, false);
+    }
   }
   if (UWorld *World = GetWorld()) {
     if (USkaldGameInstance *GI =
@@ -557,6 +646,12 @@ void AFighterPawn::OnRep_Stats(const FFighterStats &OldStats) {
 
 void AFighterPawn::OnRep_ActionsRemaining() { BroadcastActionsRemaining(); }
 
+void AFighterPawn::OnRep_GridFootprint() {
+  ApplyFootprintScale();
+  UpdateMeshOffset();
+  AlignToCurrentCell();
+}
+
 void AFighterPawn::BroadcastActionsRemaining() {
   OnActionsChanged.Broadcast(ActionsRemaining);
 }
@@ -576,15 +671,8 @@ void AFighterPawn::FaceTowardsCells(const FIntPoint &FromCell,
     return;
   }
 
-  FVector FromLocation(static_cast<double>(FromCell.X),
-                       static_cast<double>(FromCell.Y), 0.0);
-  FVector TargetLocation(static_cast<double>(ToCell.X),
-                         static_cast<double>(ToCell.Y), 0.0);
-
-  if (UGridOverlayComponent *Grid = GetGrid()) {
-    FromLocation = Grid->GridToWorld(FromCell);
-    TargetLocation = Grid->GridToWorld(ToCell);
-  }
+  FVector FromLocation = GetAlignedWorldLocation(FromCell);
+  FVector TargetLocation = GetAlignedWorldLocation(ToCell);
 
   FVector Direction = TargetLocation - FromLocation;
   Direction.Z = 0.f;

--- a/Source/Skald/FighterPawn.cpp
+++ b/Source/Skald/FighterPawn.cpp
@@ -88,7 +88,6 @@ void AFighterPawn::OnConstruction(const FTransform &Transform) {
   Super::OnConstruction(Transform);
   ApplyFootprintScale();
   UpdateMeshOffset();
-  AlignToCurrentCell();
 }
 
 void AFighterPawn::BeginPlay() {
@@ -384,6 +383,11 @@ FVector AFighterPawn::GetAlignedWorldLocation(const FIntPoint &Anchor) const {
 
 void AFighterPawn::AlignToCurrentCell() {
   if (UGridOverlayComponent *Grid = GetGrid()) {
+    const FIntPoint DerivedCell = Grid->WorldToGrid(GetActorLocation());
+    if (DerivedCell != CurrentCell) {
+      return;
+    }
+
     const FVector AlignedLocation = GetAlignedWorldLocation(CurrentCell);
     SetActorLocation(AlignedLocation);
     MovementTargetLocation = AlignedLocation;

--- a/Source/Skald/FighterPawn.h
+++ b/Source/Skald/FighterPawn.h
@@ -84,6 +84,21 @@ public:
   /** Returns true if the fighter's footprint overlaps the specified cell. */
   bool OccupiesCell(const FIntPoint &Cell) const;
 
+  /** Manhattan distance from the fighter's footprint to a specific cell. */
+  int32 GetFootprintDistanceToCell(const FIntPoint &Cell,
+                                   FIntPoint *OutClosestCell = nullptr) const;
+
+  /** Manhattan distance between this fighter's footprint and another's. */
+  int32 GetFootprintDistanceToFighter(
+      const AFighterPawn *Other, FIntPoint *OutSelfCell = nullptr,
+      FIntPoint *OutOtherCell = nullptr) const;
+
+  /** Determine if any occupied cells have line of sight within range. */
+  bool HasLineOfSightToFighter(const AFighterPawn *Other, int32 Range,
+                               UGridOverlayComponent *Grid,
+                               FIntPoint *OutSelfCell = nullptr,
+                               FIntPoint *OutOtherCell = nullptr) const;
+
   /** Size of the fighter footprint measured in cells per side. */
   int32 GetFootprintSideLength() const;
 

--- a/Source/Skald/FighterPawn.h
+++ b/Source/Skald/FighterPawn.h
@@ -11,6 +11,12 @@
 class UGridOverlayComponent;
 class UCapsuleComponent;
 
+UENUM(BlueprintType)
+enum class EFighterPawnFootprint : uint8 {
+  SingleCell UMETA(DisplayName = "1 Cell"),
+  FourCells UMETA(DisplayName = "4 Cells")
+};
+
 DECLARE_DYNAMIC_MULTICAST_DELEGATE_OneParam(FOnHealthChanged, int32, NewHealth);
 DECLARE_DYNAMIC_MULTICAST_DELEGATE_OneParam(FOnActionsChanged, int32,
                                             NewActionsRemaining);
@@ -64,15 +70,32 @@ public:
   bool IsAlive() const;
 
   /** Get the grid overlay component, caching the result. */
-  UGridOverlayComponent *GetGrid();
+  UGridOverlayComponent *GetGrid() const;
 
   /** Retrieve the grid cell currently occupied by this fighter. */
   FIntPoint GetCurrentCell() const;
+
+  /** Cells occupied by this fighter given an anchor grid coordinate. */
+  TArray<FIntPoint> GetOccupiedCells(const FIntPoint &Anchor) const;
+
+  /** Cells currently occupied by this fighter. */
+  TArray<FIntPoint> GetOccupiedCells() const { return GetOccupiedCells(CurrentCell); }
+
+  /** Returns true if the fighter's footprint overlaps the specified cell. */
+  bool OccupiesCell(const FIntPoint &Cell) const;
+
+  /** Size of the fighter footprint measured in cells per side. */
+  int32 GetFootprintSideLength() const;
 
   /** Statistics describing this fighter. */
   UPROPERTY(BlueprintReadWrite, EditAnywhere, ReplicatedUsing = OnRep_Stats,
             Category = "Fighter")
   FFighterStats Stats;
+
+  /** Number of grid cells occupied by this fighter (1 or 4). */
+  UPROPERTY(EditAnywhere, BlueprintReadWrite,
+            ReplicatedUsing = OnRep_GridFootprint, Category = "Fighter|Grid")
+  EFighterPawnFootprint GridFootprint = EFighterPawnFootprint::SingleCell;
 
   /** True if this fighter belongs to the attacking side. */
   UPROPERTY(BlueprintReadWrite, EditAnywhere, Replicated,
@@ -139,6 +162,8 @@ private:
   void OnRep_Stats(const FFighterStats &OldStats);
   UFUNCTION()
   void OnRep_ActionsRemaining();
+  UFUNCTION()
+  void OnRep_GridFootprint();
 
   /** Retrieve or create a damage widget from the pool. */
   UUserWidget *GetDamageWidgetFromPool();
@@ -148,6 +173,15 @@ private:
 
   /** Align the visible mesh with the collision capsule. */
   void UpdateMeshOffset();
+
+  /** Apply scale changes based on the footprint size. */
+  void ApplyFootprintScale();
+
+  /** Align the fighter's world position with its occupied cells. */
+  void AlignToCurrentCell();
+
+  /** Calculate the aligned world location for a given anchor cell. */
+  FVector GetAlignedWorldLocation(const FIntPoint &Anchor) const;
 
   /** Helper to broadcast the current actions remaining value. */
   void BroadcastActionsRemaining();
@@ -206,7 +240,7 @@ private:
   FIntPoint CurrentCell;
 
   /** Cached grid overlay component. */
-  UGridOverlayComponent *CachedGrid = nullptr;
+  mutable UGridOverlayComponent *CachedGrid = nullptr;
 
   /** True while the fighter is interpolating towards a grid cell. */
   bool bIsMoving = false;

--- a/Source/Skald/GridOverlayComponent.cpp
+++ b/Source/Skald/GridOverlayComponent.cpp
@@ -1185,26 +1185,37 @@ void UGridOverlayComponent::HighlightAttack(AFighterPawn *Fighter) {
   const FColor SelectionColor = SelectionHighlightColor.ToFColor(true);
   const FColor AttackColor = AttackHighlightColor.ToFColor(true);
 
-  auto HighlightFootprint = [&](const FIntPoint &Anchor, const FColor &Color) {
-    const TArray<FIntPoint> Footprint = Fighter->GetOccupiedCells(Anchor);
-    for (const FIntPoint &Cell : Footprint) {
-      HighlightCell(Cell, Color, 0.f, false);
-    }
-  };
+  const TArray<FIntPoint> Footprint = Fighter->GetOccupiedCells(StartCell);
+  TSet<FIntPoint> Occupied;
+  for (const FIntPoint &Cell : Footprint) {
+    Occupied.Add(Cell);
+    HighlightCell(Cell, SelectionColor, 0.f, false);
+  }
 
-  HighlightFootprint(StartCell, SelectionColor);
+  const int32 Width = GetWidth();
+  const int32 Height = GetHeight();
 
-  for (int32 Dy = -Range; Dy <= Range; ++Dy) {
-    for (int32 Dx = -Range; Dx <= Range; ++Dx) {
-      if (FMath::Abs(Dx) + FMath::Abs(Dy) > Range) {
+  for (int32 Y = 0; Y < Height; ++Y) {
+    for (int32 X = 0; X < Width; ++X) {
+      const FIntPoint Target(X, Y);
+      if (Occupied.Contains(Target)) {
         continue;
       }
-      const FIntPoint Target = StartCell + FIntPoint(Dx, Dy);
-      if (!IsValidGrid(Target) || Target == StartCell) {
-        continue;
+
+      bool bWithinRange = false;
+      for (const FIntPoint &SelfCell : Footprint) {
+        const int32 Distance =
+            FMath::Abs(SelfCell.X - Target.X) + FMath::Abs(SelfCell.Y - Target.Y);
+        if (Distance > Range) {
+          continue;
+        }
+        if (HasLineOfSight(SelfCell, Target)) {
+          bWithinRange = true;
+          break;
+        }
       }
 
-      if (HasLineOfSight(StartCell, Target)) {
+      if (bWithinRange) {
         HighlightCell(Target, AttackColor, 0.f, false);
       }
     }

--- a/Source/Skald/GridOverlayComponent.cpp
+++ b/Source/Skald/GridOverlayComponent.cpp
@@ -1002,8 +1002,10 @@ void UGridOverlayComponent::RefreshPersistentSelectionHighlight() {
     return;
   }
 
-  const FIntPoint Cell = WorldToGrid(Fighter->GetActorLocation());
-  HighlightCell(Cell, SelectionHighlightColor.ToFColor(true), 0.f, false);
+  const FColor SelectionColor = SelectionHighlightColor.ToFColor(true);
+  for (const FIntPoint &Cell : Fighter->GetOccupiedCells()) {
+    HighlightCell(Cell, SelectionColor, 0.f, false);
+  }
 }
 
 void UGridOverlayComponent::RegisterObstacle(UGridObstacleComponent *Obstacle) {
@@ -1100,18 +1102,44 @@ void UGridOverlayComponent::HighlightMovement(AFighterPawn *Fighter) {
 
   ClearHighlights();
 
-  const FIntPoint StartCell = WorldToGrid(Fighter->GetActorLocation());
+  const FIntPoint StartCell = Fighter->GetCurrentCell();
   const int32 Range = Fighter->Stats.Movement;
 
   const FColor SelectionColor = SelectionHighlightColor.ToFColor(true);
   const FColor MovementColor = MovementHighlightColor.ToFColor(true);
 
-  HighlightCell(StartCell, SelectionColor, 0.f, false);
+  auto HighlightFootprint = [&](const FIntPoint &Anchor, const FColor &Color) {
+    const TArray<FIntPoint> Footprint = Fighter->GetOccupiedCells(Anchor);
+    for (const FIntPoint &Cell : Footprint) {
+      HighlightCell(Cell, Color, 0.f, false);
+    }
+  };
+
+  HighlightFootprint(StartCell, SelectionColor);
 
   TSet<FIntPoint> Visited;
   TQueue<TPair<FIntPoint, int32>> Frontier;
   Visited.Add(StartCell);
   Frontier.Enqueue(TPair<FIntPoint, int32>(StartCell, 0));
+
+  TSet<FIntPoint> IgnoredCells;
+  const TArray<FIntPoint> CurrentFootprint = Fighter->GetOccupiedCells();
+  for (const FIntPoint &Cell : CurrentFootprint) {
+    IgnoredCells.Add(Cell);
+  }
+
+  auto CanOccupyAnchor = [&](const FIntPoint &Anchor) {
+    const TArray<FIntPoint> CandidateCells = Fighter->GetOccupiedCells(Anchor);
+    for (const FIntPoint &Cell : CandidateCells) {
+      if (!IsCellInBounds(Cell) || IsObscured(Cell)) {
+        return false;
+      }
+      if (IsOccupied(Cell) && !IgnoredCells.Contains(Cell)) {
+        return false;
+      }
+    }
+    return true;
+  };
 
   while (!Frontier.IsEmpty()) {
     TPair<FIntPoint, int32> Node;
@@ -1120,7 +1148,7 @@ void UGridOverlayComponent::HighlightMovement(AFighterPawn *Fighter) {
     const int32 Distance = Node.Value;
 
     if (Distance > 0) {
-      HighlightCell(Cell, MovementColor, 0.f, false);
+      HighlightFootprint(Cell, MovementColor);
     }
 
     if (Distance >= Range) {
@@ -1132,8 +1160,10 @@ void UGridOverlayComponent::HighlightMovement(AFighterPawn *Fighter) {
 
     for (const FIntPoint &Dir : Directions) {
       const FIntPoint Next = Cell + Dir;
-      if (!IsValidGrid(Next) || IsOccupied(Next) || IsObscured(Next) ||
-          Visited.Contains(Next)) {
+      if (Visited.Contains(Next)) {
+        continue;
+      }
+      if (!CanOccupyAnchor(Next)) {
         continue;
       }
       Visited.Add(Next);
@@ -1149,13 +1179,20 @@ void UGridOverlayComponent::HighlightAttack(AFighterPawn *Fighter) {
 
   ClearHighlights();
 
-  const FIntPoint StartCell = WorldToGrid(Fighter->GetActorLocation());
+  const FIntPoint StartCell = Fighter->GetCurrentCell();
   const int32 Range = Fighter->Stats.AttackRange;
 
   const FColor SelectionColor = SelectionHighlightColor.ToFColor(true);
   const FColor AttackColor = AttackHighlightColor.ToFColor(true);
 
-  HighlightCell(StartCell, SelectionColor, 0.f, false);
+  auto HighlightFootprint = [&](const FIntPoint &Anchor, const FColor &Color) {
+    const TArray<FIntPoint> Footprint = Fighter->GetOccupiedCells(Anchor);
+    for (const FIntPoint &Cell : Footprint) {
+      HighlightCell(Cell, Color, 0.f, false);
+    }
+  };
+
+  HighlightFootprint(StartCell, SelectionColor);
 
   for (int32 Dy = -Range; Dy <= Range; ++Dy) {
     for (int32 Dx = -Range; Dx <= Range; ++Dx) {

--- a/Source/Skald/Skald_AIController.cpp
+++ b/Source/Skald/Skald_AIController.cpp
@@ -308,8 +308,8 @@ int32 ASkaldAIController::ComputeManhattanDistance(UGridOverlayComponent *Grid,
     return TNumericLimits<int32>::Max();
   }
 
-  const FIntPoint CellA = Grid->WorldToGrid(A->GetActorLocation());
-  const FIntPoint CellB = Grid->WorldToGrid(B->GetActorLocation());
+  const FIntPoint CellA = A->GetCurrentCell();
+  const FIntPoint CellB = B->GetCurrentCell();
   if (!Grid->IsCellInBounds(CellA) || !Grid->IsCellInBounds(CellB)) {
     return TNumericLimits<int32>::Max();
   }
@@ -335,7 +335,7 @@ AFighterPawn *ASkaldAIController::FindNearestEnemy(AFighterPawn *Fighter) const 
   AFighterPawn *BestEnemy = nullptr;
   int32 BestDistance = TNumericLimits<int32>::Max();
 
-  const FIntPoint StartCell = Grid->WorldToGrid(Fighter->GetActorLocation());
+  const FIntPoint StartCell = Fighter->GetCurrentCell();
   if (!Grid->IsCellInBounds(StartCell)) {
     return nullptr;
   }
@@ -407,8 +407,8 @@ bool ASkaldAIController::TryAttackNearestEnemy(AFighterPawn *Fighter) {
     return false;
   }
 
-  const FIntPoint SelfCell = Grid->WorldToGrid(Fighter->GetActorLocation());
-  const FIntPoint TargetCell = Grid->WorldToGrid(Target->GetActorLocation());
+  const FIntPoint SelfCell = Fighter->GetCurrentCell();
+  const FIntPoint TargetCell = Target->GetCurrentCell();
   if (!Grid->IsCellInBounds(SelfCell) || !Grid->IsCellInBounds(TargetCell)) {
     return false;
   }
@@ -443,8 +443,8 @@ bool ASkaldAIController::TryMoveTowardsNearestEnemy(AFighterPawn *Fighter) {
     return false;
   }
 
-  const FIntPoint StartCell = Grid->WorldToGrid(Fighter->GetActorLocation());
-  const FIntPoint EnemyCell = Grid->WorldToGrid(Enemy->GetActorLocation());
+  const FIntPoint StartCell = Fighter->GetCurrentCell();
+  const FIntPoint EnemyCell = Enemy->GetCurrentCell();
   if (!Grid->IsCellInBounds(StartCell) || !Grid->IsCellInBounds(EnemyCell)) {
     return false;
   }
@@ -454,6 +454,26 @@ bool ASkaldAIController::TryMoveTowardsNearestEnemy(AFighterPawn *Fighter) {
                           FMath::Abs(EnemyCell.Y - Current.Y);
 
   const int32 MaxSteps = Fighter->Stats.Movement;
+
+  TSet<FIntPoint> IgnoredCells;
+  const TArray<FIntPoint> CurrentFootprint = Fighter->GetOccupiedCells();
+  for (const FIntPoint &Cell : CurrentFootprint) {
+    IgnoredCells.Add(Cell);
+  }
+
+  auto CanOccupyAnchor = [&](const FIntPoint &Anchor) {
+    const TArray<FIntPoint> CandidateCells = Fighter->GetOccupiedCells(Anchor);
+    for (const FIntPoint &Cell : CandidateCells) {
+      if (!Grid->IsCellInBounds(Cell) || Grid->IsObscured(Cell)) {
+        return false;
+      }
+      if (Grid->IsOccupied(Cell) && !IgnoredCells.Contains(Cell)) {
+        return false;
+      }
+    }
+    return true;
+  };
+
   for (int32 Step = 0; Step < MaxSteps; ++Step) {
     TArray<FIntPoint> Directions = {FIntPoint(1, 0), FIntPoint(-1, 0),
                                     FIntPoint(0, 1), FIntPoint(0, -1)};
@@ -470,8 +490,7 @@ bool ASkaldAIController::TryMoveTowardsNearestEnemy(AFighterPawn *Fighter) {
     bool bMovedThisStep = false;
     for (const FIntPoint &Dir : Directions) {
       const FIntPoint Candidate = Current + Dir;
-      if (!Grid->IsCellInBounds(Candidate) || Grid->IsOccupied(Candidate) ||
-          Grid->IsObscured(Candidate)) {
+      if (!CanOccupyAnchor(Candidate)) {
         continue;
       }
 

--- a/Source/Skald/Skald_AIController.cpp
+++ b/Source/Skald/Skald_AIController.cpp
@@ -301,20 +301,14 @@ bool ASkaldAIController::IsMyTurn() const {
          (!bAttackerTurn && bAIControlsDefenderSide);
 }
 
-int32 ASkaldAIController::ComputeManhattanDistance(UGridOverlayComponent *Grid,
+int32 ASkaldAIController::ComputeManhattanDistance(UGridOverlayComponent * /*Grid*/,
                                                    const AFighterPawn *A,
                                                    const AFighterPawn *B) const {
-  if (!Grid || !A || !B) {
+  if (!A || !B) {
     return TNumericLimits<int32>::Max();
   }
 
-  const FIntPoint CellA = A->GetCurrentCell();
-  const FIntPoint CellB = B->GetCurrentCell();
-  if (!Grid->IsCellInBounds(CellA) || !Grid->IsCellInBounds(CellB)) {
-    return TNumericLimits<int32>::Max();
-  }
-
-  return FMath::Abs(CellA.X - CellB.X) + FMath::Abs(CellA.Y - CellB.Y);
+  return A->GetFootprintDistanceToFighter(B);
 }
 
 AFighterPawn *ASkaldAIController::FindNearestEnemy(AFighterPawn *Fighter) const {
@@ -407,19 +401,13 @@ bool ASkaldAIController::TryAttackNearestEnemy(AFighterPawn *Fighter) {
     return false;
   }
 
-  const FIntPoint SelfCell = Fighter->GetCurrentCell();
-  const FIntPoint TargetCell = Target->GetCurrentCell();
-  if (!Grid->IsCellInBounds(SelfCell) || !Grid->IsCellInBounds(TargetCell)) {
-    return false;
-  }
-
-  const int32 Distance = FMath::Abs(SelfCell.X - TargetCell.X) +
-                         FMath::Abs(SelfCell.Y - TargetCell.Y);
+  const int32 Distance = Fighter->GetFootprintDistanceToFighter(Target);
   if (Distance > Fighter->Stats.AttackRange) {
     return false;
   }
 
-  if (!Grid->HasLineOfSight(SelfCell, TargetCell)) {
+  if (Grid &&
+      !Fighter->HasLineOfSightToFighter(Target, Fighter->Stats.AttackRange, Grid)) {
     return false;
   }
 
@@ -449,9 +437,31 @@ bool ASkaldAIController::TryMoveTowardsNearestEnemy(AFighterPawn *Fighter) {
     return false;
   }
 
+  const TArray<FIntPoint> EnemyFootprint = Enemy->GetOccupiedCells();
+
+  auto ComputeDistanceFromAnchor = [&](const FIntPoint &Anchor) {
+    const TArray<FIntPoint> CandidateCells = Fighter->GetOccupiedCells(Anchor);
+    int32 BestDistance = TNumericLimits<int32>::Max();
+    for (const FIntPoint &SelfCell : CandidateCells) {
+      for (const FIntPoint &EnemyCellCoord : EnemyFootprint) {
+        const int32 Distance = FMath::Abs(SelfCell.X - EnemyCellCoord.X) +
+                               FMath::Abs(SelfCell.Y - EnemyCellCoord.Y);
+        if (Distance < BestDistance) {
+          BestDistance = Distance;
+          if (BestDistance == 0) {
+            break;
+          }
+        }
+      }
+      if (BestDistance == 0) {
+        break;
+      }
+    }
+    return BestDistance;
+  };
+
   FIntPoint Current = StartCell;
-  int32 CurrentDistance = FMath::Abs(EnemyCell.X - Current.X) +
-                          FMath::Abs(EnemyCell.Y - Current.Y);
+  int32 CurrentDistance = ComputeDistanceFromAnchor(Current);
 
   const int32 MaxSteps = Fighter->Stats.Movement;
 
@@ -478,12 +488,8 @@ bool ASkaldAIController::TryMoveTowardsNearestEnemy(AFighterPawn *Fighter) {
     TArray<FIntPoint> Directions = {FIntPoint(1, 0), FIntPoint(-1, 0),
                                     FIntPoint(0, 1), FIntPoint(0, -1)};
     Directions.Sort([&](const FIntPoint &A, const FIntPoint &B) {
-      const FIntPoint PosA = Current + A;
-      const FIntPoint PosB = Current + B;
-      const int32 DistA =
-          FMath::Abs(EnemyCell.X - PosA.X) + FMath::Abs(EnemyCell.Y - PosA.Y);
-      const int32 DistB =
-          FMath::Abs(EnemyCell.X - PosB.X) + FMath::Abs(EnemyCell.Y - PosB.Y);
+      const int32 DistA = ComputeDistanceFromAnchor(Current + A);
+      const int32 DistB = ComputeDistanceFromAnchor(Current + B);
       return DistA < DistB;
     });
 
@@ -494,8 +500,7 @@ bool ASkaldAIController::TryMoveTowardsNearestEnemy(AFighterPawn *Fighter) {
         continue;
       }
 
-      const int32 CandidateDistance = FMath::Abs(EnemyCell.X - Candidate.X) +
-                                      FMath::Abs(EnemyCell.Y - Candidate.Y);
+      const int32 CandidateDistance = ComputeDistanceFromAnchor(Candidate);
       if (CandidateDistance >= CurrentDistance) {
         continue;
       }

--- a/Source/Skald/Skald_PlayerController.cpp
+++ b/Source/Skald/Skald_PlayerController.cpp
@@ -761,7 +761,7 @@ AFighterPawn *ASkaldPlayerController::FindFighterAtCell(
   if (UWorld *World = GetWorld()) {
     for (TActorIterator<AFighterPawn> It(World); It; ++It) {
       AFighterPawn *Fighter = *It;
-      if (Fighter && Fighter->GetCurrentCell() == Cell) {
+      if (Fighter && Fighter->OccupiesCell(Cell)) {
         return Fighter;
       }
     }


### PR DESCRIPTION
## Summary
- add a replicated grid footprint setting to AFighterPawn so pawns can occupy one or four cells and auto-scale the display mesh
- update fighter movement, placement, destruction, and facing logic to align multi-cell pawns and maintain grid occupancy
- expand grid highlighting, player lookups, and AI pathing to respect larger fighter footprints when selecting, moving, and attacking

## Testing
- not run (Unreal project)


------
https://chatgpt.com/codex/tasks/task_e_68d9ec363d008324ae5ea63e5fb7fb4a