### PR TITLE
Fix battle map state transitions for streamed encounters

### DIFF
--- a/Source/Skald/Skald_BattleLevelManager.cpp
+++ b/Source/Skald/Skald_BattleLevelManager.cpp
@@ -161,7 +161,7 @@ void USkaldBattleLevelManager::HandleLevelLoaded() {
 
   if (USkaldGameInstance *GI = OwningInstance.Get()) {
     GI->SetTravelPending(false);
-    GI->bIsInBattleMap = true;
+    GI->SetBattleMapActive(true);
 
     if (!GI->GetActiveBattleGameMode() && ActiveStreamingLevel.IsValid()) {
       UWorld *OwningWorld = ActiveStreamingLevel->GetWorld();
@@ -258,7 +258,7 @@ void USkaldBattleLevelManager::HandleLevelUnloaded() {
     }
     GI->SetActiveBattleGameMode(nullptr);
     GI->SetTravelPending(false);
-    GI->bIsInBattleMap = false;
+    GI->SetBattleMapActive(false);
   }
 }
 

--- a/Source/Skald/Skald_GameInstance.cpp
+++ b/Source/Skald/Skald_GameInstance.cpp
@@ -27,6 +27,7 @@ void USkaldGameInstance::Init() {
   PendingBattle = FS_BattlePayload();
   PendingBattleResolution = FGridBattleResolution();
   bPendingBattleResolution = false;
+  SetBattleMapActive(false);
 
   if (!BattleLevelStreamingManager) {
     BattleLevelStreamingManager = NewObject<USkaldBattleLevelManager>(this);
@@ -124,6 +125,15 @@ void USkaldGameInstance::SetActiveBattleGameMode(
   UE_LOG(LogSkald, Log,
          TEXT("GameInstance set active battle game mode: %s"),
          *GetNameSafe(InGameMode));
+}
+
+void USkaldGameInstance::SetBattleMapActive(bool bInBattleMap) {
+  if (bIsInBattleMap == bInBattleMap) {
+    return;
+  }
+
+  bIsInBattleMap = bInBattleMap;
+  OnBattleMapStateChanged.Broadcast(bIsInBattleMap);
 }
 
 void USkaldGameInstance::SeedCombatRandomStream(int32 Seed) {
@@ -225,7 +235,7 @@ void USkaldGameInstance::ResetSessionState() {
     }
   }
   SetActiveBattleGameMode(nullptr);
-  bIsInBattleMap = false;
+  SetBattleMapActive(false);
   bTravelPending = false;
   CachedWorldMapTerritories.Empty();
   TravelState = FSkaldTravelState();

--- a/Source/Skald/Skald_GameInstance.h
+++ b/Source/Skald/Skald_GameInstance.h
@@ -42,6 +42,9 @@ struct FSkaldTravelState
 };
 
 DECLARE_DYNAMIC_MULTICAST_DELEGATE(FSkaldFactionsUpdated);
+DECLARE_DYNAMIC_MULTICAST_DELEGATE_OneParam(FSkaldBattleMapStateChanged,
+                                            bool,
+                                            bIsInBattleMap);
 /** Game instance storing player selections from the lobby. */
 UCLASS()
 class SKALD_API USkaldGameInstance : public UGameInstance {
@@ -82,6 +85,10 @@ public:
   /** Event fired when the taken faction list changes. */
   UPROPERTY(BlueprintAssignable, Category = "Player|Events")
   FSkaldFactionsUpdated OnFactionsUpdated;
+
+  /** Event fired whenever the game enters or exits the streamed battle map. */
+  UPROPERTY(BlueprintAssignable, Category = "Battle|Events")
+  FSkaldBattleMapStateChanged OnBattleMapStateChanged;
 
   /** Payload describing the battle to resolve when returning from the battle
    * map. */
@@ -154,6 +161,9 @@ public:
   USkaldBattleLevelManager *GetBattleLevelManager() const { return BattleLevelStreamingManager; }
 
   void SetActiveBattleGameMode(ASkald_BattleGameMode *InGameMode);
+
+  UFUNCTION(BlueprintCallable, Category = "Battle")
+  void SetBattleMapActive(bool bInBattleMap);
 
   ASkald_BattleGameMode *GetActiveBattleGameMode() const {
     return ActiveBattleGameMode.Get();

--- a/Source/Skald/Skald_PlayerController.cpp
+++ b/Source/Skald/Skald_PlayerController.cpp
@@ -156,6 +156,10 @@ void ASkaldPlayerController::CacheGameReferences() {
   } else {
     CachedGameInstance->OnFactionsUpdated.AddDynamic(
         this, &ASkaldPlayerController::HandleFactionsUpdated);
+    CachedGameInstance->OnBattleMapStateChanged.RemoveDynamic(
+        this, &ASkaldPlayerController::HandleBattleMapStateChanged);
+    CachedGameInstance->OnBattleMapStateChanged.AddDynamic(
+        this, &ASkaldPlayerController::HandleBattleMapStateChanged);
   }
 }
 
@@ -293,6 +297,11 @@ void ASkaldPlayerController::EndPlay(const EEndPlayReason::Type EndPlayReason) {
   if (PostLoadMapHandle.IsValid()) {
     FCoreUObjectDelegates::PostLoadMapWithWorld.Remove(PostLoadMapHandle);
     PostLoadMapHandle.Reset();
+  }
+
+  if (CachedGameInstance) {
+    CachedGameInstance->OnBattleMapStateChanged.RemoveDynamic(
+        this, &ASkaldPlayerController::HandleBattleMapStateChanged);
   }
 
   if (MainHUD) {
@@ -1689,6 +1698,11 @@ void ASkaldPlayerController::HandleFactionsUpdated() {
   if (ASkaldPlayerState *LocalPS = GetPlayerState<ASkaldPlayerState>()) {
     MainHUD->UpdateResources(LocalPS->Resources);
   }
+}
+
+void ASkaldPlayerController::HandleBattleMapStateChanged(bool /*bInBattleMap*/) {
+  DetectBattleMap();
+  InitializeFighterSelectionIfNeeded();
 }
 
 void ASkaldPlayerController::HandleWorldStateChanged() {

--- a/Source/Skald/Skald_PlayerController.h
+++ b/Source/Skald/Skald_PlayerController.h
@@ -286,6 +286,10 @@ public:
   UFUNCTION()
   void HandleFactionsUpdated();
 
+  /** React to the game entering or exiting the streamed battle map. */
+  UFUNCTION()
+  void HandleBattleMapStateChanged(bool bInBattleMap);
+
   /** React to world state changes broadcast by the turn manager. */
   UFUNCTION()
   void HandleWorldStateChanged();

--- a/Source/Skald/Skald_TurnManager.cpp
+++ b/Source/Skald/Skald_TurnManager.cpp
@@ -769,7 +769,7 @@ void ATurnManager::TriggerGridBattle(const FS_BattlePayload &Battle) {
       } else {
         GI->SetTravelPending(true);
       }
-      GI->bIsInBattleMap = true;
+      GI->SetBattleMapActive(true);
     }
 
     UE_LOG(LogSkald, Log,
@@ -811,7 +811,7 @@ void ATurnManager::MulticastStreamBattleLevel_Implementation(
 
   GI->SetTravelState(TravelState);
   GI->PendingBattle = BattlePayload;
-  GI->bIsInBattleMap = true;
+  GI->SetBattleMapActive(true);
 
   if (USkaldBattleLevelManager *BattleLevelManager =
           GI->GetBattleLevelManager()) {
@@ -839,7 +839,7 @@ void ATurnManager::ResolveGridBattleResult_Implementation() {
     return;
   }
 
-  GI->bIsInBattleMap = false;
+  GI->SetBattleMapActive(false);
   if (USkaldBattleLevelManager *BattleLevelManager =
           GI->GetBattleLevelManager()) {
     BattleLevelManager->ReleaseBattleLevel();


### PR DESCRIPTION
## Summary
- add a delegate in the game instance to broadcast when the streamed battle map becomes active or hidden
- hook the player controller to the new signal so it updates HUD visibility and fighter selection whenever battle travel occurs
- switch the turn manager and battle level manager to use the centralized setter when toggling the battle map flag

## Testing
- not run (not available in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68e682eb403c8324ac5841e772fedec8