### PR TITLE
Update battle level manager for UE5.5 delegate changes

### DIFF
--- a/Source/Skald/Skald_BattleLevelManager.cpp
+++ b/Source/Skald/Skald_BattleLevelManager.cpp
@@ -89,7 +89,6 @@ bool USkaldBattleLevelManager::RequestBattleLevel(
   ActiveStreamingLevel = StreamingLevel;
   bActiveLevelShouldBeLoaded = true;
 
-  RegisterStreamingDelegates(StreamingLevel);
   RegisterWorldDelegates();
 
   StreamingLevel->SetShouldBeVisible(false);
@@ -106,7 +105,6 @@ bool USkaldBattleLevelManager::RequestBattleLevel(
 
 void USkaldBattleLevelManager::ReleaseBattleLevel() {
   if (!ActiveStreamingLevel.IsValid()) {
-    UnregisterStreamingDelegates();
     UnregisterWorldDelegates();
     return;
   }
@@ -131,13 +129,6 @@ void USkaldBattleLevelManager::HandleLevelLoaded() {
     return;
   }
 
-  if (ULevelStreamingDynamic *StreamingLevel = ActiveStreamingLevel.Get()) {
-    if (StreamingLevelLoadedHandle.IsValid()) {
-      StreamingLevel->OnLevelLoaded.Remove(StreamingLevelLoadedHandle);
-      StreamingLevelLoadedHandle.Reset();
-    }
-  }
-
   if (LevelAddedToWorldHandle.IsValid()) {
     FWorldDelegates::LevelAddedToWorld.Remove(LevelAddedToWorldHandle);
     LevelAddedToWorldHandle.Reset();
@@ -155,15 +146,7 @@ void USkaldBattleLevelManager::HandleLevelLoaded() {
 void USkaldBattleLevelManager::HandleLevelUnloaded() {
   UE_LOG(LogSkald, Log, TEXT("BattleLevelManager: Battle level unloaded"));
 
-  if (ULevelStreamingDynamic *StreamingLevel = ActiveStreamingLevel.Get()) {
-    if (StreamingLevelUnloadedHandle.IsValid()) {
-      StreamingLevel->OnLevelUnloaded.Remove(StreamingLevelUnloadedHandle);
-      StreamingLevelUnloadedHandle.Reset();
-    }
-  }
-
   UnregisterWorldDelegates();
-  UnregisterStreamingDelegates();
 
   bActiveLevelShouldBeLoaded = false;
   ActiveStreamingLevel.Reset();
@@ -244,32 +227,3 @@ void USkaldBattleLevelManager::UnregisterWorldDelegates() {
   }
 }
 
-void USkaldBattleLevelManager::RegisterStreamingDelegates(
-    ULevelStreamingDynamic *StreamingLevel) {
-  UnregisterStreamingDelegates();
-
-  if (!StreamingLevel) {
-    return;
-  }
-
-  StreamingLevelLoadedHandle =
-      StreamingLevel->OnLevelLoaded.AddUObject(
-          this, &USkaldBattleLevelManager::HandleLevelLoaded);
-  StreamingLevelUnloadedHandle =
-      StreamingLevel->OnLevelUnloaded.AddUObject(
-          this, &USkaldBattleLevelManager::HandleLevelUnloaded);
-}
-
-void USkaldBattleLevelManager::UnregisterStreamingDelegates() {
-  if (ULevelStreamingDynamic *StreamingLevel = ActiveStreamingLevel.Get()) {
-    if (StreamingLevelLoadedHandle.IsValid()) {
-      StreamingLevel->OnLevelLoaded.Remove(StreamingLevelLoadedHandle);
-    }
-    if (StreamingLevelUnloadedHandle.IsValid()) {
-      StreamingLevel->OnLevelUnloaded.Remove(StreamingLevelUnloadedHandle);
-    }
-  }
-
-  StreamingLevelLoadedHandle.Reset();
-  StreamingLevelUnloadedHandle.Reset();
-}

--- a/Source/Skald/Skald_BattleLevelManager.h
+++ b/Source/Skald/Skald_BattleLevelManager.h
@@ -41,16 +41,12 @@ private:
   bool DoesEventMatchActiveLevel(ULevel *InLevel, UWorld *InWorld) const;
   void RegisterWorldDelegates();
   void UnregisterWorldDelegates();
-  void RegisterStreamingDelegates(ULevelStreamingDynamic *StreamingLevel);
-  void UnregisterStreamingDelegates();
 
   TWeakObjectPtr<USkaldGameInstance> OwningInstance;
   TWeakObjectPtr<ULevelStreamingDynamic> ActiveStreamingLevel;
   TSoftObjectPtr<UWorld> RequestedBattleLevel;
   FDelegateHandle LevelAddedToWorldHandle;
   FDelegateHandle LevelRemovedFromWorldHandle;
-  FDelegateHandle StreamingLevelLoadedHandle;
-  FDelegateHandle StreamingLevelUnloadedHandle;
   FS_BattlePayload PendingPayload;
   bool bActiveLevelShouldBeLoaded = false;
 };


### PR DESCRIPTION
## Summary
- stop registering ULevelStreamingDynamic load/unload delegates now that the API signatures have changed
- rely solely on world-level delegates to track battle map load/unload lifecycle

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e59da1e42083249ce59890e333e9e0