### PR TITLE
Restore multi-hop movement validation

### DIFF
--- a/Source/Skald/Skald_PlayerController.cpp
+++ b/Source/Skald/Skald_PlayerController.cpp
@@ -1166,14 +1166,16 @@ void ASkaldPlayerController::HandleMoveRequested(int32 FromID, int32 ToID,
     return;
   }
 
-  if (!Source->IsAdjacentTo(Target)) {
-    NotifyActionError(TEXT("Territories must be adjacent"));
-    return;
-  }
-
   const int32 MaxMovable = Source->ArmyUnits - 1;
   if (Troops <= 0 || Troops > MaxMovable) {
     NotifyActionError(TEXT("Invalid troop count for movement"));
+    return;
+  }
+
+  TArray<ATerritory *> Path;
+  if (!WorldMap->FindPath(Source, Target, Path) || Path.Num() < 2) {
+    NotifyActionError(
+        TEXT("Selected territories must be connected by a friendly path"));
     return;
   }
 


### PR DESCRIPTION
## Summary
- allow HandleMoveRequested to validate moves using the existing friendly path search instead of adjacency only
- surface a clear error when no owned path exists so multi-hop redeployment is permitted again

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d9ff65d93c8324bb486d7788394daf