### PR TITLE
Ensure pending battle resolutions trigger on world map load

### DIFF
--- a/Source/Skald/Skald_TurnManager.cpp
+++ b/Source/Skald/Skald_TurnManager.cpp
@@ -108,8 +108,14 @@ void ATurnManager::BeginPlay() {
   const bool bOnWorldMap = (CachedWorldMap != nullptr);
 
   if (USkaldGameInstance *GI = GetGameInstance<USkaldGameInstance>()) {
-    // Only resolve results when we are back on the world map
-    if (bOnWorldMap && (GI->GridBattleManager || GI->bPendingBattleResolution)) {
+    const bool bHasPendingResolution =
+        GI->bPendingBattleResolution || GI->PendingBattleResolution.bValid;
+
+    // If a battle finished while we were away, make sure we resolve it even if
+    // the world map actors are still streaming in. ResolveGridBattleResult
+    // already handles deferring until the map is ready, so we only need to
+    // trigger it here when we know a resolution is pending.
+    if (bHasPendingResolution) {
       ResolveGridBattleResult();
     }
 


### PR DESCRIPTION
## Summary
- ensure `ATurnManager` resolves pending battle results when returning to the world map even if the map actors are still streaming
- rely on the existing deferral logic to wait until the world map is ready so the travel overlay clears correctly

## Testing
- not run (not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68e3ccc715b08324b615f17bb5409221