### PR TITLE
Prevent AI controllers from spawning HUD/UI and make battle manager bindings unique

### DIFF
--- a/Source/Skald/Skald_AIController.cpp
+++ b/Source/Skald/Skald_AIController.cpp
@@ -166,8 +166,9 @@ void ASkaldAIController::InitializeHUDWidget() {
 
 void ASkaldAIController::ShowPrepareForBattlePromptLocal(
     const FPrepareForBattlePromptData &PromptData) {
-  Super::ShowPrepareForBattlePromptLocal(PromptData);
-
+  // AI controllers never display local widgets. Avoid the base implementation
+  // because it can queue UI prompt retries/timers intended for human players.
+  HidePrepareForBattlePromptLocal();
   ProcessPrepareForBattlePrompt(PromptData);
 }
 
@@ -1514,17 +1515,17 @@ void ASkaldAIController::SetupBattleAutomation() {
   // across PIE travel / BeginPlay re-entry edge cases.
   CachedBattleManager->OnActiveFighterChanged.RemoveDynamic(
       this, &ASkaldAIController::HandleActiveFighterChanged);
-  CachedBattleManager->OnActiveFighterChanged.AddDynamic(
+  CachedBattleManager->OnActiveFighterChanged.AddUniqueDynamic(
       this, &ASkaldAIController::HandleActiveFighterChanged);
 
   CachedBattleManager->OnRoundStarted.RemoveDynamic(
       this, &ASkaldAIController::HandleRoundStarted);
-  CachedBattleManager->OnRoundStarted.AddDynamic(
+  CachedBattleManager->OnRoundStarted.AddUniqueDynamic(
       this, &ASkaldAIController::HandleRoundStarted);
 
   CachedBattleManager->OnBattleEnded.RemoveDynamic(
       this, &ASkaldAIController::HandleBattleEnded);
-  CachedBattleManager->OnBattleEnded.AddDynamic(
+  CachedBattleManager->OnBattleEnded.AddUniqueDynamic(
       this, &ASkaldAIController::HandleBattleEnded);
 
   DetermineControlledBattleSide();

--- a/Source/Skald/Skald_GameState.cpp
+++ b/Source/Skald/Skald_GameState.cpp
@@ -162,7 +162,7 @@ void ASkaldGameState::RefreshControllersFromPlayers()
         {
             if (ASkaldPlayerController* PC = Cast<ASkaldPlayerController>(It->Get()))
             {
-                if (!PC->IsLocalController())
+                if (!PC->CanCreateLocalUIWidget())
                 {
                     continue;
                 }
@@ -196,7 +196,7 @@ void ASkaldGameState::OnRep_CurrentTurnIndex()
         {
             if (ASkaldPlayerController* PC = Cast<ASkaldPlayerController>(It->Get()))
             {
-                if (!PC->IsLocalController() || PC->GetLocalPlayer() == nullptr)
+                if (!PC->CanCreateLocalUIWidget())
                 {
                     continue;
                 }
@@ -222,7 +222,7 @@ void ASkaldGameState::OnRep_ActivePlayerId()
         {
             if (ASkaldPlayerController* PC = Cast<ASkaldPlayerController>(It->Get()))
             {
-                if (!PC->IsLocalController() || PC->GetLocalPlayer() == nullptr)
+                if (!PC->CanCreateLocalUIWidget())
                 {
                     continue;
                 }
@@ -423,7 +423,7 @@ void ASkaldGameState::OnRep_BattlePayload()
         {
             if (ASkaldPlayerController* PC = Cast<ASkaldPlayerController>(It->Get()))
             {
-                if (!PC->IsLocalController() || PC->GetLocalPlayer() == nullptr)
+                if (!PC->CanCreateLocalUIWidget())
                 {
                     continue;
                 }
@@ -469,7 +469,7 @@ void ASkaldGameState::OnRep_BattleParticipants()
         {
             if (ASkaldPlayerController* PC = Cast<ASkaldPlayerController>(It->Get()))
             {
-                if (!PC->IsLocalController() || PC->GetLocalPlayer() == nullptr)
+                if (!PC->CanCreateLocalUIWidget())
                 {
                     continue;
                 }
@@ -517,7 +517,7 @@ void ASkaldGameState::OnRep_PendingBattleReady()
         {
             if (ASkaldPlayerController* PC = Cast<ASkaldPlayerController>(It->Get()))
             {
-                if (!PC->IsLocalController() || PC->GetLocalPlayer() == nullptr)
+                if (!PC->CanCreateLocalUIWidget())
                 {
                     continue;
                 }
@@ -549,7 +549,7 @@ void ASkaldGameState::OnRep_BattleRoundState()
         {
             if (ASkaldPlayerController* PC = Cast<ASkaldPlayerController>(It->Get()))
             {
-                if (!PC->IsLocalController() || PC->GetLocalPlayer() == nullptr)
+                if (!PC->CanCreateLocalUIWidget())
                 {
                     continue;
                 }
@@ -738,7 +738,7 @@ void ASkaldGameState::OnRep_BattlePhase()
         {
             if (ASkaldPlayerController* PC = Cast<ASkaldPlayerController>(It->Get()))
             {
-                if (!PC->IsLocalController())
+                if (!PC->CanCreateLocalUIWidget())
                 {
                     continue;
                 }

--- a/Source/Skald/Skald_PlayerController.cpp
+++ b/Source/Skald/Skald_PlayerController.cpp
@@ -244,6 +244,32 @@ ASkald_BattleGameMode *ASkaldPlayerController::ResolveBattleGameMode() {
   return nullptr;
 }
 
+
+namespace {
+bool IsAIControllerIdentity(const ASkaldPlayerController* Controller) {
+  if (!Controller) {
+    return false;
+  }
+
+  if (Controller->IsA<ASkaldAIController>()) {
+    return true;
+  }
+
+  if (const ASkaldPlayerState* PS = Controller->GetPlayerState<ASkaldPlayerState>()) {
+    if (PS->bIsAI) {
+      return true;
+    }
+  }
+
+  const FString ClassName = Controller->GetClass() ? Controller->GetClass()->GetName() : FString();
+  const FString InstanceName = Controller->GetName();
+  return ClassName.Contains(TEXT("AiController"), ESearchCase::IgnoreCase) ||
+         ClassName.Contains(TEXT("AIController"), ESearchCase::IgnoreCase) ||
+         InstanceName.Contains(TEXT("AiController"), ESearchCase::IgnoreCase) ||
+         InstanceName.Contains(TEXT("AIController"), ESearchCase::IgnoreCase);
+}
+}
+
 ASkaldPlayerController::ASkaldPlayerController() {
   TurnManager = nullptr;
   HUDRef = nullptr;
@@ -427,7 +453,7 @@ bool ASkaldPlayerController::TryUseAbilitySlot(ESkaldAbilitySlot Slot) {
 }
 
 void ASkaldPlayerController::HandleAbilityInput(ESkaldAbilitySlot Slot) {
-  if (!IsLocalController() || GetLocalPlayer() == nullptr) {
+  if (!CanCreateLocalUIWidget()) {
     return;
   }
 
@@ -1515,6 +1541,10 @@ AFighterPawn *ASkaldPlayerController::ResolveCellAbilityPrimaryTarget(
 }
 
 void ASkaldPlayerController::InitializeHUDWidget() {
+  if (IsAIControllerIdentity(this)) {
+    return;
+  }
+
   if (MainHUD) {
     return;
   }
@@ -1607,8 +1637,16 @@ void ASkaldPlayerController::InitializeHUDWidget() {
 }
 
 bool ASkaldPlayerController::CanCreateLocalUIWidget() const {
-  return IsLocalController() && IsLocalPlayerController() &&
-         GetLocalPlayer() != nullptr;
+  if (!IsLocalController() || !IsLocalPlayerController() ||
+      GetLocalPlayer() == nullptr || Player == nullptr) {
+    return false;
+  }
+
+  if (IsAIControllerIdentity(this)) {
+    return false;
+  }
+
+  return true;
 }
 
 void ASkaldPlayerController::InitializeChoosePlayerWidget() {
@@ -2472,7 +2510,7 @@ ATurnManager *ASkaldPlayerController::FindTurnManagerActor() const {
 }
 
 void ASkaldPlayerController::InitializeFighterSelectionIfNeeded() {
-  if (!IsLocalController() || GetLocalPlayer() == nullptr) {
+  if (!CanCreateLocalUIWidget()) {
     return;
   }
 
@@ -2774,7 +2812,7 @@ void ASkaldPlayerController::Client_OnLockInResult_Implementation(
 }
 
 void ASkaldPlayerController::HandleBattlePhaseChanged() {
-  if (!IsLocalController() || GetLocalPlayer() == nullptr) {
+  if (!CanCreateLocalUIWidget()) {
     return;
   }
 
@@ -5306,6 +5344,13 @@ void ASkaldPlayerController::HandleReplicatedBattlePayload() {
     return;
   }
 
+  // AI controllers can be considered local on the server but have no attached
+  // local player, so they must never attempt to spawn UI widgets.
+  if (!CanCreateLocalUIWidget()) {
+    RefreshTurnDataFromState();
+    return;
+  }
+
   DetectBattleMap();
   InitializeBattleHUD();
   RefreshFactionCursorFromState();
@@ -5323,7 +5368,7 @@ void ASkaldPlayerController::HandleReplicatedBattlePayload() {
 }
 
 void ASkaldPlayerController::HandleReplicatedTurnOwnership() {
-  if (!IsLocalController() || GetLocalPlayer() == nullptr) {
+  if (IsAIControllerIdentity(this) || !CanCreateLocalUIWidget()) {
     return;
   }
 
@@ -6977,7 +7022,7 @@ void ASkaldPlayerController::ResetPendingReadyPromptState() {
 
 void ASkaldPlayerController::ShowPrepareForBattlePromptLocal(
     const FPrepareForBattlePromptData &PromptData) {
-  if (!IsLocalController() || GetLocalPlayer() == nullptr) {
+  if (!CanCreateLocalUIWidget()) {
     UE_LOG(LogSkaldReady, Verbose,
            TEXT("Skipping prepare-for-battle prompt for %s: controller has no local player."),
            *GetName());
@@ -7002,7 +7047,7 @@ void ASkaldPlayerController::ShowPrepareForBattlePromptLocal(
 
 void ASkaldPlayerController::ShowPrepareForBattlePromptLocal_Internal(
     const FPrepareForBattlePromptData &PromptData) {
-  if (!IsLocalController() || GetLocalPlayer() == nullptr) {
+  if (!CanCreateLocalUIWidget()) {
     ResetPendingReadyPromptState();
     return;
   }


### PR DESCRIPTION
### Motivation
- Prevent AI controllers from creating or interacting with local UI widgets and avoid queuing UI timers/prompts intended for human players.
- Centralize and strengthen the check for whether a controller can create local UI via `CanCreateLocalUIWidget()` and an explicit AI identity detector.
- Avoid duplicate multicast delegate bindings to `GridBattleManager` across PIE/travel edge cases.

### Description
- Added an internal helper `IsAIControllerIdentity()` to detect AI controllers by class, instance name, or `PlayerState::bIsAI` and used it to prevent AI from creating UI widgets.
- Updated `CanCreateLocalUIWidget()` to require `Player` and to return false for AI controllers by calling `IsAIControllerIdentity()`.
- Replaced many `IsLocalController()`/`GetLocalPlayer() == nullptr` checks with `CanCreateLocalUIWidget()` across `ASkaldPlayerController` and `ASkaldGameState` replication handlers so only eligible controllers attempt HUD/UI work.
- Modified `ASkaldAIController::ShowPrepareForBattlePromptLocal()` to avoid the base implementation and call `HidePrepareForBattlePromptLocal()` before processing prompts so AI never queues local UI retries/timers.
- Added an early non-UI path in `HandleReplicatedBattlePayload()` for local-but-non-UI controllers so they still refresh turn data but do not spawn HUD widgets.
- Switched delegate registrations in `SetupBattleAutomation()` to `AddUniqueDynamic()` to prevent duplicate bindings to `OnActiveFighterChanged`, `OnRoundStarted`, and `OnBattleEnded`.

### Testing
- Project codebase compiled successfully with the Unreal build tool without errors.
- Project automated unit and functional tests were executed and completed with no regressions reported.
- Targeted automated gameplay/UI tests for battle flows and AI controller behavior were run and passed, confirming AI no longer spawns HUD widgets and delegate rebinding issues are resolved.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f4f7f72f08832482faa357915a7750)