### PR TITLE
Replicate spawn yaw delta for fighter pawns

### DIFF
--- a/Source/Skald/FighterPawn.cpp
+++ b/Source/Skald/FighterPawn.cpp
@@ -86,6 +86,7 @@ void AFighterPawn::GetLifetimeReplicatedProps(
   DOREPLIFETIME(AFighterPawn, bIsCurrentlyActive);
   DOREPLIFETIME(AFighterPawn, GridFootprint);
   DOREPLIFETIME(AFighterPawn, CurrentCell);
+  DOREPLIFETIME(AFighterPawn, SpawnFacingYawDelta);
 }
 
 void AFighterPawn::OnConstruction(const FTransform &Transform) {

--- a/Source/Skald/FighterPawn.h
+++ b/Source/Skald/FighterPawn.h
@@ -153,6 +153,11 @@ public:
             meta = (EditCondition = "bOverrideSpawnFacingYaw"))
   float SpawnFacingYaw = 0.f;
 
+  /** Offset applied to locally computed facings to preserve the desired spawn
+      orientation when overriding incoming rotations. */
+  UPROPERTY(Replicated)
+  float SpawnFacingYawDelta = 0.f;
+
   /** Mesh used to display the fighter. */
   UPROPERTY(VisibleAnywhere, BlueprintReadOnly)
   UStaticMeshComponent *DisplayMesh;
@@ -199,7 +204,6 @@ protected:
 private:
   bool ShouldOverrideSpawnFacingYaw() const;
   float GetCurrentWorldFacingYaw() const;
-  float SpawnFacingYawDelta = 0.f;
 
   /** Update the health widget with a new value. */
   UFUNCTION()


### PR DESCRIPTION
## Summary
- replicate SpawnFacingYawDelta on AFighterPawn so clients maintain the server-computed spawn facing offset
- register the new replicated property in GetLifetimeReplicatedProps to keep local facing updates aligned

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68de956fece88324a128b070e5124d6a