### PR TITLE
Add in-game pause menu accessible via hotkey

### DIFF
--- a/Source/Skald/LoadGameWidget.cpp
+++ b/Source/Skald/LoadGameWidget.cpp
@@ -3,16 +3,21 @@
 #include "SkaldLogging.h"
 #include "Components/Button.h"
 #include "Kismet/GameplayStatics.h"
-#include "LobbyMenuWidget.h"
 #include "SlotNameConstants.h"
 #include "GameFramework/PlayerController.h"
 #include "SkaldSaveGame.h"
 #include "Skald_GameInstance.h"
 #include "Blueprint/WidgetBlueprintLibrary.h"
+#include "UI/InGameMenuWidget.h"
 
 void ULoadGameWidget::SetLobbyMenu(ULobbyMenuWidget* InMenu)
 {
-    LobbyMenu = InMenu;
+    SetOwningMenu(InMenu);
+}
+
+void ULoadGameWidget::SetOwningMenu(UUserWidget* InMenu)
+{
+    OwningMenu = InMenu;
 }
 
 void ULoadGameWidget::NativeConstruct()
@@ -67,16 +72,20 @@ void ULoadGameWidget::OnMainMenu()
     UWidgetBlueprintLibrary::GetAllWidgetsOfClass(this, Widgets, UUserWidget::StaticClass(), /*TopLevelOnly*/ true);
     for (UUserWidget* Widget : Widgets)
     {
-        if (Widget && Widget != LobbyMenu.Get())
+        if (Widget && Widget != OwningMenu.Get())
         {
             Widget->RemoveFromParent();
         }
     }
 
-    if (LobbyMenu.IsValid())
+    if (OwningMenu.IsValid())
     {
-        // Re-enable the lobby once the load-game widget closes
-        LobbyMenu->SetVisibility(ESlateVisibility::Visible);
+        if (UInGameMenuWidget* Menu = Cast<UInGameMenuWidget>(OwningMenu.Get()))
+        {
+            Menu->HandleSubMenuClosed(this);
+        }
+        // Re-enable the menu once the load-game widget closes
+        OwningMenu->SetVisibility(ESlateVisibility::Visible);
     }
 }
 

--- a/Source/Skald/LoadGameWidget.h
+++ b/Source/Skald/LoadGameWidget.h
@@ -6,6 +6,7 @@
 
 class UButton;
 class ULobbyMenuWidget;
+class UUserWidget;
 /**
  * Simple load game menu listing a few save slots.
  */
@@ -30,6 +31,9 @@ public:
     UFUNCTION(BlueprintCallable, Category="Skald|Widgets")
     void SetLobbyMenu(ULobbyMenuWidget* InMenu);
 
+    UFUNCTION(BlueprintCallable, Category="Skald|Widgets")
+    void SetOwningMenu(UUserWidget* InMenu);
+
 protected:
     virtual void NativeConstruct() override;
 
@@ -51,6 +55,6 @@ private:
 
     UPROPERTY()
     /** Weak reference back to the lobby so it can be re-enabled when closing. */
-    TWeakObjectPtr<ULobbyMenuWidget> LobbyMenu;
+    TWeakObjectPtr<UUserWidget> OwningMenu;
 };
 

--- a/Source/Skald/SaveGameWidget.cpp
+++ b/Source/Skald/SaveGameWidget.cpp
@@ -1,16 +1,22 @@
 #include "SaveGameWidget.h"
 #include "Components/Button.h"
 #include "Kismet/GameplayStatics.h"
-#include "LobbyMenuWidget.h"
+#include "Blueprint/UserWidget.h"
 #include "Skald.h"
 #include "SkaldLogging.h"
 #include "SkaldSaveGame.h"
 #include "Skald_GameMode.h"
 #include "SlotNameConstants.h"
