### PR TITLE
Defensively rebind battle delegates and limit controller UI updates to local controllers

### DIFF
--- a/Source/Skald/Skald_AIController.cpp
+++ b/Source/Skald/Skald_AIController.cpp
@@ -1510,21 +1510,22 @@ void ASkaldAIController::SetupBattleAutomation() {
     return;
   }
 
-  if (!CachedBattleManager->OnActiveFighterChanged.IsAlreadyBound(
-          this, &ASkaldAIController::HandleActiveFighterChanged)) {
-    CachedBattleManager->OnActiveFighterChanged.AddDynamic(
-        this, &ASkaldAIController::HandleActiveFighterChanged);
-  }
-  if (!CachedBattleManager->OnRoundStarted.IsAlreadyBound(
-          this, &ASkaldAIController::HandleRoundStarted)) {
-    CachedBattleManager->OnRoundStarted.AddDynamic(
-        this, &ASkaldAIController::HandleRoundStarted);
-  }
-  if (!CachedBattleManager->OnBattleEnded.IsAlreadyBound(
-          this, &ASkaldAIController::HandleBattleEnded)) {
-    CachedBattleManager->OnBattleEnded.AddDynamic(
-        this, &ASkaldAIController::HandleBattleEnded);
-  }
+  // Defensive rebind: remove first to avoid duplicate multicast bindings
+  // across PIE travel / BeginPlay re-entry edge cases.
+  CachedBattleManager->OnActiveFighterChanged.RemoveDynamic(
+      this, &ASkaldAIController::HandleActiveFighterChanged);
+  CachedBattleManager->OnActiveFighterChanged.AddDynamic(
+      this, &ASkaldAIController::HandleActiveFighterChanged);
+
+  CachedBattleManager->OnRoundStarted.RemoveDynamic(
+      this, &ASkaldAIController::HandleRoundStarted);
+  CachedBattleManager->OnRoundStarted.AddDynamic(
+      this, &ASkaldAIController::HandleRoundStarted);
+
+  CachedBattleManager->OnBattleEnded.RemoveDynamic(
+      this, &ASkaldAIController::HandleBattleEnded);
+  CachedBattleManager->OnBattleEnded.AddDynamic(
+      this, &ASkaldAIController::HandleBattleEnded);
 
   DetermineControlledBattleSide();
   ScheduleTryActivateNextFighter();

