### PR TITLE
Guard territory owner access during world map restore

### DIFF
--- a/Source/Skald/Territory.cpp
+++ b/Source/Skald/Territory.cpp
@@ -275,14 +275,17 @@ void ATerritory::OnRep_IsCapital() { RefreshAppearance(); }
 void ATerritory::OnRep_ArmyUnits() { UpdateLabel(); }
 
 void ATerritory::UpdateTerritoryColor() {
-  if (DynamicMaterial) {
-    FLinearColor NewColor = DefaultColor;
-    if (OwningPlayer) {
-      NewColor = GetFactionColor(OwningPlayer->Faction);
-    }
-    DynamicMaterial->SetVectorParameterValue(FName("Color"), NewColor);
-    DefaultColor = NewColor;
+  if (!DynamicMaterial) {
+    return;
   }
+
+  FLinearColor NewColor = DefaultColor;
+  if (IsValid(OwningPlayer)) {
+    NewColor = GetFactionColor(OwningPlayer->Faction);
+  }
+
+  DynamicMaterial->SetVectorParameterValue(FName("Color"), NewColor);
+  DefaultColor = NewColor;
 }
 
 void ATerritory::UpdateLabel() {
@@ -290,10 +293,11 @@ void ATerritory::UpdateLabel() {
     return;
   }
 
-  const FString OwnerName = OwningPlayer
-                               ? OwningPlayer->GetResolvedPlayerName(
-                                     TEXT("Territory::UpdateLabel"))
-                               : TEXT("Neutral");
+  const ASkaldPlayerState *OwnerPS = IsValid(OwningPlayer) ? OwningPlayer : nullptr;
+  const FString OwnerName = OwnerPS
+                                ? OwnerPS->GetResolvedPlayerName(
+                                      TEXT("Territory::UpdateLabel"))
+                                : TEXT("Neutral");
   const FString Text = FString::Printf(TEXT("%s\nOwner: %s\nUnits: %d"),
                                        *TerritoryName, *OwnerName, ArmyUnits);
   LabelComponent->SetText(FText::FromString(Text));

--- a/Source/Skald/UI/SkaldMainHUDWidget.cpp
+++ b/Source/Skald/UI/SkaldMainHUDWidget.cpp
@@ -514,7 +514,7 @@ void USkaldMainHUDWidget::OnTerritoryClickedUI(ATerritory *Territory) {
   }
 
   const bool bOwnedByLocal =
-      LocalPS && Territory->OwningPlayer &&
+      LocalPS && IsValid(Territory->OwningPlayer) &&
       Territory->OwningPlayer->GetPlayerId() == LocalPS->GetPlayerId();
 
   if (bSelectingForAttack) {
@@ -920,14 +920,12 @@ void USkaldMainHUDWidget::HandleAttackApproved() {
                 Cast<AWorldMap>(UGameplayStatics::GetActorOfClass(
                     GetWorld(), AWorldMap::StaticClass()))) {
           if (ATerritory *Source = WorldMap->GetTerritoryById(SourceID)) {
-            if (Source->OwningPlayer) {
+            if (IsValid(Source->OwningPlayer)) {
               Battle.AttackerPlayerID = Source->OwningPlayer->GetPlayerId();
               Battle.AttackerFaction = Source->OwningPlayer->Faction;
-              Battle.AttackerDisplayName = Source->OwningPlayer
-                                                 ? Source->OwningPlayer
-                                                       ->GetResolvedPlayerName(
-                                                           TEXT("HUD_Attack_Attacker"))
-                                                 : TEXT("Neutral");
+              Battle.AttackerDisplayName =
+                  Source->OwningPlayer->GetResolvedPlayerName(
+                      TEXT("HUD_Attack_Attacker"));
               Battle.bAttackerIsAI = Source->OwningPlayer->bIsAI;
             }
             if (bUseSiege && Source->BuiltSiegeID > 0) {
@@ -936,14 +934,12 @@ void USkaldMainHUDWidget::HandleAttackApproved() {
             }
           }
           if (ATerritory *Target = WorldMap->GetTerritoryById(TargetID)) {
-            if (Target->OwningPlayer) {
+            if (IsValid(Target->OwningPlayer)) {
               Battle.DefenderPlayerID = Target->OwningPlayer->GetPlayerId();
               Battle.DefenderFaction = Target->OwningPlayer->Faction;
-              Battle.DefenderDisplayName = Target->OwningPlayer
-                                                 ? Target->OwningPlayer
-                                                       ->GetResolvedPlayerName(
-                                                           TEXT("HUD_Attack_Defender"))
-                                                 : TEXT("Neutral");
+              Battle.DefenderDisplayName =
+                  Target->OwningPlayer->GetResolvedPlayerName(
+                      TEXT("HUD_Attack_Defender"));
               Battle.bDefenderIsAI = Target->OwningPlayer->bIsAI;
             }
             Battle.IsCapitalAttack = Target->bIsCapital;

--- a/Source/Skald/WorldMap.cpp
+++ b/Source/Skald/WorldMap.cpp
@@ -503,7 +503,7 @@ bool AWorldMap::AreTerritoriesAdjacent(const ATerritory *A,
 
 bool AWorldMap::IsOwnedBy(const ATerritory *Territory,
                           const ASkaldPlayerState *Player) const {
-  if (!Territory || !Player || !Territory->OwningPlayer) {
+  if (!Territory || !Player || !IsValid(Territory->OwningPlayer)) {
     return false;
   }
   return Territory->OwningPlayer->GetPlayerId() == Player->GetPlayerId();


### PR DESCRIPTION
## Summary
- prevent world map territory rendering from dereferencing stale owner pointers
- add owner validity checks in HUD interactions when preparing battles

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68deee827d808324a28bc9bd2091795b