### PR TITLE
Ensure battle game mode soft class loads when resolving

### DIFF
--- a/Source/Skald/Skald_BattleLevelManager.cpp
+++ b/Source/Skald/Skald_BattleLevelManager.cpp
@@ -13,6 +13,7 @@
 #include "SkaldLogging.h"
 #include "UObject/Package.h"
 #include "UObject/SoftObjectPath.h"
+#include "UObject/SoftObjectPtr.h"
 #include "Misc/EngineVersionComparison.h"
 #include "Kismet/GameplayStatics.h"
 
@@ -175,6 +176,12 @@ void USkaldBattleLevelManager::HandleLevelLoaded() {
 #else
           if (WorldSettings->DefaultGameMode) {
             DefaultGameModeClass = WorldSettings->DefaultGameMode.Get();
+
+            if (!DefaultGameModeClass &&
+                WorldSettings->DefaultGameMode.ToSoftObjectPath().IsValid()) {
+              DefaultGameModeClass =
+                  WorldSettings->DefaultGameMode.LoadSynchronous();
+            }
           }
 #endif
 


### PR DESCRIPTION
## Summary
- include the soft object pointer header needed for synchronous loading
- load the default game mode soft class when only the path has been set so streamed levels honor their configured battle mode

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e646c84de083249c906f2c8cb0472b