### PR TITLE
Fix battle level manager build failure on UE 5.5

### DIFF
--- a/Source/Skald/Skald_BattleLevelManager.cpp
+++ b/Source/Skald/Skald_BattleLevelManager.cpp
@@ -45,12 +45,10 @@ bool USkaldBattleLevelManager::RequestBattleLevel(
       return false;
     }
 
-    if (ULevelStreamingDynamic *StreamingLevel = ActiveStreamingLevel.Get()) {
-      if (!StreamingLevel->GetShouldBeLoaded()) {
-        UE_LOG(LogSkald, Warning,
-               TEXT("BattleLevelManager RequestBattleLevel retry ignored: battle level currently unloading"));
-        return false;
-      }
+    if (!bActiveLevelShouldBeLoaded) {
+      UE_LOG(LogSkald, Warning,
+             TEXT("BattleLevelManager RequestBattleLevel retry ignored: battle level currently unloading"));
+      return false;
     }
 
     // A streaming request is already in flight for the desired level, so treat
@@ -89,6 +87,7 @@ bool USkaldBattleLevelManager::RequestBattleLevel(
   RequestedBattleLevel = LevelToStream;
   PendingPayload = BattlePayload;
   ActiveStreamingLevel = StreamingLevel;
+  bActiveLevelShouldBeLoaded = true;
 
   RegisterWorldDelegates();
 
@@ -119,6 +118,8 @@ void USkaldBattleLevelManager::ReleaseBattleLevel() {
     StreamingLevel->SetShouldBeLoaded(false);
   }
 
+  bActiveLevelShouldBeLoaded = false;
+
   UE_LOG(LogSkald, Log, TEXT("BattleLevelManager: Unloading battle level"));
 
 }
@@ -147,6 +148,7 @@ void USkaldBattleLevelManager::HandleLevelUnloaded() {
 
   UnregisterWorldDelegates();
 
+  bActiveLevelShouldBeLoaded = false;
   ActiveStreamingLevel.Reset();
   RequestedBattleLevel.Reset();
   PendingPayload = FS_BattlePayload();

--- a/Source/Skald/Skald_BattleLevelManager.h
+++ b/Source/Skald/Skald_BattleLevelManager.h
@@ -48,4 +48,5 @@ private:
   FDelegateHandle LevelAddedToWorldHandle;
   FDelegateHandle LevelRemovedFromWorldHandle;
   FS_BattlePayload PendingPayload;
+  bool bActiveLevelShouldBeLoaded = false;
 };


### PR DESCRIPTION
## Summary
- replace the removed `GetShouldBeLoaded` call with an internal flag that mirrors the streaming state
- reset the new tracking flag whenever levels are loaded or unloaded so retries are validated correctly

## Testing
- Not run (Unreal build not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68e59602f7788324b7b2133d4d0d6588