### PR TITLE
Fix UHT function parameter naming in BattleEndIdempotencyTestListener

### DIFF
--- a/Source/Skald/Tests/BattleEndIdempotencyTestListener.h
+++ b/Source/Skald/Tests/BattleEndIdempotencyTestListener.h
@@ -13,8 +13,11 @@ public:
     int32 NotificationCount = 0;
 
     UFUNCTION()
-    void HandleBattleEnded(ESkaldFaction /*WinningFaction*/, int32 /*AttackerCasualties*/, int32 /*DefenderCasualties*/)
+    void HandleBattleEnded(ESkaldFaction WinningFaction, int32 AttackerCasualties, int32 DefenderCasualties)
     {
+        (void)WinningFaction;
+        (void)AttackerCasualties;
+        (void)DefenderCasualties;
         ++NotificationCount;
     }
 };


### PR DESCRIPTION
### Motivation
- UnrealHeaderTool failed with `Function parameter: Expected name` because the `UFUNCTION` used comment placeholders instead of actual parameter names, causing UHT to be unable to parse the header.

### Description
- Replace commented parameter placeholders with concrete parameter names in `UBattleEndIdempotencyTestListener::HandleBattleEnded` and add `(void)` casts for each parameter to preserve original behaviour and avoid unused-parameter warnings.

### Testing
- Verified the updated header with `sed -n '1,120p' Source/Skald/Tests/BattleEndIdempotencyTestListener.h` and `nl -ba Source/Skald/Tests/BattleEndIdempotencyTestListener.h | sed -n '1,120p'`, and both checks showed the corrected signature and file content as expected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3f517094c83249015776a180cd7d6)