### PR TITLE
fix(ui): update in-game menu widget input handling

### DIFF
--- a/Source/Skald/Skald.Build.cs
+++ b/Source/Skald/Skald.Build.cs
@@ -15,6 +15,7 @@ public class Skald : ModuleRules
                         "Engine",
                         "InputCore",
                         "AIModule",
+                        // Required for runtime widget construction/input helpers
                         "UMG",
                         "Slate",
                         "SlateCore",

--- a/Source/Skald/UI/InGameMenuWidget.cpp
+++ b/Source/Skald/UI/InGameMenuWidget.cpp
@@ -12,6 +12,7 @@
 #include "Skald_GameInstance.h"
 #include "Skald_PlayerController.h"
 #include "UObject/ConstructorHelpers.h"
+#include "Widgets/SWidget.h"
 
 namespace
 {
@@ -128,9 +129,9 @@ void UInGameMenuWidget::NativeDestruct()
     Super::NativeDestruct();
 }
 
-void UInGameMenuWidget::NativeOnVisibilityChanged(ESlateVisibility InVisibility)
+void UInGameMenuWidget::OnVisibilityChanged(ESlateVisibility InVisibility)
 {
-    Super::NativeOnVisibilityChanged(InVisibility);
+    Super::OnVisibilityChanged(InVisibility);
 
     CachedVisibility = InVisibility;
     HandleVisibilityChange(InVisibility);
@@ -213,14 +214,21 @@ void UInGameMenuWidget::HandleSettingsClicked()
 
 void UInGameMenuWidget::HandleMainMenuClicked()
 {
-    if (ASkaldPlayerController* PC = GetOwningPlayer<ASkaldPlayerController>())
+    if (ASkaldPlayerController* PC = Cast<ASkaldPlayerController>(GetOwningPlayer()))
     {
-        UWidgetBlueprintLibrary::SetInputMode_GameAndUIEx(PC, nullptr, EMouseLockMode::DoNotLock, false);
+        FInputModeGameAndUIEx InputMode;
+        InputMode.SetWidgetToFocus(TSharedPtr<SWidget>());
+        InputMode.SetLockMouseToViewportBehavior(EMouseLockMode::DoNotLock);
+        InputMode.SetHideCursorDuringCapture(false);
+        PC->SetInputMode(InputMode);
     }
 
-    if (USkaldGameInstance* GI = GetWorld() ? GetWorld()->GetGameInstance<USkaldGameInstance>() : nullptr)
+    if (const UWorld* World = GetWorld())
     {
-        GI->ReturnToMainMenu();
+        if (USkaldGameInstance* GI = World->GetGameInstance<USkaldGameInstance>())
+        {
+            GI->ReturnToMainMenu();
+        }
     }
 }
 
@@ -237,29 +245,33 @@ void UInGameMenuWidget::ShowChildWidget(TSubclassOf<UUserWidget> WidgetClass)
         ActiveChildWidget.Reset();
     }
 
-    if (UUserWidget* Child = CreateWidget<UUserWidget>(GetOwningPlayer(), WidgetClass))
+    if (ASkaldPlayerController* PC = Cast<ASkaldPlayerController>(GetOwningPlayer()))
     {
-        if (USaveGameWidget* SaveWidget = Cast<USaveGameWidget>(Child))
+        if (UUserWidget* Child = CreateWidget<UUserWidget>(PC, WidgetClass))
         {
-            SaveWidget->SetOwningMenu(this);
-        }
-        else if (ULoadGameWidget* LoadWidget = Cast<ULoadGameWidget>(Child))
-        {
-            LoadWidget->SetOwningMenu(this);
-        }
-        else if (USettingsWidget* Settings = Cast<USettingsWidget>(Child))
-        {
-            Settings->SetOwningMenu(this);
-        }
+            if (USaveGameWidget* SaveWidget = Cast<USaveGameWidget>(Child))
+            {
+                SaveWidget->SetOwningMenu(this);
+            }
+            else if (ULoadGameWidget* LoadWidget = Cast<ULoadGameWidget>(Child))
+            {
+                LoadWidget->SetOwningMenu(this);
+            }
+            else if (USettingsWidget* Settings = Cast<USettingsWidget>(Child))
+            {
+                Settings->SetOwningMenu(this);
+            }
 
-        Child->AddToViewport(100);
-        ActiveChildWidget = Child;
+            Child->AddToViewport(100);
+            ActiveChildWidget = Child;
 
-        SetVisibility(ESlateVisibility::Hidden);
+            SetVisibility(ESlateVisibility::Hidden);
 
-        if (ASkaldPlayerController* PC = GetOwningPlayer<ASkaldPlayerController>())
-        {
-            UWidgetBlueprintLibrary::SetInputMode_GameAndUIEx(PC, Child, EMouseLockMode::DoNotLock, false);
+            FInputModeGameAndUIEx InputMode;
+            InputMode.SetWidgetToFocus(Child->GetCachedWidget());
+            InputMode.SetLockMouseToViewportBehavior(EMouseLockMode::DoNotLock);
+            InputMode.SetHideCursorDuringCapture(false);
+            PC->SetInputMode(InputMode);
             PC->bShowMouseCursor = true;
         }
     }

--- a/Source/Skald/UI/InGameMenuWidget.h
+++ b/Source/Skald/UI/InGameMenuWidget.h
@@ -41,7 +41,7 @@ public:
 protected:
     virtual void NativeConstruct() override;
     virtual void NativeDestruct() override;
-    virtual void NativeOnVisibilityChanged(ESlateVisibility InVisibility) override;
+    virtual void OnVisibilityChanged(ESlateVisibility InVisibility) override;
 
 private:
     ESlateVisibility CachedVisibility = ESlateVisibility::Collapsed;


### PR DESCRIPTION
## Summary
- replace the obsolete NativeOnVisibilityChanged override with OnVisibilityChanged and keep active child bookkeeping intact
- switch to Cast<> lookups and FInputModeGameAndUIEx for menu/player controller input handling and guard GameInstance access
- note the UMG/Slate dependency requirement directly in the module rules

## Testing
- not run (Unreal Engine build not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68ddb17275088324a832552c4fe1a01c