### PR TITLE
Fix automation test helper declarations

### DIFF
--- a/Source/Skald/Tests/BattleResolutionSyncTest.h
+++ b/Source/Skald/Tests/BattleResolutionSyncTest.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#if WITH_AUTOMATION_TESTS
 #include "CoreMinimal.h"
 #include "BattleResolutionSyncTest.generated.h"
 
@@ -13,6 +12,7 @@ class SKALD_API UWorldStateChangedListener : public UObject
     GENERATED_BODY()
 
 public:
+    /** Whether the delegate broadcast has been observed. */
     bool bBroadcasted = false;
 
     UFUNCTION()
@@ -21,6 +21,4 @@ public:
         bBroadcasted = true;
     }
 };
-
-#endif // WITH_AUTOMATION_TESTS
 

--- a/Source/Skald/Tests/DeploySelectionCachingTest.h
+++ b/Source/Skald/Tests/DeploySelectionCachingTest.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#if WITH_AUTOMATION_TESTS
 #include "CoreMinimal.h"
 #include "UI/SkaldMainHUDWidget.h"
 #include "DeploySelectionCachingTest.generated.h"
@@ -20,6 +19,4 @@ public:
 
     UDeployWidget* GetActiveDeployWidget() const { return ActiveDeployWidget; }
 };
-
-#endif // WITH_AUTOMATION_TESTS
 

--- a/Source/Skald/Tests/DeployUnitsReplicationTest.h
+++ b/Source/Skald/Tests/DeployUnitsReplicationTest.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#if WITH_AUTOMATION_TESTS
 #include "CoreMinimal.h"
 #include "Skald_PlayerController.h"
 #include "UI/SkaldMainHUDWidget.h"
@@ -8,19 +7,20 @@
 
 /** HUD widget capturing the last deployable units value for tests. */
 UCLASS()
-class UDeployTestHUDWidget : public USkaldMainHUDWidget {
+class SKALD_API UDeployTestHUDWidget : public USkaldMainHUDWidget {
     GENERATED_BODY()
+
 public:
     int32 LastUnits = -1;
+
     virtual void UpdateDeployableUnits(int32 UnitsRemaining) override { LastUnits = UnitsRemaining; }
 };
 
-#endif // WITH_AUTOMATION_TESTS
-
 /** Player controller with accessible HUD setter for tests. */
 UCLASS()
-class ADeployTestPlayerController : public ASkaldPlayerController {
+class SKALD_API ADeployTestPlayerController : public ASkaldPlayerController {
     GENERATED_BODY()
+
 public:
     void SetHUD(USkaldMainHUDWidget* InHUD) { MainHUD = InHUD; }
 };

--- a/Source/Skald/Tests/PlayerControllerValidationTest.cpp
+++ b/Source/Skald/Tests/PlayerControllerValidationTest.cpp
@@ -4,16 +4,6 @@
 #include "Misc/AutomationTest.h"
 #include "Tests/AutomationEditorCommon.h"
 
-void UTestHUDWidget::ShowErrorMessage(const FString& Message)
-{
-    LastError = Message;
-}
-
-void ATestPlayerController::SetHUD(USkaldMainHUDWidget* InHUD)
-{
-    MainHUD = InHUD;
-}
-
 IMPLEMENT_SIMPLE_AUTOMATION_TEST(FSkaldPlayerControllerValidationFeedbackTest,
                                  "Skald.PlayerController.ValidationFeedback",
                                  EAutomationTestFlags::EditorContext |

--- a/Source/Skald/Tests/PlayerControllerValidationTest.h
+++ b/Source/Skald/Tests/PlayerControllerValidationTest.h
@@ -1,27 +1,33 @@
 #pragma once
 
-#if WITH_AUTOMATION_TESTS
 #include "CoreMinimal.h"
 #include "Skald_PlayerController.h"
 #include "UI/SkaldMainHUDWidget.h"
 #include "PlayerControllerValidationTest.generated.h"
 
 UCLASS()
-class UTestHUDWidget : public USkaldMainHUDWidget
+class SKALD_API UTestHUDWidget : public USkaldMainHUDWidget
 {
     GENERATED_BODY()
+
 public:
     FString LastError;
-    virtual void ShowErrorMessage(const FString& Message) override;
+
+    virtual void ShowErrorMessage(const FString& Message) override
+    {
+        LastError = Message;
+    }
 };
 
 UCLASS()
-class ATestPlayerController : public ASkaldPlayerController
+class SKALD_API ATestPlayerController : public ASkaldPlayerController
 {
     GENERATED_BODY()
-public:
-    void SetHUD(USkaldMainHUDWidget* InHUD);
-};
 
-#endif // WITH_AUTOMATION_TESTS
+public:
+    void SetHUD(USkaldMainHUDWidget* InHUD)
+    {
+        MainHUD = InHUD;
+    }
+};
 

--- a/Source/Skald/Tests/TerritorySelectionTest.h
+++ b/Source/Skald/Tests/TerritorySelectionTest.h
@@ -1,21 +1,20 @@
 #pragma once
 
-#if WITH_AUTOMATION_TESTS
 #include "CoreMinimal.h"
 #include "Skald_PlayerController.h"
 #include "TerritorySelectionTest.generated.h"
 
 /** Player controller capturing server selection calls for tests. */
 UCLASS()
-class ATerritorySelectionTestPC : public ASkaldPlayerController {
+class SKALD_API ATerritorySelectionTestPC : public ASkaldPlayerController {
     GENERATED_BODY()
+
 public:
     bool bServerSelectCalled = false;
+
     virtual void ServerSelectTerritory_Implementation(int32 TerritoryID) override {
         bServerSelectCalled = true;
         Super::ServerSelectTerritory_Implementation(TerritoryID);
     }
 };
-
-#endif // WITH_AUTOMATION_TESTS
 


### PR DESCRIPTION
## Summary
- move automation test helper UCLASS declarations out of preprocessor guards so UHT can parse them
- export the helper classes and inline their trivial implementations to keep buildable in non-test configurations

## Testing
- not run (Unreal build not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68d9f78bec5883249e8f842db6ece676