### PR TITLE
Fix battle level initialization for UE 5.5 API updates

### DIFF
--- a/Source/Skald/Skald_BattleGameMode.cpp
+++ b/Source/Skald/Skald_BattleGameMode.cpp
@@ -269,6 +269,12 @@ ASkaldPlayerState *EnsureBattleParticipant(ASkaldGameState *GameState, UWorld *W
 }
 } // namespace
 
+void ASkald_BattleGameMode::InitializeBattleGameMode(const FString &MapName,
+                                                     const FString &Options,
+                                                     FString &ErrorMessage) {
+  InitGame(MapName, Options, ErrorMessage);
+}
+
 void ASkald_BattleGameMode::InitGame(const FString &Map, const FString &Options,
                                      FString &Error) {
   Super::InitGame(Map, Options, Error);

--- a/Source/Skald/Skald_BattleGameMode.h
+++ b/Source/Skald/Skald_BattleGameMode.h
@@ -23,6 +23,10 @@ public:
   // Returns true once we’ve detected at least two valid controllers and kicked off setup.
   bool TrySetupBattleWhenReady();
 
+  /** Wrapper that allows external systems to trigger the protected InitGame lifecycle. */
+  void InitializeBattleGameMode(const FString &MapName, const FString &Options,
+                                FString &ErrorMessage);
+
   void BeginPreBattleSelection(class ASkaldPlayerState* AttackerPS,
                                class ASkaldPlayerState* DefenderPS,
                                int32 AttackerBudget, int32 DefenderBudget);

--- a/Source/Skald/Skald_BattleLevelManager.cpp
+++ b/Source/Skald/Skald_BattleLevelManager.cpp
@@ -166,10 +166,12 @@ void USkaldBattleLevelManager::HandleLevelLoaded() {
       if (OwningWorld && LoadedLevel && OwningWorld->GetNetMode() != NM_Client) {
         TSubclassOf<ASkald_BattleGameMode> BattleGameModeClass = nullptr;
         if (AWorldSettings *WorldSettings = LoadedLevel->GetWorldSettings()) {
-          if (WorldSettings->GameModeOverride) {
-            BattleGameModeClass = WorldSettings->GameModeOverride;
-          } else if (WorldSettings->DefaultGameMode) {
-            BattleGameModeClass = WorldSettings->DefaultGameMode;
+          if (UClass *DefaultGameModeClass =
+                  WorldSettings->GetDefaultGameModeClass()) {
+            if (DefaultGameModeClass->IsChildOf(
+                    ASkald_BattleGameMode::StaticClass())) {
+              BattleGameModeClass = DefaultGameModeClass;
+            }
           }
         }
 
@@ -194,7 +196,7 @@ void USkaldBattleLevelManager::HandleLevelLoaded() {
                 RequestedBattleLevel.IsValid()
                     ? RequestedBattleLevel.ToSoftObjectPath().ToString()
                     : LoadedLevel->GetPackage()->GetName();
-            BattleGM->InitGame(MapName, FString(), Error);
+            BattleGM->InitializeBattleGameMode(MapName, FString(), Error);
 
             UGameplayStatics::FinishSpawningActor(BattleGM, SpawnTransform);
 
@@ -236,7 +238,7 @@ void USkaldBattleLevelManager::HandleLevelUnloaded() {
   if (USkaldGameInstance *GI = OwningInstance.Get()) {
     if (ActiveBattleGameMode.IsValid()) {
       if (ASkald_BattleGameMode *BattleGM = ActiveBattleGameMode.Get()) {
-        if (!BattleGM->IsPendingKill()) {
+        if (!BattleGM->IsActorBeingDestroyed()) {
           BattleGM->Destroy();
         }
       }

--- a/Source/Skald/Skald_GameInstance.cpp
+++ b/Source/Skald/Skald_GameInstance.cpp
@@ -220,7 +220,7 @@ void USkaldGameInstance::ResetSessionState() {
     BattleLevelStreamingManager->ReleaseBattleLevel();
   }
   if (ASkald_BattleGameMode *BattleGM = ActiveBattleGameMode.Get()) {
-    if (!BattleGM->IsPendingKill()) {
+    if (!BattleGM->IsActorBeingDestroyed()) {
       BattleGM->Destroy();
     }
   }


### PR DESCRIPTION
## Summary
- add a public helper on the battle game mode so external systems can trigger its protected InitGame flow
- resolve streamed level game mode overrides via GetDefaultGameModeClass and call the new helper when spawning
- replace deprecated IsPendingKill checks with IsActorBeingDestroyed during battle level teardown

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e5cf4c1f6c8324a8c7f4d445eb779c