### PR TITLE
Fix battle sub-level loading by listening to streaming delegates

### DIFF
--- a/Source/Skald/Skald_BattleLevelManager.cpp
+++ b/Source/Skald/Skald_BattleLevelManager.cpp
@@ -89,6 +89,7 @@ bool USkaldBattleLevelManager::RequestBattleLevel(
   ActiveStreamingLevel = StreamingLevel;
   bActiveLevelShouldBeLoaded = true;
 
+  RegisterStreamingDelegates(StreamingLevel);
   RegisterWorldDelegates();
 
   StreamingLevel->SetShouldBeVisible(false);
@@ -105,6 +106,7 @@ bool USkaldBattleLevelManager::RequestBattleLevel(
 
 void USkaldBattleLevelManager::ReleaseBattleLevel() {
   if (!ActiveStreamingLevel.IsValid()) {
+    UnregisterStreamingDelegates();
     UnregisterWorldDelegates();
     return;
   }
@@ -129,6 +131,13 @@ void USkaldBattleLevelManager::HandleLevelLoaded() {
     return;
   }
 
+  if (ULevelStreamingDynamic *StreamingLevel = ActiveStreamingLevel.Get()) {
+    if (StreamingLevelLoadedHandle.IsValid()) {
+      StreamingLevel->OnLevelLoaded.Remove(StreamingLevelLoadedHandle);
+      StreamingLevelLoadedHandle.Reset();
+    }
+  }
+
   if (LevelAddedToWorldHandle.IsValid()) {
     FWorldDelegates::LevelAddedToWorld.Remove(LevelAddedToWorldHandle);
     LevelAddedToWorldHandle.Reset();
@@ -146,7 +155,15 @@ void USkaldBattleLevelManager::HandleLevelLoaded() {
 void USkaldBattleLevelManager::HandleLevelUnloaded() {
   UE_LOG(LogSkald, Log, TEXT("BattleLevelManager: Battle level unloaded"));
 
+  if (ULevelStreamingDynamic *StreamingLevel = ActiveStreamingLevel.Get()) {
+    if (StreamingLevelUnloadedHandle.IsValid()) {
+      StreamingLevel->OnLevelUnloaded.Remove(StreamingLevelUnloadedHandle);
+      StreamingLevelUnloadedHandle.Reset();
+    }
+  }
+
   UnregisterWorldDelegates();
+  UnregisterStreamingDelegates();
 
   bActiveLevelShouldBeLoaded = false;
   ActiveStreamingLevel.Reset();
@@ -225,4 +242,34 @@ void USkaldBattleLevelManager::UnregisterWorldDelegates() {
     FWorldDelegates::LevelRemovedFromWorld.Remove(LevelRemovedFromWorldHandle);
     LevelRemovedFromWorldHandle.Reset();
   }
+}
+
+void USkaldBattleLevelManager::RegisterStreamingDelegates(
+    ULevelStreamingDynamic *StreamingLevel) {
+  UnregisterStreamingDelegates();
+
+  if (!StreamingLevel) {
+    return;
+  }
+
+  StreamingLevelLoadedHandle =
+      StreamingLevel->OnLevelLoaded.AddUObject(
+          this, &USkaldBattleLevelManager::HandleLevelLoaded);
+  StreamingLevelUnloadedHandle =
+      StreamingLevel->OnLevelUnloaded.AddUObject(
+          this, &USkaldBattleLevelManager::HandleLevelUnloaded);
+}
+
+void USkaldBattleLevelManager::UnregisterStreamingDelegates() {
+  if (ULevelStreamingDynamic *StreamingLevel = ActiveStreamingLevel.Get()) {
+    if (StreamingLevelLoadedHandle.IsValid()) {
+      StreamingLevel->OnLevelLoaded.Remove(StreamingLevelLoadedHandle);
+    }
+    if (StreamingLevelUnloadedHandle.IsValid()) {
+      StreamingLevel->OnLevelUnloaded.Remove(StreamingLevelUnloadedHandle);
+    }
+  }
+
+  StreamingLevelLoadedHandle.Reset();
+  StreamingLevelUnloadedHandle.Reset();
 }

--- a/Source/Skald/Skald_BattleLevelManager.h
+++ b/Source/Skald/Skald_BattleLevelManager.h
@@ -41,12 +41,16 @@ private:
   bool DoesEventMatchActiveLevel(ULevel *InLevel, UWorld *InWorld) const;
   void RegisterWorldDelegates();
   void UnregisterWorldDelegates();
+  void RegisterStreamingDelegates(ULevelStreamingDynamic *StreamingLevel);
+  void UnregisterStreamingDelegates();
 
   TWeakObjectPtr<USkaldGameInstance> OwningInstance;
   TWeakObjectPtr<ULevelStreamingDynamic> ActiveStreamingLevel;
   TSoftObjectPtr<UWorld> RequestedBattleLevel;
   FDelegateHandle LevelAddedToWorldHandle;
   FDelegateHandle LevelRemovedFromWorldHandle;
+  FDelegateHandle StreamingLevelLoadedHandle;
+  FDelegateHandle StreamingLevelUnloadedHandle;
   FS_BattlePayload PendingPayload;
   bool bActiveLevelShouldBeLoaded = false;
 };


### PR DESCRIPTION
## Summary
- register the battle level manager with the streaming level's load and unload delegates so we hear when the battle map finishes streaming
- clear the streaming delegate bindings when the battle level is released or finishes unloading

## Testing
- not run (Unreal Editor not available in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68e59c057b948324b83818ae15caab9e