### PR TITLE
Update in-game menu widget visibility override for UE 5.5

### DIFF
--- a/Source/Skald/UI/InGameMenuWidget.cpp
+++ b/Source/Skald/UI/InGameMenuWidget.cpp
@@ -1,7 +1,6 @@
 #include "UI/InGameMenuWidget.h"
 
 #include "Blueprint/WidgetBlueprintLibrary.h"
-#include "Runtime/Launch/Resources/Version.h"
 #include "Blueprint/WidgetTree.h"
 #include "Components/Button.h"
 #include "Components/TextBlock.h"
@@ -127,21 +126,23 @@ void UInGameMenuWidget::NativeDestruct()
     Super::NativeDestruct();
 }
 
-#if ENGINE_MAJOR_VERSION > 5 || (ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION >= 5)
-void UInGameMenuWidget::NativeOnVisibilityChanged(const UE::Slate::FVisibilityChangedEvent& VisibilityChangedEvent)
+void UInGameMenuWidget::OnVisibilityChanged(ESlateVisibility InVisibility)
 {
-    Super::NativeOnVisibilityChanged(VisibilityChangedEvent);
+    Super::OnVisibilityChanged(InVisibility);
 
-    HandleVisibilityChanged(GetVisibility());
-}
-#else
-void UInGameMenuWidget::NativeOnVisibilityChanged(ESlateVisibility InVisibility)
-{
-    Super::NativeOnVisibilityChanged(InVisibility);
+    const bool bIsVisible = InVisibility == ESlateVisibility::Visible ||
+                            InVisibility == ESlateVisibility::HitTestInvisible ||
+                            InVisibility == ESlateVisibility::SelfHitTestInvisible;
 
-    HandleVisibilityChanged(InVisibility);
+    if (bIsVisible)
+    {
+        HandleVisibilityChanged(InVisibility);
+    }
+    else if (ActiveChildWidget.IsValid() && !ActiveChildWidget->IsInViewport())
+    {
+        ActiveChildWidget.Reset();
+    }
 }
-#endif
 
 void UInGameMenuWidget::HandleVisibilityChanged(ESlateVisibility NewVisibility)
 {

--- a/Source/Skald/UI/InGameMenuWidget.h
+++ b/Source/Skald/UI/InGameMenuWidget.h
@@ -2,10 +2,7 @@
 
 #include "Blueprint/UserWidget.h"
 #include "CoreMinimal.h"
-#include "Runtime/Launch/Resources/Version.h"
-#if ENGINE_MAJOR_VERSION > 5 || (ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION >= 5)
-#include "Widgets/SWidget.h"
-#endif
+#include "Components/SlateWrapperTypes.h"
 
 #include "InGameMenuWidget.generated.h"
 
@@ -44,11 +41,7 @@ public:
 protected:
     virtual void NativeConstruct() override;
     virtual void NativeDestruct() override;
-#if ENGINE_MAJOR_VERSION > 5 || (ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION >= 5)
-    virtual void NativeOnVisibilityChanged(const UE::Slate::FVisibilityChangedEvent& VisibilityChangedEvent) override;
-#else
-    virtual void NativeOnVisibilityChanged(ESlateVisibility InVisibility) override;
-#endif
+    virtual void OnVisibilityChanged(ESlateVisibility InVisibility) override;
 
 private:
     void EnsureLayout();


### PR DESCRIPTION
## Summary
- remove legacy NativeOnVisibilityChanged overrides tied to pre-5.5 visibility signatures
- implement the new OnVisibilityChanged(ESlateVisibility) override and guard child cleanup by visibility
- include SlateWrapperTypes instead of Launch headers for visibility definitions

## Testing
- not run (not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68dc684d71ec8324af12e779d52f4f09