### PR TITLE
Prevent AI controllers from creating local battle UI

### DIFF
--- a/Source/Skald/Skald_PlayerController.cpp
+++ b/Source/Skald/Skald_PlayerController.cpp
@@ -1608,7 +1608,8 @@ void ASkaldPlayerController::InitializeHUDWidget() {
 
 bool ASkaldPlayerController::CanCreateLocalUIWidget() const {
   return IsLocalController() && IsLocalPlayerController() &&
-         GetLocalPlayer() != nullptr;
+         GetLocalPlayer() != nullptr && Player != nullptr &&
+         !IsA<ASkaldAIController>();
 }
 
 void ASkaldPlayerController::InitializeChoosePlayerWidget() {
@@ -5303,6 +5304,13 @@ void ASkaldPlayerController::HandleReplicatedPhaseChange(
 
 void ASkaldPlayerController::HandleReplicatedBattlePayload() {
   if (!IsLocalController()) {
+    return;
+  }
+
+  // AI controllers can be considered local on the server but have no attached
+  // local player, so they must never attempt to spawn UI widgets.
+  if (!CanCreateLocalUIWidget()) {
+    RefreshTurnDataFromState();
     return;
   }
 


### PR DESCRIPTION
### Motivation
- AI-controlled PlayerController instances were being treated as local UI-capable controllers during battle transitions and attempted to call `CreateWidget`, producing PIE errors like "CreateWidget cannot be used on Player Controller with no attached player" and breaking singleplayer battle flow. 
- The intent is to keep AI turn/replicated state updates working while preventing AI controllers from entering UI codepaths that require an attached `LocalPlayer`.

### Description
- Tighten `ASkaldPlayerController::CanCreateLocalUIWidget()` to require an attached `Player` and explicitly exclude `ASkaldAIController`, ensuring only genuine local players can create UI widgets. 
- Short-circuit `ASkaldPlayerController::HandleReplicatedBattlePayload()` for controllers that cannot create local UI by calling `RefreshTurnDataFromState()` and returning early, which preserves replicated turn/battle state synchronization for non-UI controllers while avoiding widget creation. 
- These changes prevent AI controllers from spawning `FighterSelection`, `BattleHUD`, or other widgets while still allowing AI logic and replicated turn updates to proceed.

### Testing
- Ran targeted code inspection and repository searches (`rg`/`sed`) to confirm the modified checks cover the primary `CreateWidget` call sites involved in battle UI initialization, and verified the new early-return is placed before widget initialization. 
- No automated unit or integration tests were executed in this rollout; a full build and PIE run are recommended to validate runtime behavior in singleplayer and multiplayer scenarios.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f4f7f72f08832482faa357915a7750)