### PR TITLE
Fix dynamic delegate binding in battle end idempotency test

### DIFF
--- a/Source/Skald/Tests/BattleEndIdempotencyTest.cpp
+++ b/Source/Skald/Tests/BattleEndIdempotencyTest.cpp
@@ -3,6 +3,7 @@
 #if WITH_AUTOMATION_TESTS
 
 #include "GridBattleManager.h"
+#include "BattleEndIdempotencyTestListener.h"
 IMPLEMENT_SIMPLE_AUTOMATION_TEST(FSkaldBattleEndIdempotencyTest,
                                  "Skald.Battle.EndBattleIdempotent",
                                  EAutomationTestFlags::EditorContext |
@@ -11,7 +12,7 @@ IMPLEMENT_SIMPLE_AUTOMATION_TEST(FSkaldBattleEndIdempotencyTest,
 bool FSkaldBattleEndIdempotencyTest::RunTest(const FString& Parameters)
 {
   UGridBattleManager* Manager = NewObject<UGridBattleManager>();
-  int32 NotificationCount = 0;
+  UBattleEndIdempotencyTestListener* Listener = NewObject<UBattleEndIdempotencyTestListener>();
 
   TestNotNull(TEXT("Battle manager created"), Manager);
   if (!Manager)
@@ -19,16 +20,20 @@ bool FSkaldBattleEndIdempotencyTest::RunTest(const FString& Parameters)
     return false;
   }
 
-  Manager->OnBattleEnded.AddLambda([&NotificationCount](ESkaldFaction /*WinningFaction*/, int32 /*AttackerCasualties*/, int32 /*DefenderCasualties*/)
+  TestNotNull(TEXT("Listener created"), Listener);
+  if (!Listener)
   {
-    ++NotificationCount;
-  });
+    return false;
+  }
+
+  Manager->OnBattleEnded.AddDynamic(Listener,
+                                    &UBattleEndIdempotencyTestListener::HandleBattleEnded);
 
   Manager->EndBattle();
   Manager->EndBattle();
 
   TestEqual(TEXT("OnBattleEnded should broadcast once across duplicate EndBattle calls"),
-            NotificationCount, 1);
+            Listener->NotificationCount, 1);
   return true;
 }
 

--- a/Source/Skald/Tests/BattleEndIdempotencyTestListener.h
+++ b/Source/Skald/Tests/BattleEndIdempotencyTestListener.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "GridBattleManager.h"
+#include "BattleEndIdempotencyTestListener.generated.h"
+
+UCLASS()
+class SKALD_API UBattleEndIdempotencyTestListener : public UObject
+{
+    GENERATED_BODY()
+
+public:
+    int32 NotificationCount = 0;
+
+    UFUNCTION()
+    void HandleBattleEnded(ESkaldFaction /*WinningFaction*/, int32 /*AttackerCasualties*/, int32 /*DefenderCasualties*/)
+    {
+        ++NotificationCount;
+    }
+};


### PR DESCRIPTION
### Motivation
- The idempotency automation test bound `UGridBattleManager::OnBattleEnded` with a lambda, but `OnBattleEnded` is a `DECLARE_DYNAMIC_MULTICAST_DELEGATE_ThreeParams` and must be bound via script-delegate APIs (`AddDynamic`/`AddUniqueDynamic`) for editor/automation builds.
- Make the test buildable and correct under automation/editor configurations by using a UObject/UFUNCTION target for the delegate.

### Description
- Replaced the lambda binding in `Source/Skald/Tests/BattleEndIdempotencyTest.cpp` with an `AddDynamic` call to a UObject listener.
- Added `Source/Skald/Tests/BattleEndIdempotencyTestListener.h` which defines `UBattleEndIdempotencyTestListener` containing `NotificationCount` and a `UFUNCTION` `HandleBattleEnded(...)` that increments the counter.
- Updated the test assertion to read `Listener->NotificationCount` so the original behavior (assert one broadcast for duplicate `EndBattle()` calls) is preserved.

### Testing
- No automated test suite was executed as part of this change; only source edits, inspection, and a commit were performed.
- Static/code inspection verified the delegate type matches `AddDynamic` usage and the test assertion remains equivalent to the prior logic.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3ecf0b5608324b58af75f429e64a8)