### PR TITLE
Debounce replicated turn ownership refresh handling

### DIFF
--- a/Source/Skald/Skald_PlayerController.cpp
+++ b/Source/Skald/Skald_PlayerController.cpp
@@ -5488,6 +5488,27 @@ void ASkaldPlayerController::HandleReplicatedTurnOwnership() {
       bIsBattleMap || BattlePhase != EBattlePhase::None || bBattleTravelPending;
   const int32 ReportedActiveId =
       CachedGameState ? CachedGameState->ActivePlayerId : INDEX_NONE;
+
+  const bool bTurnOwnershipStateUnchanged =
+      LastTurnOwnershipActivePlayerId == ReportedActiveId &&
+      LastTurnOwnershipPhase == Phase &&
+      LastTurnOwnershipBattlePhase == BattlePhase &&
+      bLastTurnOwnershipIsMyTurn == bIsMyTurn &&
+      bLastTurnOwnershipBattleTravelPending == bBattleTravelPending;
+
+  LastTurnOwnershipActivePlayerId = ReportedActiveId;
+  LastTurnOwnershipPhase = Phase;
+  LastTurnOwnershipBattlePhase = BattlePhase;
+  bLastTurnOwnershipIsMyTurn = bIsMyTurn;
+  bLastTurnOwnershipBattleTravelPending = bBattleTravelPending;
+
+  // Replication callbacks fan in from multiple paths (phase, active player,
+  // payload, map transition). When all turn-ownership inputs are unchanged,
+  // avoid reapplying local input/cursor/HUD state to prevent gameplay churn.
+  if (bTurnOwnershipStateUnchanged) {
+    return;
+  }
+
   UE_LOG(LogSkald, Log,
          TEXT("[TurnState] Controller %s turn ownership check: Phase=%s ActiveId=%d IsMyTurn=%s LocalTurnActive=%s"),
          *GetName(), *UEnum::GetValueAsString(Phase), ReportedActiveId,

--- a/Source/Skald/Skald_PlayerController.h
+++ b/Source/Skald/Skald_PlayerController.h
@@ -1073,6 +1073,13 @@ private:
   /** Debounce replicated turn-announcement spam for the same active player id. */
   int32 LastAnnouncedActivePlayerId = INDEX_NONE;
 
+  /** Debounce redundant turn-ownership refreshes for identical replicated state. */
+  int32 LastTurnOwnershipActivePlayerId = INDEX_NONE;
+  ETurnPhase LastTurnOwnershipPhase = ETurnPhase::Reinforcement;
+  EBattlePhase LastTurnOwnershipBattlePhase = EBattlePhase::None;
+  bool bLastTurnOwnershipIsMyTurn = false;
+  bool bLastTurnOwnershipBattleTravelPending = false;
+
   /** Prevents redundant pending battle state requests while waiting for a reply. */
   bool bPendingBattleStateRequest = false;
 


### PR DESCRIPTION
### Motivation
- Multiple replication callbacks (phase, active player, payload, map transitions) can re-run turn-ownership UI/input updates even when the effective ownership state is unchanged, causing input/cursor/HUD churn and disrupting game flow.
- Introduce a lightweight debounce so no-op replicated updates do not reapply local state unnecessarily.

### Description
- Added cached turn-ownership fields to `ASkaldPlayerController` (`LastTurnOwnershipActivePlayerId`, `LastTurnOwnershipPhase`, `LastTurnOwnershipBattlePhase`, `bLastTurnOwnershipIsMyTurn`, `bLastTurnOwnershipBattleTravelPending`).
- Updated `HandleReplicatedTurnOwnership()` to compare the current replicated inputs (active player id, turn phase, battle phase, whether it is my turn, and battle-travel-pending) against the cache and return early if nothing changed.
- Preserved existing behavior for real state changes so logs, phase button sync, and subsequent ownership flows still run when the replicated state actually changes.

### Testing
- Inspected the produced diff with `git diff` to verify only the turn-ownership refresh logic and controller state additions were modified (verification succeeded).
- Created a commit for the change to record the update (succeeded).
- No engine runtime/unit test was run as part of this patch; runtime validation is recommended to confirm the debounce prevents redundant refreshes without blocking legitimate transitions.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f6992e7b98832480a8a890a50fcc07)