### PR TITLE
Fix compile error in Skald_PlayerController turn ownership handler

### DIFF
--- a/Source/Skald/Skald_PlayerController.cpp
+++ b/Source/Skald/Skald_PlayerController.cpp
@@ -5334,7 +5334,7 @@ void ASkaldPlayerController::HandleReplicatedTurnOwnership() {
   const EBattlePhase BattlePhase =
       CachedGameState ? CachedGameState->BattlePhase : EBattlePhase::None;
   const bool bInBattleInputFlow =
-      bOnBattleMap || BattlePhase != EBattlePhase::None;
+      bIsBattleMap || BattlePhase != EBattlePhase::None;
   UE_LOG(LogSkald, Log,
          TEXT("[TurnState] Controller %s turn ownership check: Phase=%s ActiveId=%d IsMyTurn=%s LocalTurnActive=%s"),
          *GetName(), *UEnum::GetValueAsString(Phase),


### PR DESCRIPTION
### Motivation
- Fix a C2065 compile error caused by an undeclared identifier `bOnBattleMap` in the turn ownership logic by using the controller's existing battle-map state `bIsBattleMap`.

### Description
- Replace `bOnBattleMap` with `bIsBattleMap` in `ASkaldPlayerController::HandleReplicatedTurnOwnership` so `bInBattleInputFlow` is computed from the correct member.

### Testing
- Verified the edit with `nl -ba Source/Skald/Skald_PlayerController.cpp | sed -n '5328,5342p'`, inspected the single-line diff with `git diff -- Source/Skald/Skald_PlayerController.cpp`, and committed the change with `git commit`, all of which succeeded; a full project rebuild was not executed in this session.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f4f1daecb083249f3bfcf6c0906f28)