### PR TITLE
Fix CreateWidget owner type for confirm attack dialog

### DIFF
--- a/Source/Skald/UI/SkaldMainHUDWidget.cpp
+++ b/Source/Skald/UI/SkaldMainHUDWidget.cpp
@@ -1960,14 +1960,15 @@ void USkaldMainHUDWidget::OnTerritoryClickedUI(ATerritory *Territory) {
       SelectedTargetID = Territory->TerritoryID;
       ShowSelectionPromptMessage(FText::GetEmpty(), false);
       if (ConfirmAttackWidgetClass) {
-        if (!GetOwningLocalPlayer()) {
+        APlayerController* OwningPlayerController = GetOwningPlayer();
+        if (!OwningPlayerController) {
           UE_LOG(LogSkald, Warning,
-                 TEXT("OnTerritoryClickedUI: missing owning local player for confirm widget"));
+                 TEXT("OnTerritoryClickedUI: missing owning player controller for confirm widget"));
           ShowErrorMessage(TEXT("Could not open confirm attack UI"));
           return;
         }
         ActiveConfirmWidget = CreateWidget<UConfirmAttackWidget>(
-            GetOwningLocalPlayer(), ConfirmAttackWidgetClass);
+            OwningPlayerController, ConfirmAttackWidgetClass);
         if (ActiveConfirmWidget) {
           int32 MaxUnits = 1;
           if (AWorldMap *WorldMap =


### PR DESCRIPTION
### Motivation
- The confirm-attack UI creation used `ULocalPlayer*` as the owner which does not match UE 5.5's `CreateWidget` overloads and produced a compile-time `static_assert`/overload resolution failure in `SkaldMainHUDWidget.cpp`.

### Description
- Replace `GetOwningLocalPlayer()` with `GetOwningPlayer()` to pass an `APlayerController*`, and add an explicit null-check and warning when the owning player controller is missing before calling `CreateWidget<UConfirmAttackWidget>`.

### Testing
- No automated Unreal build or tests were run in this environment, so the change was not validated by a full compile; only the source edit was applied.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f53d03ffa48324ab0fbbd86b09b16f)