+#include "UI/InGameMenuWidget.h"
 
 void USaveGameWidget::SetLobbyMenu(ULobbyMenuWidget* InMenu)
 {
-  LobbyMenu = InMenu;
+  SetOwningMenu(InMenu);
+}
+
+void USaveGameWidget::SetOwningMenu(UUserWidget* InMenu)
+{
+  OwningMenu = InMenu;
 }
 
 void USaveGameWidget::NativeConstruct() {
@@ -61,8 +67,12 @@ void USaveGameWidget::OnSaveSlot2() { HandleSaveSlot(2); }
 
 void USaveGameWidget::OnMainMenu() {
   RemoveFromParent();
-  if (LobbyMenu.IsValid()) {
-    LobbyMenu->SetVisibility(ESlateVisibility::Visible);
+  if (OwningMenu.IsValid()) {
+    if (UInGameMenuWidget* Menu = Cast<UInGameMenuWidget>(OwningMenu.Get()))
+    {
+      Menu->HandleSubMenuClosed(this);
+    }
+    OwningMenu->SetVisibility(ESlateVisibility::Visible);
   }
 }
 
@@ -77,8 +87,12 @@ void USaveGameWidget::HandleSaveSlot(int32 SlotIndex) {
                             SaveGameObject, SlotNames[SlotIndex], 0)) {
     // After saving, transition back to main menu
     RemoveFromParent();
-    if (LobbyMenu.IsValid()) {
-      LobbyMenu->SetVisibility(ESlateVisibility::Visible);
+    if (OwningMenu.IsValid()) {
+      if (UInGameMenuWidget* Menu = Cast<UInGameMenuWidget>(OwningMenu.Get()))
+      {
+        Menu->HandleSubMenuClosed(this);
+      }
+      OwningMenu->SetVisibility(ESlateVisibility::Visible);
     }
   } else {
     UE_LOG(LogSkald, Error, TEXT("Failed to save slot %s"),

--- a/Source/Skald/SaveGameWidget.h
+++ b/Source/Skald/SaveGameWidget.h
@@ -6,6 +6,7 @@
 
 class UButton;
 class ULobbyMenuWidget;
+class UUserWidget;
 /**
  * Simple save game menu listing a few save slots.
  */
@@ -30,6 +31,9 @@ public:
     UFUNCTION(BlueprintCallable, Category="Skald|Widgets")
     void SetLobbyMenu(ULobbyMenuWidget* InMenu);
 
+    UFUNCTION(BlueprintCallable, Category="Skald|Widgets")
+    void SetOwningMenu(UUserWidget* InMenu);
+
 protected:
     virtual void NativeConstruct() override;
     virtual void NativeDestruct() override;
@@ -51,6 +55,6 @@ private:
     void HandleSaveSlot(int32 SlotIndex);
 
     UPROPERTY()
-    TWeakObjectPtr<ULobbyMenuWidget> LobbyMenu;
+    TWeakObjectPtr<UUserWidget> OwningMenu;
 };
 

--- a/Source/Skald/SettingsWidget.cpp
+++ b/Source/Skald/SettingsWidget.cpp
@@ -5,14 +5,19 @@
 #include "GameFramework/GameUserSettings.h"
 #include "Kismet/GameplayStatics.h"
 #include "Engine/Engine.h"
-#include "LobbyMenuWidget.h"
 #include "Sound/SoundClass.h"
 #include "Sound/SoundMix.h"
 #include "Skald_GameUserSettings.h"
+#include "UI/InGameMenuWidget.h"
 
 void USettingsWidget::SetLobbyMenu(ULobbyMenuWidget* InMenu)
 {
-    LobbyMenu = InMenu;
+    SetOwningMenu(InMenu);
+}
+
+void USettingsWidget::SetOwningMenu(UUserWidget* InMenu)
+{
+    OwningMenu = InMenu;
 }
 
 void USettingsWidget::NativeConstruct()
@@ -165,9 +170,13 @@ void USettingsWidget::OnMainMenu()
     SetVisibility(ESlateVisibility::Hidden);
     RemoveFromParent();
 
-    if (LobbyMenu.IsValid())
+    if (OwningMenu.IsValid())
     {
-        LobbyMenu->SetVisibility(ESlateVisibility::Visible);
+        if (UInGameMenuWidget* Menu = Cast<UInGameMenuWidget>(OwningMenu.Get()))
+        {
+            Menu->HandleSubMenuClosed(this);
+        }
+        OwningMenu->SetVisibility(ESlateVisibility::Visible);
     }
 }
 

--- a/Source/Skald/SettingsWidget.h
+++ b/Source/Skald/SettingsWidget.h
@@ -5,6 +5,7 @@
 #include "SettingsWidget.generated.h"
 
 class ULobbyMenuWidget;
+class UUserWidget;
 class UButton;
 class UComboBoxString;
 class USlider;
@@ -54,6 +55,9 @@ public:
     UFUNCTION(BlueprintCallable, Category="Skald|Widgets")
     void SetLobbyMenu(ULobbyMenuWidget* InMenu);
 
+    UFUNCTION(BlueprintCallable, Category="Skald|Widgets")
+    void SetOwningMenu(UUserWidget* InMenu);
+
 protected:
     virtual void NativeConstruct() override;
 
@@ -80,7 +84,7 @@ protected:
 
 private:
     UPROPERTY()
-    TWeakObjectPtr<ULobbyMenuWidget> LobbyMenu;
+    TWeakObjectPtr<UUserWidget> OwningMenu;
 
     TMap<FString, FIntPoint> ResolutionMap;
     TMap<FString, int32> QualityMap;

--- a/Source/Skald/Skald_GameInstance.cpp
+++ b/Source/Skald/Skald_GameInstance.cpp
@@ -113,7 +113,25 @@ void USkaldGameInstance::HandleNetworkFailure(
   bIsMultiplayer = false;
   bIsHost = false;
 
-  // Clear any per-session state so a fresh lobby is created after reconnecting.
+  ResetSessionState();
+
+  if (World) {
+    const FName LobbyMap(TEXT("/Game/Blueprints/Maps/Skald_Lobby"));
+    UGameplayStatics::OpenLevel(World, LobbyMap);
+  }
+}
+
+void USkaldGameInstance::ReturnToMainMenu() {
+  ResetSessionState();
+
+  if (UWorld *World = GetWorld()) {
+    const FName LobbyMap(TEXT("/Game/Blueprints/Maps/Skald_Lobby"));
+    UGameplayStatics::OpenLevel(World, LobbyMap);
+  }
+}
+
+void USkaldGameInstance::ResetSessionState() {
+  // Clear any per-session state so a fresh lobby is created.
   JoinAddress.Empty();
   AIPlayersToSpawn = 1;
   TakenFactions.Empty();
@@ -121,16 +139,24 @@ void USkaldGameInstance::HandleNetworkFailure(
     TakenFactions.Add(Faction);
   }
   OnFactionsUpdated.Broadcast();
+
   PendingBattle = FS_BattlePayload();
   PendingBattleResolution = FGridBattleResolution();
   bPendingBattleResolution = false;
   GridBattleManager = nullptr;
+  bIsInBattleMap = false;
+  bTravelPending = false;
+  CachedWorldMapTerritories.Empty();
+  TravelState = FSkaldTravelState();
+
   SeedCombatRandomStream(FMath::Rand());
   SavedTurnIndex = 0;
   SavedTurnPhase = ETurnPhase::Reinforcement;
   bResumeTurns = false;
   LoadedSaveGame = nullptr;
 
-  const FName LobbyMap(TEXT("/Game/Blueprints/Maps/Skald_Lobby"));
-  UGameplayStatics::OpenLevel(World, LobbyMap);
+  if (DeployWidget) {
+    DeployWidget->RemoveFromParent();
+    DeployWidget = nullptr;
+  }
 }

--- a/Source/Skald/Skald_GameInstance.h
+++ b/Source/Skald/Skald_GameInstance.h
@@ -158,6 +158,10 @@ public:
                             ENetworkFailure::Type FailureType,
                             const FString &ErrorString);
 
+  /** Return to the main menu and clear any in-progress session data. */
+  UFUNCTION(BlueprintCallable, Category = "Skald|Menu")
+  void ReturnToMainMenu();
+
   /** Save game loaded when transitioning from the main menu. */
   UPROPERTY(BlueprintReadWrite, Category = "SaveGame")
   USkaldSaveGame *LoadedSaveGame = nullptr;
@@ -165,4 +169,6 @@ public:
 private:
   UPROPERTY()
   FSkaldTravelState TravelState;
+
+  void ResetSessionState();
 };

