### PR TITLE
Fix duplicate property helper definitions

### DIFF
--- a/Source/Skald/Skald_GameMode.cpp
+++ b/Source/Skald/Skald_GameMode.cpp
@@ -13,6 +13,7 @@
 #include "Skald_BattleGameMode.h"
 #include "Skald_GameInstance.h"
 #include "Skald_GameState.h"
+#include "Skald_PropertyAccess.h"
 #include "Skald_PlayerCharacter.h"
 #include "Skald_PlayerController.h"
 #include "Skald_PlayerState.h"
@@ -29,57 +30,12 @@ constexpr int32 StartingResources = 100;
 constexpr float RetryInitDelay = 0.01f;
 // Instance variables moved into ASkaldGameMode to avoid cross-instance
 // interference; see header for declarations.
-
-int32 ReadIntProperty(UObject *Object, const FName PropertyName,
-                      int32 DefaultValue = 0) {
-  if (!Object) {
-    return DefaultValue;
-  }
-
-  if (const FIntProperty *Property =
-          FindFProperty<FIntProperty>(Object->GetClass(), PropertyName)) {
-    return Property->GetPropertyValue_InContainer(Object);
-  }
-
-  return DefaultValue;
-}
-
-bool ReadBoolProperty(UObject *Object, const FName PropertyName,
-                      bool bDefaultValue = false) {
-  if (!Object) {
-    return bDefaultValue;
-  }
-
-  if (const FBoolProperty *Property =
-          FindFProperty<FBoolProperty>(Object->GetClass(), PropertyName)) {
-    return Property->GetPropertyValue_InContainer(Object);
-  }
-
-  return bDefaultValue;
-}
-
-void WriteIntProperty(UObject *Object, const FName PropertyName, int32 Value) {
-  if (!Object) {
-    return;
-  }
-
-  if (FIntProperty *Property =
-          FindFProperty<FIntProperty>(Object->GetClass(), PropertyName)) {
-    Property->SetPropertyValue_InContainer(Object, Value);
-  }
-}
-
-void WriteBoolProperty(UObject *Object, const FName PropertyName, bool bValue) {
-  if (!Object) {
-    return;
-  }
-
-  if (FBoolProperty *Property =
-          FindFProperty<FBoolProperty>(Object->GetClass(), PropertyName)) {
-    Property->SetPropertyValue_InContainer(Object, bValue);
-  }
-}
 } // namespace
+
+using Skald::PropertyAccess::ReadBoolProperty;
+using Skald::PropertyAccess::ReadIntProperty;
+using Skald::PropertyAccess::WriteBoolProperty;
+using Skald::PropertyAccess::WriteIntProperty;
 
 ASkaldGameMode::ASkaldGameMode() {
   GameStateClass = ASkaldGameState::StaticClass();

--- a/Source/Skald/Skald_PropertyAccess.h
+++ b/Source/Skald/Skald_PropertyAccess.h
@@ -1,0 +1,60 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "UObject/UnrealType.h"
+
+namespace Skald::PropertyAccess {
+
+inline int32 ReadIntProperty(UObject *Object, const FName PropertyName,
+                             int32 DefaultValue = 0) {
+  if (!Object) {
+    return DefaultValue;
+  }
+
+  if (const FIntProperty *Property =
+          FindFProperty<FIntProperty>(Object->GetClass(), PropertyName)) {
+    return Property->GetPropertyValue_InContainer(Object);
+  }
+
+  return DefaultValue;
+}
+
+inline bool ReadBoolProperty(UObject *Object, const FName PropertyName,
+                             bool bDefaultValue = false) {
+  if (!Object) {
+    return bDefaultValue;
+  }
+
+  if (const FBoolProperty *Property =
+          FindFProperty<FBoolProperty>(Object->GetClass(), PropertyName)) {
+    return Property->GetPropertyValue_InContainer(Object);
+  }
+
+  return bDefaultValue;
+}
+
+inline void WriteIntProperty(UObject *Object, const FName PropertyName,
+                             int32 Value) {
+  if (!Object) {
+    return;
+  }
+
+  if (FIntProperty *Property =
+          FindFProperty<FIntProperty>(Object->GetClass(), PropertyName)) {
+    Property->SetPropertyValue_InContainer(Object, Value);
+  }
+}
+
+inline void WriteBoolProperty(UObject *Object, const FName PropertyName,
+                              bool bValue) {
+  if (!Object) {
+    return;
+  }
+
+  if (FBoolProperty *Property =
+          FindFProperty<FBoolProperty>(Object->GetClass(), PropertyName)) {
+    Property->SetPropertyValue_InContainer(Object, bValue);
+  }
+}
+
+} // namespace Skald::PropertyAccess

--- a/Source/Skald/Skald_TurnManager.cpp
+++ b/Source/Skald/Skald_TurnManager.cpp
@@ -12,6 +12,7 @@
 #include "Skald_GameInstance.h"
 #include "Skald_GameMode.h"
 #include "Skald_GameState.h"
+#include "Skald_PropertyAccess.h"
 #include "Skald_PlayerController.h"
 #include "Skald_PlayerState.h"
 #include "Territory.h"
@@ -27,34 +28,6 @@ FString GetResolvedPlayerName(const ASkaldPlayerState *PlayerState,
   }
 
   return PlayerState->GetResolvedPlayerName(Context);
-}
-
-int32 ReadIntProperty(UObject *Object, const FName PropertyName,
-                      int32 DefaultValue = 0) {
-  if (!Object) {
-    return DefaultValue;
-  }
-
-  if (const FIntProperty *Property =
-          FindFProperty<FIntProperty>(Object->GetClass(), PropertyName)) {
-    return Property->GetPropertyValue_InContainer(Object);
-  }
-
-  return DefaultValue;
-}
-
-bool ReadBoolProperty(UObject *Object, const FName PropertyName,
-                      bool bDefaultValue = false) {
-  if (!Object) {
-    return bDefaultValue;
-  }
-
-  if (const FBoolProperty *Property =
-          FindFProperty<FBoolProperty>(Object->GetClass(), PropertyName)) {
-    return Property->GetPropertyValue_InContainer(Object);
-  }
-
-  return bDefaultValue;
 }
 
 FString NormalizeMapName(UWorld *World, FString Candidate) {
@@ -109,6 +82,9 @@ FString NormalizeMapName(UWorld *World, FString Candidate) {
   return Result;
 }
 } // namespace
+
+using Skald::PropertyAccess::ReadBoolProperty;
+using Skald::PropertyAccess::ReadIntProperty;
 
 ATurnManager::ATurnManager() {
   PrimaryActorTick.bCanEverTick = false;


### PR DESCRIPTION
## Summary
- move shared property accessor helpers into a dedicated header
- include the shared helpers in the game mode and turn manager to eliminate duplicate definitions

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68de09254cac83248fa7a9bdf1f5db91