### PR TITLE
Fix fighter-selection cursor/input mode and ensure battle HUD appears after lock-in

### DIFF
--- a/Source/Skald/Skald_PlayerController.cpp
+++ b/Source/Skald/Skald_PlayerController.cpp
@@ -2920,6 +2920,13 @@ void ASkaldPlayerController::HandleBattlePhaseChanged() {
              TEXT("PlayerController %s entering Deploy phase; fighters will be"
                   " spawned automatically."),
              *GetName());
+
+      if (bBattleHUDReadyToShow && !bBattleHUDVisible) {
+        EnsureBattleHUDVisible();
+      }
+    } else if (SGS->BattlePhase != EBattlePhase::FighterSelection &&
+               bBattleHUDReadyToShow && !bBattleHUDVisible) {
+      EnsureBattleHUDVisible();
     }
   }
 }

--- a/Source/Skald/UI/SkaldUIHelpers.h
+++ b/Source/Skald/UI/SkaldUIHelpers.h
@@ -16,7 +16,9 @@ static inline void FocusWidgetUIOnly(APlayerController *PC, UUserWidget *Widget)
   Widget->SetIsFocusable(true);
   Widget->SetFocus();
 
-  UWidgetBlueprintLibrary::SetInputMode_UIOnlyEx(
+  // Use Game+UI input while focusing modal widgets so the OS cursor remains
+  // visible/interactive even when the viewport previously captured the mouse.
+  UWidgetBlueprintLibrary::SetInputMode_GameAndUIEx(
       PC, Widget, EMouseLockMode::DoNotLock, false);
   PC->bShowMouseCursor = true;
 }


### PR DESCRIPTION
### Motivation
- Players opening the fighter-selection widget after travel could not see or interact with the OS cursor because the input mode used UI-only capture. 
- After locking in fighters some clients reached the battle map with no visible player HUD, preventing the player from participating.

### Description
- Replaced `UWidgetBlueprintLibrary::SetInputMode_UIOnlyEx` with `UWidgetBlueprintLibrary::SetInputMode_GameAndUIEx` in `FocusWidgetUIOnly` (`Source/Skald/UI/SkaldUIHelpers.h`) so modal widgets keep the OS cursor visible and interactive while the game viewport may have been capturing the mouse. 
- Updated `ASkaldPlayerController::HandleBattlePhaseChanged` (`Source/Skald/Skald_PlayerController.cpp`) to proactively call `EnsureBattleHUDVisible()` when `bBattleHUDReadyToShow` is set and the HUD is not yet visible once the game leaves fighter-selection (including the `Deploy` and other non-selection phases). 
- Preserved existing local-player ownership checks and AI guardrails while adjusting input-mode and HUD handoff timing.

### Testing
- Ran repository verification commands (`rg`/`sed`) to confirm the modified symbols and references were updated and inspected the `git` diff and commit, and those commands completed successfully. 
- No automated unit or integration tests for the UI flow were present or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f64920367883249116a790941b0dd9)