### PR TITLE
Prevent duplicate battle setup; centralize local-UI checks and refine player ID resolution

### DIFF
--- a/Source/Skald/Skald_BattleGameMode.cpp
+++ b/Source/Skald/Skald_BattleGameMode.cpp
@@ -55,17 +55,23 @@ static int32 ResolveBattlePlayerId(const ASkaldPlayerState *PlayerState) {
     return StableId;
   }
 
-  const int32 ReplicatedId = PlayerState->GetPlayerId();
-  if (ReplicatedId > 0) {
-    return ReplicatedId;
-  }
-
   const int32 AuthoritativeId = PlayerState->GetAuthoritativePlayerId();
   if (AuthoritativeId > 0) {
     return AuthoritativeId;
   }
 
   return INDEX_NONE;
+}
+
+static uint32 BuildBattleSetupSignature(const FS_BattlePayload& Battle) {
+  uint32 Hash = 0;
+  Hash = HashCombine(Hash, ::GetTypeHash(Battle.FromTerritoryID));
+  Hash = HashCombine(Hash, ::GetTypeHash(Battle.TargetTerritoryID));
+  Hash = HashCombine(Hash, ::GetTypeHash(Battle.AttackerPlayerID));
+  Hash = HashCombine(Hash, ::GetTypeHash(Battle.DefenderPlayerID));
+  Hash = HashCombine(Hash, ::GetTypeHash(Battle.ArmyCountSent));
+  Hash = HashCombine(Hash, ::GetTypeHash(Battle.DefenderArmyCount));
+  return Hash;
 }
 
 static int32 GetPlayerIdFrom(AController *C) {
@@ -892,6 +898,7 @@ void ASkald_BattleGameMode::SetupPendingBattle() {
   auto ResetSetupAttempt = [this]() {
     bSetupStarted = false;
     GBattleSetupTriggered = false;
+    ActiveSetupSignature = 0;
   };
 
   USkaldGameInstance *GI = GetGameInstance<USkaldGameInstance>();
@@ -944,6 +951,27 @@ void ASkald_BattleGameMode::SetupPendingBattle() {
   if (Battle.DefenderArmyCount <= 0 && TS.DefenderArmyBudget > 0) {
     Battle.DefenderArmyCount = TS.DefenderArmyBudget;
   }
+
+  const uint32 SetupSignature = BuildBattleSetupSignature(Battle);
+  if (LastCompletedSetupSignature != 0 &&
+      LastCompletedSetupSignature == SetupSignature) {
+    UE_LOG(LogSkaldBattle, Verbose,
+           TEXT("SetupPendingBattle: skipping duplicate completed setup (Signature=%u)"),
+           SetupSignature);
+    bSetupCompleted = true;
+    bSetupStarted = false;
+    GBattleSetupTriggered = false;
+    return;
+  }
+
+  if (ActiveSetupSignature != 0 && ActiveSetupSignature == SetupSignature &&
+      bSetupStarted) {
+    UE_LOG(LogSkaldBattle, Verbose,
+           TEXT("SetupPendingBattle: duplicate in-flight setup ignored (Signature=%u)"),
+           SetupSignature);
+    return;
+  }
+  ActiveSetupSignature = SetupSignature;
 
   auto BackfillFromSlots = [&](int32& PlayerId, FString& DisplayName,
                                ESkaldFaction& Faction, bool& bIsAI)
@@ -1276,6 +1304,8 @@ void ASkald_BattleGameMode::SetupPendingBattle() {
   }
 
   bSetupCompleted = true;
+  LastCompletedSetupSignature = SetupSignature;
+  ActiveSetupSignature = 0;
   GI->PendingBattle = Battle;
 
   TryAdvanceAfterLockIn();
@@ -2041,7 +2071,9 @@ void ASkald_BattleGameMode::OnControllerReady(AController *Controller) {
              TEXT("OnControllerReady: participant confirmed for %s (Id=%d)"),
              *GetNameSafe(Controller), ResolveBattlePlayerId(PS));
     }
-    SyncBattlePlayerEntry(PS);
+    if (ResolveBattlePlayerId(PS) > 0) {
+      SyncBattlePlayerEntry(PS);
+    }
   }
 
   AssignControllerSlot(Controller);
@@ -2411,4 +2443,3 @@ void ASkald_BattleGameMode::LogParticipantLockState(const TCHAR *Context)
          *DescribeParticipant(Battle.DefenderPlayerID), *LockedIds,
          *UEnum::GetValueAsString(GS->BattlePhase));
 }
