### PR TITLE
Battle UI/input fixes, HUD visibility handling, and fighter widget binding cleanup

### DIFF
--- a/Source/Skald/Skald_BattleGameMode.cpp
+++ b/Source/Skald/Skald_BattleGameMode.cpp
@@ -903,6 +903,13 @@ void ASkald_BattleGameMode::BeginPreBattleSelection(ASkaldPlayerState *AttackerP
   if (!HasAuthority()) {
     return;
   }
+  if (ASkaldGameState *GS = GetGameState<ASkaldGameState>()) {
+    // Battle participants can carry over stale entries across travel/setup
+    // retries in PIE. Start each pre-battle selection with a clean roster so
+    // attacker/defender lock-in and turn ownership are keyed to the current
+    // payload only.
+    GS->ResetBattleParticipants();
+  }
   NormalizeSinglePlayerControllerRoles(GetWorld(),
                                        GetGameInstance<USkaldGameInstance>());
 

--- a/Source/Skald/Skald_PlayerController.cpp
+++ b/Source/Skald/Skald_PlayerController.cpp
@@ -2782,10 +2782,15 @@ void ASkaldPlayerController::ShowFighterSelectionUI(int32 MaxBudget,
   FighterSelectionWidget->UpdateCostDisplay();
 
   FighterSelectionWidget->AddToViewport(30);
-  FocusWidgetUIOnly(this, FighterSelectionWidget);
+  FighterSelectionWidget->SetIsFocusable(true);
+  FighterSelectionWidget->SetFocus();
+  UWidgetBlueprintLibrary::SetInputMode_GameAndUIEx(
+      this, FighterSelectionWidget, EMouseLockMode::DoNotLock,
+      /*bHideCursorDuringCapture*/ false);
   bShowMouseCursor = true;
   bEnableClickEvents = true;
   bEnableMouseOverEvents = true;
+  DefaultMouseCaptureMode = EMouseCaptureMode::NoCapture;
 
   UE_LOG(LogSkaldBattle, Log,
          TEXT("ShowFighterSelectionUI: Controller=%s PlayerId=%d Budget=%d Faction=%d"),
@@ -2920,6 +2925,13 @@ void ASkaldPlayerController::HandleBattlePhaseChanged() {
              TEXT("PlayerController %s entering Deploy phase; fighters will be"
                   " spawned automatically."),
              *GetName());
+
+      if (bBattleHUDReadyToShow && !bBattleHUDVisible) {
+        EnsureBattleHUDVisible();
+      }
+    } else if (SGS->BattlePhase != EBattlePhase::FighterSelection &&
+               bBattleHUDReadyToShow && !bBattleHUDVisible) {
+      EnsureBattleHUDVisible();
     }
   }
 }
@@ -5461,8 +5473,12 @@ void ASkaldPlayerController::HandleReplicatedTurnOwnership() {
                                        : ETurnPhase::Reinforcement;
   const EBattlePhase BattlePhase =
       CachedGameState ? CachedGameState->BattlePhase : EBattlePhase::None;
+  const bool bBattleTravelPending =
+      CachedGameInstance &&
+      (CachedGameInstance->IsTravelPending() ||
+       CachedGameInstance->HasPendingBattleTravelContext());
   const bool bInBattleInputFlow =
-      bIsBattleMap || BattlePhase != EBattlePhase::None;
+      bIsBattleMap || BattlePhase != EBattlePhase::None || bBattleTravelPending;
   UE_LOG(LogSkald, Log,
          TEXT("[TurnState] Controller %s turn ownership check: Phase=%s ActiveId=%d IsMyTurn=%s LocalTurnActive=%s"),
          *GetName(), *UEnum::GetValueAsString(Phase),
@@ -7152,10 +7168,11 @@ void ASkaldPlayerController::ShowPrepareForBattlePromptLocal_Internal(
     }
 
     MainHUD->ShowPrepareForBattleDialog(PromptData);
+    bPendingReadyPrompt = true;
+    PendingReadyPrompt = PromptData;
     UE_LOG(LogSkaldReady, Verbose,
            TEXT("Displayed prepare-for-battle prompt for %s immediately."),
            *GetName());
-    ResetPendingReadyPromptState();
     return;
   }
 

--- a/Source/Skald/UI/LockedInFighterEntryWidget.cpp
+++ b/Source/Skald/UI/LockedInFighterEntryWidget.cpp
@@ -16,14 +16,20 @@ void ULockedInFighterEntryWidget::NativeConstruct() {
   Super::NativeConstruct();
 
   if (ClickButton) {
-    ClickButton->OnClicked.AddDynamic(this,
-                                      &ULockedInFighterEntryWidget::HandleEntryButtonClicked);
+    ClickButton->OnClicked.RemoveDynamic(
+        this, &ULockedInFighterEntryWidget::HandleEntryButtonClicked);
+    ClickButton->OnClicked.AddDynamic(
+        this, &ULockedInFighterEntryWidget::HandleEntryButtonClicked);
   }
 
   ApplyVisualState();
 }
 
 void ULockedInFighterEntryWidget::NativeDestruct() {
+  if (ClickButton) {
+    ClickButton->OnClicked.RemoveDynamic(
+        this, &ULockedInFighterEntryWidget::HandleEntryButtonClicked);
+  }
   ResetEntry();
   Super::NativeDestruct();
 }
@@ -238,4 +244,3 @@ void ULockedInFighterEntryWidget::BroadcastEntryClicked() {
     OnEntryClicked.Broadcast(Fighter);
   }
 }
-


### PR DESCRIPTION
### Motivation

- Prevent stale battle participant entries from carrying over across travel/setup retries in PIE by starting pre-battle selection with a clean roster. 
- Ensure fighter selection UI properly captures focus and sets input/cursor state for local players so selection is reliably interactive. 
- Make battle HUD visibility and turn-input logic robust across phase transitions and travel events so local controllers regain correct control. 
- Avoid duplicate event bindings on locked-in fighter entry widgets and ensure handlers are removed on destruct.

### Description

- Added a call to `GS->ResetBattleParticipants()` at the start of `BeginPreBattleSelection` to clear stale roster entries. 
- Reworked `ShowFighterSelectionUI` to explicitly set focus and input mode using `SetIsFocusable`, `SetFocus`, and `UWidgetBlueprintLibrary::SetInputMode_GameAndUIEx`, and set `DefaultMouseCaptureMode = EMouseCaptureMode::NoCapture` while enabling mouse cursor and click/hover events. 
- Updated phase transition handling to call `EnsureBattleHUDVisible()` when entering `Deploy` or when the HUD is ready but not visible, and added `bBattleTravelPending` (based on `CachedGameInstance->IsTravelPending()` / `HasPendingBattleTravelContext()`) into the battle input-flow check. 
- Adjusted `ShowPrepareForBattlePromptLocal_Internal` to cache `PendingReadyPrompt` and set `bPendingReadyPrompt = true` when the HUD is shown, rather than immediately resetting the cached prompt. 
- Fixed event binding in `ULockedInFighterEntryWidget` by removing any existing `OnClicked` dynamic binding before adding, and removing the binding in `NativeDestruct`, preventing duplicate handlers and leaks.

### Testing

- Built the project in the Unreal toolchain (Development configuration) successfully with the changes. 
- Exercised fighter selection and HUD transitions in Play-In-Editor (PIE) sessions to verify focus, input mode, cursor behavior, and HUD visibility. 
- Ran the existing automated test suite and verified no regressions in the tested areas.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f64920367883249116a790941b0dd9)