### PR TITLE
Refresh fighter actions when new rounds begin

### DIFF
--- a/Source/Skald/FighterPawn.cpp
+++ b/Source/Skald/FighterPawn.cpp
@@ -167,7 +167,7 @@ void AFighterPawn::BeginActivation() {
 }
 
 void AFighterPawn::ResetActivationState() {
-  ActionsRemaining = 0;
+  ActionsRemaining = ActionsPerActivation;
   bHasActivatedThisRound = false;
   bIsCurrentlyActive = false;
 


### PR DESCRIPTION
## Summary
- ensure fighters restore their full action pool when a new battle round starts so HUD updates immediately

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68da94e942648324a2886b7a393a8e39