### PR TITLE
Fix battle level streaming for UE 5.5 delegate changes

### DIFF
--- a/Source/Skald/Skald_BattleLevelManager.cpp
+++ b/Source/Skald/Skald_BattleLevelManager.cpp
@@ -1,10 +1,12 @@
 #include "Skald_BattleLevelManager.h"
 
+#include "Engine/Engine.h"
+#include "Engine/Level.h"
 #include "Engine/LevelStreamingDynamic.h"
 #include "Engine/World.h"
-#include "Kismet/GameplayStatics.h"
 #include "Skald_GameInstance.h"
 #include "SkaldLogging.h"
+#include "UObject/Package.h"
 #include "UObject/SoftObjectPath.h"
 
 void USkaldBattleLevelManager::Initialise(USkaldGameInstance *InOwner) {
@@ -46,14 +48,14 @@ bool USkaldBattleLevelManager::RequestBattleLevel(
 
   FVector SpawnLocation = FVector::ZeroVector;
   FRotator SpawnRotation = FRotator::ZeroRotator;
-  FString Error;
+  bool bLoadSuccess = false;
   ULevelStreamingDynamic *StreamingLevel =
       ULevelStreamingDynamic::LoadLevelInstanceBySoftObjectPtr(
-          World, LevelToStream, SpawnLocation, SpawnRotation, Error);
+          World, LevelToStream, SpawnLocation, SpawnRotation, bLoadSuccess);
 
-  if (!StreamingLevel) {
+  if (!StreamingLevel || !bLoadSuccess) {
     UE_LOG(LogSkald, Error,
-           TEXT("BattleLevelManager RequestBattleLevel failed: %s"), *Error);
+           TEXT("BattleLevelManager RequestBattleLevel failed: Could not stream battle level"));
     return false;
   }
 
@@ -61,10 +63,15 @@ bool USkaldBattleLevelManager::RequestBattleLevel(
   PendingPayload = BattlePayload;
   ActiveStreamingLevel = StreamingLevel;
 
-  LevelLoadedHandle = StreamingLevel->OnLevelLoaded.AddUObject(
-      this, &USkaldBattleLevelManager::HandleLevelLoaded);
-  LevelUnloadedHandle = StreamingLevel->OnLevelUnloaded.AddUObject(
-      this, &USkaldBattleLevelManager::HandleLevelUnloaded);
+  if (!LevelAddedToWorldHandle.IsValid()) {
+    LevelAddedToWorldHandle = FWorldDelegates::LevelAddedToWorld.AddUObject(
+        this, &USkaldBattleLevelManager::HandleLevelAddedToWorld);
+  }
+
+  if (!LevelRemovedFromWorldHandle.IsValid()) {
+    LevelRemovedFromWorldHandle = FWorldDelegates::LevelRemovedFromWorld.AddUObject(
+        this, &USkaldBattleLevelManager::HandleLevelRemovedFromWorld);
+  }
 
   StreamingLevel->SetShouldBeVisible(false);
   StreamingLevel->SetShouldBeLoaded(true);
@@ -101,11 +108,9 @@ void USkaldBattleLevelManager::HandleLevelLoaded() {
     return;
   }
 
-  if (LevelLoadedHandle.IsValid()) {
-    if (ULevelStreamingDynamic *StreamingLevel = ActiveStreamingLevel.Get()) {
-      StreamingLevel->OnLevelLoaded.Remove(LevelLoadedHandle);
-    }
-    LevelLoadedHandle.Reset();
+  if (LevelAddedToWorldHandle.IsValid()) {
+    FWorldDelegates::LevelAddedToWorld.Remove(LevelAddedToWorldHandle);
+    LevelAddedToWorldHandle.Reset();
   }
 
   ActiveStreamingLevel->SetShouldBeVisible(true);
@@ -120,15 +125,14 @@ void USkaldBattleLevelManager::HandleLevelLoaded() {
 void USkaldBattleLevelManager::HandleLevelUnloaded() {
   UE_LOG(LogSkald, Log, TEXT("BattleLevelManager: Battle level unloaded"));
 
-  if (ULevelStreamingDynamic *StreamingLevel = ActiveStreamingLevel.Get()) {
-    if (LevelLoadedHandle.IsValid()) {
-      StreamingLevel->OnLevelLoaded.Remove(LevelLoadedHandle);
-      LevelLoadedHandle.Reset();
-    }
-    if (LevelUnloadedHandle.IsValid()) {
-      StreamingLevel->OnLevelUnloaded.Remove(LevelUnloadedHandle);
-      LevelUnloadedHandle.Reset();
-    }
+  if (LevelAddedToWorldHandle.IsValid()) {
+    FWorldDelegates::LevelAddedToWorld.Remove(LevelAddedToWorldHandle);
+    LevelAddedToWorldHandle.Reset();
+  }
+
+  if (LevelRemovedFromWorldHandle.IsValid()) {
+    FWorldDelegates::LevelRemovedFromWorld.Remove(LevelRemovedFromWorldHandle);
+    LevelRemovedFromWorldHandle.Reset();
   }
 
   ActiveStreamingLevel.Reset();
@@ -139,4 +143,51 @@ void USkaldBattleLevelManager::HandleLevelUnloaded() {
     GI->SetTravelPending(false);
     GI->bIsInBattleMap = false;
   }
+}
+
+void USkaldBattleLevelManager::HandleLevelAddedToWorld(ULevel *InLevel,
+                                                      UWorld *InWorld) {
+  if (!DoesEventMatchActiveLevel(InLevel, InWorld)) {
+    return;
+  }
+
+  HandleLevelLoaded();
+}
+
+void USkaldBattleLevelManager::HandleLevelRemovedFromWorld(ULevel *InLevel,
+                                                           UWorld *InWorld) {
+  if (!DoesEventMatchActiveLevel(InLevel, InWorld)) {
+    return;
+  }
+
+  HandleLevelUnloaded();
+}
+
+bool USkaldBattleLevelManager::DoesEventMatchActiveLevel(ULevel *InLevel,
+                                                         UWorld *InWorld) const {
+  if (!ActiveStreamingLevel.IsValid() || !InLevel || !InWorld) {
+    return false;
+  }
+
+  if (UWorld *ActiveWorld = ActiveStreamingLevel->GetWorld()) {
+    if (ActiveWorld != InWorld) {
+      return false;
+    }
+  }
+
+  if (ActiveStreamingLevel->GetLoadedLevel() == InLevel) {
+    return true;
+  }
+
+  const FString RequestedPackage =
+      RequestedBattleLevel.ToSoftObjectPath().GetLongPackageName();
+  if (!RequestedPackage.IsEmpty()) {
+    const FString EventPackage =
+        InLevel->GetPackage() ? InLevel->GetPackage()->GetName() : FString();
+    if (RequestedPackage == EventPackage) {
+      return true;
+    }
+  }
+
+  return false;
 }

--- a/Source/Skald/Skald_BattleLevelManager.h
+++ b/Source/Skald/Skald_BattleLevelManager.h
@@ -7,6 +7,8 @@
 
 class ULevelStreamingDynamic;
 class USkaldGameInstance;
+class ULevel;
+class UWorld;
 
 /**
  * Helper object responsible for loading and unloading tactical battle levels
@@ -34,11 +36,14 @@ public:
 private:
   void HandleLevelLoaded();
   void HandleLevelUnloaded();
+  void HandleLevelAddedToWorld(ULevel *InLevel, UWorld *InWorld);
+  void HandleLevelRemovedFromWorld(ULevel *InLevel, UWorld *InWorld);
+  bool DoesEventMatchActiveLevel(ULevel *InLevel, UWorld *InWorld) const;
 
   TWeakObjectPtr<USkaldGameInstance> OwningInstance;
   TWeakObjectPtr<ULevelStreamingDynamic> ActiveStreamingLevel;
   TSoftObjectPtr<UWorld> RequestedBattleLevel;
-  FDelegateHandle LevelLoadedHandle;
-  FDelegateHandle LevelUnloadedHandle;
+  FDelegateHandle LevelAddedToWorldHandle;
+  FDelegateHandle LevelRemovedFromWorldHandle;
   FS_BattlePayload PendingPayload;
 };


### PR DESCRIPTION
## Summary
- adapt `USkaldBattleLevelManager` to the updated `LoadLevelInstanceBySoftObjectPtr` signature by checking the new success flag
- replace the removed streaming delegates with world-level load/unload handlers and helper matching logic so the battle level still toggles state correctly

## Testing
- not run (Unreal build tooling unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68e3e4541c548324b10ea2ff7431843e