### PR TITLE
Fix access level for player controller UI sync helpers

### DIFF
--- a/Source/Skald/Skald_PlayerController.h
+++ b/Source/Skald/Skald_PlayerController.h
@@ -951,6 +951,7 @@ protected:
             Category = "Turn", meta = (ExposeOnSpawn = true))
   TObjectPtr<ATurnManager> TurnManager;
 
+public:
   /** Keep HUD turn/phase widgets aligned with replicated game state. */
   void RefreshTurnDataFromState();
   UFUNCTION()


### PR DESCRIPTION
### Motivation
- `ASkaldGameState` invokes UI/turn synchronization helpers such as `CanCreateLocalUIWidget` on `ASkaldPlayerController` but those methods were `protected`, causing a `C2248` access error during compile and preventing controller HUD/turn sync calls from GameState.

### Description
- Change the access level of the turn/HUD synchronization helper block in `ASkaldPlayerController` to `public` (inserted `public:` before the block containing `RefreshTurnDataFromState`, `HandleTurnIndexChanged`, `HandleReplicatedTurnOwnership`, `HandleReplicatedTurnStart`, `CanCreateLocalUIWidget`, etc.), which is an access-only change with no runtime logic modifications.

### Testing
- No automated Unreal/Visual Studio build was executed in this environment because the Windows/Unreal toolchain is not available here, so the original compile error was observed but the updated code was not rebuilt (please run a full Windows Unreal build to verify the fix).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f5067a1ee48324a0aca83c97280706)