### PR TITLE
Fix version-conditional code for UE 5.5 builds

### DIFF
--- a/Source/Skald/Skald_TurnManager.cpp
+++ b/Source/Skald/Skald_TurnManager.cpp
@@ -4,7 +4,9 @@
 #include "EngineUtils.h"
 #include "GridBattleManager.h"
 #include "Kismet/GameplayStatics.h"
+#include "Misc/PackageName.h"
 #include "Net/UnrealNetwork.h"
+#include "Runtime/Launch/Resources/Version.h"
 #include "Skald.h"
 #include "SkaldLogging.h"
 #include "Skald_GameInstance.h"
@@ -15,7 +17,6 @@
 #include "Territory.h"
 #include "UI/SkaldMainHUDWidget.h"
 #include "WorldMap.h"
-#include "Misc/PackageName.h"
 
 namespace {
 FString GetResolvedPlayerName(const ASkaldPlayerState *PlayerState,

--- a/Source/Skald/UI/InGameMenuWidget.cpp
+++ b/Source/Skald/UI/InGameMenuWidget.cpp
@@ -1,6 +1,7 @@
 #include "UI/InGameMenuWidget.h"
 
 #include "Blueprint/WidgetBlueprintLibrary.h"
+#include "Runtime/Launch/Resources/Version.h"
 #include "Blueprint/WidgetTree.h"
 #include "Components/Button.h"
 #include "Components/TextBlock.h"

--- a/Source/Skald/UI/InGameMenuWidget.h
+++ b/Source/Skald/UI/InGameMenuWidget.h
@@ -2,6 +2,8 @@
 
 #include "Blueprint/UserWidget.h"
 #include "CoreMinimal.h"
+#include "Runtime/Launch/Resources/Version.h"
+
 #include "InGameMenuWidget.generated.h"
 
 class UButton;


### PR DESCRIPTION
## Summary
- include Unreal version definitions where ENGINE_MAJOR_VERSION is used
- ensure the in-game menu visibility override matches the engine version used

## Testing
- not run (build system unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68dc29885664832488760d69a0de5591