### PR TITLE
Fix UE 5.5 CreateWidget owner types and DeployWidget controller reference

### DIFF
--- a/Source/Skald/Skald_GameInstance.cpp
+++ b/Source/Skald/Skald_GameInstance.cpp
@@ -1195,7 +1195,7 @@ void USkaldGameInstance::ShowDeployWidget() {
     }
 
     if (ULocalPlayer* LocalPlayer = LocalSkaldPC->GetLocalPlayer()) {
-      DeployWidget = CreateWidget<UUserWidget>(PC, WidgetClass);
+      DeployWidget = CreateWidget<UUserWidget>(LocalSkaldPC, WidgetClass);
     } else {
       UE_LOG(LogSkald, Warning,
              TEXT("ShowDeployWidget skipped: local controller has no LocalPlayer."));

--- a/Source/Skald/Skald_PlayerController.cpp
+++ b/Source/Skald/Skald_PlayerController.cpp
@@ -2685,7 +2685,7 @@ void ASkaldPlayerController::ShowFighterSelectionUI(int32 MaxBudget,
     }
 
     FighterSelectionWidget = CreateWidget<UFighterSelectionWidget>(
-        LocalPlayer, FighterSelectionWidgetClass);
+        this, FighterSelectionWidgetClass);
   }
 
   if (!FighterSelectionWidget) {

--- a/Source/Skald/UI/SkaldMainHUDWidget.cpp
+++ b/Source/Skald/UI/SkaldMainHUDWidget.cpp
@@ -844,7 +844,7 @@ void USkaldMainHUDWidget::ShowPrepareForBattleDialog(
   }
 
   ActivePrepareForBattleWidget = CreateWidget<UPrepareForBattleWidget>(
-      GetOwningLocalPlayer(), PrepareForBattleWidgetClass);
+      GetOwningPlayer(), PrepareForBattleWidgetClass);
   if (!ActivePrepareForBattleWidget) {
     UE_LOG(LogSkald, Warning,
            TEXT("ShowPrepareForBattleDialog: failed to create widget"));


### PR DESCRIPTION
### Motivation
- Resolve compile failures caused by UE 5.5 rejecting `ULocalPlayer*` as the `CreateWidget` owner type and an undeclared `PC` identifier in `ShowDeployWidget`.

### Description
- Replace `GetOwningLocalPlayer()` with `GetOwningPlayer()` in `USkaldMainHUDWidget::ShowPrepareForBattleDialog` when calling `CreateWidget`.
- Pass `this` (an `APlayerController*`) to `CreateWidget` in `ASkaldPlayerController::ShowFighterSelectionUI` instead of a `ULocalPlayer*`.
- Fix `USkaldGameInstance::ShowDeployWidget` to pass `LocalSkaldPC` into `CreateWidget`, removing the use of the undeclared `PC` identifier.
- Files changed: `Source/Skald/UI/SkaldMainHUDWidget.cpp`, `Source/Skald/Skald_PlayerController.cpp`, and `Source/Skald/Skald_GameInstance.cpp`.

### Testing
- No automated build or CI was executed in this environment, so no compile or test runs were performed.
- Verified the three modified call sites by searching for `CreateWidget<` usages and confirmed they now use supported owner types; the verification succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f53974cea88324858c059eb04730f5)