### PR TITLE
fix(ui): pass Slate widget to SetWidgetToFocus (UE 5.5)

### DIFF
--- a/Source/Skald/UI/InGameMenuWidget.cpp
+++ b/Source/Skald/UI/InGameMenuWidget.cpp
@@ -220,7 +220,8 @@ void UInGameMenuWidget::HandleMainMenuClicked()
     if (ASkaldPlayerController* PC = Cast<ASkaldPlayerController>(GetOwningPlayer()))
     {
         FInputModeGameAndUI Mode;
-        Mode.SetWidgetToFocus(nullptr);
+        // Clear focus explicitly with an empty shared ptr (safer than nullptr on some UE builds)
+        Mode.SetWidgetToFocus(TSharedPtr<SWidget>());
         Mode.SetLockMouseToViewportBehavior(EMouseLockMode::DoNotLock);
         Mode.SetHideCursorDuringCapture(false);
         PC->SetInputMode(Mode);
@@ -272,7 +273,8 @@ void UInGameMenuWidget::ShowChildWidget(TSubclassOf<UUserWidget> WidgetClass)
             HandleVisibilityChange(ESlateVisibility::Hidden);
 
             FInputModeGameAndUI Mode;
-            Mode.SetWidgetToFocus(Child);
+            // Focus the Slate widget produced by the UUserWidget
+            Mode.SetWidgetToFocus(Child->TakeWidget());
             Mode.SetLockMouseToViewportBehavior(EMouseLockMode::DoNotLock);
             Mode.SetHideCursorDuringCapture(false);
             PC->SetInputMode(Mode);


### PR DESCRIPTION
## Summary
- clear input focus with an empty `TSharedPtr<SWidget>` when leaving the in-game menu
- focus the Slate widget produced by the active child widget so UE 5.5 accepts the target

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ddc10005e08324a5ed5de64756c9b9