### PR TITLE
Add missing NormalizeSinglePlayerControllerRoles defs to GameMode and BattleGameMode

### DIFF
--- a/Source/Skald/Skald_BattleGameMode.cpp
+++ b/Source/Skald/Skald_BattleGameMode.cpp
@@ -192,6 +192,35 @@ static void RefreshControllerSlotForState(ASkaldPlayerState *State) {
   }
 }
 
+static void NormalizeSinglePlayerControllerRoles(UWorld *World,
+                                                 const USkaldGameInstance *GI) {
+  if (!World || !GI || GI->bIsMultiplayer) {
+    return;
+  }
+
+  for (FConstPlayerControllerIterator It = World->GetPlayerControllerIterator();
+       It; ++It) {
+    ASkaldPlayerController *PC = Cast<ASkaldPlayerController>(*It);
+    if (!PC) {
+      continue;
+    }
+
+    ASkaldPlayerState *PS = PC->GetPlayerState<ASkaldPlayerState>();
+    if (!PS) {
+      continue;
+    }
+
+    const bool bShouldBeAI = IsAIControllerIdentity(PC);
+    if (PS->bIsAI != bShouldBeAI) {
+      UE_LOG(LogSkaldBattle, Verbose,
+             TEXT("NormalizeSinglePlayerControllerRoles: %s bIsAI %d -> %d"),
+             *GetNameSafe(PC), PS->bIsAI ? 1 : 0, bShouldBeAI ? 1 : 0);
+      PS->bIsAI = bShouldBeAI;
+      AssignControllerSlot(PC);
+    }
+  }
+}
+
 void BuildTerritoryMap(const TArray<FS_Territory> &Source,
                        TMap<int32, FS_Territory> &Destination) {
   Destination.Reset();

--- a/Source/Skald/Skald_GameMode.cpp
+++ b/Source/Skald/Skald_GameMode.cpp
@@ -81,6 +81,34 @@ bool IsAIControllerIdentity(const ASkaldPlayerController *Controller) {
          InstanceName.Contains(TEXT("AiController"), ESearchCase::IgnoreCase) ||
          InstanceName.Contains(TEXT("AIController"), ESearchCase::IgnoreCase);
 }
+
+static void NormalizeSinglePlayerControllerRoles(UWorld *World,
+                                                 const USkaldGameInstance *GI) {
+  if (!World || !GI || GI->bIsMultiplayer) {
+    return;
+  }
+
+  for (FConstPlayerControllerIterator It = World->GetPlayerControllerIterator();
+       It; ++It) {
+    ASkaldPlayerController *PC = Cast<ASkaldPlayerController>(*It);
+    if (!PC) {
+      continue;
+    }
+
+    ASkaldPlayerState *PS = PC->GetPlayerState<ASkaldPlayerState>();
+    if (!PS) {
+      continue;
+    }
+
+    const bool bShouldBeAI = IsAIControllerIdentity(PC);
+    if (PS->bIsAI != bShouldBeAI) {
+      UE_LOG(LogSkald, Verbose,
+             TEXT("NormalizeSinglePlayerControllerRoles: %s bIsAI %d -> %d"),
+             *GetNameSafe(PC), PS->bIsAI ? 1 : 0, bShouldBeAI ? 1 : 0);
+      PS->bIsAI = bShouldBeAI;
+    }
+  }
+}
 // Instance variables moved into ASkaldGameMode to avoid cross-instance
 // interference; see header for declarations.
 } // namespace


### PR DESCRIPTION
### Motivation
- The build failed with `C2129` because `NormalizeSinglePlayerControllerRoles` was declared in anonymous namespaces but not defined in both `Skald_GameMode.cpp` and `Skald_BattleGameMode.cpp`. 
- The intent is to ensure single-player controller role flags (`ASkaldPlayerState::bIsAI`) are consistent with controller identity in non-multiplayer sessions.

### Description
- Added a local static `NormalizeSinglePlayerControllerRoles(UWorld*, const USkaldGameInstance*)` definition to `Source/Skald/Skald_GameMode.cpp` that no-ops for multiplayer and updates `bIsAI` from controller identity while logging changes. 
- Added a corresponding definition to `Source/Skald/Skald_BattleGameMode.cpp` with the same normalization behavior and an additional `AssignControllerSlot(PC)` call to refresh pending battle controller slots when a role changes. 
- Both implementations use the existing `IsAIControllerIdentity` helper and protect against null `World`/`GI` or multiplayer sessions.

### Testing
- Ran `rg` to locate declarations/usages and confirmed each translation unit now contains a matching local static definition for `NormalizeSinglePlayerControllerRoles` (search succeeded). 
- Inspected the modified files with `sed`/`nl` to verify the inserted function bodies are present and that logging and slot assignment are included (inspection succeeded). 
- No full project build was executed in this rollout, so compilation and CI should be re-run to verify the linker/compiler errors are resolved.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f51c15ba1c83249a54ed2ac06658c6)