### PR TITLE
Battle & UI fixes: player ID resolution, travel/territory handling, HUD/input improvements

### DIFF
--- a/Source/Skald/Skald_BattleGameMode.cpp
+++ b/Source/Skald/Skald_BattleGameMode.cpp
@@ -74,14 +74,14 @@ static int32 ResolveBattlePlayerId(const ASkaldPlayerState *PlayerState) {
     return INDEX_NONE;
   }
 
-  const int32 StableId = PlayerState->GetStablePlayerId();
-  if (StableId > 0) {
-    return StableId;
-  }
-
   const int32 AuthoritativeId = PlayerState->GetAuthoritativePlayerId();
   if (AuthoritativeId > 0) {
     return AuthoritativeId;
+  }
+
+  const int32 StableId = PlayerState->GetStablePlayerId();
+  if (StableId > 0) {
+    return StableId;
   }
 
   return INDEX_NONE;
@@ -892,6 +892,52 @@ void ASkald_BattleGameMode::SyncBattlePlayerEntry(ASkaldPlayerState *PlayerState
          Entry.PlayerId, *Entry.DisplayName, static_cast<int32>(Entry.Faction),
          Entry.PendingArmyBudget, Entry.bIsAI ? TEXT("true") : TEXT("false"));
 
+  const FS_BattlePayload ActiveBattle = GS->GetActiveBattlePayload();
+  if (ActiveBattle.AttackerPlayerID > 0 && ActiveBattle.DefenderPlayerID > 0 &&
+      Entry.PlayerId > 0 &&
+      Entry.PlayerId != ActiveBattle.AttackerPlayerID &&
+      Entry.PlayerId != ActiveBattle.DefenderPlayerID) {
+    int32 CanonicalId = INDEX_NONE;
+    for (const FBattlePlayerEntry &ExistingEntry : GS->BattleParticipants) {
+      const bool bNameMatches = ExistingEntry.DisplayName.Equals(
+          Entry.DisplayName, ESearchCase::CaseSensitive);
+      const bool bIsExpectedId =
+          ExistingEntry.PlayerId == ActiveBattle.AttackerPlayerID ||
+          ExistingEntry.PlayerId == ActiveBattle.DefenderPlayerID;
+      if (bNameMatches && bIsExpectedId) {
+        CanonicalId = ExistingEntry.PlayerId;
+        break;
+      }
+    }
+
+    if (CanonicalId <= 0) {
+      if (!ActiveBattle.AttackerDisplayName.IsEmpty() &&
+          ActiveBattle.AttackerDisplayName.Equals(Entry.DisplayName,
+                                                  ESearchCase::CaseSensitive)) {
+        CanonicalId = ActiveBattle.AttackerPlayerID;
+      } else if (!ActiveBattle.DefenderDisplayName.IsEmpty() &&
+                 ActiveBattle.DefenderDisplayName.Equals(
+                     Entry.DisplayName, ESearchCase::CaseSensitive)) {
+        CanonicalId = ActiveBattle.DefenderPlayerID;
+      }
+    }
+
+    if (CanonicalId > 0 && CanonicalId != Entry.PlayerId) {
+      UE_LOG(LogSkaldBattle, Warning,
+             TEXT("Battle participant ID remap: SyncBattlePlayerEntry resolved PlayerId=%d (%s), remapping to canonical payload-linked id %d."),
+             Entry.PlayerId, *Entry.DisplayName, CanonicalId);
+      Entry.PlayerId = CanonicalId;
+    }
+
+    if (Entry.PlayerId != ActiveBattle.AttackerPlayerID &&
+        Entry.PlayerId != ActiveBattle.DefenderPlayerID) {
+      UE_LOG(LogSkaldBattle, Warning,
+             TEXT("Battle participant ID mismatch: SyncBattlePlayerEntry resolved PlayerId=%d (%s) but active payload expects Attacker=%d Defender=%d. This can desync fighter-selection/HUD ownership."),
+             Entry.PlayerId, *Entry.DisplayName, ActiveBattle.AttackerPlayerID,
+             ActiveBattle.DefenderPlayerID);
+    }
+  }
+
   GS->UpsertBattleEntry(Entry);
 }
 
