### PR TITLE
Sync/selection fixes: participant ID handling, HUD/input focus, and widget binding cleanup

### DIFF
--- a/Source/Skald/Skald_BattleGameMode.cpp
+++ b/Source/Skald/Skald_BattleGameMode.cpp
@@ -74,14 +74,14 @@ static int32 ResolveBattlePlayerId(const ASkaldPlayerState *PlayerState) {
     return INDEX_NONE;
   }
 
-  const int32 StableId = PlayerState->GetStablePlayerId();
-  if (StableId > 0) {
-    return StableId;
-  }
-
   const int32 AuthoritativeId = PlayerState->GetAuthoritativePlayerId();
   if (AuthoritativeId > 0) {
     return AuthoritativeId;
+  }
+
+  const int32 StableId = PlayerState->GetStablePlayerId();
+  if (StableId > 0) {
+    return StableId;
   }
 
   return INDEX_NONE;
@@ -892,6 +892,17 @@ void ASkald_BattleGameMode::SyncBattlePlayerEntry(ASkaldPlayerState *PlayerState
          Entry.PlayerId, *Entry.DisplayName, static_cast<int32>(Entry.Faction),
          Entry.PendingArmyBudget, Entry.bIsAI ? TEXT("true") : TEXT("false"));
 
+  const FS_BattlePayload ActiveBattle = GS->GetActiveBattlePayload();
+  if (ActiveBattle.AttackerPlayerID > 0 && ActiveBattle.DefenderPlayerID > 0 &&
+      Entry.PlayerId > 0 &&
+      Entry.PlayerId != ActiveBattle.AttackerPlayerID &&
+      Entry.PlayerId != ActiveBattle.DefenderPlayerID) {
+    UE_LOG(LogSkaldBattle, Warning,
+           TEXT("Battle participant ID mismatch: SyncBattlePlayerEntry resolved PlayerId=%d (%s) but active payload expects Attacker=%d Defender=%d. This can desync fighter-selection/HUD ownership."),
+           Entry.PlayerId, *Entry.DisplayName, ActiveBattle.AttackerPlayerID,
+           ActiveBattle.DefenderPlayerID);
+  }
+
   GS->UpsertBattleEntry(Entry);
 }
 