--- a/Source/Skald/Skald_PlayerController.cpp
+++ b/Source/Skald/Skald_PlayerController.cpp
@@ -28,6 +28,7 @@
 #include "UI/BattleHUDWidget.h"
 #include "UI/BattleResultWidget.h"
 #include "UI/FighterSelectionWidget.h"
+#include "UI/InGameMenuWidget.h"
 #include "UI/SkaldMainHUDWidget.h"
 #include "UI/SkaldUIHelpers.h"
 #include "UObject/ConstructorHelpers.h"
@@ -106,6 +107,7 @@ ASkaldPlayerController::ASkaldPlayerController() {
   BattleHUDWidgetClass = UBattleHUDWidget::StaticClass();
   FighterSelectionWidgetClass = UFighterSelectionWidget::StaticClass();
   VictoryWidgetClass = UBattleResultWidget::StaticClass();
+  InGameMenuWidgetClass = UInGameMenuWidget::StaticClass();
   bBattleHUDVisible = false;
   bBattleHUDReadyToShow = false;
 
@@ -304,6 +306,11 @@ void ASkaldPlayerController::EndPlay(const EEndPlayReason::Type EndPlayReason) {
     BattleResultWidget = nullptr;
   }
 
+  if (InGameMenuWidget) {
+    InGameMenuWidget->RemoveFromParent();
+    InGameMenuWidget = nullptr;
+  }
+
   Super::EndPlay(EndPlayReason);
 }
 
