### PR TITLE
Refine in-game menu visibility handling

### DIFF
--- a/Source/Skald/UI/InGameMenuWidget.cpp
+++ b/Source/Skald/UI/InGameMenuWidget.cpp
@@ -97,6 +97,10 @@ void UInGameMenuWidget::NativeConstruct()
     }
 
     SetIsFocusable(true);
+
+    CachedVisibility = GetVisibility();
+    HandleVisibilityChange(CachedVisibility);
+    SetCanTick(true);
 }
 
 void UInGameMenuWidget::NativeDestruct()
@@ -123,39 +127,42 @@ void UInGameMenuWidget::NativeDestruct()
 
     ActiveChildWidget.Reset();
 
+    SetCanTick(false);
     Super::NativeDestruct();
 }
 
-void UInGameMenuWidget::OnVisibilityChanged(ESlateVisibility InVisibility)
+void UInGameMenuWidget::NativeTick(const FGeometry& MyGeometry, float InDeltaTime)
 {
-    Super::OnVisibilityChanged(InVisibility);
+    Super::NativeTick(MyGeometry, InDeltaTime);
 
-    const bool bIsVisible = InVisibility == ESlateVisibility::Visible ||
-                            InVisibility == ESlateVisibility::HitTestInvisible ||
-                            InVisibility == ESlateVisibility::SelfHitTestInvisible;
-
-    if (bIsVisible)
+    const ESlateVisibility Current = GetVisibility();
+    if (Current != CachedVisibility)
     {
-        HandleVisibilityChanged(InVisibility);
-    }
-    else if (ActiveChildWidget.IsValid() && !ActiveChildWidget->IsInViewport())
-    {
-        ActiveChildWidget.Reset();
+        CachedVisibility = Current;
+        HandleVisibilityChange(Current);
     }
 }
 
 void UInGameMenuWidget::HandleVisibilityChanged(ESlateVisibility NewVisibility)
 {
-    if (NewVisibility != ESlateVisibility::Visible && NewVisibility != ESlateVisibility::HitTestInvisible &&
-        NewVisibility != ESlateVisibility::SelfHitTestInvisible)
+    if (NewVisibility == ESlateVisibility::Visible)
     {
-        return;
-    }
+        // became visible -> setup (play animations, refresh data, bind delegates, etc.)
 
-    if (ActiveChildWidget.IsValid())
+        if (ActiveChildWidget.IsValid())
+        {
+            ActiveChildWidget->RemoveFromParent();
+            ActiveChildWidget.Reset();
+        }
+    }
+    else
     {
-        ActiveChildWidget->RemoveFromParent();
-        ActiveChildWidget.Reset();
+        // became hidden/collapsed -> cleanup (stop timers, unbind, pause, etc.)
+
+        if (ActiveChildWidget.IsValid() && !ActiveChildWidget->IsInViewport())
+        {
+            ActiveChildWidget.Reset();
+        }
     }
 }
 

--- a/Source/Skald/UI/InGameMenuWidget.h
+++ b/Source/Skald/UI/InGameMenuWidget.h
@@ -1,7 +1,7 @@
 #pragma once
 
-#include "Blueprint/UserWidget.h"
 #include "CoreMinimal.h"
+#include "Blueprint/UserWidget.h"
 #include "Components/SlateWrapperTypes.h"
 
 #include "InGameMenuWidget.generated.h"
@@ -41,9 +41,10 @@ public:
 protected:
     virtual void NativeConstruct() override;
     virtual void NativeDestruct() override;
-    virtual void OnVisibilityChanged(ESlateVisibility InVisibility) override;
+    virtual void NativeTick(const FGeometry& MyGeometry, float InDeltaTime) override;
 
 private:
+    ESlateVisibility CachedVisibility = ESlateVisibility::Collapsed;
     void EnsureLayout();
     void HandleVisibilityChanged(ESlateVisibility NewVisibility);
 


### PR DESCRIPTION
## Summary
- remove the invalid OnVisibilityChanged override from UInGameMenuWidget
- add a cached visibility field and tick-based watcher to drive menu setup and cleanup
- initialize and stop ticking alongside construct/destruct so visibility transitions stay synchronized

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dc720a3a58832484877870187627f2