### PR TITLE
Fix post-merge compile regressions in battle setup and turn manager logs

### DIFF
--- a/Source/Skald/Skald_BattleGameMode.cpp
+++ b/Source/Skald/Skald_BattleGameMode.cpp
@@ -87,6 +87,8 @@ static int32 ResolveBattlePlayerId(const ASkaldPlayerState *PlayerState) {
   return INDEX_NONE;
 }
 
+static int32 GetPlayerIdFrom(AController *C);
+
 static int32 ResolveCanonicalStableId(AController* Controller,
                                       ASkaldPlayerState* PlayerState,
                                       const FSkaldTravelState* TravelState,
@@ -1065,7 +1067,7 @@ void ASkald_BattleGameMode::SetupPendingBattle() {
     UE_LOG(LogSkaldBattle, Verbose,
            TEXT("SetupPendingBattle: skipping duplicate completed setup (Signature=%u)"),
            SetupSignature);
-    bSetupCompleted = true; SetupCompleteToken = Token; if (USkaldGameInstance* GI = GetGameInstance<USkaldGameInstance>()) { GI->bTurnStateFrozenForTravel = false; UE_LOG(LogSkald, Log, TEXT("[TurnFreeze] Ctx=SetupPendingBattle Frozen=0 ActiveId=%d LocalTurnActive=0 Action=evaluate"), GI->GetTravelState().AttackerPlayerId); } UE_LOG(LogSkaldBattle, Log, TEXT("[TravelSummary] Token=%s Expected=%d ParticipantCount=%d SetupAttempts=%d"), *Token, ExpectedControllers, BattleParticipants.Num(), SetupAttemptCounter);
+    bSetupCompleted = true; SetupCompleteToken = Token; if (USkaldGameInstance* LocalGI = GetGameInstance<USkaldGameInstance>()) { LocalGI->bTurnStateFrozenForTravel = false; UE_LOG(LogSkald, Log, TEXT("[TurnFreeze] Ctx=SetupPendingBattle Frozen=0 ActiveId=%d LocalTurnActive=0 Action=evaluate"), LocalGI->GetTravelState().AttackerPlayerId); } UE_LOG(LogSkaldBattle, Log, TEXT("[TravelSummary] Token=%s Expected=%d ParticipantCount=%d SetupAttempts=%d"), *Token, ExpectedControllers, GS ? GS->GetBattleEntries().Num() : 0, SetupAttemptCounter);
     bSetupStarted = false;
     GBattleSetupTriggered = false;
     return;
@@ -1410,7 +1412,7 @@ void ASkald_BattleGameMode::SetupPendingBattle() {
     RegisterPlayerLockIn(ResolveBattlePlayerId(DefenderPS));
   }
 
-  bSetupCompleted = true; SetupCompleteToken = Token; if (USkaldGameInstance* GI = GetGameInstance<USkaldGameInstance>()) { GI->bTurnStateFrozenForTravel = false; UE_LOG(LogSkald, Log, TEXT("[TurnFreeze] Ctx=SetupPendingBattle Frozen=0 ActiveId=%d LocalTurnActive=0 Action=evaluate"), GI->GetTravelState().AttackerPlayerId); } UE_LOG(LogSkaldBattle, Log, TEXT("[TravelSummary] Token=%s Expected=%d ParticipantCount=%d SetupAttempts=%d"), *Token, ExpectedControllers, BattleParticipants.Num(), SetupAttemptCounter);
+  bSetupCompleted = true; SetupCompleteToken = Token; if (USkaldGameInstance* LocalGI = GetGameInstance<USkaldGameInstance>()) { LocalGI->bTurnStateFrozenForTravel = false; UE_LOG(LogSkald, Log, TEXT("[TurnFreeze] Ctx=SetupPendingBattle Frozen=0 ActiveId=%d LocalTurnActive=0 Action=evaluate"), LocalGI->GetTravelState().AttackerPlayerId); } UE_LOG(LogSkaldBattle, Log, TEXT("[TravelSummary] Token=%s Expected=%d ParticipantCount=%d SetupAttempts=%d"), *Token, ExpectedControllers, GS ? GS->GetBattleEntries().Num() : 0, SetupAttemptCounter);
   LastCompletedSetupSignature = SetupSignature;
   ActiveSetupSignature = 0;
   GI->PendingBattle = Battle;

--- a/Source/Skald/Skald_TurnManager.cpp
+++ b/Source/Skald/Skald_TurnManager.cpp
@@ -1470,7 +1470,7 @@ void ATurnManager::HandleAttackConfirmed(const FS_BattlePayload &Battle) {
          Battle.FromTerritoryID, Battle.TargetTerritoryID,
          Battle.AttackerPlayerID, Battle.DefenderPlayerID);
 
-  if (USkaldGameInstance* GI = GetGameInstance<USkaldGameInstance>()) { GI->bTurnStateFrozenForTravel = true; UE_LOG(LogSkald, Log, TEXT("[TurnFreeze] Ctx=HandleAttackConfirmed Frozen=1 ActiveId=%d LocalTurnActive=0 Action=skip"), ActivePlayerID); }
+  if (USkaldGameInstance* GI = GetGameInstance<USkaldGameInstance>()) { GI->bTurnStateFrozenForTravel = true; UE_LOG(LogSkald, Log, TEXT("[TurnFreeze] Ctx=HandleAttackConfirmed Frozen=1 ActiveId=%d LocalTurnActive=0 Action=skip"), GetActivePlayerId()); }
   BeginReadyPhase(Battle, TEXT("HandleAttackConfirmed"));
 }
 
@@ -4404,7 +4404,7 @@ bool ATurnManager::BroadcastCurrentPhase() {
 
   const FString PhaseString = UEnum::GetValueAsString(CurrentPhase);
   UE_LOG(LogSkald, Log, TEXT("[PhaseGuard] From=%s To=%s Active=%d Allowed=%d Reason=%s"),
-         TEXT("Unknown"), *PhaseString, ActivePlayerID, 1, TEXT("BroadcastCurrentPhase"));
+         TEXT("Unknown"), *PhaseString, GetActivePlayerId(), 1, TEXT("BroadcastCurrentPhase"));
   UE_LOG(LogSkald, Log, TEXT("BroadcastCurrentPhase: %s"), *PhaseString);
   if (GEngine) {
     GEngine->AddOnScreenDebugMessage(


### PR DESCRIPTION
### Motivation
- Resolve multiple compile errors introduced after a merge where symbols were referenced out of scope or with the wrong identifiers. 
- Prevent runtime/logging issues caused by shadowed variables and invalid member usage in battle setup and turn manager code.

### Description
- Added a forward declaration `static int32 GetPlayerIdFrom(AController *C);` before `ResolveCanonicalStableId` to fix the `GetPlayerIdFrom` identifier-not-found error in `Skald_BattleGameMode.cpp`.
- Replaced a shadowing local `GI` with `LocalGI` in `SetupPendingBattle` and made the travel summary participant count safe by using `GS ? GS->GetBattleEntries().Num() : 0` instead of referencing `BattleParticipants.Num()` out of scope.
- Replaced invalid `ActivePlayerID` references with calls to `GetActivePlayerId()` in `Skald_TurnManager.cpp` for `HandleAttackConfirmed` and `BroadcastCurrentPhase` logging.
- Committed the fixes to the branch to resolve the symbols and make the source compile-ready for a full engine build.

### Testing
- Ran repository symbol searches and diffs (`rg`, `git diff`) to verify the offending identifiers were corrected; these inspections succeeded.
- Performed targeted source edits and committed the changes; the commit succeeded.
- Did not run a full Unreal Engine build or CI in this environment due to missing UE toolchain access, so recommend running the `Development_Editor x64` build in CI or locally to validate end-to-end.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f67f1eaf9c83249802bc2054a4866b)