@@ -324,6 +331,68 @@ void ASkaldPlayerController::HideMainHUD() {
     UWidgetBlueprintLibrary::SetInputMode_GameOnly(this);
     bShowMouseCursor = false;
   }
+}
+
+void ASkaldPlayerController::ToggleInGameMenu() {
+  if (!IsLocalController()) {
+    return;
+  }
+
+  if (InGameMenuWidget &&
+      InGameMenuWidget->GetVisibility() != ESlateVisibility::Hidden &&
+      InGameMenuWidget->GetVisibility() != ESlateVisibility::Collapsed) {
+    HideInGameMenu();
+  } else {
+    ShowInGameMenu();
+  }
+}
+
+void ASkaldPlayerController::ShowInGameMenu() {
+  if (!IsLocalController()) {
+    return;
+  }
+
+  if (!InGameMenuWidget) {
+    if (!InGameMenuWidgetClass) {
+      InGameMenuWidgetClass = UInGameMenuWidget::StaticClass();
+    }
+
+    if (InGameMenuWidgetClass) {
+      InGameMenuWidget = CreateWidget<UInGameMenuWidget>(this, InGameMenuWidgetClass);
+      if (InGameMenuWidget) {
+        InGameMenuWidget->SetVisibility(ESlateVisibility::Hidden);
+        InGameMenuWidget->AddToViewport(90);
+      }
+    }
+  }
+
+  if (!InGameMenuWidget) {
+    return;
+  }
+
+  if (!InGameMenuWidget->IsInViewport()) {
+    InGameMenuWidget->AddToViewport(90);
+  }
+
+  InGameMenuWidget->SetVisibility(ESlateVisibility::Visible);
+  UWidgetBlueprintLibrary::SetInputMode_GameAndUIEx(
+      this, InGameMenuWidget, EMouseLockMode::DoNotLock, /*bHideCursorDuringCapture*/ false);
+  bShowMouseCursor = true;
+}
+
+void ASkaldPlayerController::HideInGameMenu() {
+  if (!IsLocalController()) {
+    return;
+  }
+
+  if (!InGameMenuWidget) {
+    return;
+  }
+
+  InGameMenuWidget->SetVisibility(ESlateVisibility::Hidden);
+  UWidgetBlueprintLibrary::SetInputMode_GameAndUIEx(
+      this, nullptr, EMouseLockMode::DoNotLock, /*bHideCursorDuringCapture*/ false);
+  bShowMouseCursor = true;
 }
 
 void ASkaldPlayerController::TryBindWorldMap() {
@@ -1700,6 +1769,8 @@ void ASkaldPlayerController::SetupInputComponent() {
                             &ASkaldPlayerController::HandleGridClick);
     InputComponent->BindKey(EKeys::RightMouseButton, IE_Pressed, this,
                             &ASkaldPlayerController::HandleRightClick);
+    InputComponent->BindKey(EKeys::O, IE_Pressed, this,
+                            &ASkaldPlayerController::ToggleInGameMenu);
   }
 }
 

