### PR TITLE
Fix InGameMenuWidget visibility event guard for UE 5.5

### DIFF
--- a/Source/Skald/UI/InGameMenuWidget.h
+++ b/Source/Skald/UI/InGameMenuWidget.h
@@ -11,7 +11,7 @@ class UUserWidget;
 class USaveGameWidget;
 class ULoadGameWidget;
 class USettingsWidget;
-#if ENGINE_MAJOR_VERSION > 5 || (ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION >= 6)
+#if ENGINE_MAJOR_VERSION > 5 || (ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION >= 5)
 struct FVisibilityChangedEvent;
 #endif
 


### PR DESCRIPTION
## Summary
- update the forward declaration guard for `FVisibilityChangedEvent` so Unreal Engine 5.5 builds can see the type

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dc52bf8de48324a5eeefa579417930