### PR TITLE
Fix DefaultGameMode resolution for UE 5.5

### DIFF
--- a/Source/Skald/Skald_BattleLevelManager.cpp
+++ b/Source/Skald/Skald_BattleLevelManager.cpp
@@ -174,14 +174,8 @@ void USkaldBattleLevelManager::HandleLevelLoaded() {
 #if UE_VERSION_OLDER_THAN(5, 5, 0)
           DefaultGameModeClass = WorldSettings->GetDefaultGameMode();
 #else
-          if (WorldSettings->DefaultGameMode) {
-            DefaultGameModeClass = WorldSettings->DefaultGameMode.Get();
-
-            if (!DefaultGameModeClass &&
-                WorldSettings->DefaultGameMode.ToSoftObjectPath().IsValid()) {
-              DefaultGameModeClass =
-                  WorldSettings->DefaultGameMode.LoadSynchronous();
-            }
+          if (UClass *ResolvedClass = WorldSettings->DefaultGameMode.Get()) {
+            DefaultGameModeClass = ResolvedClass;
           }
 #endif
 


### PR DESCRIPTION
## Summary
- resolve the default battle game mode class using WorldSettings->DefaultGameMode.Get() when compiling against UE 5.5+
- keep existing code path for earlier engine versions

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e64a493de48324ac70f41d2483706b