### PR TITLE
Fix overworld resume after grid battle

### DIFF
--- a/Source/Skald/Skald_TurnManager.cpp
+++ b/Source/Skald/Skald_TurnManager.cpp
@@ -119,7 +119,9 @@ void ATurnManager::BeginPlay() {
           this, &ATurnManager::HandleGridBattleEnded);
     }
 
-    TryResumeSavedTurnState(GI);
+    if (bOnWorldMap) {
+      TryResumeSavedTurnState(GI);
+    }
   }
 
   if (ASkaldGameMode *GM = GetWorld()->GetAuthGameMode<ASkaldGameMode>()) {


### PR DESCRIPTION
## Summary
- avoid clearing the post-battle resume flag while the turn manager is running on the battle map

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dea073b8c883248a6eea6bf8b6bc4e