### PR TITLE
Fix local battle-phase resync when LocalPlayer attaches late

### DIFF
--- a/Source/Skald/Skald_GameState.cpp
+++ b/Source/Skald/Skald_GameState.cpp
@@ -162,7 +162,7 @@ void ASkaldGameState::RefreshControllersFromPlayers()
         {
             if (ASkaldPlayerController* PC = Cast<ASkaldPlayerController>(It->Get()))
             {
-                if (!PC->IsLocalController() || PC->GetLocalPlayer() == nullptr)
+                if (!PC->IsLocalController())
                 {
                     continue;
                 }
@@ -738,7 +738,7 @@ void ASkaldGameState::OnRep_BattlePhase()
         {
             if (ASkaldPlayerController* PC = Cast<ASkaldPlayerController>(It->Get()))
             {
-                if (!PC->IsLocalController() || PC->GetLocalPlayer() == nullptr)
+                if (!PC->IsLocalController())
                 {
                     continue;
                 }


### PR DESCRIPTION
### Motivation
- Late Attachments of `ULocalPlayer` could cause `OnRep_BattlePhase` work to be skipped because the code excluded controllers whose `GetLocalPlayer()` returned `nullptr`, leaving clients without HUD/state reconstruction during seamless travel or late-join scenarios.
- The same `GetLocalPlayer() == nullptr` gate was also dropping turn-owner refresh during player-roster updates in `RefreshControllersFromPlayers`.

### Description
- Removed the `GetLocalPlayer() == nullptr` check from the local-controller iteration in `ASkaldGameState::OnRep_BattlePhase` so local controllers are always given the chance to run reconstruction hooks (e.g., `RequestBattleStateIfNeeded`, `InitializeBattleHUD`, `InitializeFighterSelectionIfNeeded`, etc.).
- Applied the same local-controller-only gating change to `ASkaldGameState::RefreshControllersFromPlayers` so turn-data refresh calls (`RefreshTurnDataFromState`, `HandleReplicatedTurnOwnership`, `HandleReplicatedTurnStart`) are not skipped when `ULocalPlayer` is not yet attached.
- Changes are in `Source/Skald/Skald_GameState.cpp` and are limited to the two guarded `if` conditions that previously combined `IsLocalController()` and `GetLocalPlayer() == nullptr`.

### Testing
- Ran `git diff -- Source/Skald/Skald_GameState.cpp` to validate the delta and `git status --short` to confirm the working tree; both completed successfully.
- Committed the change with message `Fix battle phase sync when LocalPlayer attaches late` and verified file contents with `nl`/file inspection; the commit succeeded.
- No unit or integration test suites were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f4e4e0c228832491562add5ad02f60)