### PR TITLE
Handle rotated grid overlay transforms

### DIFF
--- a/Source/Skald/GridOverlayComponent.cpp
+++ b/Source/Skald/GridOverlayComponent.cpp
@@ -82,8 +82,15 @@ void UGridOverlayComponent::ApplyRandomizedOrigin() {
 
 void UGridOverlayComponent::RefreshOriginFromOwner(bool bMarkPlacementRandomized) {
   if (AActor *Owner = GetOwner()) {
-    const FVector NewOrigin = Owner->GetActorLocation();
+    const FTransform NewTransform = Owner->GetActorTransform();
+    const FVector NewOrigin = NewTransform.GetLocation();
     const bool bOriginChanged = !Origin.Equals(NewOrigin, KINDA_SMALL_NUMBER);
+
+    if (!CachedGridTransform.Equals(NewTransform, KINDA_SMALL_NUMBER)) {
+      CachedGridTransform = NewTransform;
+      CachedGridInverseTransform = CachedGridTransform.Inverse();
+    }
+
     Origin = NewOrigin;
     if (bMarkPlacementRandomized && bRandomizePlacement) {
       bHasRandomizedPlacement = true;
@@ -308,15 +315,18 @@ void UGridOverlayComponent::SampleEnvironmentAtOrigin() {
 
 FIntPoint
 UGridOverlayComponent::WorldToGrid(const FVector &WorldLocation) const {
-  FVector Local = WorldLocation - Origin;
+  const FVector Local =
+      CachedGridInverseTransform.TransformPosition(WorldLocation);
   int32 X = FMath::FloorToInt(Local.X / CellSize);
   int32 Y = FMath::FloorToInt(Local.Y / CellSize);
   return FIntPoint(X, Y);
 }
 
 FVector UGridOverlayComponent::GridToWorld(const FIntPoint &GridCoord) const {
-  FVector World = Origin + FVector((GridCoord.X + 0.5f) * CellSize,
-                                   (GridCoord.Y + 0.5f) * CellSize, 0.f);
+  const FVector LocalCenter =
+      FVector((GridCoord.X + 0.5f) * CellSize, (GridCoord.Y + 0.5f) * CellSize,
+              0.f);
+  FVector World = CachedGridTransform.TransformPosition(LocalCenter);
   World.Z = GetCellHeight(GridCoord);
   return World;
 }

--- a/Source/Skald/GridOverlayComponent.h
+++ b/Source/Skald/GridOverlayComponent.h
@@ -316,6 +316,12 @@ protected:
   /** World origin of the grid (cell 0,0). */
   FVector Origin = FVector::ZeroVector;
 
+  /** Cached transform of the grid in world space (matches owning actor). */
+  FTransform CachedGridTransform = FTransform::Identity;
+
+  /** Cached inverse transform used for world/local grid conversions. */
+  FTransform CachedGridInverseTransform = FTransform::Identity;
+
   /** Occupancy array; true if the cell is occupied. */
   UPROPERTY()
   TArray<bool> Cells;


### PR DESCRIPTION
## Summary
- cache the owning actor transform on the grid overlay component
- convert between world and grid space using the cached transforms so rotated grids map correctly

## Testing
- not run (UE editor validation required)


------
https://chatgpt.com/codex/tasks/task_e_68dc04243b208324adc92ccf39f6d3e6