### PR TITLE
Defer turn state resume until after world snapshot restore

### DIFF
--- a/Source/Skald/Skald_TurnManager.cpp
+++ b/Source/Skald/Skald_TurnManager.cpp
@@ -119,9 +119,6 @@ void ATurnManager::BeginPlay() {
           this, &ATurnManager::HandleGridBattleEnded);
     }
 
-    if (bOnWorldMap) {
-      TryResumeSavedTurnState(GI);
-    }
   }
 
   if (ASkaldGameMode *GM = GetWorld()->GetAuthGameMode<ASkaldGameMode>()) {


### PR DESCRIPTION
## Summary
- stop the turn manager from resuming saved turn state during BeginPlay on the world map so the flag persists until the snapshot is restored
- allow the game mode to restore the world snapshot before requesting turn resumption

## Testing
- not run (engine build not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68df1c6ca99083249964880400f445c4