### PR TITLE
Prevent AI controllers from spawning local UI and harden UI creation checks

### DIFF
--- a/Source/Skald/Skald_AIController.cpp
+++ b/Source/Skald/Skald_AIController.cpp
@@ -164,6 +164,32 @@ void ASkaldAIController::InitializeHUDWidget() {
          *GetName());
 }
 
+void ASkaldAIController::ShowMainHUD() {
+  // AI controllers do not own local HUD/UI.
+}
+
+void ASkaldAIController::HideMainHUD() {
+  // AI controllers do not own local HUD/UI.
+}
+
+void ASkaldAIController::ShowBattleResultWidget(
+    const FBattleResultDisplayData & /*DisplayData*/) {
+  // AI controllers do not display local battle-result widgets.
+}
+
+void ASkaldAIController::InitializeBattleHUD() {
+  // AI controllers do not create local battle HUD widgets.
+}
+
+void ASkaldAIController::ShowFighterSelectionUI(
+    int32 /*MaxBudget*/, ESkaldFaction /*Faction*/) {
+  // AI controllers do not create local fighter-selection widgets.
+}
+
+void ASkaldAIController::InitializeFighterSelectionIfNeeded() {
+  // AI controllers do not initialize local fighter-selection widgets.
+}
+
 void ASkaldAIController::ShowPrepareForBattlePromptLocal(
     const FPrepareForBattlePromptData &PromptData) {
   // AI controllers never display local widgets. Avoid the base implementation
@@ -3478,4 +3504,3 @@ int32 ASkaldAIController::ChooseRetreatDestination(
              ? CandidateTerritoryIDs[0]
              : BestTerritoryId;
 }
-

--- a/Source/Skald/Skald_AIController.h
+++ b/Source/Skald/Skald_AIController.h
@@ -30,6 +30,14 @@ public:
   virtual void EndTurn() override;
 
   virtual void InitializeHUDWidget() override;
+  virtual void ShowMainHUD() override;
+  virtual void HideMainHUD() override;
+  virtual void ShowBattleResultWidget(
+      const FBattleResultDisplayData &DisplayData) override;
+  virtual void InitializeBattleHUD() override;
+  virtual void ShowFighterSelectionUI(
+      int32 MaxBudget, ESkaldFaction Faction) override;
+  virtual void InitializeFighterSelectionIfNeeded() override;
   virtual void ShowPrepareForBattlePromptLocal(
       const FPrepareForBattlePromptData &PromptData) override;
 
@@ -333,4 +341,3 @@ private:
   /** PlayerState associated with the current animated placement sequence. */
   TWeakObjectPtr<ASkaldPlayerState> AnimatedPlacementPlayerState;
 };
-

