### PR TITLE
Guard UI widget creation to local human controllers

### DIFF
--- a/Source/Skald/Skald_PlayerController.cpp
+++ b/Source/Skald/Skald_PlayerController.cpp
@@ -1613,6 +1613,10 @@ void ASkaldPlayerController::InitializeHUDWidget() {
 }
 
 void ASkaldPlayerController::InitializeChoosePlayerWidget() {
+  if (!IsLocalPlayerController() || !GetLocalPlayer()) {
+    return;
+  }
+
   if (ChoosePlayerWidget || !ChoosePlayerWidgetClass) {
     return;
   }
@@ -2863,7 +2867,7 @@ void ASkaldPlayerController::Server_CommitArmy_Implementation(
 }
 
 void ASkaldPlayerController::InitializeBattleHUD() {
-  if (!IsLocalController())
+  if (!IsLocalPlayerController() || !GetLocalPlayer())
     return;
   if (!BattleHUDWidgetClass)
     return;


### PR DESCRIPTION
### Motivation
- Prevent UI creation on AI/authority controllers that lack an attached `ULocalPlayer`, which was producing repeated `CreateWidget cannot be used on Player Controller with no attached player` PIE errors and interfering with fighter-selection/battle bootstrap sequencing.

### Description
- Add local-player guards to `ASkaldPlayerController` so `InitializeChoosePlayerWidget()` and `InitializeBattleHUD()` require `IsLocalPlayerController()` and a valid `GetLocalPlayer()` before calling `CreateWidget`, avoiding widget creation on AI controllers.

### Testing
- No automated unit/integration tests were executed; performed static verification via `rg` to confirm relevant widget creation sites and committed the change successfully (git commit completed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f4c9d3f6088324afaf905f1985ceb4)