### PR TITLE
Enable troop transfers during movement phase

### DIFF
--- a/Source/Skald/Skald_AIController.cpp
+++ b/Source/Skald/Skald_AIController.cpp
@@ -133,33 +133,75 @@ void ASkaldAIController::MakeAIDecision() {
                Phase == ETurnPhase::Treasure) {
       TurnManager->AdvancePhase();
     } else if (Phase == ETurnPhase::Movement) {
+      auto CountEnemyNeighbors = [PS](ATerritory *Territory) {
+        int32 Count = 0;
+        if (!Territory) {
+          return Count;
+        }
+        for (ATerritory *Neighbor : Territory->AdjacentTerritories) {
+          if (Neighbor && Neighbor->OwningPlayer != PS) {
+            ++Count;
+          }
+        }
+        return Count;
+      };
+
       ATerritory *BestSource = nullptr;
       ATerritory *BestTarget = nullptr;
-      int32 WeakestStrength = std::numeric_limits<int32>::max();
+      int32 BestSourcePressure = 0;
+      int32 BestTargetPressure = 0;
+      float BestScore = std::numeric_limits<float>::lowest();
 
       for (ATerritory *Source : WorldMap->Territories) {
         if (!Source || Source->OwningPlayer != PS || Source->ArmyUnits <= 1) {
           continue;
         }
 
+        const int32 SourcePressure = CountEnemyNeighbors(Source);
+
         for (ATerritory *Neighbor : Source->AdjacentTerritories) {
           if (!Neighbor || Neighbor->OwningPlayer != PS) {
             continue;
           }
 
-          if (Neighbor->ArmyUnits < WeakestStrength) {
+          const int32 TargetPressure = CountEnemyNeighbors(Neighbor);
+          const int32 PressureDiff = TargetPressure - SourcePressure;
+          const int32 SourceUnits = Source->ArmyUnits;
+          const int32 TargetUnits = Neighbor->ArmyUnits;
+
+          if (PressureDiff <= 0 && SourceUnits <= TargetUnits + 1) {
+            continue;
+          }
+
+          const int32 StrengthDiff = SourceUnits - TargetUnits;
+          const float Score = PressureDiff * 10.f + StrengthDiff;
+
+          if (Score > BestScore && Score > 0.f) {
+            BestScore = Score;
             BestSource = Source;
             BestTarget = Neighbor;
-            WeakestStrength = Neighbor->ArmyUnits;
+            BestSourcePressure = SourcePressure;
+            BestTargetPressure = TargetPressure;
           }
         }
       }
 
       if (BestSource && BestTarget) {
-        int32 TroopsToMove = BestSource->ArmyUnits / 2;
-        TroopsToMove = FMath::Clamp(TroopsToMove, 1, BestSource->ArmyUnits - 1);
-        HandleMoveRequested(BestSource->TerritoryID, BestTarget->TerritoryID,
-                            TroopsToMove);
+        const int32 SourceUnits = BestSource->ArmyUnits;
+        const int32 TargetUnits = BestTarget->ArmyUnits;
+        const int32 MaxMovable = SourceUnits - 1;
+        if (MaxMovable > 0) {
+          int32 Surplus = SourceUnits - TargetUnits;
+          Surplus = FMath::Max(Surplus, 0);
+          int32 TroopsToMove = FMath::Clamp(Surplus / 2, 1, MaxMovable);
+          if (BestTargetPressure > BestSourcePressure) {
+            const int32 PressureGap = BestTargetPressure - BestSourcePressure;
+            TroopsToMove = FMath::Clamp(FMath::Max(TroopsToMove, PressureGap), 1,
+                                        MaxMovable);
+          }
+          HandleMoveRequested(BestSource->TerritoryID, BestTarget->TerritoryID,
+                              TroopsToMove);
+        }
       }
 
       TurnManager->AdvancePhase();

--- a/Source/Skald/Skald_PlayerController.cpp
+++ b/Source/Skald/Skald_PlayerController.cpp
@@ -1155,13 +1155,24 @@ void ASkaldPlayerController::HandleMoveRequested(int32 FromID, int32 ToID,
     return;
   }
 
-  TArray<ATerritory *> Path;
-  if (!WorldMap->FindPath(Source, Target, Path)) {
-    NotifyActionError(TEXT("No valid path for movement"));
+  ASkaldPlayerState *PS = GetPlayerState<ASkaldPlayerState>();
+  if (!PS) {
+    NotifyActionError(TEXT("Missing player state"));
     return;
   }
 
-  if (Troops <= 0 || Troops >= Source->ArmyUnits) {
+  if (Source->OwningPlayer != PS || Target->OwningPlayer != PS) {
+    NotifyActionError(TEXT("You may only move between your territories"));
+    return;
+  }
+
+  if (!Source->IsAdjacentTo(Target)) {
+    NotifyActionError(TEXT("Territories must be adjacent"));
+    return;
+  }
+
+  const int32 MaxMovable = Source->ArmyUnits - 1;
+  if (Troops <= 0 || Troops > MaxMovable) {
     NotifyActionError(TEXT("Invalid troop count for movement"));
     return;
   }

--- a/Source/Skald/UI/DeployWidget.cpp
+++ b/Source/Skald/UI/DeployWidget.cpp
@@ -27,11 +27,31 @@ void UDeployWidget::NativeConstruct() {
   }
 }
 
-void UDeployWidget::Setup(ATerritory *InTerritory, ASkaldPlayerState *InPlayerState,
-                           USkaldMainHUDWidget *InHUD, int32 MaxAmount) {
-  Territory = InTerritory;
+void UDeployWidget::SetupDeployment(ATerritory *InTerritory,
+                                    ASkaldPlayerState *InPlayerState,
+                                    USkaldMainHUDWidget *InHUD,
+                                    int32 MaxAmount) {
+  SourceTerritory = InTerritory;
+  TargetTerritory = InTerritory;
   PlayerState = InPlayerState;
   OwningHUD = InHUD;
+  Mode = EDeployWidgetMode::Deployment;
+  MaxSelectableAmount = MaxAmount;
+  if (AmountSelector) {
+    AmountSelector->SetMaxValue(MaxAmount);
+    AmountSelector->SetValue(FMath::Clamp(1, 1, MaxAmount));
+  }
+}
+
+void UDeployWidget::SetupTransfer(ATerritory *InSource, ATerritory *InTarget,
+                                  USkaldMainHUDWidget *InHUD,
+                                  int32 MaxAmount) {
+  SourceTerritory = InSource;
+  TargetTerritory = InTarget;
+  PlayerState = nullptr;
+  OwningHUD = InHUD;
+  Mode = EDeployWidgetMode::Transfer;
+  MaxSelectableAmount = MaxAmount;
   if (AmountSelector) {
     AmountSelector->SetMaxValue(MaxAmount);
     AmountSelector->SetValue(FMath::Clamp(1, 1, MaxAmount));
@@ -39,7 +59,7 @@ void UDeployWidget::Setup(ATerritory *InTerritory, ASkaldPlayerState *InPlayerSt
 }
 
 void UDeployWidget::HandleAccept() {
-  if (!Territory || !PlayerState || !OwningHUD.IsValid()) {
+  if (!SourceTerritory || !OwningHUD.IsValid()) {
     if (OwningHUD.IsValid()) {
       OwningHUD->ClearDeployWidget();
     } else if (IsInViewport()) {
@@ -48,25 +68,43 @@ void UDeployWidget::HandleAccept() {
     return;
   }
 
+  const int32 MaxAllowed = MaxSelectableAmount > 0 ? MaxSelectableAmount : 0;
   const int32 Selected = AmountSelector
                               ? FMath::Clamp(FMath::RoundToInt(AmountSelector->GetValue()), 0,
-                                             PlayerState->DeployableUnits)
+                                             MaxAllowed)
                               : 0;
+
   if (Selected > 0) {
-    ATurnManager *TurnManager = nullptr;
-    if (APlayerController *PC = OwningHUD->GetOwningPlayer()) {
-      if (ASkaldPlayerController *SKPC = Cast<ASkaldPlayerController>(PC)) {
-        SKPC->ServerDeployUnits(Territory->TerritoryID, Selected);
-        TurnManager = SKPC->GetTurnManager();
-        if (TurnManager) {
-          TurnManager->BroadcastDeployableUnits(PlayerState);
+    if (Mode == EDeployWidgetMode::Deployment) {
+      if (!PlayerState) {
+        if (OwningHUD.IsValid()) {
+          OwningHUD->ClearDeployWidget();
+        } else if (IsInViewport()) {
+          RemoveFromParent();
+        }
+        return;
+      }
+
+      ATurnManager *TurnManager = nullptr;
+      if (APlayerController *PC = OwningHUD->GetOwningPlayer()) {
+        if (ASkaldPlayerController *SKPC = Cast<ASkaldPlayerController>(PC)) {
+          SKPC->ServerDeployUnits(SourceTerritory->TerritoryID, Selected);
+          TurnManager = SKPC->GetTurnManager();
+          if (TurnManager) {
+            TurnManager->BroadcastDeployableUnits(PlayerState);
+          }
         }
       }
-    }
 
-    const int32 Remaining = PlayerState->DeployableUnits - Selected;
-    if (Remaining <= 0 && OwningHUD->DeployButton) {
-      OwningHUD->DeployButton->SetVisibility(ESlateVisibility::Collapsed);
+      const int32 Remaining = PlayerState->DeployableUnits - Selected;
+      if (Remaining <= 0 && OwningHUD->DeployButton) {
+        OwningHUD->DeployButton->SetVisibility(ESlateVisibility::Collapsed);
+      }
+    } else if (Mode == EDeployWidgetMode::Transfer) {
+      if (OwningHUD.IsValid() && TargetTerritory) {
+        OwningHUD->SubmitMove(SourceTerritory->TerritoryID,
+                              TargetTerritory->TerritoryID, Selected);
+      }
     }
   }
 
@@ -79,6 +117,9 @@ void UDeployWidget::HandleAccept() {
 
 void UDeployWidget::HandleDecline() {
   if (OwningHUD.IsValid()) {
+    if (Mode == EDeployWidgetMode::Transfer) {
+      OwningHUD->CancelMoveSelection();
+    }
     OwningHUD->ClearDeployWidget();
   } else if (IsInViewport()) {
     RemoveFromParent();

--- a/Source/Skald/UI/DeployWidget.h
+++ b/Source/Skald/UI/DeployWidget.h
@@ -10,9 +10,9 @@ class ASkaldPlayerState;
 class USkaldMainHUDWidget;
 
 /**
- * Simple widget allowing the player to choose how many units to deploy to a
- * territory.
-*/
+ * Simple widget allowing the player to choose how many units to deploy or
+ * transfer between territories.
+ */
 UCLASS(BlueprintType, Blueprintable)
 class SKALD_API UDeployWidget : public UUserWidget {
   GENERATED_BODY()
@@ -20,10 +20,15 @@ class SKALD_API UDeployWidget : public UUserWidget {
 public:
   virtual void NativeConstruct() override;
 
-  /** Configure the widget for the given territory and player state. */
+  /** Configure the widget for deploying reinforcements to a territory. */
   UFUNCTION(BlueprintCallable, Category = "Skald|Deploy")
-  void Setup(ATerritory *InTerritory, ASkaldPlayerState *InPlayerState,
-             USkaldMainHUDWidget *InHUD, int32 MaxAmount);
+  void SetupDeployment(ATerritory *InTerritory, ASkaldPlayerState *InPlayerState,
+                       USkaldMainHUDWidget *InHUD, int32 MaxAmount);
+
+  /** Configure the widget for transferring troops between territories. */
+  UFUNCTION(BlueprintCallable, Category = "Skald|Deploy")
+  void SetupTransfer(ATerritory *InSource, ATerritory *InTarget,
+                     USkaldMainHUDWidget *InHUD, int32 MaxAmount);
 
   UPROPERTY(BlueprintReadOnly, meta = (BindWidget))
   USpinBox *AmountSelector;
@@ -41,13 +46,22 @@ private:
   UFUNCTION(BlueprintCallable, Category = "Skald|Deploy")
   void HandleDecline();
 
-  UPROPERTY()
-  ATerritory *Territory;
+  enum class EDeployWidgetMode : uint8 { Deployment, Transfer };
 
   UPROPERTY()
-  ASkaldPlayerState *PlayerState;
+  ATerritory *SourceTerritory = nullptr;
+
+  UPROPERTY()
+  ATerritory *TargetTerritory = nullptr;
+
+  UPROPERTY()
+  ASkaldPlayerState *PlayerState = nullptr;
 
   UPROPERTY()
   TWeakObjectPtr<USkaldMainHUDWidget> OwningHUD;
+
+  EDeployWidgetMode Mode = EDeployWidgetMode::Deployment;
+
+  int32 MaxSelectableAmount = 0;
 };
 

--- a/Source/Skald/UI/SkaldMainHUDWidget.cpp
+++ b/Source/Skald/UI/SkaldMainHUDWidget.cpp
@@ -385,11 +385,20 @@ void USkaldMainHUDWidget::ShowErrorMessage(const FString &Message) {
   BP_ShowErrorMessage(Message);
 }
 
-void USkaldMainHUDWidget::BeginAttackSelection() {
-  bSelectingForAttack = true;
-  bSelectingForMove = false;
-  SelectedSourceID = -1;
-  SelectedTargetID = -1;
+void USkaldMainHUDWidget::ClearTerritoryHighlights() {
+  if (AWorldMap *WorldMap = Cast<AWorldMap>(UGameplayStatics::GetActorOfClass(
+          GetWorld(), AWorldMap::StaticClass()))) {
+    if (SelectedSourceID != -1) {
+      if (ATerritory *Source = WorldMap->GetTerritoryById(SelectedSourceID)) {
+        Source->Deselect();
+      }
+    }
+    if (SelectedTargetID != -1) {
+      if (ATerritory *Target = WorldMap->GetTerritoryById(SelectedTargetID)) {
+        Target->Deselect();
+      }
+    }
+  }
 
   for (ATerritory *Terr : HighlightedTerritories) {
     if (Terr) {
@@ -397,6 +406,30 @@ void USkaldMainHUDWidget::BeginAttackSelection() {
     }
   }
   HighlightedTerritories.Empty();
+}
+
+void USkaldMainHUDWidget::ShowSelectionPromptMessage(const FString &Message,
+                                                     bool bShow) {
+  if (!SelectionPrompt) {
+    return;
+  }
+
+  SelectionPrompt->SetText(FText::FromString(Message));
+  SelectionPrompt->SetVisibility(bShow ? ESlateVisibility::Visible
+                                       : ESlateVisibility::Collapsed);
+}
+
+void USkaldMainHUDWidget::ShowSelectionErrorMessage(const FString &Message) {
+  ShowSelectionPromptMessage(Message);
+  ShowErrorMessage(Message);
+}
+
+void USkaldMainHUDWidget::BeginAttackSelection() {
+  ClearTerritoryHighlights();
+  bSelectingForAttack = true;
+  bSelectingForMove = false;
+  SelectedSourceID = -1;
+  SelectedTargetID = -1;
 
   if (ActiveConfirmWidget) {
     ActiveConfirmWidget->RemoveFromParent();
@@ -417,55 +450,39 @@ void USkaldMainHUDWidget::SubmitAttack(int32 FromID, int32 ToID, int32 ArmySent,
 }
 
 void USkaldMainHUDWidget::CancelAttackSelection() {
-  if (AWorldMap *WorldMap = Cast<AWorldMap>(UGameplayStatics::GetActorOfClass(
-          GetWorld(), AWorldMap::StaticClass()))) {
-    if (SelectedSourceID != -1) {
-      if (ATerritory *Source = WorldMap->GetTerritoryById(SelectedSourceID)) {
-        Source->Deselect();
-      }
-    }
-    if (SelectedTargetID != -1) {
-      if (ATerritory *Target = WorldMap->GetTerritoryById(SelectedTargetID)) {
-        Target->Deselect();
-      }
-    }
-    for (ATerritory *Terr : HighlightedTerritories) {
-      if (Terr) {
-        Terr->Deselect();
-      }
-    }
-  }
-  HighlightedTerritories.Empty();
+  ClearTerritoryHighlights();
   if (ActiveConfirmWidget) {
     ActiveConfirmWidget->RemoveFromParent();
     ActiveConfirmWidget = nullptr;
   }
-  if (SelectionPrompt) {
-    SelectionPrompt->SetVisibility(ESlateVisibility::Visible);
-  }
+  ShowSelectionPromptMessage(TEXT("Choose owned territory."));
   bSelectingForAttack = false;
   SelectedSourceID = -1;
   SelectedTargetID = -1;
 }
 
 void USkaldMainHUDWidget::BeginMoveSelection() {
+  ClearTerritoryHighlights();
   bSelectingForMove = true;
   bSelectingForAttack = false;
   SelectedSourceID = -1;
   SelectedTargetID = -1;
+  ShowSelectionPromptMessage(TEXT("Select a territory to move troops from."));
 }
 
 void USkaldMainHUDWidget::SubmitMove(int32 FromID, int32 ToID, int32 Troops) {
   OnMoveRequested.Broadcast(FromID, ToID, Troops);
-  bSelectingForMove = false;
-  SelectedSourceID = -1;
-  SelectedTargetID = -1;
+  CancelMoveSelection();
+  ShowSelectionPromptMessage(
+      TEXT("Troops moved. Use End Phase to finish movement."));
 }
 
 void USkaldMainHUDWidget::CancelMoveSelection() {
+  ClearTerritoryHighlights();
   bSelectingForMove = false;
   SelectedSourceID = -1;
   SelectedTargetID = -1;
+  ShowSelectionPromptMessage(TEXT(""), false);
 }
 
 void USkaldMainHUDWidget::OnTerritoryClickedUI(ATerritory *Territory) {
@@ -576,15 +593,106 @@ void USkaldMainHUDWidget::OnTerritoryClickedUI(ATerritory *Territory) {
     }
     return;
   } else if (bSelectingForMove) {
-    if (SelectedSourceID == -1) {
-      if (bOwnedByLocal) {
-        SelectedSourceID = Territory->TerritoryID;
-      }
-    } else if (SelectedTargetID == -1) {
-      if (bOwnedByLocal) {
-        SelectedTargetID = Territory->TerritoryID;
-      }
+    if (!bOwnedByLocal) {
+      ShowSelectionErrorMessage(
+          TEXT("You may only move between your own territories."));
+      return;
     }
+
+    if (SelectedSourceID == -1 || Territory->TerritoryID == SelectedSourceID) {
+      if (Territory->ArmyUnits <= 1) {
+        ShowSelectionErrorMessage(
+            TEXT("Need more than one unit to move troops."));
+        return;
+      }
+
+      ClearTerritoryHighlights();
+      SelectedSourceID = Territory->TerritoryID;
+      SelectedTargetID = -1;
+      Territory->Select();
+
+      HighlightedTerritories.Empty();
+      for (ATerritory *Neighbor : Territory->AdjacentTerritories) {
+        if (Neighbor && Neighbor->OwningPlayer == Territory->OwningPlayer) {
+          Neighbor->Select();
+          HighlightedTerritories.Add(Neighbor);
+        }
+      }
+
+      if (HighlightedTerritories.Num() == 0) {
+        ShowSelectionErrorMessage(
+            TEXT("No adjacent friendly territory to move into."));
+        SelectedSourceID = -1;
+        Territory->Deselect();
+        return;
+      }
+
+      ShowSelectionPromptMessage(
+          TEXT("Select an adjacent territory to receive troops."));
+      return;
+    }
+
+    const bool bIsHighlighted = HighlightedTerritories.ContainsByPredicate(
+        [Territory](ATerritory *T) {
+          return T && T->TerritoryID == Territory->TerritoryID;
+        });
+
+    if (!bIsHighlighted) {
+      ShowSelectionErrorMessage(TEXT("Target not valid for movement."));
+      return;
+    }
+
+    SelectedTargetID = Territory->TerritoryID;
+
+    AWorldMap *WorldMap = Cast<AWorldMap>(UGameplayStatics::GetActorOfClass(
+        GetWorld(), AWorldMap::StaticClass()));
+    if (!WorldMap) {
+      ShowSelectionErrorMessage(TEXT("World map not found."));
+      CancelMoveSelection();
+      return;
+    }
+
+    ATerritory *Source = WorldMap->GetTerritoryById(SelectedSourceID);
+    ATerritory *Target = WorldMap->GetTerritoryById(SelectedTargetID);
+    if (!Source || !Target) {
+      ShowSelectionErrorMessage(TEXT("Invalid territory selection."));
+      CancelMoveSelection();
+      return;
+    }
+
+    const int32 MaxMovable = Source->ArmyUnits - 1;
+    if (MaxMovable <= 0) {
+      ShowSelectionErrorMessage(TEXT("No troops available to move."));
+      CancelMoveSelection();
+      return;
+    }
+
+    if (!DeployWidgetClass) {
+      ShowSelectionErrorMessage(TEXT("Deploy widget unavailable."));
+      CancelMoveSelection();
+      return;
+    }
+
+    if (ActiveDeployWidget && ActiveDeployWidget->IsInViewport()) {
+      ActiveDeployWidget->RemoveFromParent();
+      ActiveDeployWidget = nullptr;
+    }
+
+    ActiveDeployWidget =
+        CreateWidget<UDeployWidget>(GetWorld(), DeployWidgetClass);
+    if (!ActiveDeployWidget) {
+      ShowSelectionErrorMessage(TEXT("Could not open deploy UI."));
+      CancelMoveSelection();
+      return;
+    }
+
+    ActiveDeployWidget->SetupTransfer(Source, Target, this, MaxMovable);
+    ActiveDeployWidget->AddToViewport();
+    if (APlayerController *FocusPC = GetOwningPlayer()) {
+      FocusWidgetUIOnly(FocusPC, ActiveDeployWidget);
+    }
+
+    ShowSelectionPromptMessage(TEXT("Choose how many troops to move."));
   } else if (CurrentPhase == ETurnPhase::Reinforcement ||
              CurrentPhase == ETurnPhase::ArmyPlacement) {
     SelectedSourceID = Territory->TerritoryID;
@@ -882,7 +990,8 @@ void USkaldMainHUDWidget::HandleDeployClicked() {
   ActiveDeployWidget =
       CreateWidget<UDeployWidget>(GetWorld(), DeployWidgetClass);
   if (ActiveDeployWidget) {
-    ActiveDeployWidget->Setup(Territory, PS, this, PS->DeployableUnits);
+    ActiveDeployWidget->SetupDeployment(Territory, PS, this,
+                                        PS->DeployableUnits);
     ActiveDeployWidget->AddToViewport();
     if (APlayerController *FocusPC = GetOwningPlayer()) {
       FocusWidgetUIOnly(FocusPC, ActiveDeployWidget);

--- a/Source/Skald/UI/SkaldMainHUDWidget.h
+++ b/Source/Skald/UI/SkaldMainHUDWidget.h
@@ -328,6 +328,11 @@ protected:
   UPROPERTY()
   TArray<ATerritory *> HighlightedTerritories;
 
+  void ClearTerritoryHighlights();
+  void ShowSelectionPromptMessage(const FString &Message,
+                                  bool bShow = true);
+  void ShowSelectionErrorMessage(const FString &Message);
+
   virtual void NativeConstruct() override;
   virtual void NativeDestruct() override;
 


### PR DESCRIPTION
## Summary
- enable movement phase UI flow to select owned source and adjacent destination territories, prompting troop transfers through the deploy widget
- extend the deploy widget to support transfer mode and validate moves on the player controller
- refine AI movement logic to reinforce threatened holdings before ending the phase

## Testing
- not run (Unreal Engine project, tests unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68d9f9be6bf4832497adf79e02b8e8af