### PR TITLE
Fix player sorting lambdas for TObjectPtr arrays

### DIFF
--- a/Source/Skald/Skald_BattleGameMode.cpp
+++ b/Source/Skald/Skald_BattleGameMode.cpp
@@ -211,21 +211,23 @@ ASkaldPlayerState *EnsureBattleParticipant(ASkaldGameState *GameState, UWorld *W
     bool bAddedToList = false;
     if (!GameState->Players.Contains(Candidate)) {
       GameState->Players.Add(Candidate);
-      GameState->Players.RemoveAll([](const ASkaldPlayerState* Player) {
-        return Player == nullptr;
+      GameState->Players.RemoveAll([](const TObjectPtr<ASkaldPlayerState>& Player) {
+        return Player.Get() == nullptr;
       });
-      GameState->Players.Sort([](ASkaldPlayerState* const& A,
-                                 ASkaldPlayerState* const& B) {
-        if (A == B) {
+      GameState->Players.Sort([](const TObjectPtr<ASkaldPlayerState>& A,
+                                 const TObjectPtr<ASkaldPlayerState>& B) {
+        ASkaldPlayerState* const PlayerA = A.Get();
+        ASkaldPlayerState* const PlayerB = B.Get();
+        if (PlayerA == PlayerB) {
           return false;
         }
-        if (!A) {
+        if (!PlayerA) {
           return false;
         }
-        if (!B) {
+        if (!PlayerB) {
           return true;
         }
-        return A->GetPlayerId() < B->GetPlayerId();
+        return PlayerA->GetPlayerId() < PlayerB->GetPlayerId();
       });
       bAddedToList = true;
     }

--- a/Source/Skald/Skald_GameState.cpp
+++ b/Source/Skald/Skald_GameState.cpp
@@ -130,28 +130,30 @@ void ASkaldGameState::SortAndDedupPlayers()
     // while PlayerStates are re-initialising. Attempting to dereference them
     // during the sort would otherwise cause access violations when returning
     // to the world map after a battle.
-    Players.RemoveAll([](const ASkaldPlayerState* Player)
+    Players.RemoveAll([](const TObjectPtr<ASkaldPlayerState>& Player)
     {
-        return Player == nullptr;
+        return Player.Get() == nullptr;
     });
 
     // Stable order by PlayerId for deterministic turns/HUD lists. Null entries
     // have been filtered out above so it is now safe to dereference.
-    Players.Sort([](ASkaldPlayerState* const& A, ASkaldPlayerState* const& B)
+    Players.Sort([](const TObjectPtr<ASkaldPlayerState>& A, const TObjectPtr<ASkaldPlayerState>& B)
     {
-        if (A == B)
+        ASkaldPlayerState* const PlayerA = A.Get();
+        ASkaldPlayerState* const PlayerB = B.Get();
+        if (PlayerA == PlayerB)
         {
             return false;
         }
-        if (!A)
+        if (!PlayerA)
         {
             return false;
         }
-        if (!B)
+        if (!PlayerB)
         {
             return true;
         }
-        return A->GetPlayerId() < B->GetPlayerId();
+        return PlayerA->GetPlayerId() < PlayerB->GetPlayerId();
     });
 
     // Dedup in case the engine calls AddPlayerState twice for the same actor


### PR DESCRIPTION
## Summary
- ensure EnsureBattleParticipant handles `TObjectPtr` entries when removing and sorting cached player states
- update `ASkaldGameState::SortAndDedupPlayers` to dereference `TObjectPtr` values before comparisons

## Testing
- not run (not available in container)

------
https://chatgpt.com/codex/tasks/task_e_68e0154f88a88324b6a4bee005095ad6