### PR TITLE
Adjust in-game menu visibility override for UE 5.5

### DIFF
--- a/Source/Skald/UI/InGameMenuWidget.cpp
+++ b/Source/Skald/UI/InGameMenuWidget.cpp
@@ -127,7 +127,7 @@ void UInGameMenuWidget::NativeDestruct()
     Super::NativeDestruct();
 }
 
-#if ENGINE_MAJOR_VERSION > 5 || (ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION >= 6)
+#if ENGINE_MAJOR_VERSION > 5 || (ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION >= 5)
 void UInGameMenuWidget::NativeOnVisibilityChanged(const FVisibilityChangedEvent& VisibilityChangedEvent)
 {
     Super::NativeOnVisibilityChanged(VisibilityChangedEvent);

--- a/Source/Skald/UI/InGameMenuWidget.h
+++ b/Source/Skald/UI/InGameMenuWidget.h
@@ -45,7 +45,7 @@ public:
 protected:
     virtual void NativeConstruct() override;
     virtual void NativeDestruct() override;
-#if ENGINE_MAJOR_VERSION > 5 || (ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION >= 6)
+#if ENGINE_MAJOR_VERSION > 5 || (ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION >= 5)
     virtual void NativeOnVisibilityChanged(const FVisibilityChangedEvent& VisibilityChangedEvent) override;
 #else
     virtual void NativeOnVisibilityChanged(ESlateVisibility InVisibility) override;


### PR DESCRIPTION
## Summary
- update the in-game menu widget's visibility override guard to match the Unreal Engine 5.5 signature

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dc50cb71b483249fd7c8ccecabd18e