### PR TITLE
Ensure travel snapshots fallback to cached data

### DIFF
--- a/Source/Skald/Skald_TurnManager.cpp
+++ b/Source/Skald/Skald_TurnManager.cpp
@@ -632,7 +632,12 @@ void ATurnManager::TriggerGridBattle(const FS_BattlePayload &Battle) {
         TerritorySnapshots.Add(MoveTemp(Snapshot));
       }
       bCapturedFromLiveWorld = TerritorySnapshots.Num() > 0;
-    } else if (GI && GI->CachedWorldMapTerritories.Num() > 0) {
+    }
+
+    const bool bHasFallbackSnapshot =
+        GI && GI->CachedWorldMapTerritories.Num() > 0;
+
+    if (!bCapturedFromLiveWorld && bHasFallbackSnapshot) {
       bUsedCachedFallback = true;
       TerritorySnapshots = GI->CachedWorldMapTerritories;
       for (const FS_Territory &Snapshot : TerritorySnapshots) {
@@ -642,6 +647,7 @@ void ATurnManager::TriggerGridBattle(const FS_BattlePayload &Battle) {
           }
         }
       }
+      bCapturedFromLiveWorld = false;
     }
 
     if (TerritorySnapshots.Num() == 0) {


### PR DESCRIPTION
## Summary
- ensure TriggerGridBattle reuses the cached overworld snapshot when a fresh capture returns empty
- keep the cached snapshot intact so the overworld can be restored correctly after returning from a battle map

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e3c87ffa488324820ea4bf85cdfed3