### PR TITLE
Fix player sorting comparator parameter types

### DIFF
--- a/Source/Skald/Skald_BattleGameMode.cpp
+++ b/Source/Skald/Skald_BattleGameMode.cpp
@@ -214,9 +214,18 @@ ASkaldPlayerState *EnsureBattleParticipant(ASkaldGameState *GameState, UWorld *W
       GameState->Players.RemoveAll([](const ASkaldPlayerState* Player) {
         return Player == nullptr;
       });
-      GameState->Players.Sort([](const ASkaldPlayerState& A,
-                                 const ASkaldPlayerState& B) {
-        return A.GetPlayerId() < B.GetPlayerId();
+      GameState->Players.Sort([](ASkaldPlayerState* const& A,
+                                 ASkaldPlayerState* const& B) {
+        if (A == B) {
+          return false;
+        }
+        if (!A) {
+          return false;
+        }
+        if (!B) {
+          return true;
+        }
+        return A->GetPlayerId() < B->GetPlayerId();
       });
       bAddedToList = true;
     }

--- a/Source/Skald/Skald_GameState.cpp
+++ b/Source/Skald/Skald_GameState.cpp
@@ -137,13 +137,21 @@ void ASkaldGameState::SortAndDedupPlayers()
 
     // Stable order by PlayerId for deterministic turns/HUD lists. Null entries
     // have been filtered out above so it is now safe to dereference.
-    Players.Sort([](const ASkaldPlayerState& A, const ASkaldPlayerState& B)
+    Players.Sort([](ASkaldPlayerState* const& A, ASkaldPlayerState* const& B)
     {
-        if (&A == &B)
+        if (A == B)
         {
             return false;
         }
-        return A.GetPlayerId() < B.GetPlayerId();
+        if (!A)
+        {
+            return false;
+        }
+        if (!B)
+        {
+            return true;
+        }
+        return A->GetPlayerId() < B->GetPlayerId();
     });
 
     // Dedup in case the engine calls AddPlayerState twice for the same actor


### PR DESCRIPTION
## Summary
- restore pointer-based comparison for player sorting lambdas to match the TArray element type
- guard against null pointers while comparing player IDs

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e0134857f4832491aa4de87e24d5cc