--- a/Source/Skald/Skald_GameState.cpp
+++ b/Source/Skald/Skald_GameState.cpp
@@ -162,6 +162,10 @@ void ASkaldGameState::RefreshControllersFromPlayers()
         {
             if (ASkaldPlayerController* PC = Cast<ASkaldPlayerController>(It->Get()))
             {
+                if (!PC->IsLocalController() || PC->GetLocalPlayer() == nullptr)
+                {
+                    continue;
+                }
                 PC->RefreshTurnDataFromState();
                 PC->HandleReplicatedTurnOwnership();
                 PC->HandleReplicatedTurnStart();
@@ -192,6 +196,10 @@ void ASkaldGameState::OnRep_CurrentTurnIndex()
         {
             if (ASkaldPlayerController* PC = Cast<ASkaldPlayerController>(It->Get()))
             {
+                if (!PC->IsLocalController() || PC->GetLocalPlayer() == nullptr)
+                {
+                    continue;
+                }
                 PC->RefreshTurnDataFromState();
                 PC->HandleReplicatedTurnOwnership();
                 PC->HandleReplicatedTurnStart();
@@ -214,6 +222,10 @@ void ASkaldGameState::OnRep_ActivePlayerId()
         {
             if (ASkaldPlayerController* PC = Cast<ASkaldPlayerController>(It->Get()))
             {
+                if (!PC->IsLocalController() || PC->GetLocalPlayer() == nullptr)
+                {
+                    continue;
+                }
                 PC->RefreshTurnDataFromState();
                 PC->HandleReplicatedTurnOwnership();
                 PC->HandleReplicatedTurnStart();
@@ -411,6 +423,10 @@ void ASkaldGameState::OnRep_BattlePayload()
         {
             if (ASkaldPlayerController* PC = Cast<ASkaldPlayerController>(It->Get()))
             {
+                if (!PC->IsLocalController() || PC->GetLocalPlayer() == nullptr)
+                {
+                    continue;
+                }
                 // Ensure late-joining controllers rebuild all dependent state from
                 // replicated payloads instead of assuming the original RPC timing
                 // path. This covers both the battle HUD and fighter selection UI.
@@ -453,6 +469,10 @@ void ASkaldGameState::OnRep_BattleParticipants()
         {
             if (ASkaldPlayerController* PC = Cast<ASkaldPlayerController>(It->Get()))
             {
+                if (!PC->IsLocalController() || PC->GetLocalPlayer() == nullptr)
+                {
+                    continue;
+                }
                 PC->RequestBattleStateIfNeeded();
 
                 // Ensure each owning client rebuilds their local HUD, camera, and
@@ -497,6 +517,10 @@ void ASkaldGameState::OnRep_PendingBattleReady()
         {
             if (ASkaldPlayerController* PC = Cast<ASkaldPlayerController>(It->Get()))
             {
+                if (!PC->IsLocalController() || PC->GetLocalPlayer() == nullptr)
+                {
+                    continue;
+                }
                 PC->RequestBattleStateIfNeeded();
                 PC->InitializeBattleHUD();
                 PC->DetermineControlledBattleSide();
@@ -525,6 +549,10 @@ void ASkaldGameState::OnRep_BattleRoundState()
         {
             if (ASkaldPlayerController* PC = Cast<ASkaldPlayerController>(It->Get()))
             {
+                if (!PC->IsLocalController() || PC->GetLocalPlayer() == nullptr)
+                {
+                    continue;
+                }
                 PC->RequestBattleStateIfNeeded();
                 PC->InitializeBattleHUD();
                 PC->DetermineControlledBattleSide();
@@ -710,6 +738,10 @@ void ASkaldGameState::OnRep_BattlePhase()
         {
             if (ASkaldPlayerController* PC = Cast<ASkaldPlayerController>(It->Get()))
             {
+                if (!PC->IsLocalController() || PC->GetLocalPlayer() == nullptr)
+                {
+                    continue;
+                }
                 // Rebuild local battle context from replicated state so every
                 // client (including listen servers) initializes their own HUD,
                 // camera, and turn ownership without relying on host-driven

--- a/Source/Skald/Skald_PlayerController.cpp
+++ b/Source/Skald/Skald_PlayerController.cpp
@@ -2493,9 +2493,10 @@ void ASkaldPlayerController::InitializeFighterSelectionIfNeeded() {
                                                   ? CachedGameInstance->PendingBattle
                                                   : FS_BattlePayload();
 
-  const bool bInSelectionPhase = CachedGameState
-                                     ? CachedGameState->BattlePhase == EBattlePhase::FighterSelection
-                                     : true;
+  const bool bInSelectionPhase =
+      !CachedGameState ||
+      CachedGameState->BattlePhase == EBattlePhase::FighterSelection ||
+      (CachedGameState->BattlePhase == EBattlePhase::None && bHasBattleContext);
 
   ASkaldPlayerState *SelectionPS = GetPlayerState<ASkaldPlayerState>();
   int32 LocalPlayerId = SelectionPS ? ResolveStablePlayerId(SelectionPS) : INDEX_NONE;
@@ -5349,12 +5350,41 @@ void ASkaldPlayerController::HandleReplicatedTurnOwnership() {
   if (!bIsMyTurn) {
     bLocalTurnActive = false;
 
-    // Ensure non-active players fully release world input and phase buttons
-    // instead of inheriting the host's UI state.
-    UWidgetBlueprintLibrary::SetInputMode_GameOnly(this);
-    bShowMouseCursor = false;
-    bEnableClickEvents = false;
-    bEnableMouseOverEvents = false;
+    bool bNeedsBattlePrepUI = bPendingReadyPrompt;
+    if (!bNeedsBattlePrepUI && FighterSelectionWidget && FighterSelectionWidget->IsInViewport()) {
+      bNeedsBattlePrepUI = true;
+    }
+
+    if (!bNeedsBattlePrepUI && CachedGameInstance) {
+      const FS_BattlePayload PendingBattle = CachedGameState
+                                                 ? CachedGameState->GetActiveBattlePayload()
+                                                 : CachedGameInstance->PendingBattle;
+      if (PendingBattle.AttackerPlayerID > 0 && PendingBattle.DefenderPlayerID > 0) {
+        if (ASkaldPlayerState* LocalPS = GetPlayerState<ASkaldPlayerState>()) {
+          const int32 LocalPlayerId = ResolveStablePlayerId(LocalPS);
+          bNeedsBattlePrepUI =
+              (PendingBattle.AttackerPlayerID == LocalPlayerId ||
+               PendingBattle.DefenderPlayerID == LocalPlayerId) &&
+              !LocalPS->bArmyLockedIn;
+        }
+      }
+    }
+
+    if (bNeedsBattlePrepUI) {
+      UWidgetBlueprintLibrary::SetInputMode_GameAndUIEx(
+          this, nullptr, EMouseLockMode::DoNotLock,
+          /*bHideCursorDuringCapture*/ false);
+      bShowMouseCursor = true;
+      bEnableClickEvents = true;
+      bEnableMouseOverEvents = true;
+    } else {
+      // Ensure non-active players fully release world input and phase buttons
+      // instead of inheriting the host's UI state.
+      UWidgetBlueprintLibrary::SetInputMode_GameOnly(this);
+      bShowMouseCursor = false;
+      bEnableClickEvents = false;
+      bEnableMouseOverEvents = false;
+    }
 
     if (MainHUD) {
       MainHUD->SyncPhaseButtons(false);
@@ -6934,6 +6964,13 @@ void ASkaldPlayerController::ResetPendingReadyPromptState() {
 
 void ASkaldPlayerController::ShowPrepareForBattlePromptLocal(
     const FPrepareForBattlePromptData &PromptData) {
+  if (!IsLocalController() || GetLocalPlayer() == nullptr) {
+    UE_LOG(LogSkaldReady, Verbose,
+           TEXT("Skipping prepare-for-battle prompt for %s: controller has no local player."),
+           *GetName());
+    return;
+  }
+
   const bool bShouldDeferLocalAuthorityPrompt = IsLocalController() && HasAuthority();
 
   if (bShouldDeferLocalAuthorityPrompt) {
@@ -6952,6 +6989,11 @@ void ASkaldPlayerController::ShowPrepareForBattlePromptLocal(
 
 void ASkaldPlayerController::ShowPrepareForBattlePromptLocal_Internal(
     const FPrepareForBattlePromptData &PromptData) {
+  if (!IsLocalController() || GetLocalPlayer() == nullptr) {
+    ResetPendingReadyPromptState();
+    return;
+  }
+
   if (!MainHUD) {
     InitializeHUDWidget();
   }
@@ -8548,7 +8590,7 @@ void ASkaldPlayerController::HandlePendingPresentationTimerTick() {
 }
 
 void ASkaldPlayerController::EnsureDiceWidgets() {
-  if (!IsLocalController()) {
+  if (!IsLocalController() || GetLocalPlayer() == nullptr) {
     return;
   }
 


### PR DESCRIPTION
### Motivation
- Prevent duplicate multicast delegate bindings for battle events across PIE travel / BeginPlay re-entry and ensure a single reliable binding point.
- Avoid running client-local UI and input logic on non-local or uninitialized controllers to prevent null-local-player crashes and incorrect HUD/input state for remote controllers.
- Preserve battle-preparation UI for non-active players who still need to interact (fighter selection / prepare-for-battle) instead of forcibly switching them to game-only input.

### Description
- Changed `ASkaldAIController::SetupBattleAutomation` to always `RemoveDynamic` then `AddDynamic` for `OnActiveFighterChanged`, `OnRoundStarted`, and `OnBattleEnded` to defensively rebind delegates and avoid duplicate multicast listeners.
- Added local-controller guards (`if (!PC->IsLocalController() || PC->GetLocalPlayer() == nullptr) continue;`) in multiple `ASkaldGameState` replication handlers (`RefreshControllersFromPlayers`, `OnRep_CurrentTurnIndex`, `OnRep_ActivePlayerId`, `OnRep_BattlePayload`, `OnRep_BattleParticipants`, `OnRep_PendingBattleReady`, `OnRep_BattleRoundState`, and `OnRep_BattlePhase`) so only controllers that own a `ULocalPlayer` run client-specific refreshes and HUD logic.
- Adjusted `ASkaldPlayerController::InitializeFighterSelectionIfNeeded` to treat `BattlePhase == None` with pending battle context as part of selection phase by updating `bInSelectionPhase` logic.
- Updated `ASkaldPlayerController::HandleReplicatedTurnOwnership` to detect whether the controller still needs battle-prep UI (pending ready prompt, selection widget present, or pending battle with unlocked local army) and keep `GameAndUI` input and cursor visible in that case, otherwise restore `GameOnly` input.
- Added local-player checks and safe exits to `ShowPrepareForBattlePromptLocal`, `ShowPrepareForBattlePromptLocal_Internal`, and `EnsureDiceWidgets` to skip UI work for controllers lacking a `ULocalPlayer`.

### Testing
- Verified project builds successfully with these changes in Development configuration.
- Ran the automated editor/unit test suite (existing tests) and observed no regressions; all executed tests passed.
- Performed automated smoke checks for delegate rebinding and controller replication handlers which completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f4cd1ab77c832486a1f9df65371f05)