### PR TITLE
Fix PIE prefix removal in map normalization

### DIFF
--- a/Source/Skald/Skald_TurnManager.cpp
+++ b/Source/Skald/Skald_TurnManager.cpp
@@ -44,6 +44,10 @@ FString NormalizeMapName(UWorld *World, FString Candidate) {
         Result.StartsWith(World->StreamingLevelsPrefix)) {
       Result.RightChopInline(World->StreamingLevelsPrefix.Len(),
                              /*bAllowShrinking=*/false);
+
+      if (Result.StartsWith(TEXT("_"))) {
+        Result.RightChopInline(1, /*bAllowShrinking=*/false);
+      }
     }
 
     FString LongPackageName;


### PR DESCRIPTION
## Summary
- ensure `NormalizeMapName` strips an underscore left after removing the streaming prefix so PIE-prefixed map names normalize correctly

## Testing
- `./Engine/Build/BatchFiles/Build.sh SkaldEditor Linux Development -project="/workspace/Skald_TurnBasedStrategy_Code/Skald.uproject"` *(fails: missing Unreal Engine build scripts in repo)*

------
https://chatgpt.com/codex/tasks/task_e_68dc1bcbf6188324b2ec1cb3936e5e6b