### PR TITLE
Fix fighter yaw alignment with display mesh

### DIFF
--- a/Source/Skald/FighterPawn.cpp
+++ b/Source/Skald/FighterPawn.cpp
@@ -92,6 +92,7 @@ void AFighterPawn::OnConstruction(const FTransform &Transform) {
   Super::OnConstruction(Transform);
   ApplyFootprintScale();
   UpdateMeshOffset();
+  RefreshDisplayMeshYawOffset();
   const float IncomingSpawnYaw = Transform.GetRotation().Rotator().Yaw;
   const float DesiredYaw =
       ShouldOverrideSpawnFacingYaw() ? SpawnFacingYaw : IncomingSpawnYaw;
@@ -111,6 +112,7 @@ void AFighterPawn::BeginPlay() {
   BroadcastActionsRemaining();
 
   UpdateMeshOffset();
+  RefreshDisplayMeshYawOffset();
 
   if (UGridOverlayComponent *Grid = GetGrid()) {
     CurrentCell = Grid->WorldToGrid(GetActorLocation());
@@ -387,6 +389,15 @@ void AFighterPawn::ApplyFootprintScale() {
   }
 }
 
+void AFighterPawn::RefreshDisplayMeshYawOffset() {
+  if (DisplayMesh) {
+    DisplayMeshYawOffset =
+        FRotator::NormalizeAxis(DisplayMesh->GetRelativeRotation().Yaw);
+  } else {
+    DisplayMeshYawOffset = 0.f;
+  }
+}
+
 FVector AFighterPawn::GetAlignedWorldLocation(const FIntPoint &Anchor) const {
   if (UGridOverlayComponent *Grid = GetGrid()) {
     const TArray<FIntPoint> Cells = GetOccupiedCells(Anchor);
@@ -502,6 +513,7 @@ void AFighterPawn::MoveToCell(FIntPoint TargetCell) {
   FVector NewLocation = Grid ? GetAlignedWorldLocation(TargetCell)
                              : GetActorLocation();
   MovementTargetLocation = NewLocation;
+  RefreshDisplayMeshYawOffset();
   FaceTowardsCells(PreviousCell, TargetCell);
   FaceTowardsLocation(NewLocation);
 
@@ -611,6 +623,7 @@ void AFighterPawn::PerformAttack(AFighterPawn *Target) {
 
   BroadcastActionsRemaining();
 
+  RefreshDisplayMeshYawOffset();
   FaceTowardsCells(CurrentCell, Target->CurrentCell);
   FaceTowardsLocation(Target->GetActorLocation());
 
@@ -830,16 +843,12 @@ bool AFighterPawn::ShouldOverrideSpawnFacingYaw() const {
 }
 
 float AFighterPawn::GetCurrentWorldFacingYaw() const {
-  const float MeshYawOffset =
-      DisplayMesh ? DisplayMesh->GetRelativeRotation().Yaw : 0.f;
-  return FRotator::NormalizeAxis(GetActorRotation().Yaw + MeshYawOffset);
+  return FRotator::NormalizeAxis(GetActorRotation().Yaw + DisplayMeshYawOffset);
 }
 
 void AFighterPawn::ApplyFacingYaw(float TargetYaw) {
-  const float MeshYawOffset =
-      DisplayMesh ? DisplayMesh->GetRelativeRotation().Yaw : 0.f;
   const float AdjustedYaw =
-      FRotator::NormalizeAxis(TargetYaw - MeshYawOffset);
+      FRotator::NormalizeAxis(TargetYaw - DisplayMeshYawOffset);
   SetActorRotation(FRotator(0.f, AdjustedYaw, 0.f));
 }
 

--- a/Source/Skald/FighterPawn.h
+++ b/Source/Skald/FighterPawn.h
@@ -230,6 +230,9 @@ private:
   /** Calculate the aligned world location for a given anchor cell. */
   FVector GetAlignedWorldLocation(const FIntPoint &Anchor) const;
 
+  /** Capture the display mesh's yaw offset for use when orienting the pawn. */
+  void RefreshDisplayMeshYawOffset();
+
   /** Helper to broadcast the current actions remaining value. */
   void BroadcastActionsRemaining();
 
@@ -297,6 +300,9 @@ private:
 
   /** World-space destination for the current interpolated move. */
   FVector MovementTargetLocation = FVector::ZeroVector;
+
+  /** Cached yaw offset derived from the display mesh's relative rotation. */
+  float DisplayMeshYawOffset = 0.f;
 
 public:
   /** Returns true if the fighter has already activated this round. */


### PR DESCRIPTION
## Summary
- cache the display mesh yaw offset so pawn facing honors any mesh rotation adjustments
- refresh the cached offset during construction, begin play, movement, and attacks before reorienting
- drive facing calculations from the cached offset so fighter movement and spawn yaw stay aligned with the mesh

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68de0f534d548324b670ad6cb9ea46d5