-

--- a/Source/Skald/Skald_BattleGameMode.h
+++ b/Source/Skald/Skald_BattleGameMode.h
@@ -124,5 +124,10 @@ private:
 
   /** True when NotifyBattleLevelActivated ran before BeginPlay completed. */
   bool bPendingStreamingActivation = false;
-};
 
+  /** Last payload signature that completed setup; used for idempotency. */
+  uint32 LastCompletedSetupSignature = 0;
+
+  /** Signature currently being processed by setup. */
+  uint32 ActiveSetupSignature = 0;
+};

--- a/Source/Skald/Skald_PlayerController.cpp
+++ b/Source/Skald/Skald_PlayerController.cpp
@@ -1524,16 +1524,9 @@ void ASkaldPlayerController::InitializeHUDWidget() {
     return;
   }
 
-  if (!IsLocalPlayerController()) {
+  if (!CanCreateLocalUIWidget()) {
     UE_LOG(LogSkald, Verbose,
-           TEXT("InitializeHUDWidget skipped: controller %s is not local."),
-           *GetName());
-    return;
-  }
-
-  if (!GetLocalPlayer()) {
-    UE_LOG(LogSkald, Verbose,
-           TEXT("InitializeHUDWidget skipped: controller %s has no local player."),
+           TEXT("InitializeHUDWidget skipped: controller %s is not eligible for local UI."),
            *GetName());
     return;
   }
@@ -1612,8 +1605,13 @@ void ASkaldPlayerController::InitializeHUDWidget() {
   }
 }
 
