### PR TITLE
Fix world map timer crash after battles

### DIFF
--- a/Source/Skald/Skald_PlayerController.cpp
+++ b/Source/Skald/Skald_PlayerController.cpp
@@ -311,6 +311,19 @@ void ASkaldPlayerController::EndPlay(const EEndPlayReason::Type EndPlayReason) {
     InGameMenuWidget = nullptr;
   }
 
+  if (AWorldMap *WorldMap = CachedWorldMap.Get()) {
+    if (WorldMap->OnTerritorySelected.IsAlreadyBound(
+            this, &ASkaldPlayerController::HandleTerritorySelected)) {
+      WorldMap->OnTerritorySelected.RemoveDynamic(
+          this, &ASkaldPlayerController::HandleTerritorySelected);
+    }
+  }
+  CachedWorldMap.Reset();
+
+  if (UWorld *World = GetWorld()) {
+    World->GetTimerManager().ClearTimer(WorldMapSearchHandle);
+  }
+
   Super::EndPlay(EndPlayReason);
 }
 
@@ -396,21 +409,33 @@ void ASkaldPlayerController::HideInGameMenu() {
 }
 
 void ASkaldPlayerController::TryBindWorldMap() {
-  if (AWorldMap *WorldMap = Cast<AWorldMap>(UGameplayStatics::GetActorOfClass(
-          GetWorld(), AWorldMap::StaticClass()))) {
-    if (!WorldMap->OnTerritorySelected.IsAlreadyBound(
+  UWorld *World = GetWorld();
+  if (!World) {
+    return;
+  }
+
+  if (CachedWorldMap.IsValid()) {
+    World->GetTimerManager().ClearTimer(WorldMapSearchHandle);
+    return;
+  }
+  CachedWorldMap.Reset();
+
+  if (AWorldMap *FoundWorldMap = Cast<AWorldMap>(UGameplayStatics::GetActorOfClass(
+          World, AWorldMap::StaticClass()))) {
+    CachedWorldMap = FoundWorldMap;
+    if (!FoundWorldMap->OnTerritorySelected.IsAlreadyBound(
             this, &ASkaldPlayerController::HandleTerritorySelected)) {
-      WorldMap->OnTerritorySelected.AddDynamic(
+      FoundWorldMap->OnTerritorySelected.AddDynamic(
           this, &ASkaldPlayerController::HandleTerritorySelected);
-      ensureMsgf(WorldMap->OnTerritorySelected.IsAlreadyBound(
+      ensureMsgf(FoundWorldMap->OnTerritorySelected.IsAlreadyBound(
                      this, &ASkaldPlayerController::HandleTerritorySelected),
                  TEXT("Failed to bind HandleTerritorySelected to WorldMap."));
     }
-    GetWorldTimerManager().ClearTimer(WorldMapSearchHandle);
+    World->GetTimerManager().ClearTimer(WorldMapSearchHandle);
   } else {
-    GetWorldTimerManager().SetTimer(WorldMapSearchHandle, this,
-                                    &ASkaldPlayerController::TryBindWorldMap,
-                                    0.5f, false);
+    World->GetTimerManager().SetTimer(WorldMapSearchHandle, this,
+                                      &ASkaldPlayerController::TryBindWorldMap,
+                                      0.5f, false);
   }
 }
 

--- a/Source/Skald/Skald_PlayerController.h
+++ b/Source/Skald/Skald_PlayerController.h
@@ -392,6 +392,9 @@ private:
   /** Attempt to locate the world map and bind to its selection event. */
   void TryBindWorldMap();
 
+  /** Cached pointer to the active world map to manage delegate bindings safely. */
+  TWeakObjectPtr<AWorldMap> CachedWorldMap;
+
   /** Timer used to poll for the world map actor until it exists. */
   FTimerHandle WorldMapSearchHandle;
 


### PR DESCRIPTION
## Summary
- clear the cached world map delegate and polling timer when the player controller tears down
- cache the world map actor safely and guard timer reuse when rebinding after level transitions

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68deb3574cf48324ac3c23238a71cfc4