### PR TITLE
Prevent duplicate delegate bindings and debounce replicated turn announcements

### DIFF
--- a/Source/Skald/FighterPawn.cpp
+++ b/Source/Skald/FighterPawn.cpp
@@ -402,6 +402,7 @@ void AFighterPawn::BeginPlay() {
     ActivationWidgetBack->InitWidget();
   }
 
+  OnHealthChanged.RemoveDynamic(this, &AFighterPawn::HandleHealthChanged);
   OnHealthChanged.AddDynamic(this, &AFighterPawn::HandleHealthChanged);
   OnHealthChanged.Broadcast(Stats.Health);
 

--- a/Source/Skald/Skald_GameState.cpp
+++ b/Source/Skald/Skald_GameState.cpp
@@ -210,7 +210,6 @@ void ASkaldGameState::RefreshControllersFromPlayers()
                 }
                 PC->RefreshTurnDataFromState();
                 PC->HandleReplicatedTurnOwnership();
-                PC->HandleReplicatedTurnStart();
             }
         }
     }
@@ -244,7 +243,6 @@ void ASkaldGameState::OnRep_CurrentTurnIndex()
                 }
                 PC->RefreshTurnDataFromState();
                 PC->HandleReplicatedTurnOwnership();
-                PC->HandleReplicatedTurnStart();
             }
         }
     }

--- a/Source/Skald/Skald_PlayerController.cpp
+++ b/Source/Skald/Skald_PlayerController.cpp
@@ -5583,6 +5583,12 @@ void ASkaldPlayerController::HandleReplicatedTurnStart()
 
   if (!GS || GS->ActivePlayerId == INDEX_NONE)
   {
+    LastAnnouncedActivePlayerId = INDEX_NONE;
+    return;
+  }
+
+  if (LastAnnouncedActivePlayerId == GS->ActivePlayerId)
+  {
     return;
   }
 
@@ -5595,6 +5601,7 @@ void ASkaldPlayerController::HandleReplicatedTurnStart()
   const FString PlayerName = ActivePS->GetResolvedPlayerName(TEXT("HandleReplicatedTurnStart"));
   const bool bIsMyTurn = IsMyTurn();
   ShowTurnAnnouncementLocal(PlayerName, bIsMyTurn);
+  LastAnnouncedActivePlayerId = GS->ActivePlayerId;
 
   // Clear any lingering initiative overlays or dice holds now that the owning
   // client is starting a replicated turn, ensuring UI setup does not depend on

--- a/Source/Skald/Skald_PlayerController.h
+++ b/Source/Skald/Skald_PlayerController.h
@@ -1070,6 +1070,9 @@ private:
   /** Tracks if ExecuteLocalTurnStart has been triggered for the active turn. */
   bool bLocalTurnActive = false;
 
+  /** Debounce replicated turn-announcement spam for the same active player id. */
+  int32 LastAnnouncedActivePlayerId = INDEX_NONE;
+
   /** Prevents redundant pending battle state requests while waiting for a reply. */
   bool bPendingBattleStateRequest = false;
 