+bool ASkaldPlayerController::CanCreateLocalUIWidget() const {
+  return IsLocalController() && IsLocalPlayerController() &&
+         GetLocalPlayer() != nullptr;
+}
+
 void ASkaldPlayerController::InitializeChoosePlayerWidget() {
-  if (!IsLocalPlayerController() || !GetLocalPlayer()) {
+  if (!CanCreateLocalUIWidget()) {
     return;
   }
 
@@ -1919,7 +1917,7 @@ void ASkaldPlayerController::HideMainHUD() {
 
 void ASkaldPlayerController::ShowBattleResultWidget(
     const FBattleResultDisplayData &DisplayData) {
-  if (!IsLocalController() || !DisplayData.bValid) {
+  if (!CanCreateLocalUIWidget() || !DisplayData.bValid) {
     return;
   }
 
@@ -1993,7 +1991,7 @@ void ASkaldPlayerController::ToggleInGameMenu() {
 }
 
 void ASkaldPlayerController::ShowInGameMenu() {
-  if (!IsLocalController()) {
+  if (!CanCreateLocalUIWidget()) {
     return;
   }
 
@@ -2139,7 +2137,7 @@ void ASkaldPlayerController::RefreshFactionCursorFromState() {
 }
 
 void ASkaldPlayerController::ApplyFactionCursor() {
-  if (!IsLocalController()) {
+  if (!CanCreateLocalUIWidget()) {
     return;
   }
 
@@ -2629,7 +2627,7 @@ void ASkaldPlayerController::RequestBattleStateIfNeeded() {
 
 void ASkaldPlayerController::ShowFighterSelectionUI(int32 MaxBudget,
                                                     ESkaldFaction Faction) {
-  if (!IsLocalController() || GetLocalPlayer() == nullptr) {
+  if (!CanCreateLocalUIWidget()) {
     return;
   }
 
@@ -2872,7 +2870,7 @@ void ASkaldPlayerController::Server_CommitArmy_Implementation(
 }
 
 void ASkaldPlayerController::InitializeBattleHUD() {
-  if (!IsLocalPlayerController() || !GetLocalPlayer())
+  if (!CanCreateLocalUIWidget())
     return;
   if (!BattleHUDWidgetClass)
     return;
@@ -5333,6 +5331,10 @@ void ASkaldPlayerController::HandleReplicatedTurnOwnership() {
   const bool bIsMyTurn = IsMyTurn();
   const ETurnPhase Phase = TurnManager ? TurnManager->GetCurrentPhase()
                                        : ETurnPhase::Reinforcement;
+  const EBattlePhase BattlePhase =
+      CachedGameState ? CachedGameState->BattlePhase : EBattlePhase::None;
+  const bool bInBattleInputFlow =
+      bOnBattleMap || BattlePhase != EBattlePhase::None;
   UE_LOG(LogSkald, Log,
          TEXT("[TurnState] Controller %s turn ownership check: Phase=%s ActiveId=%d IsMyTurn=%s LocalTurnActive=%s"),
          *GetName(), *UEnum::GetValueAsString(Phase),
@@ -5342,6 +5344,12 @@ void ASkaldPlayerController::HandleReplicatedTurnOwnership() {
 
   if (MainHUD) {
     MainHUD->SyncPhaseButtons(bIsMyTurn);
+  }
+
+  // Battle preparation/selection controls are managed by battle flow. Avoid
+  // having overworld turn ownership logic steal input mode or cursor state.
+  if (bInBattleInputFlow) {
+    return;
   }
 
   if (bIsMyTurn && !bLocalTurnActive) {
@@ -8594,7 +8602,7 @@ void ASkaldPlayerController::HandlePendingPresentationTimerTick() {
 }
 
 void ASkaldPlayerController::EnsureDiceWidgets() {
-  if (!IsLocalController() || GetLocalPlayer() == nullptr) {
+  if (!CanCreateLocalUIWidget()) {
     return;
   }
 

--- a/Source/Skald/Skald_PlayerController.h
+++ b/Source/Skald/Skald_PlayerController.h
@@ -981,6 +981,9 @@ protected:
   /** Set up the main HUD widget for the local player. */
   virtual void InitializeHUDWidget();
 
+  /** True when this controller is allowed to create viewport/UI widgets. */
+  bool CanCreateLocalUIWidget() const;
+
 public:
   void BeginRetreatSelectionLocal(int32 DefendingTerritoryID,
                                   const TArray<int32> &CandidateTerritoryIDs);


### PR DESCRIPTION
### Motivation
- Avoid duplicate or concurrent battle setup runs caused by repeated pending payloads and ensure setup runs only once per unique payload.
- Prevent non-local controllers from creating viewport/UI widgets via a single helper check to reduce duplicated conditionals.
- Make player ID resolution more authoritative by removing an unreliable fallback and avoid syncing empty player entries.

### Description
- Added `BuildBattleSetupSignature` plus `ActiveSetupSignature` and `LastCompletedSetupSignature` members and used them inside `SetupPendingBattle` to skip duplicate completed or in-flight setups and to clear the active signature when finished.
- Removed the fallback to `PlayerState->GetPlayerId()` from `ResolveBattlePlayerId` so stable/authoritative IDs are preferred, and only call `SyncBattlePlayerEntry` when `ResolveBattlePlayerId(PS) > 0`.
- Introduced `CanCreateLocalUIWidget()` on `ASkaldPlayerController` and replaced multiple `IsLocalController()/GetLocalPlayer()` checks with this single helper across HUD, battle UI, menus, dice overlays and related methods.
- Prevented overworld turn ownership logic from stealing input/cursor state when the controller is inside the battle input flow by detecting battle phase and returning early in `HandleReplicatedTurnOwnership`.

### Testing
- Ran the project's automated C++ compilation (build) checks and engine unit/automation tests; all automated tests completed successfully.
- Executed automated UI-related integration checks for player controller widget initialization; they passed under the modified conditions.
- Verified existing automated battle flow tests that exercise `SetupPendingBattle` to ensure idempotency behavior; they passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f4e7fd62f083248cb35c01464c9588)