### PR TITLE
Fix InGameMenu visibility override guard for UE 5.5

### DIFF
--- a/Source/Skald/UI/InGameMenuWidget.cpp
+++ b/Source/Skald/UI/InGameMenuWidget.cpp
@@ -127,7 +127,7 @@ void UInGameMenuWidget::NativeDestruct()
     Super::NativeDestruct();
 }
 
-#if ENGINE_MAJOR_VERSION > 5 || (ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION >= 5)
+#if ENGINE_MAJOR_VERSION > 5 || (ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION >= 6)
 void UInGameMenuWidget::NativeOnVisibilityChanged(const FVisibilityChangedEvent& VisibilityChangedEvent)
 {
     Super::NativeOnVisibilityChanged(VisibilityChangedEvent);

--- a/Source/Skald/UI/InGameMenuWidget.h
+++ b/Source/Skald/UI/InGameMenuWidget.h
@@ -11,7 +11,7 @@ class UUserWidget;
 class USaveGameWidget;
 class ULoadGameWidget;
 class USettingsWidget;
-#if ENGINE_MAJOR_VERSION > 5 || (ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION >= 5)
+#if ENGINE_MAJOR_VERSION > 5 || (ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION >= 6)
 struct FVisibilityChangedEvent;
 #endif
 
@@ -45,7 +45,7 @@ public:
 protected:
     virtual void NativeConstruct() override;
     virtual void NativeDestruct() override;
-#if ENGINE_MAJOR_VERSION > 5 || (ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION >= 5)
+#if ENGINE_MAJOR_VERSION > 5 || (ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION >= 6)
     virtual void NativeOnVisibilityChanged(const FVisibilityChangedEvent& VisibilityChangedEvent) override;
 #else
     virtual void NativeOnVisibilityChanged(ESlateVisibility InVisibility) override;


### PR DESCRIPTION
## Summary
- adjust the NativeOnVisibilityChanged override guard so UE 5.5 still uses the legacy signature
- maintain support for newer engine versions that require the FVisibilityChangedEvent parameter

## Testing
- not run (not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68dc4c95d5248324842d15e7290bdca5