@@ -902,6 +913,13 @@ void ASkald_BattleGameMode::BeginPreBattleSelection(ASkaldPlayerState *AttackerP
 {
   if (!HasAuthority()) {
     return;
+  }
+  if (ASkaldGameState *GS = GetGameState<ASkaldGameState>()) {
+    // Battle participants can carry over stale entries across travel/setup
+    // retries in PIE. Start each pre-battle selection with a clean roster so
+    // attacker/defender lock-in and turn ownership are keyed to the current
+    // payload only.
+    GS->ResetBattleParticipants();
   }
   NormalizeSinglePlayerControllerRoles(GetWorld(),
                                        GetGameInstance<USkaldGameInstance>());

--- a/Source/Skald/Skald_PlayerController.cpp
+++ b/Source/Skald/Skald_PlayerController.cpp
@@ -2782,10 +2782,15 @@ void ASkaldPlayerController::ShowFighterSelectionUI(int32 MaxBudget,
   FighterSelectionWidget->UpdateCostDisplay();
 
   FighterSelectionWidget->AddToViewport(30);
-  FocusWidgetUIOnly(this, FighterSelectionWidget);
+  FighterSelectionWidget->SetIsFocusable(true);
+  FighterSelectionWidget->SetFocus();
+  UWidgetBlueprintLibrary::SetInputMode_GameAndUIEx(
+      this, FighterSelectionWidget, EMouseLockMode::DoNotLock,
+      /*bHideCursorDuringCapture*/ false);
   bShowMouseCursor = true;
   bEnableClickEvents = true;
   bEnableMouseOverEvents = true;
+  DefaultMouseCaptureMode = EMouseCaptureMode::NoCapture;
 
   UE_LOG(LogSkaldBattle, Log,
          TEXT("ShowFighterSelectionUI: Controller=%s PlayerId=%d Budget=%d Faction=%d"),
@@ -2920,6 +2925,13 @@ void ASkaldPlayerController::HandleBattlePhaseChanged() {
              TEXT("PlayerController %s entering Deploy phase; fighters will be"
                   " spawned automatically."),
              *GetName());
+
+      if (bBattleHUDReadyToShow && !bBattleHUDVisible) {
+        EnsureBattleHUDVisible();
+      }
+    } else if (SGS->BattlePhase != EBattlePhase::FighterSelection &&
+               bBattleHUDReadyToShow && !bBattleHUDVisible) {
+      EnsureBattleHUDVisible();
     }
   }
 }
@@ -5461,8 +5473,12 @@ void ASkaldPlayerController::HandleReplicatedTurnOwnership() {
                                        : ETurnPhase::Reinforcement;
   const EBattlePhase BattlePhase =
       CachedGameState ? CachedGameState->BattlePhase : EBattlePhase::None;
+  const bool bBattleTravelPending =
+      CachedGameInstance &&
+      (CachedGameInstance->IsTravelPending() ||
+       CachedGameInstance->HasPendingBattleTravelContext());
   const bool bInBattleInputFlow =
-      bIsBattleMap || BattlePhase != EBattlePhase::None;
+      bIsBattleMap || BattlePhase != EBattlePhase::None || bBattleTravelPending;
   UE_LOG(LogSkald, Log,
          TEXT("[TurnState] Controller %s turn ownership check: Phase=%s ActiveId=%d IsMyTurn=%s LocalTurnActive=%s"),
          *GetName(), *UEnum::GetValueAsString(Phase),
@@ -7152,10 +7168,11 @@ void ASkaldPlayerController::ShowPrepareForBattlePromptLocal_Internal(
     }
 
     MainHUD->ShowPrepareForBattleDialog(PromptData);
+    bPendingReadyPrompt = true;
+    PendingReadyPrompt = PromptData;
     UE_LOG(LogSkaldReady, Verbose,
            TEXT("Displayed prepare-for-battle prompt for %s immediately."),
            *GetName());
-    ResetPendingReadyPromptState();
     return;
   }
 

--- a/Source/Skald/UI/LockedInFighterEntryWidget.cpp
+++ b/Source/Skald/UI/LockedInFighterEntryWidget.cpp
@@ -16,14 +16,20 @@ void ULockedInFighterEntryWidget::NativeConstruct() {
   Super::NativeConstruct();
 
   if (ClickButton) {
-    ClickButton->OnClicked.AddDynamic(this,
-                                      &ULockedInFighterEntryWidget::HandleEntryButtonClicked);
+    ClickButton->OnClicked.RemoveDynamic(
+        this, &ULockedInFighterEntryWidget::HandleEntryButtonClicked);
+    ClickButton->OnClicked.AddDynamic(
+        this, &ULockedInFighterEntryWidget::HandleEntryButtonClicked);
   }
 
   ApplyVisualState();
 }
 
 void ULockedInFighterEntryWidget::NativeDestruct() {
+  if (ClickButton) {
+    ClickButton->OnClicked.RemoveDynamic(
+        this, &ULockedInFighterEntryWidget::HandleEntryButtonClicked);
+  }
   ResetEntry();
   Super::NativeDestruct();
 }
@@ -238,4 +244,3 @@ void ULockedInFighterEntryWidget::BroadcastEntryClicked() {
     OnEntryClicked.Broadcast(Fighter);
   }
 }
-


### PR DESCRIPTION
### Motivation
- Ensure battle participant resolution and synchronization are robust against stale IDs and travel/setup retries.
- Prevent input mode/cursor theft and ensure HUD visibility during fighter selection, deployment, and travel transitions.
- Avoid duplicate widget event bindings and dangling delegates for locked-in fighter entries.

### Description
- Change `ResolveBattlePlayerId` to prefer the authoritative player ID before falling back to the stable ID.
- Add a warning in `SyncBattlePlayerEntry` when the resolved player ID doesn't match the active battle payload attacker/defender IDs.
- Clear stale roster entries at the start of `BeginPreBattleSelection` by calling `GS->ResetBattleParticipants()`.
- Update `ShowFighterSelectionUI` to explicitly focus the widget, use `SetInputMode_GameAndUIEx`, show the mouse cursor, and set `DefaultMouseCaptureMode = EMouseCaptureMode::NoCapture` instead of `FocusWidgetUIOnly`.
- Ensure the battle HUD is shown when entering `Deploy` or other phases if ready, and treat outstanding travel/battle-travel contexts as part of the in-battle input flow to avoid overworld input logic stealing focus.
- Preserve and cache the prepare-for-battle prompt state (`bPendingReadyPrompt`/`PendingReadyPrompt`) when the HUD is available so the prompt lifecycle is managed consistently.
- Prevent duplicate click bindings in `ULockedInFighterEntryWidget::NativeConstruct` by removing existing dynamic bindings before adding, and remove the binding in `NativeDestruct`.

### Testing
- Project built successfully using the Unreal build pipeline (compilation succeeded).
- Existing automated CI/unit tests were run and completed without failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f64920367883249116a790941b0dd9)