### PR TITLE
Guard local UI widget handling for AI and non-local controllers

### DIFF
--- a/Source/Skald/Skald_GameState.cpp
+++ b/Source/Skald/Skald_GameState.cpp
@@ -7,6 +7,15 @@
 #include "GameFramework/WorldSettings.h"
 #include "SkaldLogging.h"
 #include "Skald_GameInstance.h"
+#include "Skald_AIController.h"
+
+namespace
+{
+bool ShouldProcessLocalBattleUIController(const ASkaldPlayerController* PC)
+{
+    return PC && !PC->IsA<ASkaldAIController>() && PC->CanCreateLocalUIWidget();
+}
+}
 
 ASkaldGameState::ASkaldGameState()
     : CurrentTurnIndex(0)
@@ -156,8 +165,8 @@ void ASkaldGameState::OnRep_Players()
 
 namespace {
 bool ShouldProcessUIController(const ASkaldPlayerController* PC) {
-    if (!PC || !PC->CanCreateLocalUIWidget()) {
-        return false;
+    if (!ShouldProcessLocalBattleUIController(PC)) {
+      return false;
     }
 
     const FString ClassName = PC->GetClass() ? PC->GetClass()->GetName() : FString();
@@ -181,7 +190,7 @@ void ASkaldGameState::RefreshControllersFromPlayers()
         {
             if (ASkaldPlayerController* PC = Cast<ASkaldPlayerController>(It->Get()))
             {
-                if (!PC->CanCreateLocalUIWidget())
+                if (!ShouldProcessLocalBattleUIController(PC))
                 {
                     continue;
                 }
@@ -215,7 +224,7 @@ void ASkaldGameState::OnRep_CurrentTurnIndex()
         {
             if (ASkaldPlayerController* PC = Cast<ASkaldPlayerController>(It->Get()))
             {
-                if (!PC->CanCreateLocalUIWidget())
+                if (!ShouldProcessLocalBattleUIController(PC))
                 {
                     continue;
                 }
@@ -241,7 +250,7 @@ void ASkaldGameState::OnRep_ActivePlayerId()
         {
             if (ASkaldPlayerController* PC = Cast<ASkaldPlayerController>(It->Get()))
             {
-                if (!PC->CanCreateLocalUIWidget())
+                if (!ShouldProcessLocalBattleUIController(PC))
                 {
                     continue;
                 }
@@ -442,7 +451,7 @@ void ASkaldGameState::OnRep_BattlePayload()
         {
             if (ASkaldPlayerController* PC = Cast<ASkaldPlayerController>(It->Get()))
             {
-                if (!PC->CanCreateLocalUIWidget())
+                if (!ShouldProcessLocalBattleUIController(PC))
                 {
                     continue;
                 }
@@ -488,7 +497,7 @@ void ASkaldGameState::OnRep_BattleParticipants()
         {
             if (ASkaldPlayerController* PC = Cast<ASkaldPlayerController>(It->Get()))
             {
-                if (!PC->CanCreateLocalUIWidget())
+                if (!ShouldProcessLocalBattleUIController(PC))
                 {
                     continue;
                 }
@@ -536,7 +545,7 @@ void ASkaldGameState::OnRep_PendingBattleReady()
         {
             if (ASkaldPlayerController* PC = Cast<ASkaldPlayerController>(It->Get()))
             {
-                if (!PC->CanCreateLocalUIWidget())
+                if (!ShouldProcessLocalBattleUIController(PC))
                 {
                     continue;
                 }
@@ -568,7 +577,7 @@ void ASkaldGameState::OnRep_BattleRoundState()
         {
             if (ASkaldPlayerController* PC = Cast<ASkaldPlayerController>(It->Get()))
             {
-                if (!PC->CanCreateLocalUIWidget())
+                if (!ShouldProcessLocalBattleUIController(PC))
                 {
                     continue;
                 }
@@ -757,7 +766,7 @@ void ASkaldGameState::OnRep_BattlePhase()
         {
             if (ASkaldPlayerController* PC = Cast<ASkaldPlayerController>(It->Get()))
             {
-                if (!PC->CanCreateLocalUIWidget())
+                if (!ShouldProcessLocalBattleUIController(PC))
                 {
                     continue;
                 }
@@ -861,4 +870,3 @@ void ASkaldGameState::EndPlay(const EEndPlayReason::Type EndPlayReason)
 
     Super::EndPlay(EndPlayReason);
 }
-

--- a/Source/Skald/Skald_PlayerController.cpp
+++ b/Source/Skald/Skald_PlayerController.cpp
@@ -1637,8 +1637,9 @@ void ASkaldPlayerController::InitializeHUDWidget() {
 }
 
 bool ASkaldPlayerController::CanCreateLocalUIWidget() const {
+  ULocalPlayer *LocalPlayer = GetLocalPlayer();
   return IsLocalController() && IsLocalPlayerController() &&
-         GetLocalPlayer() != nullptr && Player != nullptr &&
+         LocalPlayer != nullptr && Player != nullptr && Player == LocalPlayer &&
          !IsAIControllerIdentity(this);
 }
 
@@ -8662,6 +8663,14 @@ void ASkaldPlayerController::HandlePendingPresentationTimerTick() {
 
 void ASkaldPlayerController::EnsureDiceWidgets() {
   if (!CanCreateLocalUIWidget()) {
+    return;
+  }
+
+  ULocalPlayer *LocalPlayer = GetLocalPlayer();
+  if (!LocalPlayer || Player != LocalPlayer) {
+    UE_LOG(LogSkald, Verbose,
+           TEXT("EnsureDiceWidgets: skipping widget creation for controller without attached local player (%s)."),
+           *GetNameSafe(this));
     return;
   }
 


### PR DESCRIPTION
### Motivation
- Prevent AI controllers and non-attached controllers from creating or being processed for local battle/UI updates to avoid duplicate or incorrect HUD behavior.
- Centralize the repeated validity check used across GameState replication handlers to reduce duplication and ensure consistent logic.

### Description
- Added `ShouldProcessLocalBattleUIController` helper in `Skald_GameState.cpp` and included `Skald_AIController.h` to detect and exclude `ASkaldAIController` instances and require `CanCreateLocalUIWidget()` to be true. 
- Replaced many direct `PC->CanCreateLocalUIWidget()` checks in `ASkaldGameState` replication handlers with the new helper to skip AI or non-local controllers when rebuilding HUD/turn/battle state.
- Adjusted `ASkaldPlayerController::CanCreateLocalUIWidget()` to cache `GetLocalPlayer()` and require the controller's `Player` to match the attached `ULocalPlayer`, tightening the local-only check.
- Added an extra guard/log in `ASkaldPlayerController::EnsureDiceWidgets()` to skip dice UI creation when there is no attached local player or the controller is not attached to the local player.

### Testing
- Performed a Development build of the project to validate compilation after the refactor, and the build completed successfully. 
- Ran existing automated test suite and smoke tests for replication/HUD initialization paths, and they passed without regressions.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f543efd8e083248bf5dcdffbee3702)