### PR TITLE
Improve resilience of world map snapshot caching

### DIFF
--- a/Source/Skald/Skald_GameMode.cpp
+++ b/Source/Skald/Skald_GameMode.cpp
@@ -561,10 +561,12 @@ void ASkaldGameMode::CacheWorldMapSnapshot() {
         GetWorld(), AWorldMap::StaticClass()));
   }
 
+  const int32 PreviousSnapshotCount = GI->CachedWorldMapTerritories.Num();
+
   if (!WorldMap) {
     UE_LOG(LogSkald, Warning,
-           TEXT("CacheWorldMapSnapshot failed: WorldMap not found"));
-    GI->CachedWorldMapTerritories.Reset();
+           TEXT("CacheWorldMapSnapshot failed: WorldMap not found (keeping previous %d territories)"),
+           PreviousSnapshotCount);
     return;
   }
 
@@ -609,10 +611,18 @@ void ASkaldGameMode::CacheWorldMapSnapshot() {
     TerritorySnapshots.Add(MoveTemp(TerrData));
   }
 
+  if (TerritorySnapshots.Num() == 0) {
+    UE_LOG(LogSkald, Warning,
+           TEXT("CacheWorldMapSnapshot produced an empty snapshot; keeping previous %d territories"),
+           PreviousSnapshotCount);
+    return;
+  }
+
   GI->CachedWorldMapTerritories = MoveTemp(TerritorySnapshots);
 
-  UE_LOG(LogSkald, Verbose, TEXT("CacheWorldMapSnapshot captured %d territories"),
-         GI->CachedWorldMapTerritories.Num());
+  UE_LOG(LogSkald, Verbose,
+         TEXT("CacheWorldMapSnapshot captured %d territories (previously %d)"),
+         GI->CachedWorldMapTerritories.Num(), PreviousSnapshotCount);
 }
 
 bool ASkaldGameMode::RestoreWorldFromSnapshot() {

--- a/Source/Skald/Skald_TurnManager.cpp
+++ b/Source/Skald/Skald_TurnManager.cpp
@@ -571,6 +571,7 @@ void ATurnManager::TriggerGridBattle(const FS_BattlePayload &Battle) {
     };
 
     TArray<FS_Territory> TerritorySnapshots;
+    bool bUsedCachedFallback = false;
     if (CachedWorldMap) {
       TerritorySnapshots.Reserve(CachedWorldMap->Territories.Num());
       for (ATerritory *Territory : CachedWorldMap->Territories) {
@@ -613,6 +614,7 @@ void ATurnManager::TriggerGridBattle(const FS_BattlePayload &Battle) {
         TerritorySnapshots.Add(MoveTemp(Snapshot));
       }
     } else if (GI && GI->CachedWorldMapTerritories.Num() > 0) {
+      bUsedCachedFallback = true;
       TerritorySnapshots = GI->CachedWorldMapTerritories;
       for (const FS_Territory &Snapshot : TerritorySnapshots) {
         if (Snapshot.OwnerPlayerID > 0 && GS) {
@@ -621,6 +623,16 @@ void ATurnManager::TriggerGridBattle(const FS_BattlePayload &Battle) {
           }
         }
       }
+    }
+
+    if (TerritorySnapshots.Num() == 0) {
+      UE_LOG(LogSkald, Warning,
+             TEXT("TriggerGridBattle could not capture a territory snapshot (fallbackUsed=%d)"),
+             bUsedCachedFallback ? 1 : 0);
+    } else {
+      UE_LOG(LogSkald, Verbose,
+             TEXT("TriggerGridBattle captured %d territory snapshots (fallbackUsed=%d)"),
+             TerritorySnapshots.Num(), bUsedCachedFallback ? 1 : 0);
     }
 
     TravelState.CachedTerritories = MoveTemp(TerritorySnapshots);


### PR DESCRIPTION
## Summary
- preserve the existing cached world map snapshot when the actor is missing instead of clearing it
- add verbose and warning logging to cache capture so we can see when the fallback is used and when zero territories are captured

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68de0ec4b67c8324ae5855a8b7bcdf09