### PR TITLE
Fix battle level game mode loading for UE 5.5

### DIFF
--- a/Source/Skald/Skald_BattleLevelManager.cpp
+++ b/Source/Skald/Skald_BattleLevelManager.cpp
@@ -173,12 +173,8 @@ void USkaldBattleLevelManager::HandleLevelLoaded() {
 #if UE_VERSION_OLDER_THAN(5, 5, 0)
           DefaultGameModeClass = WorldSettings->GetDefaultGameMode();
 #else
-          if (!WorldSettings->DefaultGameMode.IsNull()) {
+          if (WorldSettings->DefaultGameMode) {
             DefaultGameModeClass = WorldSettings->DefaultGameMode.Get();
-            if (!DefaultGameModeClass) {
-              DefaultGameModeClass =
-                  WorldSettings->DefaultGameMode.LoadSynchronous();
-            }
           }
 #endif
 


### PR DESCRIPTION
## Summary
- replace deprecated `IsNull` and `LoadSynchronous` usage on `DefaultGameMode`
- rely on the `TSubclassOf` pointer to retrieve the battle game mode class

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e6415849d48324b27c9b922be439e7