### PR TITLE
Create widgets with LocalPlayer and guard missing LocalPlayer in UI code

### DIFF
--- a/Source/Skald/LobbyMenuWidget.cpp
+++ b/Source/Skald/LobbyMenuWidget.cpp
@@ -3,6 +3,7 @@
 #include "LoadGameWidget.h"
 #include "SettingsWidget.h"
 #include "Components/Button.h"
+#include "Engine/LocalPlayer.h"
 #include "Kismet/GameplayStatics.h"
 #include "Kismet/KismetSystemLibrary.h"
 #include "UObject/ConstructorHelpers.h"
@@ -57,15 +58,18 @@ void ULobbyMenuWidget::NativeConstruct()
 
 void ULobbyMenuWidget::OnStartGame()
 {
-    if (UWorld* World = GetWorld())
+    if (APlayerController* PC = GetOwningPlayer())
     {
         if (StartGameWidgetClass)
         {
-            if (UStartGameWidget* Widget = CreateWidget<UStartGameWidget>(World, StartGameWidgetClass))
+            if (ULocalPlayer* LocalPlayer = PC->GetLocalPlayer())
             {
-                Widget->SetLobbyMenu(this);
-                Widget->AddToViewport();
-                SetVisibility(ESlateVisibility::Hidden);
+                if (UStartGameWidget* Widget = CreateWidget<UStartGameWidget>(LocalPlayer, StartGameWidgetClass))
+                {
+                    Widget->SetLobbyMenu(this);
+                    Widget->AddToViewport();
+                    SetVisibility(ESlateVisibility::Hidden);
+                }
             }
         }
     }
@@ -73,7 +77,7 @@ void ULobbyMenuWidget::OnStartGame()
 
 void ULobbyMenuWidget::OnLoadGame()
 {
-    if (UWorld* World = GetWorld())
+    if (APlayerController* PC = GetOwningPlayer())
     {
         if (!LoadGameWidgetClass)
         {
@@ -81,21 +85,24 @@ void ULobbyMenuWidget::OnLoadGame()
             return;
         }
 
-        if (ULoadGameWidget* Widget = CreateWidget<ULoadGameWidget>(World, LoadGameWidgetClass))
+        if (ULocalPlayer* LocalPlayer = PC->GetLocalPlayer())
         {
-            // Pass a reference to the lobby so it can be restored later
-            Widget->SetLobbyMenu(this);
-            Widget->AddToViewport();
+            if (ULoadGameWidget* Widget = CreateWidget<ULoadGameWidget>(LocalPlayer, LoadGameWidgetClass))
+            {
+                // Pass a reference to the lobby so it can be restored later
+                Widget->SetLobbyMenu(this);
+                Widget->AddToViewport();
 
-            // Hide the lobby while the load-game menu is active
-            SetVisibility(ESlateVisibility::Hidden);
+                // Hide the lobby while the load-game menu is active
+                SetVisibility(ESlateVisibility::Hidden);
+            }
         }
     }
 }
 
 void ULobbyMenuWidget::OnSettings()
 {
-    if (UWorld* World = GetWorld())
+    if (APlayerController* PC = GetOwningPlayer())
     {
         if (!SettingsWidgetClass)
         {
@@ -103,11 +110,14 @@ void ULobbyMenuWidget::OnSettings()
             return;
         }
 
-        if (USettingsWidget* Widget = CreateWidget<USettingsWidget>(World, SettingsWidgetClass))
+        if (ULocalPlayer* LocalPlayer = PC->GetLocalPlayer())
         {
-            Widget->SetLobbyMenu(this);
-            Widget->AddToViewport();
-            SetVisibility(ESlateVisibility::Hidden);
+            if (USettingsWidget* Widget = CreateWidget<USettingsWidget>(LocalPlayer, SettingsWidgetClass))
+            {
+                Widget->SetLobbyMenu(this);
+                Widget->AddToViewport();
+                SetVisibility(ESlateVisibility::Hidden);
+            }
         }
     }
 }
@@ -130,4 +140,3 @@ void ULobbyMenuWidget::HandleFighterRosterUpdated()
         }
     }
 }
-

--- a/Source/Skald/Private/LobbyPlayerController.cpp
+++ b/Source/Skald/Private/LobbyPlayerController.cpp
@@ -1,5 +1,6 @@
 #include "LobbyPlayerController.h"
 #include "Blueprint/UserWidget.h"
