### PR TITLE
Prevent battle returns from resetting to army placement

### DIFF
--- a/Source/Skald/Skald_GameMode.cpp
+++ b/Source/Skald/Skald_GameMode.cpp
@@ -704,6 +704,14 @@ void ASkaldGameMode::TryInitializeWorldAndStart() {
   }
 
   USkaldGameInstance *GI = GetGameInstance<USkaldGameInstance>();
+  if (GI && (GI->bResumeTurns || GI->SavedTurnIndex != 0 ||
+             GI->SavedTurnPhase != ETurnPhase::Reinforcement)) {
+    bWorldInitialized = true;
+    bTurnsStarted = true;
+    GetWorldTimerManager().ClearTimer(RetryInitTimerHandle);
+    return;
+  }
+
   if (GI && !GI->bIsMultiplayer) {
     TArray<ASkaldPlayerState *> AutoLockPlayers;
     for (APlayerState *PSBase : GS->PlayerArray) {

--- a/Source/Skald/Skald_TurnManager.cpp
+++ b/Source/Skald/Skald_TurnManager.cpp
@@ -189,7 +189,7 @@ void ATurnManager::RegisterController(ASkaldPlayerController *Controller) {
 void ATurnManager::StartArmyPlacementPhase() {
   if (const UWorld *W = GetWorld()) {
     if (const auto *GI = W->GetGameInstance<USkaldGameInstance>()) {
-      if (GI->bTravelPending) {
+      if (GI->bTravelPending || GI->bResumeTurns) {
         return;
       }
     }


### PR DESCRIPTION
## Summary
- stop the turn manager from re-entering the army placement phase when travel or turn resumption is pending
- treat resumed turn data as an initialized game so the game mode skips re-running start-of-match logic

## Testing
- not run (Unreal Engine project)


------
https://chatgpt.com/codex/tasks/task_e_68da1c72e53483249a8af49bd1a0bc61