### PR TITLE
Reset battle participants, ensure battle HUD visibility, and use Game+UI input mode

### DIFF
--- a/Source/Skald/Skald_BattleGameMode.cpp
+++ b/Source/Skald/Skald_BattleGameMode.cpp
@@ -903,6 +903,13 @@ void ASkald_BattleGameMode::BeginPreBattleSelection(ASkaldPlayerState *AttackerP
   if (!HasAuthority()) {
     return;
   }
+  if (ASkaldGameState *GS = GetGameState<ASkaldGameState>()) {
+    // Battle participants can carry over stale entries across travel/setup
+    // retries in PIE. Start each pre-battle selection with a clean roster so
+    // attacker/defender lock-in and turn ownership are keyed to the current
+    // payload only.
+    GS->ResetBattleParticipants();
+  }
   NormalizeSinglePlayerControllerRoles(GetWorld(),
                                        GetGameInstance<USkaldGameInstance>());
 

--- a/Source/Skald/Skald_PlayerController.cpp
+++ b/Source/Skald/Skald_PlayerController.cpp
@@ -2920,6 +2920,13 @@ void ASkaldPlayerController::HandleBattlePhaseChanged() {
              TEXT("PlayerController %s entering Deploy phase; fighters will be"
                   " spawned automatically."),
              *GetName());
+
+      if (bBattleHUDReadyToShow && !bBattleHUDVisible) {
+        EnsureBattleHUDVisible();
+      }
+    } else if (SGS->BattlePhase != EBattlePhase::FighterSelection &&
+               bBattleHUDReadyToShow && !bBattleHUDVisible) {
+      EnsureBattleHUDVisible();
     }
   }
 }

--- a/Source/Skald/UI/SkaldUIHelpers.h
+++ b/Source/Skald/UI/SkaldUIHelpers.h
@@ -16,7 +16,9 @@ static inline void FocusWidgetUIOnly(APlayerController *PC, UUserWidget *Widget)
   Widget->SetIsFocusable(true);
   Widget->SetFocus();
 
-  UWidgetBlueprintLibrary::SetInputMode_UIOnlyEx(
+  // Use Game+UI input while focusing modal widgets so the OS cursor remains
+  // visible/interactive even when the viewport previously captured the mouse.
+  UWidgetBlueprintLibrary::SetInputMode_GameAndUIEx(
       PC, Widget, EMouseLockMode::DoNotLock, false);
   PC->bShowMouseCursor = true;
 }


### PR DESCRIPTION
### Motivation

- Prevent stale battle participant entries from persisting across PIE travel/setup retries so pre-battle roles and turn ownership reflect the current payload only.
- Ensure the battle HUD is shown when entering the Deploy phase or whenever the HUD is ready but not visible so clients don't miss the battle UI.
- Keep the OS cursor visible and interactive for modal UI widgets by using a Game+UI input mode instead of UI-only.

### Description

- Call `GS->ResetBattleParticipants()` in `ASkald_BattleGameMode::BeginPreBattleSelection` when authoritative to clear any stale roster entries before selection begins.
- In `ASkaldPlayerController::HandleBattlePhaseChanged`, call `EnsureBattleHUDVisible()` when entering the `Deploy` phase and also when the phase is not `FighterSelection` but the HUD is ready and still hidden to guarantee HUD visibility.
- Replace `UWidgetBlueprintLibrary::SetInputMode_UIOnlyEx` with `SetInputMode_GameAndUIEx` in `SkaldUIHelpers.h` and add a comment explaining the change so the OS cursor remains visible/interactive for modal widgets.

### Testing

- Performed a full project build (editor and game modules) which succeeded.
- Ran automated tests exercising battle flow and UI visibility; the relevant tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f64920367883249116a790941b0dd9)