### PR TITLE
Fix compile error in BattleEndIdempotencyTest by removing in-file UCLASS

### DIFF
--- a/Source/Skald/Tests/BattleEndIdempotencyTest.cpp
+++ b/Source/Skald/Tests/BattleEndIdempotencyTest.cpp
@@ -3,23 +3,6 @@
 #if WITH_AUTOMATION_TESTS
 
 #include "GridBattleManager.h"
-#include "UObject/Object.h"
-
-UCLASS()
-class USkaldBattleEndListener final : public UObject
-{
-  GENERATED_BODY()
-
-public:
-  int32 NotificationCount = 0;
-
-  UFUNCTION()
-  void HandleBattleEnded(ESkaldFaction /*WinningFaction*/, int32 /*AttackerCasualties*/, int32 /*DefenderCasualties*/)
-  {
-    ++NotificationCount;
-  }
-};
-
 IMPLEMENT_SIMPLE_AUTOMATION_TEST(FSkaldBattleEndIdempotencyTest,
                                  "Skald.Battle.EndBattleIdempotent",
                                  EAutomationTestFlags::EditorContext |
@@ -28,22 +11,24 @@ IMPLEMENT_SIMPLE_AUTOMATION_TEST(FSkaldBattleEndIdempotencyTest,
 bool FSkaldBattleEndIdempotencyTest::RunTest(const FString& Parameters)
 {
   UGridBattleManager* Manager = NewObject<UGridBattleManager>();
-  USkaldBattleEndListener* Listener = NewObject<USkaldBattleEndListener>();
+  int32 NotificationCount = 0;
 
   TestNotNull(TEXT("Battle manager created"), Manager);
-  TestNotNull(TEXT("Listener created"), Listener);
-  if (!Manager || !Listener)
+  if (!Manager)
   {
     return false;
   }
 
-  Manager->OnBattleEnded.AddDynamic(Listener, &USkaldBattleEndListener::HandleBattleEnded);
+  Manager->OnBattleEnded.AddLambda([&NotificationCount](ESkaldFaction /*WinningFaction*/, int32 /*AttackerCasualties*/, int32 /*DefenderCasualties*/)
+  {
+    ++NotificationCount;
+  });
 
   Manager->EndBattle();
   Manager->EndBattle();
 
   TestEqual(TEXT("OnBattleEnded should broadcast once across duplicate EndBattle calls"),
-            Listener->NotificationCount, 1);
+            NotificationCount, 1);
   return true;
 }
 


### PR DESCRIPTION
### Motivation
- The Windows/MSVC build was failing with C++ errors (`C2143`, `C4430`) originating from `Source/Skald/Tests/BattleEndIdempotencyTest.cpp` due to an invalid in-file reflected `UCLASS`/UObject pattern in that translation unit.
- The test needs to verify event idempotency but must avoid declaring a reflected UObject type inside the test TU which caused the parser/type errors.

### Description
- Removed the temporary `UCLASS` listener type and its `UObject` include from `BattleEndIdempotencyTest.cpp`. 
- Replaced the instance listener and `AddDynamic` binding with a local `int32 NotificationCount` and an `AddLambda` which increments the counter. 
- Updated the assertion to compare the local `NotificationCount` and preserved the original test intent that duplicate `EndBattle()` calls only broadcast once.

### Testing
- Verified the change with `git diff` and file inspection to confirm the listener removal and lambda binding were applied. 
- Committed the change (`Fix battle end automation test compile error`) to the repository to record the fix. 
- Did not re-run the Windows/MSVC Unreal build or AutomationTool in this environment, so no full compile verification was performed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3d3fbc4cc8324a70f0df06db1090c)