### PR TITLE
Fix battle selection UI being invoked on AI controllers and prevent duplicate AI delegate binding

### DIFF
--- a/Source/Skald/Skald_AIController.cpp
+++ b/Source/Skald/Skald_AIController.cpp
@@ -1510,12 +1510,21 @@ void ASkaldAIController::SetupBattleAutomation() {
     return;
   }
 
-  CachedBattleManager->OnActiveFighterChanged.AddDynamic(
-      this, &ASkaldAIController::HandleActiveFighterChanged);
-  CachedBattleManager->OnRoundStarted.AddDynamic(
-      this, &ASkaldAIController::HandleRoundStarted);
-  CachedBattleManager->OnBattleEnded.AddDynamic(
-      this, &ASkaldAIController::HandleBattleEnded);
+  if (!CachedBattleManager->OnActiveFighterChanged.IsAlreadyBound(
+          this, &ASkaldAIController::HandleActiveFighterChanged)) {
+    CachedBattleManager->OnActiveFighterChanged.AddDynamic(
+        this, &ASkaldAIController::HandleActiveFighterChanged);
+  }
+  if (!CachedBattleManager->OnRoundStarted.IsAlreadyBound(
+          this, &ASkaldAIController::HandleRoundStarted)) {
+    CachedBattleManager->OnRoundStarted.AddDynamic(
+        this, &ASkaldAIController::HandleRoundStarted);
+  }
+  if (!CachedBattleManager->OnBattleEnded.IsAlreadyBound(
+          this, &ASkaldAIController::HandleBattleEnded)) {
+    CachedBattleManager->OnBattleEnded.AddDynamic(
+        this, &ASkaldAIController::HandleBattleEnded);
+  }
 
   DetermineControlledBattleSide();
   ScheduleTryActivateNextFighter();

--- a/Source/Skald/Skald_PlayerController.cpp
+++ b/Source/Skald/Skald_PlayerController.cpp
@@ -426,7 +426,7 @@ bool ASkaldPlayerController::TryUseAbilitySlot(ESkaldAbilitySlot Slot) {
 }
 
 void ASkaldPlayerController::HandleAbilityInput(ESkaldAbilitySlot Slot) {
-  if (!IsLocalController()) {
+  if (!IsLocalController() || GetLocalPlayer() == nullptr) {
     return;
   }
 
@@ -2059,7 +2059,7 @@ void ASkaldPlayerController::TryBindWorldMap() {
                      this, &ASkaldPlayerController::HandleTerritorySelected),
                  TEXT("Failed to bind HandleTerritorySelected to WorldMap."));
     }
-    if (IsLocalController()) {
+    if (IsLocalController() && GetLocalPlayer() != nullptr) {
       if (RefreshLocalTerritorySelection()) {
         bPendingLocalSelectionRefresh = false;
       }
@@ -2469,7 +2469,7 @@ ATurnManager *ASkaldPlayerController::FindTurnManagerActor() const {
 }
 
 void ASkaldPlayerController::InitializeFighterSelectionIfNeeded() {
-  if (!IsLocalController()) {
+  if (!IsLocalController() || GetLocalPlayer() == nullptr) {
     return;
   }
 
@@ -2624,7 +2624,7 @@ void ASkaldPlayerController::RequestBattleStateIfNeeded() {
 
 void ASkaldPlayerController::ShowFighterSelectionUI(int32 MaxBudget,
                                                     ESkaldFaction Faction) {
-  if (!IsLocalController()) {
+  if (!IsLocalController() || GetLocalPlayer() == nullptr) {
     return;
   }
 
@@ -2774,7 +2774,7 @@ void ASkaldPlayerController::HandleBattlePhaseChanged() {
           GetWorld() ? GetWorld()->GetGameState<ASkaldGameState>() : nullptr) {
     // Ensure each owning client initializes its own HUD/camera when entering a
     // battle-related phase instead of waiting for host-driven RPCs.
-    if (IsLocalController()) {
+    if (IsLocalController() && GetLocalPlayer() != nullptr) {
       DetectBattleMap();
       InitializeBattleHUD();
       UpdateBattleCameraMode();


### PR DESCRIPTION
### Motivation
- Logs showed repeated PIE errors `CreateWidget cannot be used on Player Controller with no attached player` indicating AI controllers were entering client UI paths and stealing input/cursor focus. 
- The same session produced an ensure from `ScriptDelegates.h` during AI setup, showing duplicate delegate bindings in `ASkaldAIController::SetupBattleAutomation`. 
- These issues caused unstable input state (missing cursor until tabbing) and apparent spectator-only behavior after fighters spawned. 

### Description
- Added local-player guards to client-only UI/bootstrap paths in `ASkaldPlayerController` by checking `GetLocalPlayer() != nullptr` in `InitializeFighterSelectionIfNeeded`, `ShowFighterSelectionUI`, and the local HUD/camera bootstrap in `HandleBattlePhaseChanged` so non-local (AI/server) controllers do not call `CreateWidget` or change input mode. 
- Tightened other local-only checks (e.g. `HandleAbilityInput` and `TryBindWorldMap` local-refresh) to require an attached `ULocalPlayer` before performing UI/input operations. 
- Made `ASkaldAIController::SetupBattleAutomation()` idempotent by checking `IsAlreadyBound` before calling `AddDynamic` on `OnActiveFighterChanged`, `OnRoundStarted`, and `OnBattleEnded` delegates to avoid duplicate binding ensures. 

### Testing
- Ran repository searches with `rg` to verify insertion points and that guards/delegate checks were added, and the `rg` checks completed successfully. 
- Performed repository verification with `git status --short` and committed the changes using `git commit`, which succeeded. 
- No automated runtime unit tests were executed as part of this patch; changes are focused on input/UI guard logic and delegate binding safety and should be validated in PIE/editor runs to confirm the `CreateWidget` PIE errors and the delegate ensure are resolved.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f4bdb1695083248243a346816bc5f7)