### PR TITLE
Fix ticker handle forward declaration

### DIFF
--- a/Source/Skald/Skald_BattleLevelManager.h
+++ b/Source/Skald/Skald_BattleLevelManager.h
@@ -3,10 +3,7 @@
 #include "CoreMinimal.h"
 #include "SkaldTypes.h"
 #include "UObject/Object.h"
-
-namespace FTSTicker {
-struct FDelegateHandle;
-}
+#include "Containers/Ticker.h"
 #include "Skald_BattleLevelManager.generated.h"
 
 class ULevelStreamingDynamic;


### PR DESCRIPTION
## Summary
- include Containers/Ticker.h so FTSTicker::FDelegateHandle is fully defined before use in Skald_BattleLevelManager.h

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e5b06240388324b077db4ddfa40621