### PR TITLE
Fix player sorting comparator for pointer array

### DIFF
--- a/Source/Skald/Skald_GameState.cpp
+++ b/Source/Skald/Skald_GameState.cpp
@@ -137,21 +137,13 @@ void ASkaldGameState::SortAndDedupPlayers()
 
     // Stable order by PlayerId for deterministic turns/HUD lists. Null entries
     // have been filtered out above so it is now safe to dereference.
-    Players.Sort([](ASkaldPlayerState* const& A, ASkaldPlayerState* const& B)
+    Players.Sort([](const ASkaldPlayerState& A, const ASkaldPlayerState& B)
     {
-        if (A == B)
+        if (&A == &B)
         {
             return false;
         }
-        if (A == nullptr)
-        {
-            return false;
-        }
-        if (B == nullptr)
-        {
-            return true;
-        }
-        return A->GetPlayerId() < B->GetPlayerId();
+        return A.GetPlayerId() < B.GetPlayerId();
     });
 
     // Dedup in case the engine calls AddPlayerState twice for the same actor


### PR DESCRIPTION
## Summary
- fix the player sorting comparator in `ASkaldGameState` so the lambda receives dereferenced player states
- remove redundant null checks now that the comparator works on dereferenced values

## Testing
- not run (native build not available in container)

------
https://chatgpt.com/codex/tasks/task_e_68e011cf385c83248ab4fe556ed184f9