@@ -902,6 +948,13 @@ void ASkald_BattleGameMode::BeginPreBattleSelection(ASkaldPlayerState *AttackerP
 {
   if (!HasAuthority()) {
     return;
+  }
+  if (ASkaldGameState *GS = GetGameState<ASkaldGameState>()) {
+    // Battle participants can carry over stale entries across travel/setup
+    // retries in PIE. Start each pre-battle selection with a clean roster so
+    // attacker/defender lock-in and turn ownership are keyed to the current
+    // payload only.
+    GS->ResetBattleParticipants();
   }
   NormalizeSinglePlayerControllerRoles(GetWorld(),
                                        GetGameInstance<USkaldGameInstance>());
@@ -1335,6 +1388,10 @@ void ASkald_BattleGameMode::SetupPendingBattle() {
 
   LockedInPlayers.Reset();
 
+  if (ASkaldGameState *SyncGS = GetGameState<ASkaldGameState>()) {
+    SyncGS->SetActiveBattlePayload(Battle);
+  }
+
   BeginPreBattleSelection(AttackerPS, DefenderPS, AttackerBudget, DefenderBudget);
   UE_LOG(LogSkaldBattle, Log,
          TEXT("BattleGM: BeginPreBattleSelection started (AttackerID=%d DefenderID=%d Budgets=%d/%d)"),
@@ -1344,10 +1401,6 @@ void ASkald_BattleGameMode::SetupPendingBattle() {
   UE_LOG(LogSkaldBattle, Log,
          TEXT("BattleGM: Battle phase advancing to FighterSelection (NetMode=%d)"),
          static_cast<int32>(GetNetMode()));
-
-  if (ASkaldGameState *SyncGS = GetGameState<ASkaldGameState>()) {
-    SyncGS->SetActiveBattlePayload(Battle);
-  }
 
   SyncBattlePlayerEntry(AttackerPS);
   SyncBattlePlayerEntry(DefenderPS);

--- a/Source/Skald/Skald_GameInstance.cpp
+++ b/Source/Skald/Skald_GameInstance.cpp
@@ -236,6 +236,11 @@ USkaldGameInstance::GetFactionEmblem(ESkaldFaction InFaction) const {
 void USkaldGameInstance::SetTravelState(const FSkaldTravelState &InState) {
   TravelState = InState;
   TravelState.bValid = true;
+  if (TravelState.CachedTerritories.Num() == 0 &&
+      CachedWorldMapTerritories.Num() > 0) {
+    TravelState.CachedTerritories = CachedWorldMapTerritories;
+  }
+
   if (TravelState.CachedTerritories.Num() > 0) {
     CachedWorldMapTerritories = TravelState.CachedTerritories;
     PendingTravelTerritories = TravelState.CachedTerritories;
@@ -248,7 +253,9 @@ void USkaldGameInstance::SetTravelState(const FSkaldTravelState &InState) {
          TravelState.DefenderPlayerId, TravelState.AttackerArmyBudget,
          TravelState.DefenderArmyBudget);
 
-  if (TravelState.CachedTerritories.Num() == 0) {
+  const bool bHasBattleTerritoryContext =
+      TravelState.AttackerTerritory > 0 || TravelState.DefenderTerritory > 0;
+  if (TravelState.CachedTerritories.Num() == 0 && bHasBattleTerritoryContext) {
     UE_LOG(LogSkald, Warning,
            TEXT("GameInstance travel state missing cached territories snapshot"));
   }

--- a/Source/Skald/Skald_PlayerController.cpp
+++ b/Source/Skald/Skald_PlayerController.cpp
@@ -2782,10 +2782,15 @@ void ASkaldPlayerController::ShowFighterSelectionUI(int32 MaxBudget,
   FighterSelectionWidget->UpdateCostDisplay();
 
   FighterSelectionWidget->AddToViewport(30);
-  FocusWidgetUIOnly(this, FighterSelectionWidget);
+  FighterSelectionWidget->SetIsFocusable(true);
+  FighterSelectionWidget->SetFocus();
+  UWidgetBlueprintLibrary::SetInputMode_GameAndUIEx(
+      this, FighterSelectionWidget, EMouseLockMode::DoNotLock,
+      /*bHideCursorDuringCapture*/ false);
   bShowMouseCursor = true;
   bEnableClickEvents = true;
   bEnableMouseOverEvents = true;
+  DefaultMouseCaptureMode = EMouseCaptureMode::NoCapture;
 
   UE_LOG(LogSkaldBattle, Log,
          TEXT("ShowFighterSelectionUI: Controller=%s PlayerId=%d Budget=%d Faction=%d"),
@@ -2920,6 +2925,13 @@ void ASkaldPlayerController::HandleBattlePhaseChanged() {
              TEXT("PlayerController %s entering Deploy phase; fighters will be"
                   " spawned automatically."),
              *GetName());
+
+      if (bBattleHUDReadyToShow && !bBattleHUDVisible) {
+        EnsureBattleHUDVisible();
+      }
+    } else if (SGS->BattlePhase != EBattlePhase::FighterSelection &&
+               bBattleHUDReadyToShow && !bBattleHUDVisible) {
+      EnsureBattleHUDVisible();
     }
   }
 }
@@ -4721,6 +4733,13 @@ void ASkaldPlayerController::ServerSelectTerritory_Implementation(
     return;
   }
 
+  if (PS->GetSelectedTerritory() == Territory) {
+    UE_LOG(LogSkald, Verbose,
+           TEXT("ServerSelectTerritory ignoring duplicate selection of %s for player %s (id %d)."),
+           *TerrDesc, *GetName(), SelectingPlayerId);
+    return;
+  }
+
   PS->SetSelectedTerritory(Territory);
   UE_LOG(LogSkald, Log,
          TEXT("ServerSelectTerritory applied selection of %s for player %s (StableId=%d)"),
@@ -5461,12 +5480,20 @@ void ASkaldPlayerController::HandleReplicatedTurnOwnership() {
                                        : ETurnPhase::Reinforcement;
   const EBattlePhase BattlePhase =
       CachedGameState ? CachedGameState->BattlePhase : EBattlePhase::None;
+  const bool bBattleTravelPending =
+      CachedGameInstance &&
+      (CachedGameInstance->IsTravelPending() ||
+       CachedGameInstance->HasPendingBattleTravelContext());
   const bool bInBattleInputFlow =
-      bIsBattleMap || BattlePhase != EBattlePhase::None;
+      bIsBattleMap || BattlePhase != EBattlePhase::None || bBattleTravelPending;
+  int32 ReportedActiveId = CachedGameState ? CachedGameState->ActivePlayerId : INDEX_NONE;
+  if (ReportedActiveId == INDEX_NONE && TurnManager) {
+    ReportedActiveId = TurnManager->GetActivePlayerId();
+  }
+
   UE_LOG(LogSkald, Log,
          TEXT("[TurnState] Controller %s turn ownership check: Phase=%s ActiveId=%d IsMyTurn=%s LocalTurnActive=%s"),
-         *GetName(), *UEnum::GetValueAsString(Phase),
-         CachedGameState ? CachedGameState->ActivePlayerId : INDEX_NONE,
+         *GetName(), *UEnum::GetValueAsString(Phase), ReportedActiveId,
          bIsMyTurn ? TEXT("true") : TEXT("false"),
          bLocalTurnActive ? TEXT("true") : TEXT("false"));
 
@@ -5511,16 +5538,20 @@ void ASkaldPlayerController::HandleReplicatedTurnOwnership() {
     }
 
     if (bNeedsBattlePrepUI) {
-      UWidgetBlueprintLibrary::SetInputMode_GameAndUIEx(
-          this, nullptr, EMouseLockMode::DoNotLock,
-          /*bHideCursorDuringCapture*/ false);
+      if (!bShowMouseCursor || !bEnableClickEvents || !bEnableMouseOverEvents) {
+        UWidgetBlueprintLibrary::SetInputMode_GameAndUIEx(
+            this, nullptr, EMouseLockMode::DoNotLock,
+            /*bHideCursorDuringCapture*/ false);
+      }
       bShowMouseCursor = true;
       bEnableClickEvents = true;
       bEnableMouseOverEvents = true;
     } else {
       // Ensure non-active players fully release world input and phase buttons
       // instead of inheriting the host's UI state.
-      UWidgetBlueprintLibrary::SetInputMode_GameOnly(this);
+      if (bShowMouseCursor || bEnableClickEvents || bEnableMouseOverEvents) {
+        UWidgetBlueprintLibrary::SetInputMode_GameOnly(this);
+      }
       bShowMouseCursor = false;
       bEnableClickEvents = false;
       bEnableMouseOverEvents = false;
@@ -7152,10 +7183,11 @@ void ASkaldPlayerController::ShowPrepareForBattlePromptLocal_Internal(
     }
 
     MainHUD->ShowPrepareForBattleDialog(PromptData);
+    bPendingReadyPrompt = true;
+    PendingReadyPrompt = PromptData;
     UE_LOG(LogSkaldReady, Verbose,
            TEXT("Displayed prepare-for-battle prompt for %s immediately."),
            *GetName());
-    ResetPendingReadyPromptState();
     return;
   }
 
@@ -9285,6 +9317,11 @@ int32 ASkaldPlayerController::ResolveStablePlayerId(
     const ASkaldPlayerState *InPlayerState) const {
   if (!InPlayerState) {
     return static_cast<int32>(INDEX_NONE);
+  }
+
+  const int32 AuthoritativeId = InPlayerState->GetAuthoritativePlayerId();
+  if (AuthoritativeId > 0) {
+    return AuthoritativeId;
   }
 
   return InPlayerState->GetStablePlayerId();

--- a/Source/Skald/Skald_TurnManager.cpp
+++ b/Source/Skald/Skald_TurnManager.cpp
@@ -2472,13 +2472,19 @@ void ATurnManager::TriggerGridBattle(const FS_BattlePayload &Battle) {
     ASkaldGameState *GS = World->GetGameState<ASkaldGameState>();
 
     FSkaldTravelState TravelState;
-    int32 ValidControllers = 0;
+    int32 ValidHumanControllers = 0;
     for (const TWeakObjectPtr<ASkaldPlayerController> &Ptr : Controllers) {
-      if (Ptr.IsValid()) {
-        ++ValidControllers;
+      if (!Ptr.IsValid()) {
+        continue;
+      }
+
+      const ASkaldPlayerState *ControllerPS =
+          Ptr->GetPlayerState<ASkaldPlayerState>();
+      if (!ControllerPS || !ControllerPS->bIsAI) {
+        ++ValidHumanControllers;
       }
     }
-    TravelState.ExpectedControllers = ValidControllers;
+    TravelState.ExpectedControllers = FMath::Max(1, ValidHumanControllers);
     TravelState.AttackerTerritory = SeededBattle.FromTerritoryID;
     TravelState.DefenderTerritory = SeededBattle.TargetTerritoryID;
     TravelState.AttackerPlayerId = SeededBattle.AttackerPlayerID;

--- a/Source/Skald/UI/LockedInFighterEntryWidget.cpp
+++ b/Source/Skald/UI/LockedInFighterEntryWidget.cpp
@@ -16,14 +16,20 @@ void ULockedInFighterEntryWidget::NativeConstruct() {
   Super::NativeConstruct();
 
   if (ClickButton) {
-    ClickButton->OnClicked.AddDynamic(this,
-                                      &ULockedInFighterEntryWidget::HandleEntryButtonClicked);
+    ClickButton->OnClicked.RemoveDynamic(
+        this, &ULockedInFighterEntryWidget::HandleEntryButtonClicked);
+    ClickButton->OnClicked.AddDynamic(
+        this, &ULockedInFighterEntryWidget::HandleEntryButtonClicked);
   }
 
   ApplyVisualState();
 }
 
 void ULockedInFighterEntryWidget::NativeDestruct() {
+  if (ClickButton) {
+    ClickButton->OnClicked.RemoveDynamic(
+        this, &ULockedInFighterEntryWidget::HandleEntryButtonClicked);
+  }
   ResetEntry();
   Super::NativeDestruct();
 }
@@ -238,4 +244,3 @@ void ULockedInFighterEntryWidget::BroadcastEntryClicked() {
     OnEntryClicked.Broadcast(Fighter);
   }
 }
-

--- a/Source/Skald/WorldMap.cpp
+++ b/Source/Skald/WorldMap.cpp
@@ -496,9 +496,19 @@ void AWorldMap::RegisterTerritory(ATerritory *Territory) {
   if (Territory && !Territories.Contains(Territory)) {
     if (HasAuthority()) {
       if (Territory->TerritoryID == 0) {
+        int32 MaxExistingTerritoryId = 0;
+        for (const ATerritory *ExistingTerritory : Territories) {
+          if (!IsValid(ExistingTerritory)) {
+            continue;
+          }
+          MaxExistingTerritoryId =
+              FMath::Max(MaxExistingTerritoryId, ExistingTerritory->TerritoryID);
+        }
+
+        Territory->TerritoryID = MaxExistingTerritoryId + 1;
         UE_LOG(LogSkald, Warning,
-               TEXT("WorldMap %s registering territory %s with missing ID; clients may see ID 0"),
-               *GetName(), *Territory->GetName());
+               TEXT("WorldMap %s auto-assigned missing TerritoryID=%d to %s during registration."),
+               *GetName(), Territory->TerritoryID, *Territory->GetName());
       }
       Territory->ForceNetUpdate();
     }


### PR DESCRIPTION
### Motivation

- Fix player identity/resolution and desyncs during battle setup and travel so HUD and fighter ownership remain consistent.
- Improve controller/UI input handling during battle selection and turn ownership to avoid stolen input and stale cursor state.
- Ensure travel snapshots and territory IDs are robust across map travel and PIE retries.

### Description

- Reworked player ID resolution and mapping in `Skald_BattleGameMode`: prefer authoritative IDs, remap `SyncBattlePlayerEntry` to canonical payload-linked IDs when possible, set active payload earlier during setup, and clear stale participants on pre-battle start by calling `ResetBattleParticipants`.
- Updated `Skald_PlayerController` to improve fighter-selection UI focus and input by making the widget focusable, calling `SetFocus`, using `SetInputMode_GameAndUIEx`, and setting `DefaultMouseCaptureMode`; avoid redundant input-mode RPCs and only toggle modes when state changes; ignore duplicate territory selections; prefer authoritative player id in `ResolveStablePlayerId`; surface pending battle/travel context into turn-ownership logic; persist prepare-for-battle prompt state when HUD unavailable.
- Adjusted `ATurnManager::TriggerGridBattle` travel snapshot to count expected controllers as human controllers only (exclude AI) and ensure at least one expected controller.
- Enhanced `USkaldGameInstance::SetTravelState` to reuse cached world map territories when available and only warn about missing cached territories when battle territory context exists.
- Made `AWorldMap::RegisterTerritory` auto-assign missing `TerritoryID` values on the authority by incrementing from the current max and log the assignment.
- Fixed UI binding lifecycle in `LockedInFighterEntryWidget` by removing existing delegates before adding, and removing on destruct to avoid duplicate callbacks.

### Testing

- Project compiled successfully (Unreal build) after the changes.
- Performed editor play-in-editor smoke verification to exercise battle travel, fighter selection, and HUD behavior which completed without runtime errors.
- No automated unit tests were added or failed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f64920367883249116a790941b0dd9)