### PR TITLE
Fix fighter-selection cursor loss during single-player battle prep

### DIFF
--- a/Source/Skald/Skald_PlayerController.cpp
+++ b/Source/Skald/Skald_PlayerController.cpp
@@ -5498,6 +5498,22 @@ void ASkaldPlayerController::HandleReplicatedTurnOwnership() {
     MainHUD->SyncPhaseButtons(bIsMyTurn);
   }
 
+  // Keep fighter-selection interaction stable even if replicated turn/battle
+  // flags momentarily lag. Without this guard, turn-ownership refreshes can
+  // fall through to the non-active-player branch and force GameOnly input,
+  // which hides the cursor on click until focus changes.
+  if (FighterSelectionWidget && FighterSelectionWidget->IsInViewport()) {
+    if (!bShowMouseCursor || !bEnableClickEvents || !bEnableMouseOverEvents) {
+      UWidgetBlueprintLibrary::SetInputMode_GameAndUIEx(
+          this, FighterSelectionWidget, EMouseLockMode::DoNotLock,
+          /*bHideCursorDuringCapture*/ false);
+    }
+    bShowMouseCursor = true;
+    bEnableClickEvents = true;
+    bEnableMouseOverEvents = true;
+    return;
+  }
+
   // Battle preparation/selection controls are managed by battle flow. Avoid
   // having overworld turn ownership logic steal input mode or cursor state.
   if (bInBattleInputFlow) {


### PR DESCRIPTION
### Motivation
- The fighter selection UI could be visible while turn-ownership/replication briefly flips controller state to non-active, which causes `GameOnly` input mode to be applied and the mouse cursor to disappear after clicks. 
- This produced the observed PI E behaviour where tabbing out/in restores the cursor but clicks hide it again due to an input-mode race.

### Description
- Added an early guard in `ASkaldPlayerController::HandleReplicatedTurnOwnership` that checks if `FighterSelectionWidget` is in the viewport and, if so, forces `GameAndUI` input mode targeting the widget and enables `bShowMouseCursor`, `bEnableClickEvents`, and `bEnableMouseOverEvents`, then returns. 
- The change is deliberately narrow and only affects input-mode/cursor handling during pre-battle fighter selection; no gameplay or selection logic was modified.

### Testing
- No automated unit or integration tests were executed as part of this rollout. 
- The change was committed to the branch successfully (one-file change, 16 insertions).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f6933bdcbc83249cc2803e00e001db)