### PR TITLE
Fix battle level manager default GameMode lookup

### DIFF
--- a/Source/Skald/Skald_BattleLevelManager.cpp
+++ b/Source/Skald/Skald_BattleLevelManager.cpp
@@ -167,7 +167,7 @@ void USkaldBattleLevelManager::HandleLevelLoaded() {
         TSubclassOf<ASkald_BattleGameMode> BattleGameModeClass = nullptr;
         if (AWorldSettings *WorldSettings = LoadedLevel->GetWorldSettings()) {
           if (UClass *DefaultGameModeClass =
-                  WorldSettings->GetDefaultGameModeClass()) {
+                  WorldSettings->GetDefaultGameMode()) {
             if (DefaultGameModeClass->IsChildOf(
                     ASkald_BattleGameMode::StaticClass())) {
               BattleGameModeClass = DefaultGameModeClass;


### PR DESCRIPTION
## Summary
- update the battle level manager to use the new WorldSettings API when retrieving a level's default GameMode

## Testing
- not run (Unreal build not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68e5d27ce11083248d5b085484311d54