### PR TITLE
Fix InGameMenuWidget visibility override for UE 5.5

### DIFF
--- a/Source/Skald/UI/InGameMenuWidget.cpp
+++ b/Source/Skald/UI/InGameMenuWidget.cpp
@@ -128,7 +128,7 @@ void UInGameMenuWidget::NativeDestruct()
 }
 
 #if ENGINE_MAJOR_VERSION > 5 || (ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION >= 5)
-void UInGameMenuWidget::NativeOnVisibilityChanged(const FVisibilityChangedEvent& VisibilityChangedEvent)
+void UInGameMenuWidget::NativeOnVisibilityChanged(const UE::Slate::FVisibilityChangedEvent& VisibilityChangedEvent)
 {
     Super::NativeOnVisibilityChanged(VisibilityChangedEvent);
 

--- a/Source/Skald/UI/InGameMenuWidget.h
+++ b/Source/Skald/UI/InGameMenuWidget.h
@@ -3,6 +3,9 @@
 #include "Blueprint/UserWidget.h"
 #include "CoreMinimal.h"
 #include "Runtime/Launch/Resources/Version.h"
+#if ENGINE_MAJOR_VERSION > 5 || (ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION >= 5)
+#include "Widgets/SWidget.h"
+#endif
 
 #include "InGameMenuWidget.generated.h"
 
@@ -11,10 +14,6 @@ class UUserWidget;
 class USaveGameWidget;
 class ULoadGameWidget;
 class USettingsWidget;
-#if ENGINE_MAJOR_VERSION > 5 || (ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION >= 5)
-struct FVisibilityChangedEvent;
-#endif
-
 /**
  * Lightweight in-game pause/menu widget surfaced from the player controller.
  */
@@ -46,7 +45,7 @@ protected:
     virtual void NativeConstruct() override;
     virtual void NativeDestruct() override;
 #if ENGINE_MAJOR_VERSION > 5 || (ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION >= 5)
-    virtual void NativeOnVisibilityChanged(const FVisibilityChangedEvent& VisibilityChangedEvent) override;
+    virtual void NativeOnVisibilityChanged(const UE::Slate::FVisibilityChangedEvent& VisibilityChangedEvent) override;
 #else
     virtual void NativeOnVisibilityChanged(ESlateVisibility InVisibility) override;
 #endif


### PR DESCRIPTION
## Summary
- include the engine visibility event header for UE 5.5 builds
- update the in-game menu widget visibility override to use UE::Slate::FVisibilityChangedEvent in 5.5+

## Testing
- `./Engine/Build/BatchFiles/Linux/Build.sh SkaldEditor Linux Development -project="$(pwd)/Skald.uproject"` *(fails: missing Engine directory in repository)*

------
https://chatgpt.com/codex/tasks/task_e_68dc6272a8a483249dc1ee5bf4f9d3a9