### PR TITLE
Only show battle-prep and fighter-selection UI for local/affected players; refine input-mode handling

### DIFF
--- a/Source/Skald/Skald_PlayerController.cpp
+++ b/Source/Skald/Skald_PlayerController.cpp
@@ -2493,9 +2493,10 @@ void ASkaldPlayerController::InitializeFighterSelectionIfNeeded() {
                                                   ? CachedGameInstance->PendingBattle
                                                   : FS_BattlePayload();
 
-  const bool bInSelectionPhase = CachedGameState
-                                     ? CachedGameState->BattlePhase == EBattlePhase::FighterSelection
-                                     : true;
+  const bool bInSelectionPhase =
+      !CachedGameState ||
+      CachedGameState->BattlePhase == EBattlePhase::FighterSelection ||
+      (CachedGameState->BattlePhase == EBattlePhase::None && bHasBattleContext);
 
   ASkaldPlayerState *SelectionPS = GetPlayerState<ASkaldPlayerState>();
   int32 LocalPlayerId = SelectionPS ? ResolveStablePlayerId(SelectionPS) : INDEX_NONE;
@@ -5349,12 +5350,41 @@ void ASkaldPlayerController::HandleReplicatedTurnOwnership() {
   if (!bIsMyTurn) {
     bLocalTurnActive = false;
 
-    // Ensure non-active players fully release world input and phase buttons
-    // instead of inheriting the host's UI state.
-    UWidgetBlueprintLibrary::SetInputMode_GameOnly(this);
-    bShowMouseCursor = false;
-    bEnableClickEvents = false;
-    bEnableMouseOverEvents = false;
+    bool bNeedsBattlePrepUI = bPendingReadyPrompt;
+    if (!bNeedsBattlePrepUI && FighterSelectionWidget && FighterSelectionWidget->IsInViewport()) {
+      bNeedsBattlePrepUI = true;
+    }
+
+    if (!bNeedsBattlePrepUI && CachedGameInstance) {
+      const FS_BattlePayload PendingBattle = CachedGameState
+                                                 ? CachedGameState->GetActiveBattlePayload()
+                                                 : CachedGameInstance->PendingBattle;
+      if (PendingBattle.AttackerPlayerID > 0 && PendingBattle.DefenderPlayerID > 0) {
+        if (ASkaldPlayerState* LocalPS = GetPlayerState<ASkaldPlayerState>()) {
+          const int32 LocalPlayerId = ResolveStablePlayerId(LocalPS);
+          bNeedsBattlePrepUI =
+              (PendingBattle.AttackerPlayerID == LocalPlayerId ||
+               PendingBattle.DefenderPlayerID == LocalPlayerId) &&
+              !LocalPS->bArmyLockedIn;
+        }
+      }
+    }
+
+    if (bNeedsBattlePrepUI) {
+      UWidgetBlueprintLibrary::SetInputMode_GameAndUIEx(
+          this, nullptr, EMouseLockMode::DoNotLock,
+          /*bHideCursorDuringCapture*/ false);
+      bShowMouseCursor = true;
+      bEnableClickEvents = true;
+      bEnableMouseOverEvents = true;
+    } else {
+      // Ensure non-active players fully release world input and phase buttons
+      // instead of inheriting the host's UI state.
+      UWidgetBlueprintLibrary::SetInputMode_GameOnly(this);
+      bShowMouseCursor = false;
+      bEnableClickEvents = false;
+      bEnableMouseOverEvents = false;
+    }
 
     if (MainHUD) {
       MainHUD->SyncPhaseButtons(false);
@@ -6934,6 +6964,13 @@ void ASkaldPlayerController::ResetPendingReadyPromptState() {
 
 void ASkaldPlayerController::ShowPrepareForBattlePromptLocal(
     const FPrepareForBattlePromptData &PromptData) {
+  if (!IsLocalController() || GetLocalPlayer() == nullptr) {
+    UE_LOG(LogSkaldReady, Verbose,
+           TEXT("Skipping prepare-for-battle prompt for %s: controller has no local player."),
+           *GetName());
+    return;
+  }
+
   const bool bShouldDeferLocalAuthorityPrompt = IsLocalController() && HasAuthority();
 
   if (bShouldDeferLocalAuthorityPrompt) {
@@ -6952,6 +6989,11 @@ void ASkaldPlayerController::ShowPrepareForBattlePromptLocal(
 
 void ASkaldPlayerController::ShowPrepareForBattlePromptLocal_Internal(
     const FPrepareForBattlePromptData &PromptData) {
+  if (!IsLocalController() || GetLocalPlayer() == nullptr) {
+    ResetPendingReadyPromptState();
+    return;
+  }
+
   if (!MainHUD) {
     InitializeHUDWidget();
   }


### PR DESCRIPTION
### Motivation

- Prevent prepare-for-battle prompts and fighter-selection UI from appearing for non-local controllers and to avoid leaking UI/input state from the host to non-active players.
- Ensure the fighter selection phase is detected correctly when `BattlePhase` is `None` but a battle context exists, and defer input locking when local players still need to prepare for battle.

### Description

- Update the selection-phase detection in `InitializeFighterSelectionIfNeeded` so `bInSelectionPhase` is true when `CachedGameState` is null or when `BattlePhase` is `FighterSelection`, or when `BattlePhase` is `None` and a battle context exists.
- Revise `HandleReplicatedTurnOwnership` to compute `bNeedsBattlePrepUI` from `bPendingReadyPrompt`, the presence of `FighterSelectionWidget`, or from a pending `FS_BattlePayload` where the local player is a participant and `!bArmyLockedIn`, and set input mode to `SetInputMode_GameAndUIEx` with visible cursor and click/mouseover enabled when needed; otherwise fall back to `SetInputMode_GameOnly` and hide cursor and input events.
- Add local-controller/local-player guards in `ShowPrepareForBattlePromptLocal` and `ShowPrepareForBattlePromptLocal_Internal` so prompts are skipped (with a verbose log) for non-local controllers and so pending prompt state is reset when the controller is not local.

### Testing

- Project compiled successfully for the editor and client after the changes.
- Ran automated unit/engine tests related to battle/turn management and UI automation; tests passed.
- Ran automated sanity (smoke) checks for prompt display and input-mode transitions; checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f4cd1ab77c832486a1f9df65371f05)