### PR TITLE
Display fighter ID and portrait on battle HUD

### DIFF
--- a/Source/Skald/FighterPawn.cpp
+++ b/Source/Skald/FighterPawn.cpp
@@ -4,6 +4,7 @@
 #include "Components/StaticMeshComponent.h"
 #include "Components/TextBlock.h"
 #include "Engine/CollisionProfile.h"
+#include "Engine/Texture2D.h"
 #include "EngineUtils.h"
 #include "GridBattleManager.h"
 #include "GridOverlayComponent.h"
@@ -66,6 +67,7 @@ AFighterPawn::AFighterPawn() {
   bHasActivatedThisRound = false;
   bIsCurrentlyActive = false;
   CurrentCell = FIntPoint::ZeroValue;
+  FighterId = NAME_None;
 
   ApplyFootprintScale();
   UpdateMeshOffset();
@@ -76,6 +78,8 @@ void AFighterPawn::GetLifetimeReplicatedProps(
   Super::GetLifetimeReplicatedProps(OutLifetimeProps);
 
   DOREPLIFETIME(AFighterPawn, Stats);
+  DOREPLIFETIME(AFighterPawn, FighterId);
+  DOREPLIFETIME(AFighterPawn, FighterPortrait);
   DOREPLIFETIME(AFighterPawn, bIsAttacker);
   DOREPLIFETIME(AFighterPawn, ActionsRemaining);
   DOREPLIFETIME(AFighterPawn, bHasActivatedThisRound);
@@ -124,6 +128,18 @@ void AFighterPawn::BeginPlay() {
       }
     }
   }
+}
+
+UTexture2D *AFighterPawn::GetPortraitTexture() const {
+  if (FighterPortrait.IsValid()) {
+    return FighterPortrait.Get();
+  }
+
+  if (!FighterPortrait.IsNull()) {
+    return FighterPortrait.LoadSynchronous();
+  }
+
+  return nullptr;
 }
 
 void AFighterPawn::Tick(float DeltaSeconds) {

--- a/Source/Skald/FighterPawn.h
+++ b/Source/Skald/FighterPawn.h
@@ -10,6 +10,7 @@
 
 class UGridOverlayComponent;
 class UCapsuleComponent;
+class UTexture2D;
 
 UENUM(BlueprintType)
 enum class EFighterPawnFootprint : uint8 {
@@ -111,6 +112,14 @@ public:
             Category = "Fighter")
   FFighterStats Stats;
 
+  /** Identifier of the fighter definition used to spawn this pawn. */
+  UPROPERTY(BlueprintReadOnly, Replicated, Category = "Fighter")
+  FName FighterId;
+
+  /** Portrait associated with this fighter definition. */
+  UPROPERTY(BlueprintReadOnly, Replicated, Category = "Fighter|UI")
+  TSoftObjectPtr<UTexture2D> FighterPortrait;
+
   /** Number of grid cells occupied by this fighter (1 or 4). */
   UPROPERTY(EditAnywhere, BlueprintReadWrite,
             ReplicatedUsing = OnRep_GridFootprint, Category = "Fighter|Grid")
@@ -166,6 +175,12 @@ public:
   /** Event broadcast when actions remaining changes. */
   UPROPERTY(BlueprintAssignable, Category = "Fighter|Events")
   FOnActionsChanged OnActionsChanged;
+
+  /** Retrieve the identifier associated with this fighter. */
+  FName GetFighterId() const { return FighterId; }
+
+  /** Resolve the portrait texture for this fighter if available. */
+  UTexture2D *GetPortraitTexture() const;
 
 protected:
   /** Clear grid occupancy when the fighter is destroyed. */

--- a/Source/Skald/Skald_BattleGameMode.cpp
+++ b/Source/Skald/Skald_BattleGameMode.cpp
@@ -1067,6 +1067,8 @@ void ASkald_BattleGameMode::SpawnFighterSide(const TArray<FFighterDefinition> &R
         Pawn->SetActorLocation(AdjustedLocation, /*bSweep*/ true, &HitResult);
       }
       Pawn->Stats = Def.Stats;
+      Pawn->FighterId = Def.Id;
+      Pawn->FighterPortrait = Def.Portrait;
       Pawn->bIsAttacker = bAsAttacker;
       BattleManager->RegisterFighter(Pawn, bAsAttacker);
     }

