### PR TITLE
Retry territory snapshot capture when world map not ready

### DIFF
--- a/Source/Skald/Skald_GameMode.cpp
+++ b/Source/Skald/Skald_GameMode.cpp
@@ -529,9 +529,17 @@ void ASkaldGameMode::HandlePlayerLockedIn(ASkaldPlayerState *PS) {
 
       if (TerritorySnapshots.Num() > 0) {
         GI->CachedWorldMapTerritories = MoveTemp(TerritorySnapshots);
+        GetWorldTimerManager().ClearTimer(TerritorySnapshotRetryHandle);
       } else {
         UE_LOG(LogSkald, Warning,
                TEXT("HandlePlayerLockedIn: Skipping empty territory snapshot capture."));
+
+        if (!GetWorldTimerManager().IsTimerActive(TerritorySnapshotRetryHandle)) {
+          FTimerDelegate RetryDelegate = FTimerDelegate::CreateUObject(
+              this, &ASkaldGameMode::CacheWorldMapSnapshot);
+          GetWorldTimerManager().SetTimer(TerritorySnapshotRetryHandle, RetryDelegate,
+                                          RetryInitDelay, false);
+        }
       }
     }
   }
@@ -625,9 +633,16 @@ void ASkaldGameMode::CacheWorldMapSnapshot() {
     UE_LOG(LogSkald, Warning,
            TEXT("CacheWorldMapSnapshot produced an empty snapshot; keeping previous %d territories"),
            PreviousSnapshotCount);
+    if (!GetWorldTimerManager().IsTimerActive(TerritorySnapshotRetryHandle)) {
+      FTimerDelegate RetryDelegate = FTimerDelegate::CreateUObject(
+          this, &ASkaldGameMode::CacheWorldMapSnapshot);
+      GetWorldTimerManager().SetTimer(TerritorySnapshotRetryHandle, RetryDelegate,
+                                      RetryInitDelay, false);
+    }
     return;
   }
 
+  GetWorldTimerManager().ClearTimer(TerritorySnapshotRetryHandle);
   GI->CachedWorldMapTerritories = MoveTemp(TerritorySnapshots);
 
   UE_LOG(LogSkald, Verbose,

--- a/Source/Skald/Skald_GameMode.h
+++ b/Source/Skald/Skald_GameMode.h
@@ -201,4 +201,7 @@ private:
 
   /** Attempt to restore the overworld from the cached travel snapshot. */
   bool RestoreWorldFromSnapshot();
+
+  /** Timer used to retry snapshot capture when no territories are present yet. */
+  FTimerHandle TerritorySnapshotRetryHandle;
 };


### PR DESCRIPTION
## Summary
- schedule a retry to capture world map territory snapshots when the initial attempt returns empty
- clear the retry timer once a snapshot succeeds so cached data stays up to date

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dee17435e88324a94143bf33560c7a