### PR TITLE
Fix InGameMenuWidget visibility override and input mode

### DIFF
--- a/Source/Skald/UI/InGameMenuWidget.cpp
+++ b/Source/Skald/UI/InGameMenuWidget.cpp
@@ -129,9 +129,9 @@ void UInGameMenuWidget::NativeDestruct()
     Super::NativeDestruct();
 }
 
-void UInGameMenuWidget::OnVisibilityChanged(ESlateVisibility InVisibility)
+void UInGameMenuWidget::NativeOnVisibilityChanged(ESlateVisibility InVisibility)
 {
-    Super::OnVisibilityChanged(InVisibility);
+    Super::NativeOnVisibilityChanged(InVisibility);
 
     CachedVisibility = InVisibility;
     HandleVisibilityChange(InVisibility);
@@ -216,7 +216,7 @@ void UInGameMenuWidget::HandleMainMenuClicked()
 {
     if (ASkaldPlayerController* PC = Cast<ASkaldPlayerController>(GetOwningPlayer()))
     {
-        FInputModeGameAndUIEx InputMode;
+        FInputModeGameAndUI InputMode;
         InputMode.SetWidgetToFocus(TSharedPtr<SWidget>());
         InputMode.SetLockMouseToViewportBehavior(EMouseLockMode::DoNotLock);
         InputMode.SetHideCursorDuringCapture(false);
@@ -267,7 +267,7 @@ void UInGameMenuWidget::ShowChildWidget(TSubclassOf<UUserWidget> WidgetClass)
 
             SetVisibility(ESlateVisibility::Hidden);
 
-            FInputModeGameAndUIEx InputMode;
+            FInputModeGameAndUI InputMode;
             InputMode.SetWidgetToFocus(Child->GetCachedWidget());
             InputMode.SetLockMouseToViewportBehavior(EMouseLockMode::DoNotLock);
             InputMode.SetHideCursorDuringCapture(false);

--- a/Source/Skald/UI/InGameMenuWidget.h
+++ b/Source/Skald/UI/InGameMenuWidget.h
@@ -41,7 +41,7 @@ public:
 protected:
     virtual void NativeConstruct() override;
     virtual void NativeDestruct() override;
-    virtual void OnVisibilityChanged(ESlateVisibility InVisibility) override;
+    virtual void NativeOnVisibilityChanged(ESlateVisibility InVisibility) override;
 
 private:
     ESlateVisibility CachedVisibility = ESlateVisibility::Collapsed;


### PR DESCRIPTION
## Summary
- override `NativeOnVisibilityChanged` instead of `OnVisibilityChanged` so the visibility hook matches the UUserWidget API
- use `FInputModeGameAndUI` when changing the player controller input mode

## Testing
- not run (requires Unreal Engine build environment)


------
https://chatgpt.com/codex/tasks/task_e_68ddb35a26c483249f93f4d5e931bea3