### PR TITLE
Prevent AI from reactivating already-active fighters

### DIFF
--- a/Source/Skald/GridBattleManager.cpp
+++ b/Source/Skald/GridBattleManager.cpp
@@ -386,8 +386,15 @@ bool UGridBattleManager::CanActivateFighter(AFighterPawn* Fighter) const
         return false;
     }
 
-    if (ActiveFighter && ActiveFighter != Fighter)
+    if (ActiveFighter)
     {
+        if (ActiveFighter == Fighter)
+        {
+            UE_LOG(LogSkaldBattle, Verbose, TEXT("[Battle] CanActivateFighter rejected (Fighter already active) -> %s"),
+                *DescribeFighter(Fighter));
+            return false;
+        }
+
         UE_LOG(LogSkaldBattle, Verbose, TEXT("[Battle] CanActivateFighter rejected (Another active fighter %s)"),
             *DescribeFighter(ActiveFighter));
         return false;

--- a/Source/Skald/Skald_AIController.cpp
+++ b/Source/Skald/Skald_AIController.cpp
@@ -616,6 +616,14 @@ void ASkaldAIController::TryActivateNextFighter() {
   }
 
   if (!CachedBattleManager->CanActivateFighter(NextFighter)) {
+    const FString FighterName = NextFighter
+                                    ? NextFighter->GetHumanReadableName()
+                                    : FString(TEXT("<None>"));
+    UE_LOG(LogSkaldBattle, Verbose,
+           TEXT("[AI] Skipping activation for %s; advancing turn."),
+           FighterName.IsEmpty() ? TEXT("<Unnamed Fighter>")
+                                 : *FighterName);
+    CachedBattleManager->AdvanceTurn();
     return;
   }
 


### PR DESCRIPTION
## Summary
- stop the battle manager from allowing the same fighter to be activated multiple times concurrently
- teach the AI controller to advance the turn when its chosen fighter cannot be activated

## Testing
- not run (not available in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68da18e9b1b48324bc5c6b6220403a24