### PR TITLE
Refine AI battle activation pacing

### DIFF
--- a/Source/Skald/FighterPawn.cpp
+++ b/Source/Skald/FighterPawn.cpp
@@ -725,6 +725,8 @@ void AFighterPawn::FinalizeQueuedAttack() {
   PendingAttackTarget = nullptr;
   bPendingAttackTargetDied = false;
   bHasProcessedPendingRoll = false;
+
+  OnQueuedAttackFinalized.Broadcast();
 }
 
 void AFighterPawn::UpdateMeshOffset() {

--- a/Source/Skald/FighterPawn.h
+++ b/Source/Skald/FighterPawn.h
@@ -20,6 +20,7 @@ enum class EFighterPawnFootprint : uint8 {
 DECLARE_DYNAMIC_MULTICAST_DELEGATE_OneParam(FOnHealthChanged, int32, NewHealth);
 DECLARE_DYNAMIC_MULTICAST_DELEGATE_OneParam(FOnActionsChanged, int32,
                                             NewActionsRemaining);
+DECLARE_MULTICAST_DELEGATE(FOnQueuedAttackFinalized);
 
 /** Pawn representing a fighter in grid battles. */
 UCLASS()
@@ -64,6 +65,9 @@ public:
   /** Perform an attack against another fighter. */
   UFUNCTION(BlueprintCallable, Category = "Fighter")
   void PerformAttack(AFighterPawn *Target);
+
+  /** Event fired after any queued attack finishes resolving. */
+  FOnQueuedAttackFinalized OnQueuedAttackFinalized;
 
   /** Check whether this fighter is still alive. */
   UFUNCTION(BlueprintCallable, BlueprintPure, Category = "Fighter")

--- a/Source/Skald/Skald_AIController.cpp
+++ b/Source/Skald/Skald_AIController.cpp
@@ -392,7 +392,7 @@ void ASkaldAIController::SetupBattleAutomation() {
       this, &ASkaldAIController::HandleBattleEnded);
 
   DetermineControlledBattleSide();
-  TryActivateNextFighter();
+  ScheduleTryActivateNextFighter();
 }
 
 void ASkaldAIController::TeardownBattleAutomation() {
@@ -680,34 +680,175 @@ bool ASkaldAIController::TryMoveTowardsNearestEnemy(AFighterPawn *Fighter) {
   return Fighter->ActionsRemaining < ActionsBefore;
 }
 
-void ASkaldAIController::ExecuteActivationForFighter(AFighterPawn *Fighter) {
-  if (!Fighter || !CachedBattleManager.IsValid()) {
+void ASkaldAIController::QueueActivationIntent(
+    AFighterPawn *Fighter, EAIBattleActivationIntent Intent) {
+  if (!Fighter) {
     return;
   }
 
-  int32 SafetyCounter = 0;
-  while (Fighter->IsAlive() && Fighter->bIsCurrentlyActive &&
-         Fighter->ActionsRemaining > 0 && SafetyCounter < 8) {
-    bool bActionTaken = false;
-    if (TryAttackNearestEnemy(Fighter)) {
-      bActionTaken = true;
-    } else if (TryMoveTowardsNearestEnemy(Fighter)) {
-      bActionTaken = true;
-    }
-
-    if (!bActionTaken) {
-      break;
-    }
-
-    ++SafetyCounter;
+  if (PendingActivationFighter != Fighter) {
+    PendingActivationFighter = Fighter;
   }
 
-  if (CachedBattleManager.IsValid()) {
-    CachedBattleManager->FinishActivation(Fighter, EGridActivationFinishReason::Auto);
+  PendingActivationIntents.Enqueue(Intent);
+}
+
+bool ASkaldAIController::ShouldContinueActivation(
+    const AFighterPawn *Fighter) const {
+  return Fighter && Fighter->IsAlive() && Fighter->bIsCurrentlyActive &&
+         Fighter->ActionsRemaining > 0 && ActivationIntentIterationCount < 8;
+}
+
+void ASkaldAIController::ScheduleNextActivationAttempt() {
+  if (UWorld *World = GetWorld()) {
+    World->GetTimerManager().ClearTimer(FighterActionTimerHandle);
+    World->GetTimerManager().SetTimer(
+        FighterActionTimerHandle, this,
+        &ASkaldAIController::ProcessQueuedActivationIntent, BattleActionDelay,
+        false);
   }
 }
 
+void ASkaldAIController::ProcessQueuedActivationIntent() {
+  if (bAwaitingQueuedAttackResolution) {
+    return;
+  }
+
+  AFighterPawn *Fighter = PendingActivationFighter.Get();
+  if (!ShouldContinueActivation(Fighter)) {
+    CompleteFighterActivation();
+    return;
+  }
+
+  EAIBattleActivationIntent Intent;
+  if (!PendingActivationIntents.Dequeue(Intent)) {
+    QueueActivationIntent(Fighter, EAIBattleActivationIntent::Attack);
+    if (!PendingActivationIntents.Dequeue(Intent)) {
+      return;
+    }
+  }
+
+  bool bActionTaken = false;
+  bool bRequiresAttackResolution = false;
+
+  switch (Intent) {
+  case EAIBattleActivationIntent::Attack:
+    bActionTaken = TryAttackNearestEnemy(Fighter);
+    bRequiresAttackResolution = bActionTaken;
+    if (!bActionTaken && ShouldContinueActivation(Fighter)) {
+      QueueActivationIntent(Fighter, EAIBattleActivationIntent::Move);
+      ScheduleNextActivationAttempt();
+      return;
+    }
+    break;
+  case EAIBattleActivationIntent::Move:
+    bActionTaken = TryMoveTowardsNearestEnemy(Fighter);
+    break;
+  }
+
+  if (!bActionTaken) {
+    CompleteFighterActivation();
+    return;
+  }
+
+  ++ActivationIntentIterationCount;
+
+  if (!ShouldContinueActivation(Fighter)) {
+    if (bRequiresAttackResolution) {
+      bAwaitingQueuedAttackResolution = true;
+    } else {
+      CompleteFighterActivation();
+    }
+    return;
+  }
+
+  if (bRequiresAttackResolution) {
+    bAwaitingQueuedAttackResolution = true;
+    return;
+  }
+
+  QueueActivationIntent(Fighter, EAIBattleActivationIntent::Attack);
+  ScheduleNextActivationAttempt();
+}
+
+void ASkaldAIController::HandleQueuedAttackFinalized() {
+  if (!bAwaitingQueuedAttackResolution) {
+    return;
+  }
+
+  bAwaitingQueuedAttackResolution = false;
+
+  AFighterPawn *Fighter = PendingActivationFighter.Get();
+  if (!ShouldContinueActivation(Fighter)) {
+    CompleteFighterActivation();
+    return;
+  }
+
+  QueueActivationIntent(Fighter, EAIBattleActivationIntent::Attack);
+  ScheduleNextActivationAttempt();
+}
+
+void ASkaldAIController::ClearActivationTimers() {
+  if (UWorld *World = GetWorld()) {
+    World->GetTimerManager().ClearTimer(FighterActionTimerHandle);
+    World->GetTimerManager().ClearTimer(ActivationGapTimerHandle);
+  }
+
+  PendingActivationIntents.Empty();
+  bAwaitingQueuedAttackResolution = false;
+}
+
+void ASkaldAIController::CompleteFighterActivation() {
+  ClearActivationTimers();
+
+  AFighterPawn *Fighter = PendingActivationFighter.Get();
+  if (Fighter) {
+    Fighter->OnQueuedAttackFinalized.RemoveAll(this);
+  }
+
+  bProcessingActivation = false;
+  ActivationIntentIterationCount = 0;
+
+  if (CachedBattleManager.IsValid() && Fighter) {
+    CachedBattleManager->FinishActivation(Fighter, EGridActivationFinishReason::Auto);
+  }
+
+  PendingActivationFighter = nullptr;
+}
+
+void ASkaldAIController::ScheduleTryActivateNextFighter() {
+  if (UWorld *World = GetWorld()) {
+    World->GetTimerManager().ClearTimer(ActivationGapTimerHandle);
+    World->GetTimerManager().SetTimer(
+        ActivationGapTimerHandle, this, &ASkaldAIController::TryActivateNextFighter,
+        ActivationGapDelay, false);
+  }
+}
+
+void ASkaldAIController::ExecuteActivationForFighter(AFighterPawn *Fighter) {
+  if (!Fighter || !CachedBattleManager.IsValid()) {
+    bProcessingActivation = false;
+    return;
+  }
+
+  ClearActivationTimers();
+  ActivationIntentIterationCount = 0;
+  PendingActivationFighter = Fighter;
+  bAwaitingQueuedAttackResolution = false;
+
+  Fighter->OnQueuedAttackFinalized.RemoveAll(this);
+  Fighter->OnQueuedAttackFinalized.AddUObject(
+      this, &ASkaldAIController::HandleQueuedAttackFinalized);
+
+  QueueActivationIntent(Fighter, EAIBattleActivationIntent::Attack);
+  ScheduleNextActivationAttempt();
+}
+
 void ASkaldAIController::TryActivateNextFighter() {
+  if (UWorld *World = GetWorld()) {
+    World->GetTimerManager().ClearTimer(ActivationGapTimerHandle);
+  }
+
   if (!CachedBattleManager.IsValid()) {
     SetupBattleAutomation();
     return;
@@ -744,8 +885,8 @@ void ASkaldAIController::TryActivateNextFighter() {
 }
 
 void ASkaldAIController::HandleActiveFighterChanged(AFighterPawn *NewFighter) {
-  if (bProcessingActivation) {
-    return;
+  if (UWorld *World = GetWorld()) {
+    World->GetTimerManager().ClearTimer(ActivationGapTimerHandle);
   }
 
   if (NewFighter) {
@@ -755,23 +896,33 @@ void ASkaldAIController::HandleActiveFighterChanged(AFighterPawn *NewFighter) {
 
     bProcessingActivation = true;
     ExecuteActivationForFighter(NewFighter);
-    bProcessingActivation = false;
-    TryActivateNextFighter();
     return;
   }
 
-  TryActivateNextFighter();
+  if (bProcessingActivation) {
+    return;
+  }
+
+  ScheduleTryActivateNextFighter();
 }
 
 void ASkaldAIController::HandleRoundStarted(int32 /*RoundNumber*/,
                                             ESkaldFaction /*InitiativeWinner*/) {
   DetermineControlledBattleSide();
-  TryActivateNextFighter();
+  ScheduleTryActivateNextFighter();
 }
 
 void ASkaldAIController::HandleBattleEnded(ESkaldFaction /*WinningFaction*/,
                                            int32 /*AttackerCasualties*/,
                                            int32 /*DefenderCasualties*/) {
+  ClearActivationTimers();
+  if (AFighterPawn *Fighter = PendingActivationFighter.Get()) {
+    Fighter->OnQueuedAttackFinalized.RemoveAll(this);
+  }
+  PendingActivationFighter = nullptr;
+  bProcessingActivation = false;
+  bAwaitingQueuedAttackResolution = false;
+  ActivationIntentIterationCount = 0;
   TeardownBattleAutomation();
 }
 

--- a/Source/Skald/Skald_AIController.h
+++ b/Source/Skald/Skald_AIController.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "CoreMinimal.h"
+#include "Containers/Queue.h"
 #include "Skald_PlayerController.h"
 #include "TimerManager.h"
 #include "Skald_AIController.generated.h"
@@ -29,6 +30,8 @@ protected:
   virtual void EndPlay(const EEndPlayReason::Type EndPlayReason) override;
 
 private:
+  enum class EAIBattleActivationIntent : uint8 { Attack, Move };
+
   void ProcessCurrentPhase();
   void ScheduleNextDecisionStep(float DelaySeconds);
   void ClearDecisionTimers();
@@ -49,6 +52,15 @@ private:
   bool TryMoveTowardsNearestEnemy(AFighterPawn *Fighter);
   void ExecuteActivationForFighter(AFighterPawn *Fighter);
   void TryActivateNextFighter();
+  void QueueActivationIntent(AFighterPawn *Fighter,
+                             EAIBattleActivationIntent Intent);
+  void ProcessQueuedActivationIntent();
+  void HandleQueuedAttackFinalized();
+  void ClearActivationTimers();
+  void ScheduleNextActivationAttempt();
+  void ScheduleTryActivateNextFighter();
+  bool ShouldContinueActivation(const AFighterPawn *Fighter) const;
+  void CompleteFighterActivation();
 
   int32 ComputeManhattanDistance(UGridOverlayComponent *Grid,
                                  const AFighterPawn *A,
@@ -87,10 +99,36 @@ private:
   UPROPERTY(EditAnywhere, Category = "Turn|AI", meta = (ClampMin = "0.0"))
   float EnemyBattleTransitionPollDelay = 1.0f;
 
+  /** Delay between individual AI-controlled actions during grid battles. */
+  UPROPERTY(EditAnywhere, Category = "Battle|AI", meta = (ClampMin = "0.0"))
+  float BattleActionDelay = 0.5f;
+
+  /** Delay applied between fighter activations to provide pacing. */
+  UPROPERTY(EditAnywhere, Category = "Battle|AI", meta = (ClampMin = "0.0"))
+  float ActivationGapDelay = 0.5f;
+
   /** Timer driving world-map decision pacing. */
   FTimerHandle EnemyTurnStepTimerHandle;
 
   /** Timer used to retry battle automation binding while the manager spawns. */
   FTimerHandle BattleAutomationPollHandle;
+
+  /** Timer driving queued fighter actions. */
+  FTimerHandle FighterActionTimerHandle;
+
+  /** Timer enforcing a short delay before the next activation. */
+  FTimerHandle ActivationGapTimerHandle;
+
+  /** Fighter currently being processed by the AI. */
+  TWeakObjectPtr<AFighterPawn> PendingActivationFighter;
+
+  /** Ordered list of intents to process for the pending fighter. */
+  TQueue<EAIBattleActivationIntent> PendingActivationIntents;
+
+  /** True while waiting for an async attack sequence to resolve. */
+  bool bAwaitingQueuedAttackResolution = false;
+
+  /** Safety counter preventing infinite activation loops. */
+  int32 ActivationIntentIterationCount = 0;
 };
 


### PR DESCRIPTION
## Summary
- add configurable battle action and activation gap delays to the AI controller
- refactor fighter activations to run through a timer-driven intent queue that waits for queued attacks to finish
- expose a fighter pawn delegate for queued attack completion and clear timers on battle end

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68db33a9843083248eb27f0a3620d077