### PR TITLE
Add configurable AI pacing delays

### DIFF
--- a/Config/DefaultEngine.ini
+++ b/Config/DefaultEngine.ini
@@ -243,6 +243,7 @@ FontDPIPreset=Standard
 FontDPI=72
 
 [/Script/Engine.Engine]
+GameUserSettingsClassName=/Script/Skald.SkaldGameUserSettings
 +ActiveGameNameRedirects=(OldGameName="TP_BlankBP",NewGameName="/Script/Skald")
 +ActiveGameNameRedirects=(OldGameName="/Script/TP_BlankBP",NewGameName="/Script/Skald")
 

--- a/Source/Skald/SettingsWidget.cpp
+++ b/Source/Skald/SettingsWidget.cpp
@@ -8,6 +8,7 @@
 #include "LobbyMenuWidget.h"
 #include "Sound/SoundClass.h"
 #include "Sound/SoundMix.h"
+#include "Skald_GameUserSettings.h"
 
 void USettingsWidget::SetLobbyMenu(ULobbyMenuWidget* InMenu)
 {
@@ -17,6 +18,11 @@ void USettingsWidget::SetLobbyMenu(ULobbyMenuWidget* InMenu)
 void USettingsWidget::NativeConstruct()
 {
     Super::NativeConstruct();
+
+    PendingResolution = FIntPoint::ZeroValue;
+    PendingQuality = 0;
+    PendingEnemyTurnDelay = 0.75f;
+    PendingBattleActionDelay = 0.5f;
 
     if (ApplyButton)
     {
@@ -71,7 +77,43 @@ void USettingsWidget::NativeConstruct()
         }
     }
 
-    if (UGameUserSettings* Settings = GEngine->GetGameUserSettings())
+    if (USkaldGameUserSettings* SkaldSettings = USkaldGameUserSettings::GetSkaldGameUserSettings())
+    {
+        PendingEnemyTurnDelay = SkaldSettings->GetEnemyTurnStepDelay();
+        PendingBattleActionDelay = SkaldSettings->GetBattleActionDelay();
+    }
+
+    if (EnemyTurnDelaySlider)
+    {
+        EnemyTurnDelaySlider->OnValueChanged.AddDynamic(this, &USettingsWidget::HandleEnemyTurnDelayChanged);
+        EnemyTurnDelaySlider->SetValue(PendingEnemyTurnDelay);
+    }
+
+    if (BattleActionDelaySlider)
+    {
+        BattleActionDelaySlider->OnValueChanged.AddDynamic(this, &USettingsWidget::HandleBattleActionDelayChanged);
+        BattleActionDelaySlider->SetValue(PendingBattleActionDelay);
+    }
+
+    if (UGameUserSettings* Settings = USkaldGameUserSettings::GetSkaldGameUserSettings())
+    {
+        PendingResolution = Settings->GetScreenResolution();
+        const FString CurrentRes = FString::Printf(TEXT("%dx%d"), PendingResolution.X, PendingResolution.Y);
+        if (DisplaySizeCombo)
+        {
+            DisplaySizeCombo->SetSelectedOption(CurrentRes);
+        }
+
+        PendingQuality = Settings->GetOverallScalabilityLevel();
+        if (GraphicsQualityCombo)
+        {
+            if (const FString* Quality = QualityMap.FindKey(PendingQuality))
+            {
+                GraphicsQualityCombo->SetSelectedOption(*Quality);
+            }
+        }
+    }
+    else if (UGameUserSettings* Settings = GEngine->GetGameUserSettings())
     {
         PendingResolution = Settings->GetScreenResolution();
         const FString CurrentRes = FString::Printf(TEXT("%dx%d"), PendingResolution.X, PendingResolution.Y);
@@ -93,11 +135,21 @@ void USettingsWidget::NativeConstruct()
 
 void USettingsWidget::OnApply()
 {
-    if (UGameUserSettings* Settings = GEngine->GetGameUserSettings())
+    if (USkaldGameUserSettings* Settings = USkaldGameUserSettings::GetSkaldGameUserSettings())
+    {
+        Settings->SetScreenResolution(PendingResolution);
+        Settings->SetOverallScalabilityLevel(PendingQuality);
+        Settings->SetEnemyTurnStepDelay(PendingEnemyTurnDelay);
+        Settings->SetBattleActionDelay(PendingBattleActionDelay);
+        Settings->ApplySettings(false);
+        Settings->SaveSettings();
+    }
+    else if (UGameUserSettings* Settings = GEngine->GetGameUserSettings())
     {
         Settings->SetScreenResolution(PendingResolution);
         Settings->SetOverallScalabilityLevel(PendingQuality);
         Settings->ApplySettings(false);
+        Settings->SaveSettings();
     }
 
     if (MasterSoundMix && MasterSoundClass)
@@ -142,5 +194,15 @@ void USettingsWidget::HandleAudioChanged(float Value)
     {
         MasterSoundClass->Properties.Volume = Value;
     }
+}
+
+void USettingsWidget::HandleEnemyTurnDelayChanged(float Value)
+{
+    PendingEnemyTurnDelay = FMath::Max(0.0f, Value);
+}
+
+void USettingsWidget::HandleBattleActionDelayChanged(float Value)
+{
+    PendingBattleActionDelay = FMath::Max(0.0f, Value);
 }
 

--- a/Source/Skald/SettingsWidget.h
+++ b/Source/Skald/SettingsWidget.h
@@ -10,6 +10,7 @@ class UComboBoxString;
 class USlider;
 class USoundClass;
 class USoundMix;
+class USkaldGameUserSettings;
 namespace ESelectInfo
 {
     enum Type;
@@ -38,6 +39,12 @@ public:
     UPROPERTY(BlueprintReadOnly, Category="Skald|Widgets", meta = (BindWidgetOptional))
     USlider* AudioSlider;
 
+    UPROPERTY(BlueprintReadOnly, Category="Skald|Widgets", meta = (BindWidgetOptional))
+    USlider* EnemyTurnDelaySlider;
+
+    UPROPERTY(BlueprintReadOnly, Category="Skald|Widgets", meta = (BindWidgetOptional))
+    USlider* BattleActionDelaySlider;
+
     UPROPERTY(EditAnywhere, Category="Skald|Audio")
     USoundMix* MasterSoundMix;
 
@@ -65,6 +72,12 @@ protected:
     UFUNCTION(BlueprintCallable, Category="Skald|Widgets")
     void HandleAudioChanged(float Value);
 
+    UFUNCTION(BlueprintCallable, Category="Skald|Widgets")
+    void HandleEnemyTurnDelayChanged(float Value);
+
+    UFUNCTION(BlueprintCallable, Category="Skald|Widgets")
+    void HandleBattleActionDelayChanged(float Value);
+
 private:
     UPROPERTY()
     TWeakObjectPtr<ULobbyMenuWidget> LobbyMenu;
@@ -75,5 +88,7 @@ private:
     FIntPoint PendingResolution;
     int32 PendingQuality;
     float PendingAudioVolume;
+    float PendingEnemyTurnDelay;
+    float PendingBattleActionDelay;
 };
 

--- a/Source/Skald/Skald_AIController.cpp
+++ b/Source/Skald/Skald_AIController.cpp
@@ -12,6 +12,7 @@
 #include "SkaldLogging.h"
 #include "Skald_BattleGameMode.h"
 #include "Skald_GameInstance.h"
+#include "Skald_GameUserSettings.h"
 #include "Skald_GameMode.h"
 #include "Skald_PlayerState.h"
 #include "Skald_TurnManager.h"
@@ -32,6 +33,12 @@ constexpr TCHAR EnemyBattleTransitionMessage[] =
 
 void ASkaldAIController::BeginPlay() {
   Super::BeginPlay();
+
+  if (const USkaldGameUserSettings *Settings =
+          USkaldGameUserSettings::GetSkaldGameUserSettings()) {
+    EnemyTurnStepDelay = Settings->GetEnemyTurnStepDelay();
+    BattleActionDelay = Settings->GetBattleActionDelay();
+  }
 
   SetupBattleAutomation();
 

--- a/Source/Skald/Skald_GameUserSettings.cpp
+++ b/Source/Skald/Skald_GameUserSettings.cpp
@@ -1,0 +1,42 @@
+#include "Skald_GameUserSettings.h"
+#include "Engine/Engine.h"
+
+namespace
+{
+constexpr float DefaultEnemyTurnStepDelay = 0.75f;
+constexpr float DefaultBattleActionDelay = 0.5f;
+}
+
+USkaldGameUserSettings::USkaldGameUserSettings()
+    : EnemyTurnStepDelay(DefaultEnemyTurnStepDelay),
+      BattleActionDelay(DefaultBattleActionDelay) {}
+
+USkaldGameUserSettings *USkaldGameUserSettings::GetSkaldGameUserSettings()
+{
+  if (GEngine)
+  {
+    if (UGameUserSettings *Settings = GEngine->GetGameUserSettings())
+    {
+      return Cast<USkaldGameUserSettings>(Settings);
+    }
+  }
+  return nullptr;
+}
+
+void USkaldGameUserSettings::SetEnemyTurnStepDelay(float InDelay)
+{
+  EnemyTurnStepDelay = FMath::Max(0.0f, InDelay);
+}
+
+void USkaldGameUserSettings::SetBattleActionDelay(float InDelay)
+{
+  BattleActionDelay = FMath::Max(0.0f, InDelay);
+}
+
+void USkaldGameUserSettings::SetToDefaults()
+{
+  Super::SetToDefaults();
+
+  EnemyTurnStepDelay = DefaultEnemyTurnStepDelay;
+  BattleActionDelay = DefaultBattleActionDelay;
+}

--- a/Source/Skald/Skald_GameUserSettings.h
+++ b/Source/Skald/Skald_GameUserSettings.h
@@ -1,0 +1,36 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "GameFramework/GameUserSettings.h"
+#include "Skald_GameUserSettings.generated.h"
+
+/**
+ * Custom user settings storing pacing options for AI behaviour.
+ */
+UCLASS()
+class SKALD_API USkaldGameUserSettings : public UGameUserSettings {
+  GENERATED_BODY()
+
+public:
+  USkaldGameUserSettings();
+
+  /** Accessor that casts the engine user settings to the custom type. */
+  static USkaldGameUserSettings *GetSkaldGameUserSettings();
+
+  float GetEnemyTurnStepDelay() const { return EnemyTurnStepDelay; }
+  float GetBattleActionDelay() const { return BattleActionDelay; }
+
+  void SetEnemyTurnStepDelay(float InDelay);
+  void SetBattleActionDelay(float InDelay);
+
+protected:
+  virtual void SetToDefaults() override;
+
+  /** Time between AI decision steps on the overworld. */
+  UPROPERTY(Config, EditAnywhere, Category = "AI", meta = (ClampMin = "0.0"))
+  float EnemyTurnStepDelay;
+
+  /** Time between AI-controlled actions during battles. */
+  UPROPERTY(Config, EditAnywhere, Category = "AI", meta = (ClampMin = "0.0"))
+  float BattleActionDelay;
+};


### PR DESCRIPTION
## Summary
- add a custom USkaldGameUserSettings class to persist AI pacing delays and register it via DefaultEngine.ini
- expose overworld and battle delay sliders in the settings widget and save them alongside display options
- load the stored delay preferences when spawning AI controllers so pacing reflects the selected settings

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68db3633af048324927795ed9fe2745b