### PR TITLE
Fix battle activation logging and skip invalid adjacency

### DIFF
--- a/Source/Skald/GridBattleManager.cpp
+++ b/Source/Skald/GridBattleManager.cpp
@@ -427,14 +427,15 @@ bool UGridBattleManager::ActivateFighter(AFighterPawn* Fighter)
 
     ActiveFighter = Fighter;
     CurrentTurn = InitiativeOrder.IndexOfByKey(Fighter);
-    if (ActiveFighter)
+    AFighterPawn* const ActivatedFighter = ActiveFighter;
+    if (ActivatedFighter)
     {
-        ActiveFighter->BeginActivation();
+        ActivatedFighter->BeginActivation();
     }
-    OnActiveFighterChanged.Broadcast(ActiveFighter);
+    OnActiveFighterChanged.Broadcast(ActivatedFighter);
     UE_LOG(LogSkaldBattle, Log, TEXT("[Battle] Fighter activated: %s (Round=%d, TurnIndex=%d, AttackerTurn=%s)"),
-        *DescribeFighter(ActiveFighter), CurrentRound, CurrentTurn, bIsAttackerTurn ? TEXT("true") : TEXT("false"));
-    return ActiveFighter != nullptr;
+        *DescribeFighter(ActivatedFighter), CurrentRound, CurrentTurn, bIsAttackerTurn ? TEXT("true") : TEXT("false"));
+    return ActivatedFighter != nullptr;
 }
 
 void UGridBattleManager::FinishActivation(AFighterPawn* Fighter, EGridActivationFinishReason Reason)

--- a/Source/Skald/GridBattleManager.cpp
+++ b/Source/Skald/GridBattleManager.cpp
@@ -432,7 +432,7 @@ bool UGridBattleManager::ActivateFighter(AFighterPawn* Fighter)
     {
         ActivatedFighter->BeginActivation();
     }
-    OnActiveFighterChanged.Broadcast(ActivatedFighter);
+    OnActiveFighterChanged.Broadcast(ActiveFighter);
     UE_LOG(LogSkaldBattle, Log, TEXT("[Battle] Fighter activated: %s (Round=%d, TurnIndex=%d, AttackerTurn=%s)"),
         *DescribeFighter(ActivatedFighter), CurrentRound, CurrentTurn, bIsAttackerTurn ? TEXT("true") : TEXT("false"));
     return ActivatedFighter != nullptr;

--- a/Source/Skald/WorldMap.cpp
+++ b/Source/Skald/WorldMap.cpp
@@ -195,6 +195,10 @@ bool AWorldMap::GenerateTerritoriesFromTable() {
     }
 
     for (int32 NeighborId : SpawnData->AdjacentTerritoryIDs) {
+      if (NeighborId <= 0) {
+        continue;
+      }
+
       if (ATerritory *const *NeighborPtr = TerritoriesById.Find(NeighborId)) {
         ATerritory *Neighbor = *NeighborPtr;
         AddAdjacency(Territory, Neighbor);


### PR DESCRIPTION
## Summary
- preserve the fighter pointer while broadcasting activation events so instant AI finishes do not clear the log output or return value
- ignore non-positive territory IDs when applying table-authored adjacency to avoid warnings from placeholder entries

## Testing
- not run (not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68da9ff35fe08324aff30376e38f9e35