### PR TITLE
Ensure turn ownership correction runs even when replicated state is unchanged

### DIFF
--- a/Source/Skald/Skald_PlayerController.cpp
+++ b/Source/Skald/Skald_PlayerController.cpp
@@ -5502,20 +5502,15 @@ void ASkaldPlayerController::HandleReplicatedTurnOwnership() {
   bLastTurnOwnershipIsMyTurn = bIsMyTurn;
   bLastTurnOwnershipBattleTravelPending = bBattleTravelPending;
 
-  // Replication callbacks fan in from multiple paths (phase, active player,
-  // payload, map transition). When all turn-ownership inputs are unchanged,
-  // avoid reapplying local input/cursor/HUD state to prevent gameplay churn.
-  if (bTurnOwnershipStateUnchanged) {
-    return;
+  if (!bTurnOwnershipStateUnchanged) {
+    UE_LOG(LogSkald, Log,
+           TEXT("[TurnState] Controller %s turn ownership check: Phase=%s ActiveId=%d IsMyTurn=%s LocalTurnActive=%s"),
+           *GetName(), *UEnum::GetValueAsString(Phase), ReportedActiveId,
+           bIsMyTurn ? TEXT("true") : TEXT("false"),
+           bLocalTurnActive ? TEXT("true") : TEXT("false"));
   }
 
-  UE_LOG(LogSkald, Log,
-         TEXT("[TurnState] Controller %s turn ownership check: Phase=%s ActiveId=%d IsMyTurn=%s LocalTurnActive=%s"),
-         *GetName(), *UEnum::GetValueAsString(Phase), ReportedActiveId,
-         bIsMyTurn ? TEXT("true") : TEXT("false"),
-         bLocalTurnActive ? TEXT("true") : TEXT("false"));
-
-  if (MainHUD) {
+  if (MainHUD && !bTurnOwnershipStateUnchanged) {
     MainHUD->SyncPhaseButtons(bIsMyTurn);
   }
 


### PR DESCRIPTION
### Motivation
- Fix a bug where an early return in `HandleReplicatedTurnOwnership` prevented input/HUD correction for non-active players when replicated turn-ownership values were unchanged. 
- Prevent situations where `ShowMainHUD()` or other callers enable `GameAndUI` and leave non-active players with active cursor/click input until a later ownership change. 
- Retain churn-reduction intent by avoiding repeated verbose logs and HUD sync when state is unchanged. 

### Description
- Removed the unconditional early `return` when `bTurnOwnershipStateUnchanged` is true so the function continues to apply input/cursor/HUD corrections. 
- Gated the verbose ownership `UE_LOG` and `MainHUD->SyncPhaseButtons` behind `!bTurnOwnershipStateUnchanged` to avoid noisy repetition. 
- Change localized to `Source/Skald/Skald_PlayerController.cpp` inside `ASkaldPlayerController::HandleReplicatedTurnOwnership`, preserving all correction branches (fighter-selection, battle-flow, non-active-player handling). 

### Testing
- No automated tests were executed for this change. 
- The change was validated via local code inspection of the modified path to ensure the input/cursor/HUD correction branches are reached when replicated state is unchanged.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f6c6638e6c8324b34cfada3676d788)