### PR TITLE
Hide overworld while grid battles are active

### DIFF
--- a/Source/Skald/Skald_PlayerController.cpp
+++ b/Source/Skald/Skald_PlayerController.cpp
@@ -816,6 +816,13 @@ void ASkaldPlayerController::ShowOverworldHUD() {
 
   bBattleHUDVisible = false;
   bBattleHUDReadyToShow = false;
+
+  if (UWorld *World = GetWorld()) {
+    if (AWorldMap *WorldMap = Cast<AWorldMap>(
+            UGameplayStatics::GetActorOfClass(World, AWorldMap::StaticClass()))) {
+      WorldMap->SetWorldActive(true);
+    }
+  }
 }
 
 void ASkaldPlayerController::HideOverworldHUDForBattle() {
@@ -825,6 +832,13 @@ void ASkaldPlayerController::HideOverworldHUDForBattle() {
   bBattleHUDReadyToShow = false;
   if (BattleHudWidget) {
     BattleHudWidget->SetVisibility(ESlateVisibility::Collapsed);
+  }
+
+  if (UWorld *World = GetWorld()) {
+    if (AWorldMap *WorldMap = Cast<AWorldMap>(
+            UGameplayStatics::GetActorOfClass(World, AWorldMap::StaticClass()))) {
+      WorldMap->SetWorldActive(false);
+    }
   }
 }
 
@@ -1391,11 +1405,21 @@ void ASkaldPlayerController::ServerDeployUnits_Implementation(int32 TerritoryID,
 
 void ASkaldPlayerController::ServerSelectTerritory_Implementation(
     int32 TerritoryID) {
+  if (USkaldGameInstance *GI = GetGameInstance<USkaldGameInstance>()) {
+    if (GI->bIsInBattleMap && TerritoryID >= 0) {
+      return;
+    }
+  }
+
   UE_LOG(LogSkald, Log, TEXT("ServerSelectTerritory called with %d"),
          TerritoryID);
   AWorldMap *WorldMap = Cast<AWorldMap>(
       UGameplayStatics::GetActorOfClass(GetWorld(), AWorldMap::StaticClass()));
   if (!WorldMap) {
+    return;
+  }
+
+  if (!WorldMap->IsWorldActive() && TerritoryID >= 0) {
     return;
   }
 
@@ -1419,6 +1443,10 @@ void ASkaldPlayerController::ClientSelectTerritory_Implementation(
   AWorldMap *WorldMap = Cast<AWorldMap>(
       UGameplayStatics::GetActorOfClass(GetWorld(), AWorldMap::StaticClass()));
   if (!WorldMap) {
+    return;
+  }
+
+  if (!WorldMap->IsWorldActive() && TerritoryID >= 0) {
     return;
   }
 

--- a/Source/Skald/Territory.cpp
+++ b/Source/Skald/Territory.cpp
@@ -235,12 +235,24 @@ bool ATerritory::MoveTo(ATerritory *TargetTerritory, int32 Troops) {
 }
 
 void ATerritory::HandleMouseEnter(UPrimitiveComponent *TouchedComponent) {
+  if (AWorldMap *Map = Cast<AWorldMap>(GetOwner())) {
+    if (!Map->IsWorldActive()) {
+      return;
+    }
+  }
+
   if (!bIsSelected && MeshComponent) {
     MeshComponent->SetRenderCustomDepth(true);
   }
 }
 
 void ATerritory::HandleMouseLeave(UPrimitiveComponent *TouchedComponent) {
+  if (AWorldMap *Map = Cast<AWorldMap>(GetOwner())) {
+    if (!Map->IsWorldActive()) {
+      return;
+    }
+  }
+
   if (!bIsSelected && MeshComponent) {
     MeshComponent->SetRenderCustomDepth(false);
   }
@@ -248,6 +260,12 @@ void ATerritory::HandleMouseLeave(UPrimitiveComponent *TouchedComponent) {
 
 void ATerritory::HandleClicked(UPrimitiveComponent *TouchedComponent,
                                FKey ButtonPressed) {
+  if (AWorldMap *Map = Cast<AWorldMap>(GetOwner())) {
+    if (!Map->IsWorldActive()) {
+      return;
+    }
+  }
+
   UE_LOG(LogSkald, Log, TEXT("Territory %d clicked; currently %s"), TerritoryID,
          bIsSelected ? TEXT("selected") : TEXT("not selected"));
 

--- a/Source/Skald/WorldMap.cpp
+++ b/Source/Skald/WorldMap.cpp
@@ -1,5 +1,8 @@
 #include "WorldMap.h"
 #include "Algo/Reverse.h"
+#include "Components/ActorComponent.h"
+#include "Components/AudioComponent.h"
+#include "Components/PrimitiveComponent.h"
 #include "Components/StaticMeshComponent.h"
 #include "Containers/Map.h"
 #include "Containers/Queue.h"
@@ -27,6 +30,78 @@ AWorldMap::AWorldMap() {
 }
 
 void AWorldMap::BeginPlay() { Super::BeginPlay(); }
+
+void AWorldMap::SetWorldActive(bool bShouldBeActive) {
+  if (bIsWorldActive == bShouldBeActive) {
+    return;
+  }
+
+  bIsWorldActive = bShouldBeActive;
+
+  SetActorHiddenInGame(!bIsWorldActive);
+  SetActorTickEnabled(bIsWorldActive);
+  SetActorEnableCollision(bIsWorldActive);
+
+  TInlineComponentArray<UPrimitiveComponent *> PrimitiveComponents(this);
+  for (UPrimitiveComponent *Primitive : PrimitiveComponents) {
+    if (!Primitive) {
+      continue;
+    }
+
+    Primitive->SetHiddenInGame(!bIsWorldActive);
+    Primitive->SetVisibility(bIsWorldActive, true);
+    Primitive->SetComponentTickEnabled(bIsWorldActive);
+
+    if (!bIsWorldActive) {
+      CachedCollisionStates.FindOrAdd(Primitive) =
+          Primitive->GetCollisionEnabled();
+      Primitive->SetCollisionEnabled(ECollisionEnabled::NoCollision);
+    } else {
+      if (TEnumAsByte<ECollisionEnabled::Type> *CachedState =
+              CachedCollisionStates.Find(Primitive)) {
+        Primitive->SetCollisionEnabled(*CachedState);
+        CachedCollisionStates.Remove(Primitive);
+      }
+    }
+  }
+
+  TInlineComponentArray<UAudioComponent *> AudioComponents(this);
+  for (UAudioComponent *Audio : AudioComponents) {
+    if (!Audio) {
+      continue;
+    }
+
+    if (!bIsWorldActive) {
+      const bool bWasPlaying = Audio->IsPlaying();
+      CachedAudioPlaybackState.FindOrAdd(Audio) = bWasPlaying;
+      if (bWasPlaying) {
+        Audio->SetPaused(true);
+      }
+    } else {
+      bool bShouldResume = false;
+      if (bool *CachedValue = CachedAudioPlaybackState.Find(Audio)) {
+        bShouldResume = *CachedValue;
+        CachedAudioPlaybackState.Remove(Audio);
+      }
+
+      if (bShouldResume) {
+        Audio->SetPaused(false);
+      }
+    }
+  }
+
+  for (auto It = CachedCollisionStates.CreateIterator(); It; ++It) {
+    if (!It.Key().IsValid()) {
+      It.RemoveCurrent();
+    }
+  }
+
+  for (auto It = CachedAudioPlaybackState.CreateIterator(); It; ++It) {
+    if (!It.Key().IsValid()) {
+      It.RemoveCurrent();
+    }
+  }
+}
 
 bool AWorldMap::GenerateTerritoriesFromTable() {
   if (!TerritoryClass) {
@@ -377,6 +452,13 @@ ATerritory *AWorldMap::GetTerritoryById(int32 TerritoryId) const {
 }
 
 void AWorldMap::SelectTerritory(ATerritory *Territory) {
+  if (!bIsWorldActive && Territory) {
+    UE_LOG(LogSkald, Verbose,
+           TEXT("WorldMap %s ignoring selection while inactive"),
+           *GetName());
+    return;
+  }
+
   if (Territory == SelectedTerritory) {
     return;
   }

--- a/Source/Skald/WorldMap.h
+++ b/Source/Skald/WorldMap.h
@@ -2,11 +2,14 @@
 
 #include "CoreMinimal.h"
 #include "Engine/DataTable.h"
+#include "Engine/EngineTypes.h"
 #include "GameFramework/Actor.h"
 #include "WorldMap.generated.h"
 
 class ATerritory;
 class ASkaldPlayerState;
+class UPrimitiveComponent;
+class UAudioComponent;
 
 // Broadcast when a territory is selected on the world map so that interested
 // systems (e.g. player controllers) can react.
@@ -120,6 +123,14 @@ public:
   UFUNCTION(BlueprintCallable, Category = "WorldMap")
   bool MoveBetween(ATerritory *From, ATerritory *To, int32 Troops);
 
+  /** Toggle whether the overworld should be visible and interactive. */
+  UFUNCTION(BlueprintCallable, Category = "WorldMap")
+  void SetWorldActive(bool bShouldBeActive);
+
+  /** Returns whether the overworld is currently visible/interactive. */
+  UFUNCTION(BlueprintPure, Category = "WorldMap")
+  bool IsWorldActive() const { return bIsWorldActive; }
+
   /** Actor class used when spawning territory instances. */
   UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "WorldMap")
   TSubclassOf<ATerritory> TerritoryClass;
@@ -159,4 +170,15 @@ public:
   int32 AutoPlaceUnitsForAI(ASkaldPlayerState *PlayerState);
 
 protected:
+  /** Whether the overworld should currently be visible and interactive. */
+  UPROPERTY(VisibleInstanceOnly, BlueprintReadOnly, Category = "WorldMap")
+  bool bIsWorldActive = true;
+
+private:
+  /** Cached collision state so we can restore original settings after battles. */
+  TMap<TWeakObjectPtr<UPrimitiveComponent>, TEnumAsByte<ECollisionEnabled::Type>>
+      CachedCollisionStates;
+
+  /** Cached audio playback state for pausing/resuming overworld ambience. */
+  TMap<TWeakObjectPtr<UAudioComponent>, bool> CachedAudioPlaybackState;
 };


### PR DESCRIPTION
## Summary
- add a controllable activation toggle on the world map that hides visuals, disables collisions, and pauses ambience while the battle level is streamed
- have the player controller switch the overworld off during battles and restore it when returning, preventing server/client territory selection requests
- gate territory interaction handlers so clicks and highlights are ignored while the overworld is inactive

## Testing
- not run (Unreal build tooling is unavailable in the container environment)

------
https://chatgpt.com/codex/tasks/task_e_68e6539863048324aabd6ebacb1effef