### PR TITLE
Adjust fighter facing to consider display mesh yaw offset

### DIFF
--- a/Source/Skald/FighterPawn.cpp
+++ b/Source/Skald/FighterPawn.cpp
@@ -810,12 +810,20 @@ void AFighterPawn::BroadcastActionsRemaining() {
   OnActionsChanged.Broadcast(ActionsRemaining);
 }
 
+void AFighterPawn::ApplyFacingYaw(float TargetYaw) {
+  const float MeshYawOffset =
+      DisplayMesh ? DisplayMesh->GetRelativeRotation().Yaw : 0.f;
+  const float AdjustedYaw =
+      FRotator::NormalizeAxis(TargetYaw - MeshYawOffset);
+  SetActorRotation(FRotator(0.f, AdjustedYaw, 0.f));
+}
+
 void AFighterPawn::FaceTowardsLocation(const FVector &TargetLocation) {
   FVector Direction = TargetLocation - GetActorLocation();
   Direction.Z = 0.f;
   if (!Direction.IsNearlyZero()) {
     const FRotator LookRotation = Direction.Rotation();
-    SetActorRotation(FRotator(0.f, LookRotation.Yaw, 0.f));
+    ApplyFacingYaw(LookRotation.Yaw);
   }
 }
 
@@ -832,6 +840,6 @@ void AFighterPawn::FaceTowardsCells(const FIntPoint &FromCell,
   Direction.Z = 0.f;
   if (!Direction.IsNearlyZero()) {
     const FRotator LookRotation = Direction.Rotation();
-    SetActorRotation(FRotator(0.f, LookRotation.Yaw, 0.f));
+    ApplyFacingYaw(LookRotation.Yaw);
   }
 }

--- a/Source/Skald/FighterPawn.h
+++ b/Source/Skald/FighterPawn.h
@@ -220,6 +220,9 @@ private:
   /** Helper to broadcast the current actions remaining value. */
   void BroadcastActionsRemaining();
 
+  /** Apply the mesh's yaw offset when orienting the fighter. */
+  void ApplyFacingYaw(float TargetYaw);
+
   /** Rotate the fighter to face a world-space location. */
   void FaceTowardsLocation(const FVector &TargetLocation);
 


### PR DESCRIPTION
## Summary
- add a helper that subtracts the display mesh yaw offset when rotating fighter pawns
- update all facing logic to use the helper so meshes align with their travel direction

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dc07d12efc8324a55d4d5d4e5c7b49