### PR TITLE
Ensure streamed battle maps initialize their game mode

### DIFF
--- a/Source/Skald/Skald_AIController.cpp
+++ b/Source/Skald/Skald_AIController.cpp
@@ -31,6 +31,22 @@ constexpr TCHAR EnemyBattleTransitionMessage[] =
     TEXT("Enemy is preparing for battle...");
 }
 
+ASkald_BattleGameMode *ASkaldAIController::ResolveBattleGameMode() const {
+  if (UWorld *World = GetWorld()) {
+    if (ASkald_BattleGameMode *BattleGameMode =
+            World->GetAuthGameMode<ASkald_BattleGameMode>()) {
+      return BattleGameMode;
+    }
+  }
+
+  if (const USkaldGameInstance *GameInstance =
+          GetGameInstance<USkaldGameInstance>()) {
+    return GameInstance->GetActiveBattleGameMode();
+  }
+
+  return nullptr;
+}
+
 void ASkaldAIController::BeginPlay() {
   Super::BeginPlay();
 
@@ -43,11 +59,8 @@ void ASkaldAIController::BeginPlay() {
   SetupBattleAutomation();
 
   if (HasAuthority()) {
-    if (UWorld *World = GetWorld()) {
-      if (ASkald_BattleGameMode *BattleGameMode =
-              World->GetAuthGameMode<ASkald_BattleGameMode>()) {
-        BattleGameMode->OnAIControllerReady(this);
-      }
+    if (ASkald_BattleGameMode *BattleGameMode = ResolveBattleGameMode()) {
+      BattleGameMode->OnAIControllerReady(this);
     }
   }
 }

--- a/Source/Skald/Skald_AIController.h
+++ b/Source/Skald/Skald_AIController.h
@@ -42,6 +42,8 @@ private:
   void SetupBattleAutomation();
   void TeardownBattleAutomation();
 
+  ASkald_BattleGameMode *ResolveBattleGameMode() const;
+
   void DetermineControlledBattleSide();
   bool ControlsFighter(const AFighterPawn *Fighter) const;
   bool IsMyTurn() const;

--- a/Source/Skald/Skald_BattleLevelManager.cpp
+++ b/Source/Skald/Skald_BattleLevelManager.cpp
@@ -6,6 +6,8 @@
 #include "Engine/LevelStreaming.h"
 #include "Engine/LevelStreamingDynamic.h"
 #include "Engine/World.h"
+#include "GameFramework/WorldSettings.h"
+#include "Skald_BattleGameMode.h"
 #include "Skald_GameInstance.h"
 #include "SkaldLogging.h"
 #include "UObject/Package.h"
@@ -156,6 +158,54 @@ void USkaldBattleLevelManager::HandleLevelLoaded() {
   if (USkaldGameInstance *GI = OwningInstance.Get()) {
     GI->SetTravelPending(false);
     GI->bIsInBattleMap = true;
+
+    if (!GI->GetActiveBattleGameMode() && ActiveStreamingLevel.IsValid()) {
+      UWorld *OwningWorld = ActiveStreamingLevel->GetWorld();
+      ULevel *LoadedLevel = ActiveStreamingLevel->GetLoadedLevel();
+      if (OwningWorld && LoadedLevel && OwningWorld->GetNetMode() != NM_Client) {
+        TSubclassOf<ASkald_BattleGameMode> BattleGameModeClass = nullptr;
+        if (AWorldSettings *WorldSettings = LoadedLevel->GetWorldSettings()) {
+          if (WorldSettings->GameModeOverride) {
+            BattleGameModeClass = WorldSettings->GameModeOverride;
+          } else if (WorldSettings->DefaultGameMode) {
+            BattleGameModeClass = WorldSettings->DefaultGameMode;
+          }
+        }
+
+        if (!BattleGameModeClass) {
+          BattleGameModeClass = ASkald_BattleGameMode::StaticClass();
+        }
+
+        if (BattleGameModeClass) {
+          FActorSpawnParameters SpawnParams;
+          SpawnParams.SpawnCollisionHandlingOverride =
+              ESpawnActorCollisionHandlingMethod::AlwaysSpawn;
+          SpawnParams.OverrideLevel = LoadedLevel;
+          SpawnParams.bDeferConstruction = false;
+
+          ASkald_BattleGameMode *BattleGM = OwningWorld->SpawnActor<ASkald_BattleGameMode>(
+              BattleGameModeClass, FTransform::Identity, SpawnParams);
+
+          if (BattleGM) {
+            FString Error;
+            const FString MapName =
+                RequestedBattleLevel.IsValid()
+                    ? RequestedBattleLevel.ToSoftObjectPath().ToString()
+                    : LoadedLevel->GetPackage()->GetName();
+            BattleGM->InitGame(MapName, FString(), Error);
+            ActiveBattleGameMode = BattleGM;
+            GI->SetActiveBattleGameMode(BattleGM);
+            UE_LOG(LogSkald, Log,
+                   TEXT("BattleLevelManager: Spawned battle game mode %s (Class=%s)"),
+                   *GetNameSafe(BattleGM), *GetNameSafe(BattleGameModeClass));
+          } else {
+            UE_LOG(LogSkald, Error,
+                   TEXT("BattleLevelManager: Failed to spawn battle game mode from %s"),
+                   *GetNameSafe(BattleGameModeClass));
+          }
+        }
+      }
+    }
   }
 }
 
@@ -172,6 +222,15 @@ void USkaldBattleLevelManager::HandleLevelUnloaded() {
   PendingPayload = FS_BattlePayload();
 
   if (USkaldGameInstance *GI = OwningInstance.Get()) {
+    if (ActiveBattleGameMode.IsValid()) {
+      if (ASkald_BattleGameMode *BattleGM = ActiveBattleGameMode.Get()) {
+        if (!BattleGM->IsPendingKill()) {
+          BattleGM->Destroy();
+        }
+      }
+      ActiveBattleGameMode.Reset();
+    }
+    GI->SetActiveBattleGameMode(nullptr);
     GI->SetTravelPending(false);
     GI->bIsInBattleMap = false;
   }

--- a/Source/Skald/Skald_BattleLevelManager.cpp
+++ b/Source/Skald/Skald_BattleLevelManager.cpp
@@ -12,6 +12,7 @@
 #include "SkaldLogging.h"
 #include "UObject/Package.h"
 #include "UObject/SoftObjectPath.h"
+#include "Kismet/GameplayStatics.h"
 
 void USkaldBattleLevelManager::Initialise(USkaldGameInstance *InOwner) {
 
@@ -177,14 +178,15 @@ void USkaldBattleLevelManager::HandleLevelLoaded() {
         }
 
         if (BattleGameModeClass) {
+          const FTransform SpawnTransform = FTransform::Identity;
           FActorSpawnParameters SpawnParams;
           SpawnParams.SpawnCollisionHandlingOverride =
               ESpawnActorCollisionHandlingMethod::AlwaysSpawn;
           SpawnParams.OverrideLevel = LoadedLevel;
-          SpawnParams.bDeferConstruction = false;
+          SpawnParams.bDeferConstruction = true;
 
           ASkald_BattleGameMode *BattleGM = OwningWorld->SpawnActor<ASkald_BattleGameMode>(
-              BattleGameModeClass, FTransform::Identity, SpawnParams);
+              BattleGameModeClass, SpawnTransform, SpawnParams);
 
           if (BattleGM) {
             FString Error;
@@ -193,8 +195,18 @@ void USkaldBattleLevelManager::HandleLevelLoaded() {
                     ? RequestedBattleLevel.ToSoftObjectPath().ToString()
                     : LoadedLevel->GetPackage()->GetName();
             BattleGM->InitGame(MapName, FString(), Error);
+
+            UGameplayStatics::FinishSpawningActor(BattleGM, SpawnTransform);
+
             ActiveBattleGameMode = BattleGM;
             GI->SetActiveBattleGameMode(BattleGM);
+
+            if (!Error.IsEmpty()) {
+              UE_LOG(LogSkald, Warning,
+                     TEXT("BattleLevelManager: InitGame for %s reported: %s"),
+                     *GetNameSafe(BattleGM), *Error);
+            }
+
             UE_LOG(LogSkald, Log,
                    TEXT("BattleLevelManager: Spawned battle game mode %s (Class=%s)"),
                    *GetNameSafe(BattleGM), *GetNameSafe(BattleGameModeClass));

--- a/Source/Skald/Skald_BattleLevelManager.h
+++ b/Source/Skald/Skald_BattleLevelManager.h
@@ -10,6 +10,7 @@ class ULevelStreamingDynamic;
 class USkaldGameInstance;
 class ULevel;
 class UWorld;
+class ASkald_BattleGameMode;
 
 /**
  * Helper object responsible for loading and unloading tactical battle levels
@@ -55,4 +56,5 @@ private:
   FS_BattlePayload PendingPayload;
   bool bActiveLevelShouldBeLoaded = false;
   bool bLastKnownLoadedState = false;
+  TWeakObjectPtr<ASkald_BattleGameMode> ActiveBattleGameMode;
 };

--- a/Source/Skald/Skald_GameInstance.cpp
+++ b/Source/Skald/Skald_GameInstance.cpp
@@ -6,6 +6,7 @@
 #include "Kismet/GameplayStatics.h"
 #include "Skald.h"
 #include "SkaldLogging.h"
+#include "Skald_BattleGameMode.h"
 #include "Skald_BattleLevelManager.h"
 #include "Skald_PlayerController.h"
 #include "Styling/CoreStyle.h"
@@ -102,6 +103,29 @@ void USkaldGameInstance::SetTravelPending(bool bInPending) {
   }
 }
 
+void USkaldGameInstance::SetActiveBattleGameMode(
+    ASkald_BattleGameMode *InGameMode) {
+  ASkald_BattleGameMode *Previous = ActiveBattleGameMode.Get();
+  if (Previous == InGameMode) {
+    return;
+  }
+
+  if (!InGameMode) {
+    if (Previous) {
+      UE_LOG(LogSkald, Log,
+             TEXT("GameInstance cleared active battle game mode %s"),
+             *GetNameSafe(Previous));
+    }
+    ActiveBattleGameMode = nullptr;
+    return;
+  }
+
+  ActiveBattleGameMode = InGameMode;
+  UE_LOG(LogSkald, Log,
+         TEXT("GameInstance set active battle game mode: %s"),
+         *GetNameSafe(InGameMode));
+}
+
 void USkaldGameInstance::SeedCombatRandomStream(int32 Seed) {
   CombatRandomStream.Initialize(Seed);
 }
@@ -195,6 +219,12 @@ void USkaldGameInstance::ResetSessionState() {
   if (BattleLevelStreamingManager) {
     BattleLevelStreamingManager->ReleaseBattleLevel();
   }
+  if (ASkald_BattleGameMode *BattleGM = ActiveBattleGameMode.Get()) {
+    if (!BattleGM->IsPendingKill()) {
+      BattleGM->Destroy();
+    }
+  }
+  SetActiveBattleGameMode(nullptr);
   bIsInBattleMap = false;
   bTravelPending = false;
   CachedWorldMapTerritories.Empty();

--- a/Source/Skald/Skald_GameInstance.h
+++ b/Source/Skald/Skald_GameInstance.h
@@ -12,6 +12,7 @@ class SWidget;
 class UGridBattleManager;
 class USkaldBattleLevelManager;
 class UUserWidget;
+class ASkald_BattleGameMode;
 class USkaldSaveGame;
 class UNetDriver;
 
@@ -111,6 +112,10 @@ public:
   UPROPERTY(Transient)
   bool bTravelPending = false;
 
+  /** Active battle game mode controlling the streamed combat scene. */
+  UPROPERTY(Transient)
+  TWeakObjectPtr<ASkald_BattleGameMode> ActiveBattleGameMode;
+
   /** Snapshot of the overworld territories captured before travelling. */
   UPROPERTY(BlueprintReadWrite, Category = "Battle")
   TArray<FS_Territory> CachedWorldMapTerritories;
@@ -147,6 +152,12 @@ public:
   void SetTravelPending(bool bInPending);
 
   USkaldBattleLevelManager *GetBattleLevelManager() const { return BattleLevelStreamingManager; }
+
+  void SetActiveBattleGameMode(ASkald_BattleGameMode *InGameMode);
+
+  ASkald_BattleGameMode *GetActiveBattleGameMode() const {
+    return ActiveBattleGameMode.Get();
+  }
 
   UFUNCTION(BlueprintCallable, BlueprintPure)
   const FSkaldTravelState &GetTravelState() const { return TravelState; }

--- a/Source/Skald/Skald_PlayerController.cpp
+++ b/Source/Skald/Skald_PlayerController.cpp
@@ -87,6 +87,21 @@ bool IsCursorOverInteractableSlateWidget() {
 }
 }
 
+ASkald_BattleGameMode *ASkaldPlayerController::ResolveBattleGameMode() {
+  if (UWorld *World = GetWorld()) {
+    if (ASkald_BattleGameMode *BattleGM =
+            World->GetAuthGameMode<ASkald_BattleGameMode>()) {
+      return BattleGM;
+    }
+  }
+
+  if (USkaldGameInstance *GI = GetGameInstance<USkaldGameInstance>()) {
+    return GI->GetActiveBattleGameMode();
+  }
+
+  return nullptr;
+}
+
 ASkaldPlayerController::ASkaldPlayerController() {
   TurnManager = nullptr;
   HUDRef = nullptr;
@@ -615,8 +630,7 @@ void ASkaldPlayerController::Server_LockInSelection_Implementation(
          TEXT("Server_LockInSelection: %s sent %d fighters"), *GetName(),
          SelectedFighters.Num());
 
-  if (ASkald_BattleGameMode *GameMode =
-          GetWorld()->GetAuthGameMode<ASkald_BattleGameMode>())
+  if (ASkald_BattleGameMode *GameMode = ResolveBattleGameMode())
   {
     GameMode->HandleHumanLockIn(this, SelectedFighters);
   }
@@ -717,8 +731,7 @@ void ASkaldPlayerController::Server_CommitArmy_Implementation(
     PS->bArmyLockedIn = true;
   }
 
-  if (ASkald_BattleGameMode *BattleGM =
-          GetWorld()->GetAuthGameMode<ASkald_BattleGameMode>()) {
+  if (ASkald_BattleGameMode *BattleGM = ResolveBattleGameMode()) {
     BattleGM->TryLaunchBattle();
   }
 }

--- a/Source/Skald/Skald_PlayerController.h
+++ b/Source/Skald/Skald_PlayerController.h
@@ -24,6 +24,7 @@ class AWorldMap;
 class AFighterPawn;
 class UGridOverlayComponent;
 class UWorld;
+class ASkald_BattleGameMode;
 
 /** Command issued by the player during a battle. */
 UENUM()
@@ -375,6 +376,8 @@ protected:
   TObjectPtr<ATurnManager> TurnManager;
 
 private:
+  ASkald_BattleGameMode *ResolveBattleGameMode();
+
   /** Cache references to key game singletons and bind delegates. */
   void CacheGameReferences();
 


### PR DESCRIPTION
## Summary
- spawn the configured `Skald_BattleGameMode` when the battle sub-level finishes streaming and destroy it when the level unloads
- let the game instance keep track of the active streamed battle game mode for controllers to access safely
- update player and AI controllers to resolve the active battle game mode from the game instance when the persistent world’s game mode does not switch

## Testing
- not run (Unreal Engine build unavailable in container)

------
https://chatgpt.com/codex/tasks/task_e_68e5b75580a08324bf689a3b202b4ddc