### PR TITLE
Ensure AI activation completes when fighter is removed

### DIFF
--- a/Source/Skald/Skald_AIController.cpp
+++ b/Source/Skald/Skald_AIController.cpp
@@ -899,6 +899,12 @@ void ASkaldAIController::HandleActiveFighterChanged(AFighterPawn *NewFighter) {
     return;
   }
 
+  const bool bPendingFighterInvalid = !PendingActivationFighter.IsValid();
+  if (bProcessingActivation &&
+      (bAwaitingQueuedAttackResolution || bPendingFighterInvalid)) {
+    CompleteFighterActivation();
+  }
+
   if (bProcessingActivation) {
     return;
   }


### PR DESCRIPTION
## Summary
- complete the AI activation workflow when the active fighter vanishes during a queued attack
- allow the controller to schedule the next activation instead of waiting on a delegate that can no longer fire

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68db37df1d748324b25bad90045aef21