### PR TITLE
Handle delayed overworld rehydration after battles

### DIFF
--- a/Source/Skald/Skald_GameInstance.cpp
+++ b/Source/Skald/Skald_GameInstance.cpp
@@ -1,12 +1,18 @@
 #include "Skald_GameInstance.h"
 
+#include "Blueprint/UserWidget.h"
 #include "Engine/Engine.h"
+#include "Engine/GameViewportClient.h"
 #include "Kismet/GameplayStatics.h"
 #include "Skald.h"
 #include "SkaldLogging.h"
-#include "Blueprint/UserWidget.h"
 #include "Skald_PlayerController.h"
+#include "Styling/CoreStyle.h"
 #include "UI/SkaldUIHelpers.h"
+#include "Widgets/Images/SImage.h"
+#include "Widgets/Layout/SBorder.h"
+#include "Widgets/SOverlay.h"
+#include "Widgets/Text/STextBlock.h"
 
 void USkaldGameInstance::Init() {
   Super::Init();
@@ -52,6 +58,42 @@ void USkaldGameInstance::SetTravelPending(bool bInPending) {
   bTravelPending = bInPending;
   UE_LOG(LogSkald, Log, TEXT("GameInstance travel pending set: %s"),
          bTravelPending ? TEXT("true") : TEXT("false"));
+
+  UGameViewportClient *Viewport = GetGameViewportClient();
+  if (!Viewport) {
+    if (!bTravelPending) {
+      TravelLoadingOverlay.Reset();
+    }
+    return;
+  }
+
+  if (bTravelPending) {
+    if (!TravelLoadingOverlay.IsValid()) {
+      TSharedRef<SOverlay> Overlay = SNew(SOverlay)
+          + SOverlay::Slot()
+                .HAlign(HAlign_Fill)
+                .VAlign(VAlign_Fill)[SNew(SImage).ColorAndOpacity(FLinearColor(0.f, 0.f, 0.f, 0.7f))]
+          + SOverlay::Slot()
+                .HAlign(HAlign_Center)
+                .VAlign(VAlign_Center)[SNew(SBorder)
+                                           .Padding(FMargin(40.f))
+                                           .BorderBackgroundColor(FLinearColor(0.f, 0.f, 0.f, 0.85f))
+                                           .HAlign(HAlign_Center)
+                                           .VAlign(VAlign_Center)[SNew(STextBlock)
+                                                                     .Justification(ETextJustify::Center)
+                                                                     .Text(NSLOCTEXT("Skald", "TravelLoadingText", "Loading overworld..."))
+                                                                     .Font(FCoreStyle::Get().GetDefaultFontStyle("Bold", 32))
+                                                                     .ColorAndOpacity(FLinearColor::White)]];
+
+      TravelLoadingOverlay = Overlay;
+      Viewport->AddViewportWidgetContent(Overlay, 100);
+    }
+  } else {
+    if (TravelLoadingOverlay.IsValid()) {
+      Viewport->RemoveViewportWidgetContent(TravelLoadingOverlay.ToSharedRef());
+      TravelLoadingOverlay.Reset();
+    }
+  }
 }
 
 void USkaldGameInstance::SeedCombatRandomStream(int32 Seed) {

--- a/Source/Skald/Skald_GameInstance.h
+++ b/Source/Skald/Skald_GameInstance.h
@@ -4,10 +4,12 @@
 #include "Engine/EngineBaseTypes.h"
 #include "Engine/GameInstance.h"
 #include "SkaldTypes.h"
+#include "Templates/SharedPointer.h"
 #include "Skald_GameInstance.generated.h"
 
-class UGridBattleManager;
 class SWidget;
+
+class UGridBattleManager;
 class UUserWidget;
 class USkaldSaveGame;
 class UNetDriver;
@@ -169,6 +171,9 @@ public:
 private:
   UPROPERTY()
   FSkaldTravelState TravelState;
+
+  /** Loading overlay displayed while travelling between maps. */
+  TSharedPtr<SWidget> TravelLoadingOverlay;
 
   void ResetSessionState();
 };

--- a/Source/Skald/Skald_TurnManager.cpp
+++ b/Source/Skald/Skald_TurnManager.cpp
@@ -789,11 +789,13 @@ void ATurnManager::ResolveGridBattleResult_Implementation() {
   }
 
   if (!GI->bPendingBattleResolution || !GI->PendingBattleResolution.bValid) {
+    GI->SetTravelPending(false);
     return;
   }
 
   ASkaldGameMode *GameMode = GetWorld()->GetAuthGameMode<ASkaldGameMode>();
   if (GameMode && !GameMode->IsWorldInitialized()) {
+    GI->SetTravelPending(true);
     UE_LOG(LogSkald, Verbose,
            TEXT("ResolveGridBattleResult: World not yet initialised; retrying after snapshot restoration."));
 
@@ -809,9 +811,33 @@ void ATurnManager::ResolveGridBattleResult_Implementation() {
     return;
   }
 
-  GetWorld()->GetTimerManager().ClearTimer(PendingBattleResolutionRetryHandle);
+  auto DeferResolution = [&](const TCHAR *Reason) {
+    UE_LOG(LogSkald, Verbose,
+           TEXT("ResolveGridBattleResult: %s; retrying."), Reason);
+    GI->SetTravelPending(true);
+    if (!GetWorld()->GetTimerManager().IsTimerActive(
+            PendingBattleResolutionRetryHandle)) {
+      FTimerDelegate RetryDelegate = FTimerDelegate::CreateUObject(
+          this, &ATurnManager::ResolveGridBattleResult);
+      constexpr float RetryDelaySeconds = 0.05f;
+      GetWorld()->GetTimerManager().SetTimer(
+          PendingBattleResolutionRetryHandle, RetryDelegate,
+          RetryDelaySeconds, false);
+    }
+  };
 
-  if (!CachedWorldMap) {
+  if (!IsValid(CachedWorldMap)) {
+    CachedWorldMap = Cast<AWorldMap>(UGameplayStatics::GetActorOfClass(
+        GetWorld(), AWorldMap::StaticClass()));
+  }
+
+  if (!IsValid(CachedWorldMap)) {
+    DeferResolution(TEXT("World map unavailable"));
+    return;
+  }
+
+  if (CachedWorldMap->Territories.Num() == 0) {
+    DeferResolution(TEXT("World map territories not yet generated"));
     return;
   }
 
@@ -820,8 +846,12 @@ void ATurnManager::ResolveGridBattleResult_Implementation() {
   ATerritory *Target =
       CachedWorldMap->GetTerritoryById(Battle.TargetTerritoryID);
   if (!Source || !Target) {
+    DeferResolution(TEXT("Battle territories pending restoration"));
     return;
   }
+
+  GetWorld()->GetTimerManager().ClearTimer(
+      PendingBattleResolutionRetryHandle);
 
   FGridBattleResolution Resolution = GI->PendingBattleResolution;
 
@@ -920,6 +950,7 @@ void ATurnManager::ResolveGridBattleResult_Implementation() {
 
   GI->bPendingBattleResolution = false;
   GI->PendingBattleResolution = FGridBattleResolution();
+  GI->SetTravelPending(false);
 
   // Resume the saved turn sequence now that the battle has been resolved.
   TryResumeSavedTurnState(GI);


### PR DESCRIPTION
## Summary
- add a travel loading overlay in the game instance so travelling players see a loading screen while data is restored
- defer grid battle resolution until the overworld map and territories are available, retrying automatically instead of failing early

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e000afa800832486351be696ab87dd