--- a/Source/Skald/Skald_PlayerController.cpp
+++ b/Source/Skald/Skald_PlayerController.cpp
@@ -1665,13 +1665,13 @@ void ASkaldPlayerController::InitializeHUDWidget() {
 bool ASkaldPlayerController::CanCreateLocalUIWidget() const {
   ULocalPlayer *LocalPlayer = GetLocalPlayer();
 
-  // During map travel the controller's generic Player pointer can be briefly
-  // re-bound before settling back to the same local player instance. Requiring
-  // strict Player==LocalPlayer equality here can incorrectly suppress widget
-  // creation (HUD, battle HUD, dice overlay) on legitimate local controllers.
-  // Gate by local-controller identity + non-AI ownership instead.
+  // Widgets must only be created by true local, non-AI controllers that are
+  // currently attached to a player object. Avoid requiring strict
+  // Player==LocalPlayer equality because travel/rebinding windows can
+  // temporarily desynchronize those pointers for legitimate local controllers.
   return IsLocalController() && IsLocalPlayerController() &&
-         LocalPlayer != nullptr && !IsAIControllerIdentity(this);
+         LocalPlayer != nullptr && Player != nullptr &&
+         !IsAIControllerIdentity(this);
 }
 
 void ASkaldPlayerController::InitializeChoosePlayerWidget() {
@@ -1965,6 +1965,10 @@ void ASkaldPlayerController::EndPlay(const EEndPlayReason::Type EndPlayReason) {
 }
 
 void ASkaldPlayerController::ShowMainHUD() {
+  if (!CanCreateLocalUIWidget()) {
+    return;
+  }
+
   if (MainHUD) {
     MainHUD->SetVisibility(ESlateVisibility::SelfHitTestInvisible);
   }
@@ -1980,6 +1984,10 @@ void ASkaldPlayerController::ShowMainHUD() {
 }
 
 void ASkaldPlayerController::HideMainHUD() {
+  if (!CanCreateLocalUIWidget()) {
+    return;
+  }
+
   if (MainHUD) {
     MainHUD->SetVisibility(ESlateVisibility::Collapsed);
     UWidgetBlueprintLibrary::SetInputMode_GameOnly(this);
@@ -1989,7 +1997,8 @@ void ASkaldPlayerController::HideMainHUD() {
 
 void ASkaldPlayerController::ShowBattleResultWidget(
     const FBattleResultDisplayData &DisplayData) {
-  if (!CanCreateLocalUIWidget() || !DisplayData.bValid) {
+  if (IsAIControllerIdentity(this) || !Player || !GetLocalPlayer() ||
+      !CanCreateLocalUIWidget() || !DisplayData.bValid) {
     return;
   }
 
@@ -2971,7 +2980,7 @@ void ASkaldPlayerController::Server_CommitArmy_Implementation(
 }
 
 void ASkaldPlayerController::InitializeBattleHUD() {
-  if (!CanCreateLocalUIWidget())
+  if (IsAIControllerIdentity(this) || !Player || !GetLocalPlayer() || !CanCreateLocalUIWidget())
     return;
   if (!BattleHUDWidgetClass)
     return;
@@ -5430,7 +5439,9 @@ void ASkaldPlayerController::HandleReplicatedBattlePayload() {
 }
 
 void ASkaldPlayerController::HandleReplicatedTurnOwnership() {
-  if (!CanCreateLocalUIWidget()) {
+  // Turn-ownership UI updates must never run on controllers without an attached
+  // local player (notably AI controllers in PIE listen-server sessions).
+  if (!Player || !GetLocalPlayer() || IsAIControllerIdentity(this) || !CanCreateLocalUIWidget()) {
     return;
   }
 
@@ -7086,7 +7097,7 @@ void ASkaldPlayerController::ResetPendingReadyPromptState() {
 
 void ASkaldPlayerController::ShowPrepareForBattlePromptLocal(
     const FPrepareForBattlePromptData &PromptData) {
-  if (!CanCreateLocalUIWidget()) {
+  if (IsAIControllerIdentity(this) || !Player || !GetLocalPlayer() || !CanCreateLocalUIWidget()) {
     UE_LOG(LogSkaldReady, Verbose,
            TEXT("Skipping prepare-for-battle prompt for %s: controller has no local player."),
            *GetName());
@@ -7111,7 +7122,7 @@ void ASkaldPlayerController::ShowPrepareForBattlePromptLocal(
 
 void ASkaldPlayerController::ShowPrepareForBattlePromptLocal_Internal(
     const FPrepareForBattlePromptData &PromptData) {
-  if (!CanCreateLocalUIWidget()) {
+  if (IsAIControllerIdentity(this) || !Player || !GetLocalPlayer() || !CanCreateLocalUIWidget()) {
     ResetPendingReadyPromptState();
     return;
   }

--- a/Source/Skald/Skald_PlayerController.h
+++ b/Source/Skald/Skald_PlayerController.h
@@ -240,10 +240,10 @@ public:
   USkaldMainHUDWidget *GetHUDWidget() const { return MainHUD; }
 
   UFUNCTION(BlueprintCallable)
-  void ShowMainHUD();
+  virtual void ShowMainHUD();
 
   UFUNCTION(BlueprintCallable)
-  void HideMainHUD();
+  virtual void HideMainHUD();
 
   UFUNCTION(BlueprintCallable, Category = "UI")
   void ToggleInGameMenu();
@@ -574,7 +574,7 @@ protected:
   /** Tracks whether the cursor was hovering an interactable widget last tick. */
   bool bWasHoveringInteractable = false;
 
-  void ShowBattleResultWidget(const FBattleResultDisplayData &DisplayData);
+  virtual void ShowBattleResultWidget(const FBattleResultDisplayData &DisplayData);
   void ClearBattleResultWidget();
 
   UFUNCTION()
@@ -1006,7 +1006,7 @@ private:
   /** Initialize the player state using lobby selections instead of the legacy widget. */
   void AutoInitializeFromLobbySelection();
 
-  void InitializeBattleHUD();
+  virtual void InitializeBattleHUD();
   void ShowOverworldHUD();
   void HideOverworldHUDForBattle();
   UGridOverlayComponent *FindGridOverlay() const;
@@ -1117,7 +1117,7 @@ private:
   void EnsureBattleHUDVisible();
 
   /** Spawn or refresh the fighter selection UI. */
-  void ShowFighterSelectionUI(int32 MaxBudget, ESkaldFaction Faction);
+  virtual void ShowFighterSelectionUI(int32 MaxBudget, ESkaldFaction Faction);
 
   /** Ensure a valid TurnManager is available, attempting reacquisition if
    * needed. */
@@ -1125,7 +1125,7 @@ private:
 
   /** Create the fighter selection widget if we are on a battle map and it is
    * not already shown. */
-  void InitializeFighterSelectionIfNeeded();
+  virtual void InitializeFighterSelectionIfNeeded();
 
   void CancelCommandMode();
   void HighlightClickedCell(UGridOverlayComponent *Grid, const FIntPoint &Cell);


### PR DESCRIPTION
### Motivation
- Prevent AI controllers from creating or interacting with local UI widgets because AI can be considered local on the server without an attached `LocalPlayer`, which can lead to improper UI spawns or input/state races.
- Make UI creation gating more robust during player travel/rebinding windows by ensuring controllers have a valid `Player` and `LocalPlayer` and by explicitly excluding AI controller identities.

### Description
- Added no-op overrides to `ASkaldAIController` for `ShowMainHUD`, `HideMainHUD`, `ShowBattleResultWidget`, `InitializeBattleHUD`, `ShowFighterSelectionUI`, and `InitializeFighterSelectionIfNeeded` so AI controllers never create or display local UI widgets.
- Hardened `CanCreateLocalUIWidget()` and added null/AI checks in multiple `ASkaldPlayerController` code paths to early-return from UI logic when `Player` or `LocalPlayer` is missing or when `IsAIControllerIdentity(this)` is true.
- Marked several UI-related methods as `virtual` in the player controller header so AI can override them, and updated implementations (e.g. `ShowBattleResultWidget`, `InitializeBattleHUD`, `ShowPrepareForBattlePromptLocal`) to bail out for AI or detached controllers.
- Improved comments and logging around turn/battle UI flows to avoid queuing timers or input changes intended only for human players.

### Testing
- Performed a project build (Editor configuration) after changes and the codebase compiled successfully.
- Executed existing automated tests and unit tests; they completed without failures.
- Performed a runtime smoke test in PIE to verify AI controllers do not spawn HUD/battle/fighter-selection widgets and that prepare-for-battle prompts are skipped for AI, with observed behavior matching expectations.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f60b171fc8832488ee94709c9bd46d)