--- a/Source/Skald/Skald_PlayerController.cpp
+++ b/Source/Skald/Skald_PlayerController.cpp
@@ -2144,7 +2144,7 @@ void ASkaldPlayerController::UpdateBattleHUDSelection() {
   BattleHudWidget->BindToFighter(SelectedFighter);
   if (SelectedFighter) {
     BattleHudWidget->SetSelectedFighterName(
-        FText::FromString(SelectedFighter->GetHumanReadableName()));
+        FText::FromName(SelectedFighter->GetFighterId()));
   } else {
     BattleHudWidget->SetSelectedFighterName(FText::GetEmpty());
   }

--- a/Source/Skald/UI/BattleHUDWidget.cpp
+++ b/Source/Skald/UI/BattleHUDWidget.cpp
@@ -51,8 +51,16 @@ void UBattleHUDWidget::BindToFighter(AFighterPawn *Fighter) {
         this, &UBattleHUDWidget::HandleActionsChanged);
     UpdateStatPanel();
     if (FighterNameText) {
-      FighterNameText->SetText(
-          FText::FromString(BoundFighter->GetHumanReadableName()));
+      FighterNameText->SetText(FText::FromName(BoundFighter->GetFighterId()));
+    }
+    if (FighterImage) {
+      if (UTexture2D *PortraitTexture = BoundFighter->GetPortraitTexture()) {
+        FighterImage->SetBrushFromTexture(PortraitTexture);
+        FighterImage->SetVisibility(ESlateVisibility::HitTestInvisible);
+      } else {
+        FighterImage->SetBrushFromTexture(nullptr);
+        FighterImage->SetVisibility(ESlateVisibility::Collapsed);
+      }
     }
   } else {
     if (HealthText) {
@@ -81,6 +89,10 @@ void UBattleHUDWidget::BindToFighter(AFighterPawn *Fighter) {
     }
     if (FighterNameText) {
       FighterNameText->SetText(FText::GetEmpty());
+    }
+    if (FighterImage) {
+      FighterImage->SetBrushFromTexture(nullptr);
+      FighterImage->SetVisibility(ESlateVisibility::Collapsed);
     }
   }
 }
@@ -190,6 +202,17 @@ void UBattleHUDWidget::SetPlayersTurnLabel(const FText &PlayerLabel) {
 void UBattleHUDWidget::SetSelectedFighterName(const FText &Name) {
   if (FighterNameText) {
     FighterNameText->SetText(Name);
+  }
+  if (FighterImage) {
+    UTexture2D *PortraitTexture =
+        BoundFighter ? BoundFighter->GetPortraitTexture() : nullptr;
+    if (PortraitTexture) {
+      FighterImage->SetBrushFromTexture(PortraitTexture);
+      FighterImage->SetVisibility(ESlateVisibility::HitTestInvisible);
+    } else {
+      FighterImage->SetBrushFromTexture(nullptr);
+      FighterImage->SetVisibility(ESlateVisibility::Collapsed);
+    }
   }
 }
 

--- a/Source/Skald/UI/BattleHUDWidget.h
+++ b/Source/Skald/UI/BattleHUDWidget.h
@@ -97,9 +97,13 @@ public:
   UPROPERTY(BlueprintReadOnly, meta = (BindWidget))
   UTextBlock *AttackDiceText;
 
-  /** Text displaying the fighter's name. */
+  /** Text displaying the fighter's identifier. */
   UPROPERTY(BlueprintReadOnly, meta = (BindWidgetOptional))
   UTextBlock *FighterNameText;
+
+  /** Image displaying the fighter's portrait. */
+  UPROPERTY(BlueprintReadOnly, meta = (BindWidgetOptional))
+  UImage *FighterImage;
 
   /** Text displaying the current round. */
   UPROPERTY(BlueprintReadOnly, meta = (BindWidgetOptional))
@@ -134,7 +138,7 @@ public:
   /** Update the label that shows whose turn is active. */
   void SetPlayersTurnLabel(const FText &PlayerLabel);
 
-  /** Update the fighter name label. */
+  /** Update the fighter identifier label and portrait. */
   void SetSelectedFighterName(const FText &Name);
 
   /** Enable or disable the Activate button. */


### PR DESCRIPTION
## Summary
- replicate and expose fighter identifiers and portraits on fighter pawns
- show the fighter ID and portrait in the battle HUD selection panel
- update the player controller to pass the fighter ID to the HUD

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dbebd146808324bcfe7a29261dbe95