### PR TITLE
Fix compile errors in Skald_PlayerController: add GetSelectedTerritory and ReportedActiveId

### DIFF
--- a/Source/Skald/Skald_PlayerController.cpp
+++ b/Source/Skald/Skald_PlayerController.cpp
@@ -5486,6 +5486,8 @@ void ASkaldPlayerController::HandleReplicatedTurnOwnership() {
        CachedGameInstance->HasPendingBattleTravelContext());
   const bool bInBattleInputFlow =
       bIsBattleMap || BattlePhase != EBattlePhase::None || bBattleTravelPending;
+  const int32 ReportedActiveId =
+      CachedGameState ? CachedGameState->ActivePlayerId : INDEX_NONE;
   UE_LOG(LogSkald, Log,
          TEXT("[TurnState] Controller %s turn ownership check: Phase=%s ActiveId=%d IsMyTurn=%s LocalTurnActive=%s"),
          *GetName(), *UEnum::GetValueAsString(Phase), ReportedActiveId,

--- a/Source/Skald/Skald_PlayerState.h
+++ b/Source/Skald/Skald_PlayerState.h
@@ -148,6 +148,9 @@ public:
   /** Stable identifier safe to use for routing selection events client-side. */
   int32 GetStablePlayerId() const;
 
+  /** Returns the currently selected territory for this player. */
+  class ATerritory *GetSelectedTerritory() const { return SelectedTerritory.Get(); }
+
   /** Server-side setter used to validate and update the player's selection. */
   void SetSelectedTerritory(class ATerritory *Territory);
 


### PR DESCRIPTION
### Motivation
- Restore buildability after a recent change that introduced two compile errors: `GetSelectedTerritory` missing from `ASkaldPlayerState` and an undefined `ReportedActiveId` used in a `UE_LOG` call.

### Description
- Add a small accessor `ATerritory *GetSelectedTerritory() const` to `Source/Skald/Skald_PlayerState.h` and introduce a local `int32 ReportedActiveId = CachedGameState ? CachedGameState->ActivePlayerId : INDEX_NONE;` in `Source/Skald/Skald_PlayerController.cpp` before the log call.

### Testing
- Ran `git diff --check` to validate whitespace and patch sanity which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f66f1573d08324bd00628821fbfd76)