### PR TITLE
Guard fighter selection UI init against AI and non-owning controllers

### DIFF
--- a/Source/Skald/Skald_PlayerController.cpp
+++ b/Source/Skald/Skald_PlayerController.cpp
@@ -2517,7 +2517,15 @@ ATurnManager *ASkaldPlayerController::FindTurnManagerActor() const {
 }
 
 void ASkaldPlayerController::InitializeFighterSelectionIfNeeded() {
-  if (!CanCreateLocalUIWidget()) {
+  if (!CanCreateLocalUIWidget() || IsAIControllerIdentity(this)) {
+    return;
+  }
+
+  ULocalPlayer *LocalPlayer = GetLocalPlayer();
+  if (!LocalPlayer || Player != LocalPlayer) {
+    UE_LOG(LogSkaldBattle, Verbose,
+           TEXT("InitializeFighterSelectionIfNeeded: Skipping non-owning controller %s (Player=%s LocalPlayer=%s)"),
+           *GetNameSafe(this), *GetNameSafe(Player), *GetNameSafe(LocalPlayer));
     return;
   }
 
@@ -2839,7 +2847,7 @@ void ASkaldPlayerController::Client_OnLockInResult_Implementation(
 }
 
 void ASkaldPlayerController::HandleBattlePhaseChanged() {
-  if (!CanCreateLocalUIWidget()) {
+  if (!CanCreateLocalUIWidget() || IsAIControllerIdentity(this)) {
     return;
   }
 


### PR DESCRIPTION
### Motivation

- Logs showed repeated `CreateWidget` errors from AI controllers (e.g. `Skald_AiController_C_0`) attempting to spawn the fighter selection UI without an attached `Player`, causing crashes during the battle selection flow.  
- The initialization path for fighter selection needed stronger gating to ensure only the owning local, non-AI controller runs widget creation.  

### Description

- Added an explicit `IsAIControllerIdentity(this)` check at the top of `ASkaldPlayerController::InitializeFighterSelectionIfNeeded()` to skip AI-identity controllers before any UI logic.  
- Added an ownership guard that fetches `ULocalPlayer *LocalPlayer = GetLocalPlayer()` and returns if `!LocalPlayer || Player != LocalPlayer`, and logs a verbose message when skipping non-owning controllers.  
- Applied the same AI-identity guard to `ASkaldPlayerController::HandleBattlePhaseChanged()` so AI controllers do not enter fighter-selection UI handling.  

### Testing

- Ran a keyword search with `rg -n "CreateWidget|FighterSelection|entering FighterSelection phase|ShowFighterSelectionUI|Client_ShowFighterSelection|Broadcasting fighter selection"` to locate UI entry points and verify the modified entry paths; the updated `InitializeFighterSelectionIfNeeded` and `HandleBattlePhaseChanged` locations now include the new guards. (succeeded)  
- Inspected the patched source with `sed`/`nl` extracts of `Source/Skald/Skald_PlayerController.cpp` to confirm the new `IsAIControllerIdentity` and `LocalPlayer` checks and the added verbose `UE_LOG` were inserted at the expected lines. (succeeded)  
- Performed an automated patch script to apply the changes and validated the modified file contains the intended changes. (succeeded)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f5890310048324a326d3a476ef27b1)