### PR TITLE
Do not block world initialization for transient missing local HUDs; schedule HUD refresh

### DIFF
--- a/Source/Skald/Skald_GameMode.cpp
+++ b/Source/Skald/Skald_GameMode.cpp
@@ -1562,24 +1562,28 @@ void ASkaldGameMode::TryInitializeWorldAndStart() {
     PopulateAIPlayers();
   }
 
-  // Ensure local human controllers have their HUD widgets initialized before
-  // proceeding with world initialization. Retry on the next tick if any are
-  // still pending.
+  // Track local human controllers that do not yet have a HUD widget. This is
+  // a common transient state during map startup and should not block game
+  // initialization. We keep retrying HUD refresh separately while allowing
+  // turn/world readiness logic to continue.
+  bool bMissingLocalHUD = false;
   for (FConstPlayerControllerIterator It =
            GetWorld()->GetPlayerControllerIterator();
        It; ++It) {
     if (ASkaldPlayerController *PC = Cast<ASkaldPlayerController>(*It)) {
       if (!IsAIControllerIdentity(PC) && PC->IsLocalController() &&
           !PC->GetHUDWidget()) {
-        FTimerDelegate RetryInit = FTimerDelegate::CreateUObject(
-            this, &ASkaldGameMode::TryInitializeWorldAndStart);
-        GetWorldTimerManager().ClearTimer(RetryInitTimerHandle);
-        GetWorldTimerManager().SetTimer(RetryInitTimerHandle, RetryInit,
-                                        RetryInitDelay, false);
-        GetWorldTimerManager().SetTimerForNextTick(RetryInit);
-        return;
+        bMissingLocalHUD = true;
+        UE_LOG(LogSkald, Verbose,
+               TEXT("TryInitializeWorldAndStart: local controller %s has no HUD yet; continuing startup and scheduling HUD refresh."),
+               *GetNameSafe(PC));
       }
     }
+  }
+  if (bMissingLocalHUD) {
+    FTimerDelegate RefreshDelegate =
+        FTimerDelegate::CreateUObject(this, &ASkaldGameMode::RefreshHUDs);
+    GetWorldTimerManager().SetTimerForNextTick(RefreshDelegate);
   }
 
   const bool bNeedsSnapshotRestore =


### PR DESCRIPTION
### Motivation

- Prevent startup from stalling when a local `ASkaldPlayerController` has not yet created its HUD widget, which is a transient state during map load.

### Description

- Replace the blocking retry-and-return behavior in `TryInitializeWorldAndStart` when a local controller lacks a HUD with non-blocking logic that records the condition and continues startup. 
- Add a `bMissingLocalHUD` flag and a verbose log message to indicate which local controller is missing a HUD. 
- Schedule a `RefreshHUDs` call for the next tick using the timer manager instead of deferring all world initialization until the HUD is ready. 
- Preserve existing retry behavior for snapshot restore failures and leave other initialization logic unchanged.

### Testing

- Ran the project's automated unit and integration tests including startup/smoke checks for `TryInitializeWorldAndStart`, and they completed successfully. 
- Verified Play-in-Editor startup where local controllers initially lack HUDs and confirmed the world continues initializing and `RefreshHUDs` is invoked on the next tick. All checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0d238c7da08324a23edc3a0d0ad6f4)