### PR TITLE
Fix font style accessor usage in Skald game instance

### DIFF
--- a/Source/Skald/Skald_GameInstance.cpp
+++ b/Source/Skald/Skald_GameInstance.cpp
@@ -82,7 +82,7 @@ void USkaldGameInstance::SetTravelPending(bool bInPending) {
                                            .VAlign(VAlign_Center)[SNew(STextBlock)
                                                                      .Justification(ETextJustify::Center)
                                                                      .Text(NSLOCTEXT("Skald", "TravelLoadingText", "Loading overworld..."))
-                                                                     .Font(FCoreStyle::Get().GetDefaultFontStyle("Bold", 32))
+                                                                     .Font(FCoreStyle::GetDefaultFontStyle("Bold", 32))
                                                                      .ColorAndOpacity(FLinearColor::White)]];
 
       TravelLoadingOverlay = Overlay;


### PR DESCRIPTION
## Summary
- replace the deprecated call to `ISlateStyle::GetDefaultFontStyle` with the static `FCoreStyle::GetDefaultFontStyle` when building the travel loading overlay

## Testing
- not run (explanation: Unreal Engine build is unavailable in this environment)

------
https://chatgpt.com/codex/tasks/task_e_68e0064089f083248621468698edffd9