### PR TITLE
Fix in-game menu visibility override

### DIFF
--- a/Source/Skald/UI/InGameMenuWidget.cpp
+++ b/Source/Skald/UI/InGameMenuWidget.cpp
@@ -128,9 +128,9 @@ void UInGameMenuWidget::NativeDestruct()
     Super::NativeDestruct();
 }
 
-void UInGameMenuWidget::OnVisibilityChanged(ESlateVisibility InVisibility)
+void UInGameMenuWidget::NativeOnVisibilityChanged(ESlateVisibility InVisibility)
 {
-    Super::OnVisibilityChanged(InVisibility);
+    Super::NativeOnVisibilityChanged(InVisibility);
 
     CachedVisibility = InVisibility;
     HandleVisibilityChange(InVisibility);

--- a/Source/Skald/UI/InGameMenuWidget.h
+++ b/Source/Skald/UI/InGameMenuWidget.h
@@ -41,7 +41,7 @@ public:
 protected:
     virtual void NativeConstruct() override;
     virtual void NativeDestruct() override;
-    virtual void OnVisibilityChanged(ESlateVisibility InVisibility) override;
+    virtual void NativeOnVisibilityChanged(ESlateVisibility InVisibility) override;
 
 private:
     ESlateVisibility CachedVisibility = ESlateVisibility::Collapsed;


### PR DESCRIPTION
## Summary
- switch the in-game menu widget to override NativeOnVisibilityChanged
- call the corresponding Super implementation before handling cached visibility

## Testing
- not run (build environment unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68dda75100488324a67792672085efdc