--- a/Source/Skald/Skald_PlayerController.h
+++ b/Source/Skald/Skald_PlayerController.h
@@ -14,6 +14,7 @@ class UUserWidget;
 class USkaldMainHUDWidget;
 class UChoosePlayerWidget;
 class UBattleHUDWidget;
+class UInGameMenuWidget;
 class ATerritory;
 class ASkaldGameMode;
 class ASkaldGameState;
@@ -81,6 +82,15 @@ public:
   UFUNCTION(BlueprintCallable)
   void HideMainHUD();
 
+  UFUNCTION(BlueprintCallable, Category = "UI")
+  void ToggleInGameMenu();
+
+  UFUNCTION(BlueprintCallable, Category = "UI")
+  void ShowInGameMenu();
+
+  UFUNCTION(BlueprintCallable, Category = "UI")
+  void HideInGameMenu();
+
   /** Retrieve the turn manager controlling this player. */
   UFUNCTION(BlueprintCallable, BlueprintPure, Category = "Turn")
   ATurnManager *GetTurnManager() const { return TurnManager; }
@@ -115,6 +125,10 @@ protected:
   UPROPERTY(EditDefaultsOnly, BlueprintReadWrite, Category = "UI")
   TSubclassOf<UBattleHUDWidget> BattleHUDWidgetClass;
 
+  /** Widget class providing the in-game menu overlay. */
+  UPROPERTY(EditDefaultsOnly, BlueprintReadWrite, Category = "UI")
+  TSubclassOf<UInGameMenuWidget> InGameMenuWidgetClass;
+
   /** Widget class used for the fighter selection flow before battles. */
   UPROPERTY(EditDefaultsOnly, BlueprintReadWrite, Category = "UI")
   TSubclassOf<UFighterSelectionWidget> FighterSelectionWidgetClass;
@@ -141,6 +155,10 @@ protected:
   UPROPERTY(BlueprintReadOnly, Category = "UI",
             meta = (AllowPrivateAccess = "true"))
   TObjectPtr<UBattleHUDWidget> BattleHudWidget;
