### PR TITLE
Fix singleplayer fighter selection and prepare-for-battle UI gating

### DIFF
--- a/Source/Skald/Skald_PlayerController.cpp
+++ b/Source/Skald/Skald_PlayerController.cpp
@@ -2493,9 +2493,10 @@ void ASkaldPlayerController::InitializeFighterSelectionIfNeeded() {
                                                   ? CachedGameInstance->PendingBattle
                                                   : FS_BattlePayload();
 
-  const bool bInSelectionPhase = CachedGameState
-                                     ? CachedGameState->BattlePhase == EBattlePhase::FighterSelection
-                                     : true;
+  const bool bInSelectionPhase =
+      !CachedGameState ||
+      CachedGameState->BattlePhase == EBattlePhase::FighterSelection ||
+      (CachedGameState->BattlePhase == EBattlePhase::None && bHasBattleContext);
 
   ASkaldPlayerState *SelectionPS = GetPlayerState<ASkaldPlayerState>();
   int32 LocalPlayerId = SelectionPS ? ResolveStablePlayerId(SelectionPS) : INDEX_NONE;
@@ -6934,6 +6935,13 @@ void ASkaldPlayerController::ResetPendingReadyPromptState() {
 
 void ASkaldPlayerController::ShowPrepareForBattlePromptLocal(
     const FPrepareForBattlePromptData &PromptData) {
+  if (!IsLocalController() || GetLocalPlayer() == nullptr) {
+    UE_LOG(LogSkaldReady, Verbose,
+           TEXT("Skipping prepare-for-battle prompt for %s: controller has no local player."),
+           *GetName());
+    return;
+  }
+
   const bool bShouldDeferLocalAuthorityPrompt = IsLocalController() && HasAuthority();
 
   if (bShouldDeferLocalAuthorityPrompt) {
@@ -6952,6 +6960,11 @@ void ASkaldPlayerController::ShowPrepareForBattlePromptLocal(
 
 void ASkaldPlayerController::ShowPrepareForBattlePromptLocal_Internal(
     const FPrepareForBattlePromptData &PromptData) {
+  if (!IsLocalController() || GetLocalPlayer() == nullptr) {
+    ResetPendingReadyPromptState();
+    return;
+  }
+
   if (!MainHUD) {
     InitializeHUDWidget();
   }


### PR DESCRIPTION
### Motivation
- The fighter selection UI could be skipped in singleplayer because the replicated `BattlePhase` was transiently `None` while a pending battle context existed, leaving the human player without selection controls.
- AI controllers without an attached `LocalPlayer` were attempting to create widgets and spamming `CreateWidget cannot be used on Player Controller with no attached player`, which also interfered with UI/input ownership for the human player.

### Description
- Relaxed the selection-phase gating in `InitializeFighterSelectionIfNeeded` so the fighter selection UI will open when there is a battle context even if `CachedGameState->BattlePhase` is `None` (transient pre-replication state). (modified `bInSelectionPhase` calculation in `ASkaldPlayerController`).
- Added a strict local-player guard at the start of `ShowPrepareForBattlePromptLocal` to skip prepare-for-battle prompt flow for controllers that are not local or have no attached `LocalPlayer`, and added a verbose log message when skipped.
- Added the same local-player guard to `ShowPrepareForBattlePromptLocal_Internal` so deferred prompt execution is safe and cannot touch HUD/UI for non-local controllers.
- Kept existing behavior for AI participants while preventing non-local controllers from creating widgets, and preserved HUD initialization and focus behavior for genuine local players.

### Testing
- Performed repository-wide code inspection for relevant call sites using `rg` and reviewed the modified file using `sed` to verify the changes touched only the intended locations; these checks succeeded.
- Verified the diff of the modified source to ensure the changes are minimal and localized; the inspection succeeded.
- No automated unit tests or full build were executed in this environment, so runtime verification should be done in-editor (PIE) to confirm the fix removes the widget creation errors and restores cursor/UI control during singleplayer battle prep.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f4cd1ab77c832486a1f9df65371f05)