### PR TITLE
Fix compile errors in in-game menu widget

### DIFF
--- a/Source/Skald/UI/InGameMenuWidget.cpp
+++ b/Source/Skald/UI/InGameMenuWidget.cpp
@@ -100,7 +100,6 @@ void UInGameMenuWidget::NativeConstruct()
 
     CachedVisibility = GetVisibility();
     HandleVisibilityChange(CachedVisibility);
-    SetCanTick(true);
 }
 
 void UInGameMenuWidget::NativeDestruct()
@@ -126,21 +125,15 @@ void UInGameMenuWidget::NativeDestruct()
     }
 
     ActiveChildWidget.Reset();
-
-    SetCanTick(false);
     Super::NativeDestruct();
 }
 
-void UInGameMenuWidget::NativeTick(const FGeometry& MyGeometry, float InDeltaTime)
+void UInGameMenuWidget::OnVisibilityChanged(ESlateVisibility InVisibility)
 {
-    Super::NativeTick(MyGeometry, InDeltaTime);
+    Super::OnVisibilityChanged(InVisibility);
 
-    const ESlateVisibility Current = GetVisibility();
-    if (Current != CachedVisibility)
-    {
-        CachedVisibility = Current;
-        HandleVisibilityChange(Current);
-    }
+    CachedVisibility = InVisibility;
+    HandleVisibilityChange(InVisibility);
 }
 
 void UInGameMenuWidget::HandleVisibilityChange(ESlateVisibility NewVisibility)
@@ -193,9 +186,9 @@ void UInGameMenuWidget::EnsureLayout()
             {
                 if (Button)
                 {
-                    if (UVerticalBoxSlot* Slot = Root->AddChildToVerticalBox(Button))
+                    if (UVerticalBoxSlot* ButtonSlot = Root->AddChildToVerticalBox(Button))
                     {
-                        Slot->SetPadding(FMargin(8.0f));
+                        ButtonSlot->SetPadding(FMargin(8.0f));
                     }
                 }
             }

--- a/Source/Skald/UI/InGameMenuWidget.h
+++ b/Source/Skald/UI/InGameMenuWidget.h
@@ -41,7 +41,7 @@ public:
 protected:
     virtual void NativeConstruct() override;
     virtual void NativeDestruct() override;
-    virtual void NativeTick(const FGeometry& MyGeometry, float InDeltaTime) override;
+    virtual void OnVisibilityChanged(ESlateVisibility InVisibility) override;
 
 private:
     ESlateVisibility CachedVisibility = ESlateVisibility::Collapsed;


### PR DESCRIPTION
## Summary
- replace the nonexistent SetCanTick calls by handling visibility changes in OnVisibilityChanged
- clean up the in-game menu layout loop to avoid shadowing UWidget::Slot

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dda511c0cc8324a793c9c7a8b16ebc