### PR TITLE
Guard battle level retries when unload is pending

### DIFF
--- a/Source/Skald/Skald_BattleLevelManager.cpp
+++ b/Source/Skald/Skald_BattleLevelManager.cpp
@@ -45,6 +45,14 @@ bool USkaldBattleLevelManager::RequestBattleLevel(
       return false;
     }
 
+    if (ULevelStreamingDynamic *StreamingLevel = ActiveStreamingLevel.Get()) {
+      if (!StreamingLevel->GetShouldBeLoaded()) {
+        UE_LOG(LogSkald, Warning,
+               TEXT("BattleLevelManager RequestBattleLevel retry ignored: battle level currently unloading"));
+        return false;
+      }
+    }
+
     // A streaming request is already in flight for the desired level, so treat
     // the retry as a success and refresh any pending state without issuing a
     // second load request. This prevents fallback OpenLevel travel from


### PR DESCRIPTION
## Summary
- refuse to reuse an active streaming level request when the level is in the process of unloading
- keep fallbacks functional by only short-circuiting retries when a load is genuinely in flight

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e5912ab7f88324959633748e4ec6b6