--- a/Source/Skald/UI/SkaldMainHUDWidget.cpp
+++ b/Source/Skald/UI/SkaldMainHUDWidget.cpp
@@ -161,8 +161,12 @@ void USkaldMainHUDWidget::NativeConstruct() {
     UE_LOG(LogSkald, Warning,
            TEXT("SkaldMainHUDWidget could not find GameState."));
   } else {
+    GameState->OnPlayersUpdated.RemoveDynamic(
+        this, &USkaldMainHUDWidget::HandlePlayersUpdated);
     GameState->OnPlayersUpdated.AddDynamic(
         this, &USkaldMainHUDWidget::HandlePlayersUpdated);
+    GameState->OnTurnIndexChanged.RemoveDynamic(
+        this, &USkaldMainHUDWidget::HandleTurnIndexChanged);
     // React to replicated turn changes.
     GameState->OnTurnIndexChanged.AddDynamic(
         this, &USkaldMainHUDWidget::HandleTurnIndexChanged);
@@ -179,32 +183,44 @@ void USkaldMainHUDWidget::NativeConstruct() {
   }
 
   if (AttackButton) {
+    AttackButton->OnClicked.RemoveDynamic(
+        this, &USkaldMainHUDWidget::BeginAttackSelection);
     AttackButton->OnClicked.AddDynamic(
         this, &USkaldMainHUDWidget::BeginAttackSelection);
     AttackButton->SetVisibility(ESlateVisibility::Collapsed);
   }
   if (MoveButton) {
+    MoveButton->OnClicked.RemoveDynamic(this,
+                                        &USkaldMainHUDWidget::BeginMoveSelection);
     MoveButton->OnClicked.AddDynamic(this,
                                      &USkaldMainHUDWidget::BeginMoveSelection);
     MoveButton->SetVisibility(ESlateVisibility::Collapsed);
   }
   if (EndTurnButton) {
+    EndTurnButton->OnClicked.RemoveDynamic(
+        this, &USkaldMainHUDWidget::HandleEndTurnClicked);
     EndTurnButton->OnClicked.AddDynamic(
         this, &USkaldMainHUDWidget::HandleEndTurnClicked);
     EndTurnButton->SetVisibility(ESlateVisibility::Visible);
   }
   if (EndPhaseButton) {
+    EndPhaseButton->OnClicked.RemoveDynamic(
+        this, &USkaldMainHUDWidget::HandleEndPhaseClicked);
     EndPhaseButton->OnClicked.AddDynamic(
         this, &USkaldMainHUDWidget::HandleEndPhaseClicked);
     EndPhaseButton->SetVisibility(ESlateVisibility::Visible);
   }
   if (DeployButton) {
+    DeployButton->OnClicked.RemoveDynamic(
+        this, &USkaldMainHUDWidget::HandleDeployClicked);
     DeployButton->OnClicked.AddDynamic(
         this, &USkaldMainHUDWidget::HandleDeployClicked);
     DeployButton->SetVisibility(ESlateVisibility::Collapsed);
   }
 
   if (RollInitiativeButton) {
+    RollInitiativeButton->OnClicked.RemoveDynamic(
+        this, &USkaldMainHUDWidget::HandleStrategicInitiativeRollPressed);
     RollInitiativeButton->OnClicked.AddDynamic(
         this, &USkaldMainHUDWidget::HandleStrategicInitiativeRollPressed);
     RollInitiativeButton->SetVisibility(ESlateVisibility::Collapsed);
@@ -231,8 +247,12 @@ void USkaldMainHUDWidget::NativeConstruct() {
   }
 
   if (DiceResolutionPanel) {
+    DiceResolutionPanel->OnResolutionComplete.RemoveDynamic(
+        this, &USkaldMainHUDWidget::HandleDicePanelResolved);
     DiceResolutionPanel->OnResolutionComplete.AddDynamic(
         this, &USkaldMainHUDWidget::HandleDicePanelResolved);
+    DiceResolutionPanel->OnDiceOutcomeRevealed.RemoveDynamic(
+        this, &USkaldMainHUDWidget::HandleDiceOutcomeRevealed);
     DiceResolutionPanel->OnDiceOutcomeRevealed.AddDynamic(
         this, &USkaldMainHUDWidget::HandleDiceOutcomeRevealed);
     TArray<UTexture2D *> DiceFaceTexturePtrs;
@@ -1003,6 +1023,8 @@ void USkaldMainHUDWidget::ShowPrepareForBattleDialog(
       bLocalIsDefender ? ESlateVisibility::Visible
                         : ESlateVisibility::Collapsed);
   if (bLocalIsDefender) {
+    ActivePrepareForBattleWidget->OnRetreatButtonClicked.RemoveDynamic(
+        this, &USkaldMainHUDWidget::HandleRetreatClicked);
     ActivePrepareForBattleWidget->OnRetreatButtonClicked.AddDynamic(
         this, &USkaldMainHUDWidget::HandleRetreatClicked);
     if (ActivePrepareForBattleWidget->RetreatButton) {
@@ -1013,6 +1035,8 @@ void USkaldMainHUDWidget::ShowPrepareForBattleDialog(
   ActivePrepareForBattleWidget->SetVisibility(ESlateVisibility::Visible);
   ActivePrepareForBattleWidget->SetRenderOpacity(1.f);
   ActivePrepareForBattleWidget->SetIsEnabled(true);
+  ActivePrepareForBattleWidget->OnPrepareButtonClicked.RemoveDynamic(
+      this, &USkaldMainHUDWidget::HandlePrepareForBattleClicked);
   ActivePrepareForBattleWidget->OnPrepareButtonClicked.AddDynamic(
       this, &USkaldMainHUDWidget::HandlePrepareForBattleClicked);
   ActivePrepareForBattleWidget->AddToViewport(20);


### PR DESCRIPTION
### Motivation
- Prevent duplicate dynamic delegate bindings and redundant handler invocations in UI and pawn logic, and reduce noisy or repeated turn-start announcements driven from replicated state.

### Description
- Remove existing `OnHealthChanged` binding before re-adding it in `AFighterPawn::BeginPlay` to avoid duplicate health notifications.
- Stop invoking `PC->HandleReplicatedTurnStart()` from `ASkaldGameState::RefreshControllersFromPlayers` and `ASkaldGameState::OnRep_CurrentTurnIndex` to avoid host-driven duplicate turn-start calls.
- Add an `LastAnnouncedActivePlayerId` field to `ASkaldPlayerController` and use it in `HandleReplicatedTurnStart` to debounce replicated turn announcements and reset it when there is no active player.
- Precede `AddDynamic` calls with `RemoveDynamic` for `GameState` events, HUD buttons, `DiceResolutionPanel`, and prepare-for-battle widget callbacks in `USkaldMainHUDWidget::NativeConstruct` to ensure delegates are not bound multiple times.

### Testing
- The project built successfully after the changes.
- Automated unit and integration tests for UI and turn-management-related suites were executed and passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f688d52e308324ad3db5017c713372)