### PR TITLE
Relocate controllers when streaming battle map

### DIFF
--- a/Source/Skald/Skald_BattleGameMode.cpp
+++ b/Source/Skald/Skald_BattleGameMode.cpp
@@ -721,6 +721,21 @@ void ASkald_BattleGameMode::SetupPendingBattle() {
     return;
   }
 
+  {
+    TArray<AController *> ControllersToRelocate;
+    ControllersToRelocate.Reserve(2);
+    if (AttackerC) {
+      ControllersToRelocate.AddUnique(AttackerC);
+    }
+    if (DefenderC) {
+      ControllersToRelocate.AddUnique(DefenderC);
+    }
+
+    if (ControllersToRelocate.Num() > 0) {
+      RelocateControllersNearBattleGrid(ControllersToRelocate);
+    }
+  }
+
   ASkaldPlayerState *AttackerSlotPS =
       AttackerC->GetPlayerState<ASkaldPlayerState>();
   ASkaldPlayerState *DefenderSlotPS =


### PR DESCRIPTION
## Summary
- ensure `SetupPendingBattle` moves resolved controllers toward the streamed battle grid
- address battles remaining focused on the overworld after confirming an attack by relocating both sides immediately

## Testing
- not run (not applicable in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68e672b832f48324ae0093ad2aa848ee