### PR TITLE
Delay battle resolution until world snapshot restored

### DIFF
--- a/Source/Skald/Skald_TurnManager.cpp
+++ b/Source/Skald/Skald_TurnManager.cpp
@@ -792,6 +792,25 @@ void ATurnManager::ResolveGridBattleResult_Implementation() {
     return;
   }
 
+  ASkaldGameMode *GameMode = GetWorld()->GetAuthGameMode<ASkaldGameMode>();
+  if (GameMode && !GameMode->IsWorldInitialized()) {
+    UE_LOG(LogSkald, Verbose,
+           TEXT("ResolveGridBattleResult: World not yet initialised; retrying after snapshot restoration."));
+
+    if (!GetWorld()->GetTimerManager().IsTimerActive(
+            PendingBattleResolutionRetryHandle)) {
+      FTimerDelegate RetryDelegate = FTimerDelegate::CreateUObject(
+          this, &ATurnManager::ResolveGridBattleResult);
+      constexpr float RetryDelaySeconds = 0.05f;
+      GetWorld()->GetTimerManager().SetTimer(PendingBattleResolutionRetryHandle,
+                                             RetryDelegate, RetryDelaySeconds,
+                                             false);
+    }
+    return;
+  }
+
+  GetWorld()->GetTimerManager().ClearTimer(PendingBattleResolutionRetryHandle);
+
   if (!CachedWorldMap) {
     return;
   }

--- a/Source/Skald/Skald_TurnManager.h
+++ b/Source/Skald/Skald_TurnManager.h
@@ -3,6 +3,7 @@
 #include "CoreMinimal.h"
 #include "GameFramework/Actor.h"
 #include "SkaldTypes.h"
+#include "TimerManager.h"
 #include "Skald_TurnManager.generated.h"
 
 class ASkaldPlayerController;
@@ -119,6 +120,9 @@ protected:
 
   UPROPERTY()
   AWorldMap *CachedWorldMap;
+
+  /** Retry handle used when deferring battle resolution until the world map has been restored. */
+  FTimerHandle PendingBattleResolutionRetryHandle;
 
   UFUNCTION()
   void HandleGridBattleEnded(ESkaldFaction WinningFaction, int32 AttackerCasualties, int32 DefenderCasualties);


### PR DESCRIPTION
## Summary
- ensure the turn manager waits for the world map to finish restoring from the cached snapshot before applying battle results
- add a timer-backed retry so pending battle resolutions are re-attempted once the world initialisation completes

## Testing
- not run (not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68dff0b6fdb08324ae0179a6dcb0fbc4