### PR TITLE
Fix widget creation owner types for UE5.5 build compatibility

### DIFF
--- a/Source/Skald/LobbyMenuWidget.cpp
+++ b/Source/Skald/LobbyMenuWidget.cpp
@@ -64,7 +64,7 @@ void ULobbyMenuWidget::OnStartGame()
         {
             if (ULocalPlayer* LocalPlayer = PC->GetLocalPlayer())
             {
-                if (UStartGameWidget* Widget = CreateWidget<UStartGameWidget>(LocalPlayer, StartGameWidgetClass))
+                if (UStartGameWidget* Widget = CreateWidget<UStartGameWidget>(PC, StartGameWidgetClass))
                 {
                     Widget->SetLobbyMenu(this);
                     Widget->AddToViewport();
@@ -87,7 +87,7 @@ void ULobbyMenuWidget::OnLoadGame()
 
         if (ULocalPlayer* LocalPlayer = PC->GetLocalPlayer())
         {
-            if (ULoadGameWidget* Widget = CreateWidget<ULoadGameWidget>(LocalPlayer, LoadGameWidgetClass))
+            if (ULoadGameWidget* Widget = CreateWidget<ULoadGameWidget>(PC, LoadGameWidgetClass))
             {
                 // Pass a reference to the lobby so it can be restored later
                 Widget->SetLobbyMenu(this);
@@ -112,7 +112,7 @@ void ULobbyMenuWidget::OnSettings()
 
         if (ULocalPlayer* LocalPlayer = PC->GetLocalPlayer())
         {
-            if (USettingsWidget* Widget = CreateWidget<USettingsWidget>(LocalPlayer, SettingsWidgetClass))
+            if (USettingsWidget* Widget = CreateWidget<USettingsWidget>(PC, SettingsWidgetClass))
             {
                 Widget->SetLobbyMenu(this);
                 Widget->AddToViewport();

--- a/Source/Skald/Private/LobbyPlayerController.cpp
+++ b/Source/Skald/Private/LobbyPlayerController.cpp
@@ -41,7 +41,7 @@ void ALobbyPlayerController::InitLobbyUI()
     {
         if (!LobbySessionWidgetInstance && LobbySessionWidgetClass)
         {
-            LobbySessionWidgetInstance = CreateWidget<ULobbySessionWidget>(LocalPlayer, LobbySessionWidgetClass);
+            LobbySessionWidgetInstance = CreateWidget<ULobbySessionWidget>(this, LobbySessionWidgetClass);
             if (LobbySessionWidgetInstance)
             {
                 LobbySessionWidgetInstance->AddToViewport();
@@ -59,7 +59,7 @@ void ALobbyPlayerController::InitLobbyUI()
     {
         if (!LobbyWidgetInstance && LobbyWidgetClass)
         {
-            LobbyWidgetInstance = CreateWidget<ULobbyMenuWidget>(LocalPlayer, LobbyWidgetClass);
+            LobbyWidgetInstance = CreateWidget<ULobbyMenuWidget>(this, LobbyWidgetClass);
             if (LobbyWidgetInstance)
             {
                 LobbyWidgetInstance->AddToViewport();
@@ -70,7 +70,7 @@ void ALobbyPlayerController::InitLobbyUI()
         bool bShowingTitleScreen = false;
         if (!TitleScreenWidgetInstance && TitleScreenWidgetClass)
         {
-            TitleScreenWidgetInstance = CreateWidget<UTitleScreenWidget>(LocalPlayer, TitleScreenWidgetClass);
+            TitleScreenWidgetInstance = CreateWidget<UTitleScreenWidget>(this, TitleScreenWidgetClass);
             if (TitleScreenWidgetInstance)
             {
                 TitleScreenWidgetInstance->OnDismissed.AddDynamic(this, &ALobbyPlayerController::HandleTitleScreenDismissed);

--- a/Source/Skald/SettingsWidget.cpp
+++ b/Source/Skald/SettingsWidget.cpp
@@ -228,7 +228,7 @@ void USettingsWidget::OnExit()
     {
         if (ULocalPlayer* LocalPlayer = PC->GetLocalPlayer())
         {
-            if (UQuitConfirmationWidget* Widget = CreateWidget<UQuitConfirmationWidget>(LocalPlayer, UQuitConfirmationWidget::StaticClass()))
+            if (UQuitConfirmationWidget* Widget = CreateWidget<UQuitConfirmationWidget>(PC, UQuitConfirmationWidget::StaticClass()))
             {
                 Widget->SetOwningSettings(this);
                 Widget->AddToViewport(100);

--- a/Source/Skald/Skald_GameInstance.cpp
+++ b/Source/Skald/Skald_GameInstance.cpp
@@ -1195,7 +1195,7 @@ void USkaldGameInstance::ShowDeployWidget() {
     }
 
     if (ULocalPlayer* LocalPlayer = LocalSkaldPC->GetLocalPlayer()) {
-      DeployWidget = CreateWidget<UUserWidget>(LocalPlayer, WidgetClass);
+      DeployWidget = CreateWidget<UUserWidget>(PC, WidgetClass);
     } else {
       UE_LOG(LogSkald, Warning,
              TEXT("ShowDeployWidget skipped: local controller has no LocalPlayer."));

--- a/Source/Skald/Skald_PlayerController.cpp
+++ b/Source/Skald/Skald_PlayerController.cpp
@@ -1562,7 +1562,7 @@ void ASkaldPlayerController::InitializeHUDWidget() {
     return;
   }
 
-  MainHUD = CreateWidget<USkaldMainHUDWidget>(GetLocalPlayer(), MainHUDClass);
+  MainHUD = CreateWidget<USkaldMainHUDWidget>(this, MainHUDClass);
   if (!MainHUD) {
     return;
   }
@@ -1652,7 +1652,7 @@ void ASkaldPlayerController::InitializeChoosePlayerWidget() {
   }
 
   ChoosePlayerWidget =
-      CreateWidget<UChoosePlayerWidget>(GetLocalPlayer(), ChoosePlayerWidgetClass);
+      CreateWidget<UChoosePlayerWidget>(this, ChoosePlayerWidgetClass);
   if (!ChoosePlayerWidget) {
     return;
   }
@@ -1963,7 +1963,7 @@ void ASkaldPlayerController::ShowBattleResultWidget(
     return;
   }
 
-  if (UUserWidget *Widget = CreateWidget<UUserWidget>(GetLocalPlayer(), VictoryWidgetClass)) {
+  if (UUserWidget *Widget = CreateWidget<UUserWidget>(this, VictoryWidgetClass)) {
     if (UBattleResultWidget *ResultWidget = Cast<UBattleResultWidget>(Widget)) {
       ResultWidget->SetBattleOutcome(
           DisplayData.bPlayerWon, DisplayData.bPlayerLost,
@@ -2033,7 +2033,7 @@ void ASkaldPlayerController::ShowInGameMenu() {
     }
 
     if (InGameMenuWidgetClass) {
-      InGameMenuWidget = CreateWidget<UInGameMenuWidget>(GetLocalPlayer(), InGameMenuWidgetClass);
+      InGameMenuWidget = CreateWidget<UInGameMenuWidget>(this, InGameMenuWidgetClass);
       if (InGameMenuWidget) {
         InGameMenuWidget->SetVisibility(ESlateVisibility::Hidden);
         InGameMenuWidget->AddToViewport(90);
@@ -2190,7 +2190,7 @@ void ASkaldPlayerController::ApplyFactionCursor() {
   if (CursorTexture) {
     if (!ActiveCursorWidget) {
       ActiveCursorWidget =
-          CreateWidget<UFactionCursorWidget>(GetLocalPlayer(), UFactionCursorWidget::StaticClass());
+          CreateWidget<UFactionCursorWidget>(this, UFactionCursorWidget::StaticClass());
     }
 
     if (ActiveCursorWidget) {
@@ -2928,7 +2928,7 @@ void ASkaldPlayerController::InitializeBattleHUD() {
     return;
   if (!BattleHudWidget) {
     BattleHudWidget =
-        CreateWidget<UBattleHUDWidget>(GetLocalPlayer(), BattleHUDWidgetClass);
+        CreateWidget<UBattleHUDWidget>(this, BattleHUDWidgetClass);
     if (BattleHudWidget) {
       BattleHudWidget->AddToViewport(20);
       BattleHudWidget->SetVisibility(ESlateVisibility::Collapsed);
@@ -8667,7 +8667,7 @@ void ASkaldPlayerController::EnsureDiceWidgets() {
 
   const bool bShouldSpawnOverlay = bAutoPresentDiceRolls || bAutoPresentInitiativeRolls;
   if (bShouldSpawnOverlay && !DiceOverlayWidget && DiceOverlayWidgetClass) {
-    DiceOverlayWidget = CreateWidget<USkaldDiceOverlayWidget>(GetLocalPlayer(), DiceOverlayWidgetClass);
+    DiceOverlayWidget = CreateWidget<USkaldDiceOverlayWidget>(this, DiceOverlayWidgetClass);
     if (DiceOverlayWidget) {
       DiceOverlayWidget->AddToViewport(32);
       DiceOverlayWidget->SetVisibility(ESlateVisibility::Collapsed);
@@ -8675,7 +8675,7 @@ void ASkaldPlayerController::EnsureDiceWidgets() {
   }
 
   if (bAutoPresentInitiativeRolls && !DiceResultWidget && DiceResultWidgetClass) {
-    DiceResultWidget = CreateWidget<USkaldDiceResultWidget>(GetLocalPlayer(), DiceResultWidgetClass);
+    DiceResultWidget = CreateWidget<USkaldDiceResultWidget>(this, DiceResultWidgetClass);
     if (DiceResultWidget) {
       DiceResultWidget->AddToViewport(33);
       DiceResultWidget->SetVisibility(ESlateVisibility::Collapsed);

--- a/Source/Skald/UI/BattleHUDWidget.cpp
+++ b/Source/Skald/UI/BattleHUDWidget.cpp
@@ -702,7 +702,7 @@ UBattleHUDWidget::FindOrCreateLockedInEntry(AFighterPawn *Fighter) {
     return nullptr;
   }
   ULockedInFighterEntryWidget *NewEntry =
-      CreateWidget<ULockedInFighterEntryWidget>(OwningLocalPlayer,
+      CreateWidget<ULockedInFighterEntryWidget>(GetOwningPlayer(),
                                                 LockedInFighterEntryClass);
   if (NewEntry) {
     NewEntry->OnEntryClicked.AddDynamic(
@@ -737,7 +737,7 @@ UBattleHUDWidget::FindOrCreateEnemyLockedInEntry(AFighterPawn *Fighter) {
     return nullptr;
   }
   ULockedInFighterEntryWidget *NewEntry =
-      CreateWidget<ULockedInFighterEntryWidget>(OwningLocalPlayer,
+      CreateWidget<ULockedInFighterEntryWidget>(GetOwningPlayer(),
                                                 LockedInFighterEntryClass);
   if (NewEntry) {
     NewEntry->OnEntryClicked.AddDynamic(

--- a/Source/Skald/UI/FighterSelectionWidget.cpp
+++ b/Source/Skald/UI/FighterSelectionWidget.cpp
@@ -278,7 +278,7 @@ void UFighterSelectionWidget::PopulateFighterList() {
   }
   for (const FFighterDefinition &Fighter : AvailableFighters) {
     if (UFighterEntryWidget* Entry =
-            CreateWidget<UFighterEntryWidget>(OwningLocalPlayer, FighterEntryClass)) {
+            CreateWidget<UFighterEntryWidget>(GetOwningPlayer(), FighterEntryClass)) {
       Entry->Init(Fighter, this);
       FighterList->AddChild(Entry);
       ++Added;

--- a/Source/Skald/UI/InGameMenuWidget.cpp
+++ b/Source/Skald/UI/InGameMenuWidget.cpp
@@ -243,7 +243,7 @@ void UInGameMenuWidget::HandleMainMenuClicked()
     {
         if (ULocalPlayer* LocalPlayer = PC->GetLocalPlayer())
         {
-            if (UQuitConfirmationWidget* Widget = CreateWidget<UQuitConfirmationWidget>(LocalPlayer, WidgetClass))
+            if (UQuitConfirmationWidget* Widget = CreateWidget<UQuitConfirmationWidget>(PC, WidgetClass))
             {
                 Widget->AddToViewport(100);
                 QuitConfirmationWidget = Widget;
@@ -274,7 +274,7 @@ void UInGameMenuWidget::ShowChildWidget(TSubclassOf<UUserWidget> WidgetClass)
     {
         if (ULocalPlayer* LocalPlayer = PC->GetLocalPlayer())
         {
-            if (UUserWidget* Child = CreateWidget<UUserWidget>(LocalPlayer, WidgetClass))
+            if (UUserWidget* Child = CreateWidget<UUserWidget>(PC, WidgetClass))
             {
                 if (USaveGameWidget* SaveWidget = Cast<USaveGameWidget>(Child))
                 {

--- a/Source/Skald/UI/SkaldMainHUDWidget.cpp
+++ b/Source/Skald/UI/SkaldMainHUDWidget.cpp
@@ -665,7 +665,7 @@ void USkaldMainHUDWidget::RebuildPlayerList(
         break;
       }
       USkaldPlayerListEntryWidget *EntryWidget =
-          CreateWidget<USkaldPlayerListEntryWidget>(OwningLocalPlayer,
+          CreateWidget<USkaldPlayerListEntryWidget>(GetOwningPlayer(),
                                                     PlayerListEntryWidgetClass);
       if (!EntryWidget) {
         continue;
@@ -2155,7 +2155,7 @@ void USkaldMainHUDWidget::OnTerritoryClickedUI(ATerritory *Territory) {
     }
 
     ActiveDeployWidget =
-        CreateWidget<UDeployWidget>(GetOwningLocalPlayer(), DeployWidgetClass);
+        CreateWidget<UDeployWidget>(GetOwningPlayer(), DeployWidgetClass);
     if (!ActiveDeployWidget) {
       const FText Error = ResolveSelectionPromptText(
           SkaldSelectionPromptKeys::MoveDeployUICreationFailed,
@@ -2549,7 +2549,7 @@ void USkaldMainHUDWidget::HandleDeployClicked() {
   }
 
   ActiveDeployWidget =
-      CreateWidget<UDeployWidget>(GetOwningLocalPlayer(), DeployWidgetClass);
+      CreateWidget<UDeployWidget>(GetOwningPlayer(), DeployWidgetClass);
   if (ActiveDeployWidget) {
     ActiveDeployWidget->SetupDeployment(Territory, PS, this, MaxDeployable);
     ActiveDeployWidget->AddToViewport();

--- a/Source/Skald/UI/SkaldTooltipStatics.cpp
+++ b/Source/Skald/UI/SkaldTooltipStatics.cpp
@@ -26,8 +26,10 @@ void USkaldTooltipStatics::ApplyTooltip(
     }
 
     ULocalPlayer *OwningLocalPlayer = nullptr;
+    APlayerController* OwningPlayerController = nullptr;
     if (UUserWidget *OwningUserWidget = TargetWidget->GetTypedOuter<UUserWidget>()) {
       OwningLocalPlayer = OwningUserWidget->GetOwningLocalPlayer();
+      OwningPlayerController = OwningUserWidget->GetOwningPlayer();
     }
 
     if (!OwningLocalPlayer) {
@@ -36,7 +38,7 @@ void USkaldTooltipStatics::ApplyTooltip(
     }
 
     if (USkaldTooltipWidget *TooltipWidget =
-            CreateWidget<USkaldTooltipWidget>(OwningLocalPlayer, TooltipClass)) {
+            CreateWidget<USkaldTooltipWidget>(OwningPlayerController, TooltipClass)) {
       TooltipWidget->SetTooltipLabelText(TooltipText);
       TargetWidget->SetToolTip(TooltipWidget);
       return;

--- a/Source/Skald/UI/W_DiceResolutionPanel.cpp
+++ b/Source/Skald/UI/W_DiceResolutionPanel.cpp
@@ -30,6 +30,7 @@
 #include "Types/SlateEnums.h"
 #include "Widgets/Layout/SScrollBox.h"
 #include "Runtime/Launch/Resources/Version.h"
+#include "SkaldLogging.h"
 
 static UUniformGridSlot* AddToUniformGridWithPadding(
     UWidgetTree* WidgetTree,
@@ -743,7 +744,7 @@ void UW_DiceResolutionPanel::RevealNextDie()
                        TEXT("DiceResolutionPanel: missing owning LocalPlayer; falling back to text-only outcome row."));
             }
             UW_DiceResolutionEntryWidget* EntryWidget = OwningLocalPlayer
-                ? CreateWidget<UW_DiceResolutionEntryWidget>(OwningLocalPlayer, OutcomeEntryWidgetClass)
+                ? CreateWidget<UW_DiceResolutionEntryWidget>(GetOwningPlayer(), OutcomeEntryWidgetClass)
                 : nullptr;
             if (EntryWidget)
             {


### PR DESCRIPTION
### Motivation
- UE5.5 introduced stronger `CreateWidget` owner-type constraints that caused compile-time `static_assert`/overload errors when `ULocalPlayer*` was used as the owner in many UI creation sites.
- The project failed to build with errors like `C2338: 'The given OwningObject is not of a supported type for use with CreateWidget.'` across many UI translation units, so owner arguments need to be adjusted to supported types.

### Description
- Replaced `CreateWidget<...>(ULocalPlayer*, ...)` call sites with supported owner types (`APlayerController*`, typically `this` or `GetOwningPlayer()`) across several UI and controller files including `Skald_PlayerController.cpp`, `LobbyMenuWidget.cpp`, `InGameMenuWidget.cpp`, `SettingsWidget.cpp`, `Skald_GameInstance.cpp`, `BattleHUDWidget.cpp`, `FighterSelectionWidget.cpp`, `SkaldMainHUDWidget.cpp`, `SkaldTooltipStatics.cpp`, and `W_DiceResolutionPanel.cpp`.
- In `SkaldTooltipStatics.cpp` added capture of the owning `APlayerController*` (`OwningPlayerController`) and use it for `CreateWidget` so tooltips are created with a supported owner.
- Added missing `#include "SkaldLogging.h"` to `W_DiceResolutionPanel.cpp` to resolve `LogSkaldUI` usage.
- Committed the changes with message `Fix UE5.5 widget ownership compile errors`.

### Testing
- Ran a code search `rg "CreateWidget<" Source/Skald -n | rg "LocalPlayer\(|OwningLocalPlayer|LocalPlayer,"` to verify there are no remaining `CreateWidget` calls using `ULocalPlayer` ownership patterns in `Source/Skald`, and the search returned only updated/acceptable patterns (succeeded).
- Verified staged changes and created a commit (`git commit -m "Fix UE5.5 widget ownership compile errors"`) which completed successfully.
- No full rebuild was executed in this rollout; the original failing build was reproduced in the provided logs prior to these fixes and should be re-run in CI to confirm compilation succeeds end-to-end.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f52c821a848324a2e5239875ce4bcb)