### PR TITLE
Fix turn resumption after battle map travel

### DIFF
--- a/Source/Skald/Skald_GameMode.cpp
+++ b/Source/Skald/Skald_GameMode.cpp
@@ -706,6 +706,17 @@ void ASkaldGameMode::TryInitializeWorldAndStart() {
   USkaldGameInstance *GI = GetGameInstance<USkaldGameInstance>();
   if (GI) {
     if (GI->bResumeTurns) {
+      const bool bResumed = TurnManager && TurnManager->AttemptResumeSavedTurnState();
+      if (!bResumed) {
+        FTimerDelegate RetryInit = FTimerDelegate::CreateUObject(
+            this, &ASkaldGameMode::TryInitializeWorldAndStart);
+        GetWorldTimerManager().ClearTimer(RetryInitTimerHandle);
+        GetWorldTimerManager().SetTimer(RetryInitTimerHandle, RetryInit,
+                                        RetryInitDelay, false);
+        GetWorldTimerManager().SetTimerForNextTick(RetryInit);
+        return;
+      }
+
       bWorldInitialized = true;
       bTurnsStarted = true;
       GetWorldTimerManager().ClearTimer(RetryInitTimerHandle);

--- a/Source/Skald/Skald_TurnManager.cpp
+++ b/Source/Skald/Skald_TurnManager.cpp
@@ -96,19 +96,7 @@ void ATurnManager::BeginPlay() {
           this, &ATurnManager::HandleGridBattleEnded);
     }
 
-    if (GI->bResumeTurns) {
-      CurrentIndex = GI->SavedTurnIndex;
-      CurrentPhase = GI->SavedTurnPhase;
-      GI->bResumeTurns = false;
-
-      if (Controllers.IsValidIndex(CurrentIndex)) {
-        if (ASkaldPlayerController *Controller =
-                Controllers[CurrentIndex].Get()) {
-          Controller->StartTurn();
-          BroadcastCurrentPhase();
-        }
-      }
-    }
+    TryResumeSavedTurnState(GI);
   }
 
   if (ASkaldGameMode *GM = GetWorld()->GetAuthGameMode<ASkaldGameMode>()) {
@@ -186,6 +174,10 @@ void ATurnManager::RegisterController(ASkaldPlayerController *Controller) {
   }
 }
 
+bool ATurnManager::AttemptResumeSavedTurnState() {
+  return TryResumeSavedTurnState();
+}
+
 void ATurnManager::StartArmyPlacementPhase() {
   if (const UWorld *W = GetWorld()) {
     if (const auto *GI = W->GetGameInstance<USkaldGameInstance>()) {
@@ -255,6 +247,34 @@ void ATurnManager::SyncGameStateTurnIndex() {
     GS->CurrentTurnIndex = NewIndex;
     GS->OnTurnIndexChanged.Broadcast(NewIndex);
   }
+}
+
+bool ATurnManager::TryResumeSavedTurnState(USkaldGameInstance *GameInstance) {
+  USkaldGameInstance *GI =
+      GameInstance ? GameInstance : GetGameInstance<USkaldGameInstance>();
+  if (!GI || !GI->bResumeTurns) {
+    return false;
+  }
+
+  const int32 SavedIndex = GI->SavedTurnIndex;
+  if (!Controllers.IsValidIndex(SavedIndex) || !Controllers[SavedIndex].IsValid()) {
+    return false;
+  }
+
+  ASkaldPlayerController *Controller = Controllers[SavedIndex].Get();
+  if (!Controller) {
+    return false;
+  }
+
+  CurrentIndex = SavedIndex;
+  CurrentPhase = GI->SavedTurnPhase;
+  GI->bResumeTurns = false;
+
+  SyncGameStateTurnIndex();
+  Controller->StartTurn();
+  BroadcastCurrentPhase();
+
+  return true;
 }
 
 void ATurnManager::StartTurns(ASkaldPlayerController *StartingController) {
@@ -777,20 +797,7 @@ void ATurnManager::ResolveGridBattleResult_Implementation() {
   GI->PendingBattleResolution = FGridBattleResolution();
 
   // Resume the saved turn sequence now that the battle has been resolved.
-  if (GI->bResumeTurns) {
-    CurrentIndex = GI->SavedTurnIndex;
-    CurrentPhase = GI->SavedTurnPhase;
-    GI->bResumeTurns = false;
-
-    if (Controllers.IsValidIndex(CurrentIndex)) {
-      if (ASkaldPlayerController *Controller =
-              Controllers[CurrentIndex].Get()) {
-        SyncGameStateTurnIndex();
-        Controller->StartTurn();
-        BroadcastCurrentPhase();
-      }
-    }
-  }
+  TryResumeSavedTurnState(GI);
 
   if (ASkaldGameMode *GM = GetWorld()->GetAuthGameMode<ASkaldGameMode>()) {
     GM->CheckVictoryConditions();

--- a/Source/Skald/Skald_TurnManager.h
+++ b/Source/Skald/Skald_TurnManager.h
@@ -9,6 +9,7 @@ class ASkaldPlayerController;
 class ASkaldPlayerState;
 class AWorldMap;
 class UWorld;
+class USkaldGameInstance;
 
 // Broadcast whenever the overall world state changes so HUDs can refresh.
 DECLARE_DYNAMIC_MULTICAST_DELEGATE(FSkaldWorldStateChanged);
@@ -30,6 +31,9 @@ public:
 
   UFUNCTION(BlueprintCallable, Category = "Turn")
   void RegisterController(ASkaldPlayerController *Controller);
+
+  /** Attempt to resume the saved turn state captured before travelling. */
+  bool AttemptResumeSavedTurnState();
 
   /** Begin the pre-game army placement phase. */
   UFUNCTION(BlueprintCallable, Category = "Turn")
@@ -131,4 +135,7 @@ protected:
 
   /** Internal: set GameState.CurrentTurnIndex (and broadcast) to match CurrentIndex. */
   void SyncGameStateTurnIndex();
+
+  /** Attempt to restore a saved turn state captured before travelling. */
+  bool TryResumeSavedTurnState(USkaldGameInstance *GameInstance = nullptr);
 };


### PR DESCRIPTION
## Summary
- add a resumable turn restoration helper to the turn manager
- teach the game mode to retry initialization until the saved turn can resume
- keep battle resolution from resetting the resume flag before controllers return

## Testing
- not run (PIE only)

------
https://chatgpt.com/codex/tasks/task_e_68dbe8875768832490c2c8e044debf24