### PR TITLE
fix: update in-game menu visibility handling

### DIFF
--- a/Source/Skald/UI/InGameMenuWidget.cpp
+++ b/Source/Skald/UI/InGameMenuWidget.cpp
@@ -128,14 +128,6 @@ void UInGameMenuWidget::NativeDestruct()
     Super::NativeDestruct();
 }
 
-void UInGameMenuWidget::OnVisibilityChanged(ESlateVisibility InVisibility)
-{
-    Super::OnVisibilityChanged(InVisibility);
-
-    CachedVisibility = InVisibility;
-    HandleVisibilityChange(InVisibility);
-}
-
 void UInGameMenuWidget::HandleVisibilityChange(ESlateVisibility NewVisibility)
 {
     if (NewVisibility == ESlateVisibility::Visible)
@@ -164,6 +156,18 @@ void UInGameMenuWidget::HandleSubMenuClosed(UUserWidget* ClosedWidget)
     if (ActiveChildWidget.Get() == ClosedWidget)
     {
         ActiveChildWidget.Reset();
+    }
+}
+
+void UInGameMenuWidget::NativeTick(const FGeometry& MyGeometry, float InDeltaTime)
+{
+    Super::NativeTick(MyGeometry, InDeltaTime);
+
+    const ESlateVisibility Current = GetVisibility();
+    if (Current != CachedVisibility)
+    {
+        CachedVisibility = Current;
+        HandleVisibilityChange(Current);
     }
 }
 
@@ -265,9 +269,10 @@ void UInGameMenuWidget::ShowChildWidget(TSubclassOf<UUserWidget> WidgetClass)
             ActiveChildWidget = Child;
 
             SetVisibility(ESlateVisibility::Hidden);
+            HandleVisibilityChange(ESlateVisibility::Hidden);
 
             FInputModeGameAndUI Mode;
-            Mode.SetWidgetToFocus(Child->TakeWidget());
+            Mode.SetWidgetToFocus(Child);
             Mode.SetLockMouseToViewportBehavior(EMouseLockMode::DoNotLock);
             Mode.SetHideCursorDuringCapture(false);
             PC->SetInputMode(Mode);

--- a/Source/Skald/UI/InGameMenuWidget.h
+++ b/Source/Skald/UI/InGameMenuWidget.h
@@ -41,7 +41,7 @@ public:
 protected:
     virtual void NativeConstruct() override;
     virtual void NativeDestruct() override;
-    virtual void OnVisibilityChanged(ESlateVisibility InVisibility) override;
+    virtual void NativeTick(const FGeometry& MyGeometry, float InDeltaTime) override;
 
 private:
     ESlateVisibility CachedVisibility = ESlateVisibility::Collapsed;


### PR DESCRIPTION
## Summary
- remove the unsafe visibility override from the in-game menu widget
- poll visibility in NativeTick so HandleVisibilityChange still fires
- ensure input mode switching uses FInputModeGameAndUI and re-notifies when hiding for child widgets

## Testing
- not run (Unreal Engine project)


------
https://chatgpt.com/codex/tasks/task_e_68ddba23a0b4832483723f17a7aba175