### PR TITLE
Fix overworld snapshot after battle resolution

### DIFF
--- a/Source/Skald/Skald_TurnManager.cpp
+++ b/Source/Skald/Skald_TurnManager.cpp
@@ -833,6 +833,67 @@ void ATurnManager::ResolveGridBattleResult_Implementation() {
   Source->RefreshAppearance();
   Target->RefreshAppearance();
 
+  bool bUpdatedSnapshot = false;
+  if (ASkaldGameMode *GM = GetWorld()->GetAuthGameMode<ASkaldGameMode>()) {
+    GM->CacheWorldMapSnapshot();
+    bUpdatedSnapshot = true;
+  } else if (GI) {
+    TArray<FS_Territory> TerritorySnapshots;
+    TerritorySnapshots.Reserve(CachedWorldMap->Territories.Num());
+
+    auto CaptureSnapshot = [&](ATerritory *Territory) {
+      FS_Territory Snapshot;
+      Snapshot.TerritoryID = Territory->TerritoryID;
+      Snapshot.TerritoryName = Territory->TerritoryName;
+      Snapshot.OwnerPlayerID =
+          Territory->OwningPlayer ? Territory->OwningPlayer->GetPlayerId() : 0;
+      Snapshot.IsCapital = Territory->bIsCapital;
+      Snapshot.CapitalOwner = Snapshot.OwnerPlayerID;
+      Snapshot.ArmyUnits = Territory->ArmyUnits;
+      Snapshot.ContinentID = Territory->ContinentID;
+      Snapshot.Location = Territory->GetActorLocation();
+      Snapshot.HasTreasure = Territory->bHasTreasure;
+      Snapshot.TreasureAttachedUnitID =
+          ReadIntProperty(Territory, TEXT("TreasureAttachedUnitID"));
+      Snapshot.FortificationLevel =
+          ReadIntProperty(Territory, TEXT("FortificationLevel"));
+      Snapshot.Moat = ReadBoolProperty(Territory, TEXT("Moat"));
+      Snapshot.WallHealth = ReadIntProperty(Territory, TEXT("WallHealth"));
+      Snapshot.BuiltSiegeID = Territory->BuiltSiegeID;
+      Snapshot.ConqueredTurn =
+          ReadIntProperty(Territory, TEXT("ConqueredTurn"));
+      Snapshot.IsNeutralSpawn =
+          ReadBoolProperty(Territory, TEXT("IsNeutralSpawn"));
+      Snapshot.AdjacentIDs.Reset();
+      for (ATerritory *Adj : Territory->AdjacentTerritories) {
+        if (Adj) {
+          Snapshot.AdjacentIDs.Add(Adj->TerritoryID);
+        }
+      }
+      return Snapshot;
+    };
+
+    for (ATerritory *Territory : CachedWorldMap->Territories) {
+      if (!Territory) {
+        continue;
+      }
+      TerritorySnapshots.Add(CaptureSnapshot(Territory));
+    }
+
+    if (TerritorySnapshots.Num() > 0) {
+      GI->CachedWorldMapTerritories = MoveTemp(TerritorySnapshots);
+      bUpdatedSnapshot = true;
+    }
+  }
+
+  if (bUpdatedSnapshot && GI) {
+    FSkaldTravelState UpdatedTravelState = GI->GetTravelState();
+    if (UpdatedTravelState.bValid) {
+      UpdatedTravelState.CachedTerritories = GI->CachedWorldMapTerritories;
+      GI->SetTravelState(UpdatedTravelState);
+    }
+  }
+
   GI->PendingBattle = FS_BattlePayload();
   PendingBattle = FS_BattlePayload();
 


### PR DESCRIPTION
## Summary
- refresh the cached overworld snapshot once battle results are applied
- keep the travel state's cached territories in sync with the refreshed snapshot

## Testing
- not run (not available in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68deabeeda708324b64e47b0642581b6