### PR TITLE
Fix TryInitializeWorldAndStart resume guard

### DIFF
--- a/Source/Skald/Skald_GameMode.cpp
+++ b/Source/Skald/Skald_GameMode.cpp
@@ -704,12 +704,19 @@ void ASkaldGameMode::TryInitializeWorldAndStart() {
   }
 
   USkaldGameInstance *GI = GetGameInstance<USkaldGameInstance>();
-  if (GI && (GI->bResumeTurns || GI->SavedTurnIndex != 0 ||
-             GI->SavedTurnPhase != ETurnPhase::Reinforcement)) {
-    bWorldInitialized = true;
-    bTurnsStarted = true;
-    GetWorldTimerManager().ClearTimer(RetryInitTimerHandle);
-    return;
+  if (GI) {
+    if (GI->bResumeTurns) {
+      bWorldInitialized = true;
+      bTurnsStarted = true;
+      GetWorldTimerManager().ClearTimer(RetryInitTimerHandle);
+      return;
+    }
+
+    if (GI->SavedTurnIndex != 0 ||
+        GI->SavedTurnPhase != ETurnPhase::Reinforcement) {
+      GI->SavedTurnIndex = 0;
+      GI->SavedTurnPhase = ETurnPhase::Reinforcement;
+    }
   }
 
   if (GI && !GI->bIsMultiplayer) {


### PR DESCRIPTION
## Summary
- require an explicit resume request before skipping world initialization
- clear stale saved turn indices and phases when launching a fresh match

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68da8eb90cc8832488136ba7c964117e