+#include "Engine/LocalPlayer.h"
 #include "LobbyGameMode.h"
 #include "LobbyGameState.h"
 #include "LobbyMenuWidget.h"
@@ -27,6 +28,12 @@ void ALobbyPlayerController::BeginPlay()
 
 void ALobbyPlayerController::InitLobbyUI()
 {
+    ULocalPlayer* LocalPlayer = GetLocalPlayer();
+    if (!IsLocalController() || !IsLocalPlayerController() || !LocalPlayer || Player != LocalPlayer)
+    {
+        return;
+    }
+
     USkaldGameInstance* GI = GetGameInstance<USkaldGameInstance>();
     const bool bInMultiplayerLobby = GI && GI->bIsMultiplayer;
 
@@ -34,7 +41,7 @@ void ALobbyPlayerController::InitLobbyUI()
     {
         if (!LobbySessionWidgetInstance && LobbySessionWidgetClass)
         {
-            LobbySessionWidgetInstance = CreateWidget<ULobbySessionWidget>(this, LobbySessionWidgetClass);
+            LobbySessionWidgetInstance = CreateWidget<ULobbySessionWidget>(LocalPlayer, LobbySessionWidgetClass);
             if (LobbySessionWidgetInstance)
             {
                 LobbySessionWidgetInstance->AddToViewport();
@@ -52,7 +59,7 @@ void ALobbyPlayerController::InitLobbyUI()
     {
         if (!LobbyWidgetInstance && LobbyWidgetClass)
         {
-            LobbyWidgetInstance = CreateWidget<ULobbyMenuWidget>(this, LobbyWidgetClass);
+            LobbyWidgetInstance = CreateWidget<ULobbyMenuWidget>(LocalPlayer, LobbyWidgetClass);
             if (LobbyWidgetInstance)
             {
                 LobbyWidgetInstance->AddToViewport();
@@ -63,7 +70,7 @@ void ALobbyPlayerController::InitLobbyUI()
         bool bShowingTitleScreen = false;
         if (!TitleScreenWidgetInstance && TitleScreenWidgetClass)
         {
-            TitleScreenWidgetInstance = CreateWidget<UTitleScreenWidget>(this, TitleScreenWidgetClass);
+            TitleScreenWidgetInstance = CreateWidget<UTitleScreenWidget>(LocalPlayer, TitleScreenWidgetClass);
             if (TitleScreenWidgetInstance)
             {
                 TitleScreenWidgetInstance->OnDismissed.AddDynamic(this, &ALobbyPlayerController::HandleTitleScreenDismissed);

--- a/Source/Skald/SettingsWidget.cpp
+++ b/Source/Skald/SettingsWidget.cpp
@@ -1,4 +1,5 @@
 #include "SettingsWidget.h"
+#include "Engine/LocalPlayer.h"
 #include "Components/Button.h"
 #include "Components/ComboBoxString.h"
 #include "Components/Slider.h"
@@ -225,21 +226,19 @@ void USettingsWidget::OnExit()
 
     if (APlayerController* PC = GetOwningPlayer())
     {
-        if (UQuitConfirmationWidget* Widget = CreateWidget<UQuitConfirmationWidget>(PC, UQuitConfirmationWidget::StaticClass()))
+        if (ULocalPlayer* LocalPlayer = PC->GetLocalPlayer())
         {
-            Widget->SetOwningSettings(this);
-            Widget->AddToViewport(100);
-            ExitConfirmationWidget = Widget;
+            if (UQuitConfirmationWidget* Widget = CreateWidget<UQuitConfirmationWidget>(LocalPlayer, UQuitConfirmationWidget::StaticClass()))
+            {
+                Widget->SetOwningSettings(this);
+                Widget->AddToViewport(100);
+                ExitConfirmationWidget = Widget;
+            }
         }
     }
-    else if (UWorld* World = GetWorld())
+    else
     {
-        if (UQuitConfirmationWidget* Widget = CreateWidget<UQuitConfirmationWidget>(World, UQuitConfirmationWidget::StaticClass()))
-        {
-            Widget->SetOwningSettings(this);
-            Widget->AddToViewport(100);
-            ExitConfirmationWidget = Widget;
-        }
+        UE_LOG(LogTemp, Warning, TEXT("SettingsWidget::OnExit skipped quit confirmation: no owning player/local player."));
     }
 }
 
@@ -307,4 +306,3 @@ void USettingsWidget::ClearExitConfirmation()
         ExitConfirmationWidget.Reset();
     }
 }
-

--- a/Source/Skald/Skald_GameInstance.cpp
+++ b/Source/Skald/Skald_GameInstance.cpp
@@ -1,4 +1,5 @@
 #include "Skald_GameInstance.h"
+#include "Engine/LocalPlayer.h"
 
 #include "Engine/World.h"
 #include "Engine/Engine.h"
@@ -1193,7 +1194,13 @@ void USkaldGameInstance::ShowDeployWidget() {
       return;
     }
 
-    DeployWidget = CreateWidget<UUserWidget>(LocalSkaldPC, WidgetClass);
+    if (ULocalPlayer* LocalPlayer = LocalSkaldPC->GetLocalPlayer()) {
+      DeployWidget = CreateWidget<UUserWidget>(LocalPlayer, WidgetClass);
+    } else {
+      UE_LOG(LogSkald, Warning,
+             TEXT("ShowDeployWidget skipped: local controller has no LocalPlayer."));
+      return;
+    }
   }
 
   if (!DeployWidget) {

--- a/Source/Skald/Skald_PlayerController.cpp
+++ b/Source/Skald/Skald_PlayerController.cpp
@@ -1562,7 +1562,7 @@ void ASkaldPlayerController::InitializeHUDWidget() {
     return;
   }
 
-  MainHUD = CreateWidget<USkaldMainHUDWidget>(this, MainHUDClass);
+  MainHUD = CreateWidget<USkaldMainHUDWidget>(GetLocalPlayer(), MainHUDClass);
   if (!MainHUD) {
     return;
   }
@@ -1652,7 +1652,7 @@ void ASkaldPlayerController::InitializeChoosePlayerWidget() {
   }
 
   ChoosePlayerWidget =
-      CreateWidget<UChoosePlayerWidget>(this, ChoosePlayerWidgetClass);
+      CreateWidget<UChoosePlayerWidget>(GetLocalPlayer(), ChoosePlayerWidgetClass);
   if (!ChoosePlayerWidget) {
     return;
   }
@@ -1963,7 +1963,7 @@ void ASkaldPlayerController::ShowBattleResultWidget(
     return;
   }
 
-  if (UUserWidget *Widget = CreateWidget<UUserWidget>(this, VictoryWidgetClass)) {
+  if (UUserWidget *Widget = CreateWidget<UUserWidget>(GetLocalPlayer(), VictoryWidgetClass)) {
     if (UBattleResultWidget *ResultWidget = Cast<UBattleResultWidget>(Widget)) {
       ResultWidget->SetBattleOutcome(
           DisplayData.bPlayerWon, DisplayData.bPlayerLost,
@@ -2033,7 +2033,7 @@ void ASkaldPlayerController::ShowInGameMenu() {
     }
 
     if (InGameMenuWidgetClass) {
-      InGameMenuWidget = CreateWidget<UInGameMenuWidget>(this, InGameMenuWidgetClass);
+      InGameMenuWidget = CreateWidget<UInGameMenuWidget>(GetLocalPlayer(), InGameMenuWidgetClass);
       if (InGameMenuWidget) {
         InGameMenuWidget->SetVisibility(ESlateVisibility::Hidden);
         InGameMenuWidget->AddToViewport(90);
@@ -2190,7 +2190,7 @@ void ASkaldPlayerController::ApplyFactionCursor() {
   if (CursorTexture) {
     if (!ActiveCursorWidget) {
       ActiveCursorWidget =
-          CreateWidget<UFactionCursorWidget>(this, UFactionCursorWidget::StaticClass());
+          CreateWidget<UFactionCursorWidget>(GetLocalPlayer(), UFactionCursorWidget::StaticClass());
     }
 
     if (ActiveCursorWidget) {
@@ -2675,8 +2675,17 @@ void ASkaldPlayerController::ShowFighterSelectionUI(int32 MaxBudget,
     if (FighterSelectionWidget) {
       FighterSelectionWidget->RemoveFromParent();
     }
-    FighterSelectionWidget =
-        CreateWidget<UFighterSelectionWidget>(this, FighterSelectionWidgetClass);
+
+    ULocalPlayer *LocalPlayer = GetLocalPlayer();
+    if (!LocalPlayer || Player != LocalPlayer) {
+      UE_LOG(LogSkaldBattle, Warning,
+             TEXT("ShowFighterSelectionUI: Skipping widget creation for controller without attached local player (%s)."),
+             *GetNameSafe(this));
+      return;
+    }
+
+    FighterSelectionWidget = CreateWidget<UFighterSelectionWidget>(
+        LocalPlayer, FighterSelectionWidgetClass);
   }
 
   if (!FighterSelectionWidget) {
@@ -2919,7 +2928,7 @@ void ASkaldPlayerController::InitializeBattleHUD() {
     return;
   if (!BattleHudWidget) {
     BattleHudWidget =
-        CreateWidget<UBattleHUDWidget>(this, BattleHUDWidgetClass);
+        CreateWidget<UBattleHUDWidget>(GetLocalPlayer(), BattleHUDWidgetClass);
     if (BattleHudWidget) {
       BattleHudWidget->AddToViewport(20);
       BattleHudWidget->SetVisibility(ESlateVisibility::Collapsed);
@@ -8658,7 +8667,7 @@ void ASkaldPlayerController::EnsureDiceWidgets() {
 
   const bool bShouldSpawnOverlay = bAutoPresentDiceRolls || bAutoPresentInitiativeRolls;
   if (bShouldSpawnOverlay && !DiceOverlayWidget && DiceOverlayWidgetClass) {
-    DiceOverlayWidget = CreateWidget<USkaldDiceOverlayWidget>(this, DiceOverlayWidgetClass);
+    DiceOverlayWidget = CreateWidget<USkaldDiceOverlayWidget>(GetLocalPlayer(), DiceOverlayWidgetClass);
     if (DiceOverlayWidget) {
       DiceOverlayWidget->AddToViewport(32);
       DiceOverlayWidget->SetVisibility(ESlateVisibility::Collapsed);
@@ -8666,7 +8675,7 @@ void ASkaldPlayerController::EnsureDiceWidgets() {
   }
 
   if (bAutoPresentInitiativeRolls && !DiceResultWidget && DiceResultWidgetClass) {
-    DiceResultWidget = CreateWidget<USkaldDiceResultWidget>(this, DiceResultWidgetClass);
+    DiceResultWidget = CreateWidget<USkaldDiceResultWidget>(GetLocalPlayer(), DiceResultWidgetClass);
     if (DiceResultWidget) {
       DiceResultWidget->AddToViewport(33);
       DiceResultWidget->SetVisibility(ESlateVisibility::Collapsed);

--- a/Source/Skald/UI/BattleHUDWidget.cpp
+++ b/Source/Skald/UI/BattleHUDWidget.cpp
@@ -10,6 +10,7 @@
 #include "Engine/Canvas.h"
 #include "Engine/CanvasRenderTarget2D.h"
 #include "Engine/Engine.h"
+#include "Engine/LocalPlayer.h"
 #include "Styling/SlateBrush.h"
 #include "Styling/SlateColor.h"
 #include "Engine/World.h"
@@ -694,9 +695,16 @@ UBattleHUDWidget::FindOrCreateLockedInEntry(AFighterPawn *Fighter) {
     return nullptr;
   }
 
-  if (ULockedInFighterEntryWidget *NewEntry =
-          CreateWidget<ULockedInFighterEntryWidget>(this,
-                                                   LockedInFighterEntryClass)) {
+  ULocalPlayer *OwningLocalPlayer = GetOwningLocalPlayer();
+  if (!OwningLocalPlayer) {
+    UE_LOG(LogSkaldUI, Warning,
+           TEXT("BattleHUD: missing owning LocalPlayer; skipping locked-in fighter entry widget creation."));
+    return nullptr;
+  }
+  ULockedInFighterEntryWidget *NewEntry =
+      CreateWidget<ULockedInFighterEntryWidget>(OwningLocalPlayer,
+                                                LockedInFighterEntryClass);
+  if (NewEntry) {
     NewEntry->OnEntryClicked.AddDynamic(
         this, &UBattleHUDWidget::HandleLockedInEntryClicked);
     NewEntry->OnEntryRemoved.AddDynamic(
@@ -722,8 +730,16 @@ UBattleHUDWidget::FindOrCreateEnemyLockedInEntry(AFighterPawn *Fighter) {
     return nullptr;
   }
 
-  if (ULockedInFighterEntryWidget *NewEntry =
-          CreateWidget<ULockedInFighterEntryWidget>(this, LockedInFighterEntryClass)) {
+  ULocalPlayer *OwningLocalPlayer = GetOwningLocalPlayer();
+  if (!OwningLocalPlayer) {
+    UE_LOG(LogSkaldUI, Warning,
+           TEXT("BattleHUD: missing owning LocalPlayer; skipping enemy locked-in entry widget creation."));
+    return nullptr;
+  }
+  ULockedInFighterEntryWidget *NewEntry =
+      CreateWidget<ULockedInFighterEntryWidget>(OwningLocalPlayer,
+                                                LockedInFighterEntryClass);
+  if (NewEntry) {
     NewEntry->OnEntryClicked.AddDynamic(
         this, &UBattleHUDWidget::HandleEnemyLockedInEntryClicked);
     NewEntry->OnEntryRemoved.AddDynamic(

--- a/Source/Skald/UI/FighterSelectionWidget.cpp
+++ b/Source/Skald/UI/FighterSelectionWidget.cpp
@@ -5,6 +5,7 @@
 #include "Components/Image.h"
 #include "Components/ScrollBox.h"
 #include "Components/TextBlock.h"
+#include "Engine/LocalPlayer.h"
 #include "Engine/Texture2D.h"
 #include "Internationalization/Text.h"
 #include "SkaldLogging.h"
@@ -269,9 +270,15 @@ void UFighterSelectionWidget::PopulateFighterList() {
   });
 
   int32 Added = 0;
+  ULocalPlayer* OwningLocalPlayer = GetOwningLocalPlayer();
+  if (!OwningLocalPlayer) {
+    UE_LOG(LogSkaldUI, Warning,
+           TEXT("[FighterSelection] Skipping list population: missing owning LocalPlayer."));
+    return;
+  }
   for (const FFighterDefinition &Fighter : AvailableFighters) {
-    if (UFighterEntryWidget *Entry =
-            CreateWidget<UFighterEntryWidget>(this, FighterEntryClass)) {
+    if (UFighterEntryWidget* Entry =
+            CreateWidget<UFighterEntryWidget>(OwningLocalPlayer, FighterEntryClass)) {
       Entry->Init(Fighter, this);
       FighterList->AddChild(Entry);
       ++Added;

--- a/Source/Skald/UI/InGameMenuWidget.cpp
+++ b/Source/Skald/UI/InGameMenuWidget.cpp
@@ -1,4 +1,5 @@
 #include "UI/InGameMenuWidget.h"
+#include "Engine/LocalPlayer.h"
 
 #include "Blueprint/WidgetTree.h"
 #include "Components/Button.h"
@@ -240,19 +241,19 @@ void UInGameMenuWidget::HandleMainMenuClicked()
 
     if (APlayerController* PC = GetOwningPlayer())
     {
-        if (UQuitConfirmationWidget* Widget = CreateWidget<UQuitConfirmationWidget>(PC, WidgetClass))
+        if (ULocalPlayer* LocalPlayer = PC->GetLocalPlayer())
         {
-            Widget->AddToViewport(100);
-            QuitConfirmationWidget = Widget;
+            if (UQuitConfirmationWidget* Widget = CreateWidget<UQuitConfirmationWidget>(LocalPlayer, WidgetClass))
+            {
+                Widget->AddToViewport(100);
+                QuitConfirmationWidget = Widget;
+            }
         }
     }
-    else if (UWorld* World = GetWorld())
+    else
     {
-        if (UQuitConfirmationWidget* Widget = CreateWidget<UQuitConfirmationWidget>(World, WidgetClass))
-        {
-            Widget->AddToViewport(100);
-            QuitConfirmationWidget = Widget;
-        }
+        UE_LOG(LogTemp, Warning,
+               TEXT("InGameMenu: skipped quit confirmation widget creation (no owning player/local player)."));
     }
 }
 
@@ -271,34 +272,37 @@ void UInGameMenuWidget::ShowChildWidget(TSubclassOf<UUserWidget> WidgetClass)
 
     if (ASkaldPlayerController* PC = Cast<ASkaldPlayerController>(GetOwningPlayer()))
     {
-        if (UUserWidget* Child = CreateWidget<UUserWidget>(PC, WidgetClass))
+        if (ULocalPlayer* LocalPlayer = PC->GetLocalPlayer())
         {
-            if (USaveGameWidget* SaveWidget = Cast<USaveGameWidget>(Child))
+            if (UUserWidget* Child = CreateWidget<UUserWidget>(LocalPlayer, WidgetClass))
             {
-                SaveWidget->SetOwningMenu(this);
-            }
-            else if (ULoadGameWidget* LoadWidget = Cast<ULoadGameWidget>(Child))
-            {
-                LoadWidget->SetOwningMenu(this);
-            }
-            else if (USettingsWidget* Settings = Cast<USettingsWidget>(Child))
-            {
-                Settings->SetOwningMenu(this);
-            }
+                if (USaveGameWidget* SaveWidget = Cast<USaveGameWidget>(Child))
+                {
+                    SaveWidget->SetOwningMenu(this);
+                }
+                else if (ULoadGameWidget* LoadWidget = Cast<ULoadGameWidget>(Child))
+                {
+                    LoadWidget->SetOwningMenu(this);
+                }
+                else if (USettingsWidget* Settings = Cast<USettingsWidget>(Child))
+                {
+                    Settings->SetOwningMenu(this);
+                }
 
-            Child->AddToViewport(100);
-            ActiveChildWidget = Child;
+                Child->AddToViewport(100);
+                ActiveChildWidget = Child;
 
-            SetVisibility(ESlateVisibility::Hidden);
-            HandleVisibilityChange(ESlateVisibility::Hidden);
+                SetVisibility(ESlateVisibility::Hidden);
+                HandleVisibilityChange(ESlateVisibility::Hidden);
 
-            FInputModeGameAndUI Mode;
-            // Focus the Slate widget produced by the UUserWidget
-            Mode.SetWidgetToFocus(Child->TakeWidget());
-            Mode.SetLockMouseToViewportBehavior(EMouseLockMode::DoNotLock);
-            Mode.SetHideCursorDuringCapture(false);
-            PC->SetInputMode(Mode);
-            PC->bShowMouseCursor = true;
+                FInputModeGameAndUI Mode;
+                // Focus the Slate widget produced by the UUserWidget
+                Mode.SetWidgetToFocus(Child->TakeWidget());
+                Mode.SetLockMouseToViewportBehavior(EMouseLockMode::DoNotLock);
+                Mode.SetHideCursorDuringCapture(false);
+                PC->SetInputMode(Mode);
+                PC->bShowMouseCursor = true;
+            }
         }
     }
 }

--- a/Source/Skald/UI/SkaldMainHUDWidget.cpp
+++ b/Source/Skald/UI/SkaldMainHUDWidget.cpp
@@ -13,6 +13,7 @@
 #include "Engine/Canvas.h"
 #include "Engine/CanvasRenderTarget2D.h"
 #include "Engine/Engine.h"
+#include "Engine/LocalPlayer.h"
 #include "Engine/Texture2D.h"
 #include "CanvasItem.h"
 #include "Kismet/GameplayStatics.h"
@@ -639,6 +640,7 @@ void USkaldMainHUDWidget::RebuildPlayerList(
   }
 
   PlayerListBox->ClearChildren();
+  ULocalPlayer *OwningLocalPlayer = GetOwningLocalPlayer();
 
   UEnum *FactionEnum = StaticEnum<ESkaldFaction>();
   const bool bUseCustomEntries = PlayerListEntryWidgetClass != nullptr;
@@ -657,8 +659,13 @@ void USkaldMainHUDWidget::RebuildPlayerList(
     const int32 TerritoryCount = Player.TerritoriesOwned;
 
     if (bUseCustomEntries) {
+      if (!OwningLocalPlayer) {
+        UE_LOG(LogSkaldUI, Verbose,
+               TEXT("[HUD] Skipping custom player list entries due to missing owning local player."));
+        break;
+      }
       USkaldPlayerListEntryWidget *EntryWidget =
-          CreateWidget<USkaldPlayerListEntryWidget>(GetOwningPlayer(),
+          CreateWidget<USkaldPlayerListEntryWidget>(OwningLocalPlayer,
                                                     PlayerListEntryWidgetClass);
       if (!EntryWidget) {
         continue;
@@ -830,9 +837,14 @@ void USkaldMainHUDWidget::ShowPrepareForBattleDialog(
            TEXT("ShowPrepareForBattleDialog: PrepareForBattleWidgetClass null"));
     return;
   }
+  if (!GetOwningLocalPlayer()) {
+    UE_LOG(LogSkald, Warning,
+           TEXT("ShowPrepareForBattleDialog: missing owning local player"));
+    return;
+  }
 
   ActivePrepareForBattleWidget = CreateWidget<UPrepareForBattleWidget>(
-      GetWorld(), PrepareForBattleWidgetClass);
+      GetOwningLocalPlayer(), PrepareForBattleWidgetClass);
   if (!ActivePrepareForBattleWidget) {
     UE_LOG(LogSkald, Warning,
            TEXT("ShowPrepareForBattleDialog: failed to create widget"));
@@ -1948,8 +1960,14 @@ void USkaldMainHUDWidget::OnTerritoryClickedUI(ATerritory *Territory) {
       SelectedTargetID = Territory->TerritoryID;
       ShowSelectionPromptMessage(FText::GetEmpty(), false);
       if (ConfirmAttackWidgetClass) {
+        if (!GetOwningLocalPlayer()) {
+          UE_LOG(LogSkald, Warning,
+                 TEXT("OnTerritoryClickedUI: missing owning local player for confirm widget"));
+          ShowErrorMessage(TEXT("Could not open confirm attack UI"));
+          return;
+        }
         ActiveConfirmWidget = CreateWidget<UConfirmAttackWidget>(
-            GetWorld(), ConfirmAttackWidgetClass);
+            GetOwningLocalPlayer(), ConfirmAttackWidgetClass);
         if (ActiveConfirmWidget) {
           int32 MaxUnits = 1;
           if (AWorldMap *WorldMap =
@@ -2124,8 +2142,20 @@ void USkaldMainHUDWidget::OnTerritoryClickedUI(ATerritory *Territory) {
       ActiveDeployWidget = nullptr;
     }
 
+    if (!GetOwningLocalPlayer()) {
+      UE_LOG(LogSkald, Warning,
+             TEXT("OnTerritoryClickedUI: missing owning local player for deploy widget"));
+      const FText Error = ResolveSelectionPromptText(
+          SkaldSelectionPromptKeys::MoveDeployUICreationFailed,
+          NSLOCTEXT("SkaldHUD", "MoveDeployUICreationFailed",
+                    "Could not open deploy UI."));
+      ShowSelectionErrorMessage(Error);
+      CancelMoveSelection();
+      return;
+    }
+
     ActiveDeployWidget =
-        CreateWidget<UDeployWidget>(GetWorld(), DeployWidgetClass);
+        CreateWidget<UDeployWidget>(GetOwningLocalPlayer(), DeployWidgetClass);
     if (!ActiveDeployWidget) {
       const FText Error = ResolveSelectionPromptText(
           SkaldSelectionPromptKeys::MoveDeployUICreationFailed,
@@ -2511,8 +2541,15 @@ void USkaldMainHUDWidget::HandleDeployClicked() {
     MaxDeployable = FMath::Min(MaxDeployable, RemainingCapacity);
   }
 
+  if (!GetOwningLocalPlayer()) {
+    UE_LOG(LogSkald, Warning,
+           TEXT("HandleDeployClicked failed: missing owning local player"));
+    ShowErrorMessage(TEXT("Could not open deploy UI"));
+    return;
+  }
+
   ActiveDeployWidget =
-      CreateWidget<UDeployWidget>(GetWorld(), DeployWidgetClass);
+      CreateWidget<UDeployWidget>(GetOwningLocalPlayer(), DeployWidgetClass);
   if (ActiveDeployWidget) {
     ActiveDeployWidget->SetupDeployment(Territory, PS, this, MaxDeployable);
     ActiveDeployWidget->AddToViewport();

--- a/Source/Skald/UI/SkaldTooltipStatics.cpp
+++ b/Source/Skald/UI/SkaldTooltipStatics.cpp
@@ -1,6 +1,7 @@
 #include "UI/SkaldTooltipStatics.h"
 
 #include "Blueprint/UserWidget.h"
+#include "Engine/LocalPlayer.h"
 #include "Engine/World.h"
 #include "Internationalization/Text.h"
 #include "UI/SkaldTooltipWidget.h"
@@ -24,8 +25,18 @@ void USkaldTooltipStatics::ApplyTooltip(
       return;
     }
 
+    ULocalPlayer *OwningLocalPlayer = nullptr;
+    if (UUserWidget *OwningUserWidget = TargetWidget->GetTypedOuter<UUserWidget>()) {
+      OwningLocalPlayer = OwningUserWidget->GetOwningLocalPlayer();
+    }
+
+    if (!OwningLocalPlayer) {
+      TargetWidget->SetToolTipText(TooltipText);
+      return;
+    }
+
     if (USkaldTooltipWidget *TooltipWidget =
-            CreateWidget<USkaldTooltipWidget>(World, TooltipClass)) {
+            CreateWidget<USkaldTooltipWidget>(OwningLocalPlayer, TooltipClass)) {
       TooltipWidget->SetTooltipLabelText(TooltipText);
       TargetWidget->SetToolTip(TooltipWidget);
       return;
@@ -74,4 +85,3 @@ FText USkaldTooltipStatics::BuildBasicAbilityTooltip(
 
   return FText::GetEmpty();
 }
-

--- a/Source/Skald/UI/W_DiceResolutionPanel.cpp
+++ b/Source/Skald/UI/W_DiceResolutionPanel.cpp
@@ -19,6 +19,7 @@
 #include "Components/UniformGridSlot.h"
 #include "Components/VerticalBox.h"
 #include "Components/VerticalBoxSlot.h"
+#include "Engine/LocalPlayer.h"
 #include "Components/Widget.h"
 #include "Blueprint/WidgetTree.h"
 #include "Engine/Texture2D.h"
@@ -735,7 +736,16 @@ void UW_DiceResolutionPanel::RevealNextDie()
 
         if (OutcomeEntryWidgetClass)
         {
-            if (UW_DiceResolutionEntryWidget* EntryWidget = CreateWidget<UW_DiceResolutionEntryWidget>(this, OutcomeEntryWidgetClass))
+            ULocalPlayer* OwningLocalPlayer = GetOwningLocalPlayer();
+            if (!OwningLocalPlayer)
+            {
+                UE_LOG(LogSkaldUI, Warning,
+                       TEXT("DiceResolutionPanel: missing owning LocalPlayer; falling back to text-only outcome row."));
+            }
+            UW_DiceResolutionEntryWidget* EntryWidget = OwningLocalPlayer
+                ? CreateWidget<UW_DiceResolutionEntryWidget>(OwningLocalPlayer, OutcomeEntryWidgetClass)
+                : nullptr;
+            if (EntryWidget)
             {
                 EntryWidget->SetVisibility(ESlateVisibility::HitTestInvisible);
                 EntryWidget->ConfigureOutcome(Outcome, RevealIndex, ResolvedTexture);
@@ -1051,4 +1061,3 @@ void UW_DiceResolutionEntryWidget::ConfigureOutcome(const FDiceRollOutcome& Outc
         OutcomeLabelText->SetVisibility(ESlateVisibility::HitTestInvisible);
     }
 }
-


### PR DESCRIPTION
### Motivation
- Prevent creating UMG widgets with a `UWorld`/`APlayerController` when a `ULocalPlayer` should own the widget, avoiding issues during teardown or when controllers lack an attached local player.
- Make UI widget creation more robust across lobby, HUD, battle and tooltip code by explicitly using the owning `ULocalPlayer` where required.
- Add clearer logging and early returns to avoid crashes or silent failures when a `LocalPlayer` is missing.

### Description
- Replaced many `CreateWidget<...>(this|World, ...)` calls with `CreateWidget<...>(LocalPlayer, ...)` using `GetLocalPlayer()` or `GetOwningLocalPlayer()` and added `#include "Engine/LocalPlayer.h"` where needed.
- Added guards that check for a valid `ULocalPlayer` (and in one case that `Player == LocalPlayer`) and early-return with `UE_LOG` warnings when widget creation cannot proceed.
- Updated lobby, settings, in-game menu, HUD, battle UI, fighter selection, tooltip and dice resolution panels to obtain and use the appropriate `ULocalPlayer` when constructing widgets, and adjusted visibility/input handling to remain consistent.
- Improved tooltip creation to fall back to `SetToolTipText` when no owning `ULocalPlayer` is available.

### Testing
- Built the project with the Unreal build tool and the changes compile without errors.
- Ran automated unit/integration tests and the project's UI smoke tests that exercise lobby/HUD/widget creation, and they completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f51e54def48324bbda460d5758743f)