### PR TITLE
Fix menu visibility override for UE5.5

### DIFF
--- a/Source/Skald/Skald_TurnManager.cpp
+++ b/Source/Skald/Skald_TurnManager.cpp
@@ -37,16 +37,29 @@ FString NormalizeMapName(UWorld *World, FString Candidate) {
   if (!Result.IsEmpty()) {
     int32 OptionsIndex = INDEX_NONE;
     if (Result.FindChar(TEXT('?'), OptionsIndex)) {
+#if ENGINE_MAJOR_VERSION > 5 || (ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION >= 5)
+      Result.LeftInline(OptionsIndex, EAllowShrinking::No);
+#else
       Result.LeftInline(OptionsIndex, /*bAllowShrinking=*/false);
+#endif
     }
 
     if (World && !World->StreamingLevelsPrefix.IsEmpty() &&
         Result.StartsWith(World->StreamingLevelsPrefix)) {
       Result.RightChopInline(World->StreamingLevelsPrefix.Len(),
+#if ENGINE_MAJOR_VERSION > 5 || (ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION >= 5)
+                             EAllowShrinking::No);
+#else
                              /*bAllowShrinking=*/false);
+#endif
 
       if (Result.StartsWith(TEXT("_"))) {
-        Result.RightChopInline(1, /*bAllowShrinking=*/false);
+        Result.RightChopInline(1,
+#if ENGINE_MAJOR_VERSION > 5 || (ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION >= 5)
+                              EAllowShrinking::No);
+#else
+                              /*bAllowShrinking=*/false);
+#endif
       }
     }
 

--- a/Source/Skald/UI/InGameMenuWidget.cpp
+++ b/Source/Skald/UI/InGameMenuWidget.cpp
@@ -126,12 +126,26 @@ void UInGameMenuWidget::NativeDestruct()
     Super::NativeDestruct();
 }
 
+#if ENGINE_MAJOR_VERSION > 5 || (ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION >= 5)
+void UInGameMenuWidget::NativeOnVisibilityChanged(const FVisibilityChangedEvent& VisibilityChangedEvent)
+{
+    Super::NativeOnVisibilityChanged(VisibilityChangedEvent);
+
+    HandleVisibilityChanged(GetVisibility());
+}
+#else
 void UInGameMenuWidget::NativeOnVisibilityChanged(ESlateVisibility InVisibility)
 {
     Super::NativeOnVisibilityChanged(InVisibility);
 
-    if (InVisibility != ESlateVisibility::Visible && InVisibility != ESlateVisibility::HitTestInvisible &&
-        InVisibility != ESlateVisibility::SelfHitTestInvisible)
+    HandleVisibilityChanged(InVisibility);
+}
+#endif
+
+void UInGameMenuWidget::HandleVisibilityChanged(ESlateVisibility NewVisibility)
+{
+    if (NewVisibility != ESlateVisibility::Visible && NewVisibility != ESlateVisibility::HitTestInvisible &&
+        NewVisibility != ESlateVisibility::SelfHitTestInvisible)
     {
         return;
     }

--- a/Source/Skald/UI/InGameMenuWidget.h
+++ b/Source/Skald/UI/InGameMenuWidget.h
@@ -9,6 +9,9 @@ class UUserWidget;
 class USaveGameWidget;
 class ULoadGameWidget;
 class USettingsWidget;
+#if ENGINE_MAJOR_VERSION > 5 || (ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION >= 5)
+struct FVisibilityChangedEvent;
+#endif
 
 /**
  * Lightweight in-game pause/menu widget surfaced from the player controller.
@@ -40,10 +43,15 @@ public:
 protected:
     virtual void NativeConstruct() override;
     virtual void NativeDestruct() override;
+#if ENGINE_MAJOR_VERSION > 5 || (ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION >= 5)
+    virtual void NativeOnVisibilityChanged(const FVisibilityChangedEvent& VisibilityChangedEvent) override;
+#else
     virtual void NativeOnVisibilityChanged(ESlateVisibility InVisibility) override;
+#endif
 
 private:
     void EnsureLayout();
+    void HandleVisibilityChanged(ESlateVisibility NewVisibility);
 
     UFUNCTION()
     void HandleSaveGameClicked();


### PR DESCRIPTION
## Summary
- update UInGameMenuWidget to use the UE 5.5 NativeOnVisibilityChanged signature while retaining cleanup logic
- factor visibility cleanup into a helper method for reuse across engine versions
- switch FString inline trimming calls to the new EAllowShrinking enum overloads in Skald_TurnManager

## Testing
- not run (not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68dc26bd6dfc8324974fab7b0b7732cb