### PR TITLE
Fix UI menu overrides and include dependencies

### DIFF
--- a/Source/Skald/LoadGameWidget.cpp
+++ b/Source/Skald/LoadGameWidget.cpp
@@ -9,6 +9,7 @@
 #include "Skald_GameInstance.h"
 #include "Blueprint/WidgetBlueprintLibrary.h"
 #include "UI/InGameMenuWidget.h"
+#include "LobbyMenuWidget.h"
 
 void ULoadGameWidget::SetLobbyMenu(ULobbyMenuWidget* InMenu)
 {

--- a/Source/Skald/SaveGameWidget.cpp
+++ b/Source/Skald/SaveGameWidget.cpp
@@ -8,6 +8,7 @@
 #include "Skald_GameMode.h"
 #include "SlotNameConstants.h"
 #include "UI/InGameMenuWidget.h"
+#include "LobbyMenuWidget.h"
 
 void USaveGameWidget::SetLobbyMenu(ULobbyMenuWidget* InMenu)
 {

--- a/Source/Skald/SettingsWidget.cpp
+++ b/Source/Skald/SettingsWidget.cpp
@@ -9,6 +9,7 @@
 #include "Sound/SoundMix.h"
 #include "Skald_GameUserSettings.h"
 #include "UI/InGameMenuWidget.h"
+#include "LobbyMenuWidget.h"
 
 void USettingsWidget::SetLobbyMenu(ULobbyMenuWidget* InMenu)
 {

--- a/Source/Skald/UI/InGameMenuWidget.cpp
+++ b/Source/Skald/UI/InGameMenuWidget.cpp
@@ -126,7 +126,7 @@ void UInGameMenuWidget::NativeDestruct()
     Super::NativeDestruct();
 }
 
-void UInGameMenuWidget::NativeOnVisibilityChanged(const ESlateVisibility InVisibility)
+void UInGameMenuWidget::NativeOnVisibilityChanged(ESlateVisibility InVisibility)
 {
     Super::NativeOnVisibilityChanged(InVisibility);
 

--- a/Source/Skald/UI/InGameMenuWidget.h
+++ b/Source/Skald/UI/InGameMenuWidget.h
@@ -40,7 +40,7 @@ public:
 protected:
     virtual void NativeConstruct() override;
     virtual void NativeDestruct() override;
-    virtual void NativeOnVisibilityChanged(const ESlateVisibility InVisibility) override;
+    virtual void NativeOnVisibilityChanged(ESlateVisibility InVisibility) override;
 
 private:
     void EnsureLayout();


### PR DESCRIPTION
## Summary
- update the in-game menu widget visibility override to match the current engine signature
- include the lobby menu header in load/save/settings widgets so lobby menu pointers convert to UUserWidget

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68dc24ef6d4c832491056f8afd641432