+
+  UPROPERTY(BlueprintReadOnly, Category = "UI",
+            meta = (AllowPrivateAccess = "true"))
+  TObjectPtr<UInGameMenuWidget> InGameMenuWidget;
 
   /** Battle result widget displayed after combat resolves. */
   UPROPERTY(BlueprintReadOnly, Category = "UI",

--- a/Source/Skald/UI/InGameMenuWidget.cpp
+++ b/Source/Skald/UI/InGameMenuWidget.cpp
@@ -1,0 +1,250 @@
+#include "UI/InGameMenuWidget.h"
+
+#include "Blueprint/WidgetBlueprintLibrary.h"
+#include "Blueprint/WidgetTree.h"
+#include "Components/Button.h"
+#include "Components/TextBlock.h"
+#include "Components/VerticalBox.h"
+#include "Components/VerticalBoxSlot.h"
+#include "LoadGameWidget.h"
+#include "SaveGameWidget.h"
+#include "SettingsWidget.h"
+#include "Skald_GameInstance.h"
+#include "Skald_PlayerController.h"
+#include "UObject/ConstructorHelpers.h"
+
+namespace
+{
+UTextBlock* CreateLabel(UWidgetTree* Tree, const FString& Text)
+{
+    UTextBlock* Label = Tree->ConstructWidget<UTextBlock>(UTextBlock::StaticClass());
+    if (Label)
+    {
+        Label->SetText(FText::FromString(Text));
+        Label->SetJustification(ETextJustify::Center);
+    }
+    return Label;
+}
+
+UButton* CreateMenuButton(UWidgetTree* Tree, const FString& Text)
+{
+    if (!Tree)
+    {
+        return nullptr;
+    }
+
+    UButton* Button = Tree->ConstructWidget<UButton>(UButton::StaticClass());
+    if (!Button)
+    {
+        return nullptr;
+    }
+
+    if (UTextBlock* Label = CreateLabel(Tree, Text))
+    {
+        Button->AddChild(Label);
+    }
+
+    return Button;
+}
+}
+
+UInGameMenuWidget::UInGameMenuWidget(const FObjectInitializer& ObjectInitializer)
+    : Super(ObjectInitializer)
+{
+    static ConstructorHelpers::FClassFinder<USaveGameWidget> SaveBP(TEXT("/Game/Blueprints/UI/Skald_SaveGameWidget"));
+    if (SaveBP.Succeeded())
+    {
+        SaveGameWidgetClass = SaveBP.Class;
+    }
+
+    static ConstructorHelpers::FClassFinder<ULoadGameWidget> LoadBP(TEXT("/Game/Blueprints/UI/Skald_LoadGameWidget"));
+    if (LoadBP.Succeeded())
+    {
+        LoadGameWidgetClass = LoadBP.Class;
+    }
+
+    static ConstructorHelpers::FClassFinder<USettingsWidget> SettingsBP(TEXT("/Game/Blueprints/UI/Skald_SettingsWidget"));
+    if (SettingsBP.Succeeded())
+    {
+        SettingsWidgetClass = SettingsBP.Class;
+    }
+}
+
+void UInGameMenuWidget::NativeConstruct()
+{
+    Super::NativeConstruct();
+
+    EnsureLayout();
+
+    if (SaveGameButton)
+    {
+        SaveGameButton->OnClicked.AddDynamic(this, &UInGameMenuWidget::HandleSaveGameClicked);
+    }
+
+    if (LoadGameButton)
+    {
+        LoadGameButton->OnClicked.AddDynamic(this, &UInGameMenuWidget::HandleLoadGameClicked);
+    }
+
+    if (SettingsButton)
+    {
+        SettingsButton->OnClicked.AddDynamic(this, &UInGameMenuWidget::HandleSettingsClicked);
+    }
+
+    if (MainMenuButton)
+    {
+        MainMenuButton->OnClicked.AddDynamic(this, &UInGameMenuWidget::HandleMainMenuClicked);
+    }
+
+    SetIsFocusable(true);
+}
+
+void UInGameMenuWidget::NativeDestruct()
+{
+    if (SaveGameButton)
+    {
+        SaveGameButton->OnClicked.RemoveDynamic(this, &UInGameMenuWidget::HandleSaveGameClicked);
+    }
+
+    if (LoadGameButton)
+    {
+        LoadGameButton->OnClicked.RemoveDynamic(this, &UInGameMenuWidget::HandleLoadGameClicked);
+    }
+
+    if (SettingsButton)
+    {
+        SettingsButton->OnClicked.RemoveDynamic(this, &UInGameMenuWidget::HandleSettingsClicked);
+    }
+
+    if (MainMenuButton)
+    {
+        MainMenuButton->OnClicked.RemoveDynamic(this, &UInGameMenuWidget::HandleMainMenuClicked);
+    }
+
+    ActiveChildWidget.Reset();
+
+    Super::NativeDestruct();
+}
+
+void UInGameMenuWidget::NativeOnVisibilityChanged(const ESlateVisibility InVisibility)
+{
+    Super::NativeOnVisibilityChanged(InVisibility);
+
+    if (InVisibility != ESlateVisibility::Visible && InVisibility != ESlateVisibility::HitTestInvisible &&
+        InVisibility != ESlateVisibility::SelfHitTestInvisible)
+    {
+        return;
+    }
+
+    if (ActiveChildWidget.IsValid())
+    {
+        ActiveChildWidget->RemoveFromParent();
+        ActiveChildWidget.Reset();
+    }
+}
+
+void UInGameMenuWidget::HandleSubMenuClosed(UUserWidget* ClosedWidget)
+{
+    if (ActiveChildWidget.Get() == ClosedWidget)
+    {
+        ActiveChildWidget.Reset();
+    }
+}
+
+void UInGameMenuWidget::EnsureLayout()
+{
+    if (WidgetTree && !WidgetTree->RootWidget)
+    {
+        UVerticalBox* Root = WidgetTree->ConstructWidget<UVerticalBox>(UVerticalBox::StaticClass(), TEXT("InGameMenuRoot"));
+        WidgetTree->RootWidget = Root;
+
+        if (Root)
+        {
+            SaveGameButton = CreateMenuButton(WidgetTree, TEXT("Save Game"));
+            LoadGameButton = CreateMenuButton(WidgetTree, TEXT("Load Game"));
+            SettingsButton = CreateMenuButton(WidgetTree, TEXT("Settings"));
+            MainMenuButton = CreateMenuButton(WidgetTree, TEXT("Main Menu"));
+
+            const TArray<UButton*> Buttons = {SaveGameButton, LoadGameButton, SettingsButton, MainMenuButton};
+            for (UButton* Button : Buttons)
+            {
+                if (Button)
+                {
+                    if (UVerticalBoxSlot* Slot = Root->AddChildToVerticalBox(Button))
+                    {
+                        Slot->SetPadding(FMargin(8.0f));
+                    }
+                }
+            }
+        }
+    }
+}
+
+void UInGameMenuWidget::HandleSaveGameClicked()
+{
+    ShowChildWidget(SaveGameWidgetClass);
+}
+
+void UInGameMenuWidget::HandleLoadGameClicked()
+{
+    ShowChildWidget(LoadGameWidgetClass);
+}
+
+void UInGameMenuWidget::HandleSettingsClicked()
+{
+    ShowChildWidget(SettingsWidgetClass);
+}
+
+void UInGameMenuWidget::HandleMainMenuClicked()
+{
+    if (ASkaldPlayerController* PC = GetOwningPlayer<ASkaldPlayerController>())
+    {
+        UWidgetBlueprintLibrary::SetInputMode_GameAndUIEx(PC, nullptr, EMouseLockMode::DoNotLock, false);
+    }
+
+    if (USkaldGameInstance* GI = GetWorld() ? GetWorld()->GetGameInstance<USkaldGameInstance>() : nullptr)
+    {
+        GI->ReturnToMainMenu();
+    }
+}
+
+void UInGameMenuWidget::ShowChildWidget(TSubclassOf<UUserWidget> WidgetClass)
+{
+    if (!WidgetClass)
+    {
+        return;
+    }
+
+    if (ActiveChildWidget.IsValid())
+    {
+        ActiveChildWidget->RemoveFromParent();
+        ActiveChildWidget.Reset();
+    }
+
+    if (UUserWidget* Child = CreateWidget<UUserWidget>(GetOwningPlayer(), WidgetClass))
+    {
+        if (USaveGameWidget* SaveWidget = Cast<USaveGameWidget>(Child))
+        {
+            SaveWidget->SetOwningMenu(this);
+        }
+        else if (ULoadGameWidget* LoadWidget = Cast<ULoadGameWidget>(Child))
+        {
+            LoadWidget->SetOwningMenu(this);
+        }
+        else if (USettingsWidget* Settings = Cast<USettingsWidget>(Child))
+        {
+            Settings->SetOwningMenu(this);
+        }
+
+        Child->AddToViewport(100);
+        ActiveChildWidget = Child;
+
+        SetVisibility(ESlateVisibility::Hidden);
+
+        if (ASkaldPlayerController* PC = GetOwningPlayer<ASkaldPlayerController>())
+        {
+            UWidgetBlueprintLibrary::SetInputMode_GameAndUIEx(PC, Child, EMouseLockMode::DoNotLock, false);
+            PC->bShowMouseCursor = true;
+        }
+    }
+}

--- a/Source/Skald/UI/InGameMenuWidget.h
+++ b/Source/Skald/UI/InGameMenuWidget.h
@@ -1,0 +1,73 @@
+#pragma once
+
+#include "Blueprint/UserWidget.h"
+#include "CoreMinimal.h"
+#include "InGameMenuWidget.generated.h"
+
+class UButton;
+class UUserWidget;
+class USaveGameWidget;
+class ULoadGameWidget;
+class USettingsWidget;
+
+/**
+ * Lightweight in-game pause/menu widget surfaced from the player controller.
+ */
+UCLASS(Blueprintable, BlueprintType)
+class SKALD_API UInGameMenuWidget : public UUserWidget
+{
+    GENERATED_BODY()
+
+public:
+    UInGameMenuWidget(const FObjectInitializer& ObjectInitializer);
+
+    UPROPERTY(BlueprintReadOnly, Category="Skald|Widgets", meta=(BindWidgetOptional))
+    UButton* SaveGameButton;
+
+    UPROPERTY(BlueprintReadOnly, Category="Skald|Widgets", meta=(BindWidgetOptional))
+    UButton* LoadGameButton;
+
+    UPROPERTY(BlueprintReadOnly, Category="Skald|Widgets", meta=(BindWidgetOptional))
+    UButton* SettingsButton;
+
+    UPROPERTY(BlueprintReadOnly, Category="Skald|Widgets", meta=(BindWidgetOptional))
+    UButton* MainMenuButton;
+
+    /** Clear bookkeeping for submenus that have been closed. */
+    UFUNCTION(BlueprintCallable, Category="Skald|Widgets")
+    void HandleSubMenuClosed(UUserWidget* ClosedWidget);
+
+protected:
+    virtual void NativeConstruct() override;
+    virtual void NativeDestruct() override;
+    virtual void NativeOnVisibilityChanged(const ESlateVisibility InVisibility) override;
+
+private:
+    void EnsureLayout();
+
+    UFUNCTION()
+    void HandleSaveGameClicked();
+
+    UFUNCTION()
+    void HandleLoadGameClicked();
+
+    UFUNCTION()
+    void HandleSettingsClicked();
+
+    UFUNCTION()
+    void HandleMainMenuClicked();
+
+    void ShowChildWidget(TSubclassOf<UUserWidget> WidgetClass);
+
+    UPROPERTY(EditDefaultsOnly, Category="Skald|Widgets")
+    TSubclassOf<USaveGameWidget> SaveGameWidgetClass;
+
+    UPROPERTY(EditDefaultsOnly, Category="Skald|Widgets")
+    TSubclassOf<ULoadGameWidget> LoadGameWidgetClass;
+
+    UPROPERTY(EditDefaultsOnly, Category="Skald|Widgets")
+    TSubclassOf<USettingsWidget> SettingsWidgetClass;
+
+    UPROPERTY(Transient)
+    TWeakObjectPtr<UUserWidget> ActiveChildWidget;
+};


### PR DESCRIPTION
## Summary
- add a native in-game menu widget that exposes save, load, settings, and main menu options
- wire the player controller to toggle the menu with the O key and show it across overworld and battle maps
- let save/load/settings widgets and the game instance coordinate with the new menu to resume play or return to the lobby safely

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dc09d2fe788324b280d60c15d702ac