### PR TITLE
Add configurable spawn facing yaw for fighter pawns

### DIFF
--- a/Source/Skald/FighterPawn.cpp
+++ b/Source/Skald/FighterPawn.cpp
@@ -92,6 +92,7 @@ void AFighterPawn::OnConstruction(const FTransform &Transform) {
   Super::OnConstruction(Transform);
   ApplyFootprintScale();
   UpdateMeshOffset();
+  ApplyFacingYaw(SpawnFacingYaw);
 }
 
 void AFighterPawn::BeginPlay() {
@@ -119,6 +120,10 @@ void AFighterPawn::BeginPlay() {
   }
 
   MovementTargetLocation = GetActorLocation();
+
+  // Ensure the requested spawn facing is applied on all clients while
+  // respecting the display mesh's relative rotation.
+  ApplyFacingYaw(SpawnFacingYaw);
 
   if (UWorld *World = GetWorld()) {
     if (USkaldGameInstance *GI =

--- a/Source/Skald/FighterPawn.h
+++ b/Source/Skald/FighterPawn.h
@@ -143,6 +143,10 @@ public:
   UPROPERTY(BlueprintReadOnly, Replicated, Category = "Fighter")
   bool bIsCurrentlyActive;
 
+  /** Desired world yaw to apply at spawn while preserving mesh offsets. */
+  UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Fighter|Appearance")
+  float SpawnFacingYaw = 0.f;
+
   /** Mesh used to display the fighter. */
   UPROPERTY(VisibleAnywhere, BlueprintReadOnly)
   UStaticMeshComponent *DisplayMesh;


### PR DESCRIPTION
## Summary
- add a SpawnFacingYaw property so fighter blueprints can define their desired world-facing yaw at spawn
- apply the configured yaw during construction and begin play while keeping mesh-relative offsets intact

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ddf81fcb9883248415ddaab8f0ef8f