### PR TITLE
Add streamed dice-board transition hooks to battle level manager

### DIFF
--- a/Source/Skald/Skald_BattleLevelManager.cpp
+++ b/Source/Skald/Skald_BattleLevelManager.cpp
@@ -86,6 +86,16 @@ void USkaldBattleLevelManager::Initialise(USkaldGameInstance *InOwner) {
   OwningInstance = InOwner;
 }
 
+void USkaldBattleLevelManager::ConfigurePersistentSublevels(
+    const TSoftObjectPtr<UWorld>& InOverviewLevel,
+    const TSoftObjectPtr<UWorld>& InDiceBoardLevel) {
+  ConfiguredOverviewLevel = InOverviewLevel;
+  ConfiguredDiceBoardLevel = InDiceBoardLevel;
+  UE_LOG(LogSkald, Log,
+         TEXT("BattleLevelManager: configured persistent sublevels (overview=%s dice=%s)"),
+         *ConfiguredOverviewLevel.ToString(), *ConfiguredDiceBoardLevel.ToString());
+}
+
 bool USkaldBattleLevelManager::RequestBattleLevel(
     UWorld *World, const TSoftObjectPtr<UWorld> &BattleLevel,
     const FS_BattlePayload &BattlePayload) {
@@ -286,6 +296,41 @@ void USkaldBattleLevelManager::ReleaseBattleLevel() {
 
   UE_LOG(LogSkald, Log, TEXT("BattleLevelManager: Unloading battle level"));
 
+}
+
+bool USkaldBattleLevelManager::SetDiceBoardActive(UWorld* World, bool bShouldBeActive) {
+  if (!World) {
+    UE_LOG(LogSkald, Warning, TEXT("BattleLevelManager: SetDiceBoardActive failed (world is null)"));
+    return false;
+  }
+
+  if (ConfiguredDiceBoardLevel.IsNull()) {
+    UE_LOG(LogSkald, Warning, TEXT("BattleLevelManager: SetDiceBoardActive failed (dice board level is not configured)"));
+    return false;
+  }
+
+  if (bShouldBeActive) {
+    ULevelStreaming* DiceStreamingLevel = ActiveDiceStreamingLevel.Get();
+    if (!DiceStreamingLevel &&
+        !ResolveOrStreamLevel(World, ConfiguredDiceBoardLevel, DiceStreamingLevel, TEXT("DiceBoard"))) {
+      return false;
+    }
+
+    ActiveDiceStreamingLevel = DiceStreamingLevel;
+    DiceStreamingLevel->SetShouldBeLoaded(true);
+    DiceStreamingLevel->SetShouldBeVisible(true);
+    HideNonBattleLevels();
+    UE_LOG(LogSkald, Log, TEXT("BattleLevelManager: Dice board activated as streamed sublevel"));
+    return true;
+  }
+
+  if (ULevelStreaming* DiceStreamingLevel = ActiveDiceStreamingLevel.Get()) {
+    DiceStreamingLevel->SetShouldBeVisible(false);
+    RestoreNonBattleLevels();
+    UE_LOG(LogSkald, Log, TEXT("BattleLevelManager: Dice board hidden"));
+  }
+  ActiveDiceStreamingLevel.Reset();
+  return true;
 }
 
 void USkaldBattleLevelManager::HandleLevelLoaded() {
@@ -781,3 +826,45 @@ bool USkaldBattleLevelManager::IsStreamingLevelPartOfBattleMap(
   return false;
 }
 
+bool USkaldBattleLevelManager::ResolveOrStreamLevel(
+    UWorld* World, const TSoftObjectPtr<UWorld>& LevelAsset,
+    ULevelStreaming*& OutStreamingLevel, const TCHAR* ContextLabel) {
+  OutStreamingLevel = nullptr;
+  if (!World || LevelAsset.IsNull()) {
+    return false;
+  }
+
+  const FSoftObjectPath RequestedPath = LevelAsset.ToSoftObjectPath();
+  const FString RequestedPackage = RequestedPath.GetLongPackageName();
+  for (ULevelStreaming* ExistingLevel : World->GetStreamingLevels()) {
+    if (!ExistingLevel) {
+      continue;
+    }
+
+    const FString ExistingPackage = ResolveStreamingLevelPackageName(ExistingLevel);
+    if (!RequestedPackage.IsEmpty() &&
+        ExistingPackage.Equals(RequestedPackage, ESearchCase::IgnoreCase)) {
+      OutStreamingLevel = ExistingLevel;
+      UE_LOG(LogSkald, Log, TEXT("BattleLevelManager: Reusing %s streaming level %s"),
+             ContextLabel, *ExistingPackage);
+      return true;
+    }
+  }
+
+  bool bLoadSuccess = false;
+  OutStreamingLevel = ULevelStreamingDynamic::LoadLevelInstanceBySoftObjectPtr(
+      World, LevelAsset, FVector::ZeroVector, FRotator::ZeroRotator, bLoadSuccess);
+  if (!OutStreamingLevel || !bLoadSuccess) {
+    UE_LOG(LogSkald, Error, TEXT("BattleLevelManager: Failed to stream %s level %s"),
+           ContextLabel, *LevelAsset.ToString());
+    OutStreamingLevel = nullptr;
+    return false;
+  }
+
+  UE_LOG(LogSkald, Log, TEXT("BattleLevelManager: Stream request issued for %s level %s"),
+         ContextLabel, *LevelAsset.ToString());
+  return true;
+}
+
+void USkaldBattleLevelManager::ApplyVisibilityForCurrentMode() {}
+bool USkaldBattleLevelManager::IsStreamingLevelPartOfDiceBoard(ULevelStreaming* Level) const { return false; }

--- a/Source/Skald/Skald_BattleLevelManager.cpp
+++ b/Source/Skald/Skald_BattleLevelManager.cpp
@@ -319,6 +319,7 @@ bool USkaldBattleLevelManager::SetDiceBoardActive(UWorld* World, bool bShouldBeA
     ActiveDiceStreamingLevel = DiceStreamingLevel;
     DiceStreamingLevel->SetShouldBeLoaded(true);
     DiceStreamingLevel->SetShouldBeVisible(true);
+    ApplyVisibilityForCurrentMode();
     HideNonBattleLevels();
     UE_LOG(LogSkald, Log, TEXT("BattleLevelManager: Dice board activated as streamed sublevel"));
     return true;
@@ -326,6 +327,7 @@ bool USkaldBattleLevelManager::SetDiceBoardActive(UWorld* World, bool bShouldBeA
 
   if (ULevelStreaming* DiceStreamingLevel = ActiveDiceStreamingLevel.Get()) {
     DiceStreamingLevel->SetShouldBeVisible(false);
+    ApplyVisibilityForCurrentMode();
     RestoreNonBattleLevels();
     UE_LOG(LogSkald, Log, TEXT("BattleLevelManager: Dice board hidden"));
   }
@@ -641,7 +643,8 @@ void USkaldBattleLevelManager::HideNonBattleLevels() {
       continue;
     }
 
-    if (IsStreamingLevelPartOfBattleMap(OtherLevel)) {
+    if (IsStreamingLevelPartOfBattleMap(OtherLevel) ||
+        IsStreamingLevelPartOfDiceBoard(OtherLevel)) {
       continue;
     }
 
@@ -866,5 +869,39 @@ bool USkaldBattleLevelManager::ResolveOrStreamLevel(
   return true;
 }
 
-void USkaldBattleLevelManager::ApplyVisibilityForCurrentMode() {}
-bool USkaldBattleLevelManager::IsStreamingLevelPartOfDiceBoard(ULevelStreaming* Level) const { return false; }
+void USkaldBattleLevelManager::ApplyVisibilityForCurrentMode() {
+  if (ULevelStreaming* DiceLevel = ActiveDiceStreamingLevel.Get()) {
+    DiceLevel->SetShouldBeLoaded(true);
+    DiceLevel->SetShouldBeVisible(true);
+  }
+}
+
+bool USkaldBattleLevelManager::IsStreamingLevelPartOfDiceBoard(ULevelStreaming* Level) const {
+  if (!Level) {
+    return false;
+  }
+
+  if (ActiveDiceStreamingLevel.IsValid() && Level == ActiveDiceStreamingLevel.Get()) {
+    return true;
+  }
+
+  const FString DicePackage =
+      ConfiguredDiceBoardLevel.ToSoftObjectPath().GetLongPackageName();
+  if (DicePackage.IsEmpty()) {
+    return false;
+  }
+
+  const FString LevelPackage = ResolveStreamingLevelPackageName(Level);
+  if (LevelPackage.IsEmpty()) {
+    return false;
+  }
+
+  if (LevelPackage.Equals(DicePackage, ESearchCase::IgnoreCase)) {
+    return true;
+  }
+
+  const FString DiceShortName = FPackageName::GetShortName(DicePackage);
+  const FString LevelShortName = FPackageName::GetShortName(LevelPackage);
+  return !DiceShortName.IsEmpty() &&
+         LevelShortName.Equals(DiceShortName, ESearchCase::IgnoreCase);
+}

--- a/Source/Skald/Skald_BattleLevelManager.h
+++ b/Source/Skald/Skald_BattleLevelManager.h
@@ -25,6 +25,8 @@ class SKALD_API USkaldBattleLevelManager : public UObject {
 
 public:
   void Initialise(USkaldGameInstance *InOwner);
+  void ConfigurePersistentSublevels(const TSoftObjectPtr<UWorld>& InOverviewLevel,
+                                    const TSoftObjectPtr<UWorld>& InDiceBoardLevel);
 
   /** Attempt to stream in the specified battle level. Returns true when the
    * request was issued successfully. */
@@ -33,6 +35,8 @@ public:
 
   /** Unload any active streamed battle level. */
   void ReleaseBattleLevel();
+  bool SetDiceBoardActive(UWorld* World, bool bShouldBeActive);
+  bool IsDiceBoardActive() const { return ActiveDiceStreamingLevel.IsValid(); }
 
   /** Returns whether a streamed battle level is currently active. */
   bool IsBattleLevelActive() const { return ActiveStreamingLevel.IsValid(); }
@@ -41,6 +45,10 @@ private:
   void HideNonBattleLevels();
   void RestoreNonBattleLevels();
   bool IsStreamingLevelPartOfBattleMap(ULevelStreaming *Level) const;
+  bool ResolveOrStreamLevel(UWorld* World, const TSoftObjectPtr<UWorld>& LevelAsset,
+                            ULevelStreaming*& OutStreamingLevel, const TCHAR* ContextLabel);
+  void ApplyVisibilityForCurrentMode();
+  bool IsStreamingLevelPartOfDiceBoard(ULevelStreaming* Level) const;
 
   void HandleLevelLoaded();
   void HandleLevelUnloaded();
@@ -55,7 +63,10 @@ private:
 
   TWeakObjectPtr<USkaldGameInstance> OwningInstance;
   TWeakObjectPtr<ULevelStreaming> ActiveStreamingLevel;
+  TWeakObjectPtr<ULevelStreaming> ActiveDiceStreamingLevel;
   TSoftObjectPtr<UWorld> RequestedBattleLevel;
+  TSoftObjectPtr<UWorld> ConfiguredOverviewLevel;
+  TSoftObjectPtr<UWorld> ConfiguredDiceBoardLevel;
   FDelegateHandle LevelAddedToWorldHandle;
   FDelegateHandle LevelRemovedFromWorldHandle;
   FTSTicker::FDelegateHandle StreamingStatusTickerHandle;

--- a/Source/Skald/Skald_GameInstance.cpp
+++ b/Source/Skald/Skald_GameInstance.cpp
@@ -194,6 +194,10 @@ void USkaldGameInstance::Init() {
     BattleLevelStreamingManager = NewObject<USkaldBattleLevelManager>(this);
     BattleLevelStreamingManager->Initialise(this);
   }
+  if (BattleLevelStreamingManager) {
+    BattleLevelStreamingManager->ConfigurePersistentSublevels(
+        OverviewSublevel, DiceBoardSublevel);
+  }
 
   if (GEngine) {
     GEngine->OnNetworkFailure().AddUObject(
@@ -1146,6 +1150,27 @@ void USkaldGameInstance::SeedCombatRandomStream(int32 Seed) {
 
 void USkaldGameInstance::ApplyDiceRollConfig() {
   InitialiseDiceManager();
+}
+
+bool USkaldGameInstance::SetDiceBoardStreamedActive(bool bShouldBeActive) {
+  if (!BattleLevelStreamingManager) {
+    UE_LOG(LogSkald, Warning,
+           TEXT("GameInstance SetDiceBoardStreamedActive failed: Battle level manager missing"));
+    return false;
+  }
+
+  UWorld* World = GetWorld();
+  if (!World) {
+    UE_LOG(LogSkald, Warning,
+           TEXT("GameInstance SetDiceBoardStreamedActive failed: no active world"));
+    return false;
+  }
+
+  const bool bSuccess = BattleLevelStreamingManager->SetDiceBoardActive(World, bShouldBeActive);
+  UE_LOG(LogSkald, Log, TEXT("GameInstance SetDiceBoardStreamedActive -> %s (success=%s)"),
+         bShouldBeActive ? TEXT("active") : TEXT("inactive"),
+         bSuccess ? TEXT("true") : TEXT("false"));
+  return bSuccess;
 }
 
 void USkaldGameInstance::InitialiseDiceManager() {

--- a/Source/Skald/Skald_GameInstance.h
+++ b/Source/Skald/Skald_GameInstance.h
@@ -184,6 +184,10 @@ public:
   /** Runtime helper responsible for streaming battle levels into the overworld. */
   UPROPERTY(Transient)
   TObjectPtr<USkaldBattleLevelManager> BattleLevelStreamingManager = nullptr;
+  UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category = "Streaming")
+  TSoftObjectPtr<UWorld> OverviewSublevel;
+  UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category = "Streaming")
+  TSoftObjectPtr<UWorld> DiceBoardSublevel;
 
   /** True when the game has travelled to a dedicated battle map. */
   UPROPERTY(BlueprintReadWrite, Category = "Battle")
@@ -389,6 +393,8 @@ public:
   /** Apply the configured dice roll data asset to the dice subsystem. */
   UFUNCTION(BlueprintCallable, Category = "Dice")
   void ApplyDiceRollConfig();
+  UFUNCTION(BlueprintCallable, Category = "Streaming")
+  bool SetDiceBoardStreamedActive(bool bShouldBeActive);
 
   /** Handle network failures and return to the lobby. */
   UFUNCTION()


### PR DESCRIPTION
### Motivation
- Move dice-board and overview transitions toward a persistent-root + streamed-sublevels architecture to avoid hard travel and preserve runtime/battle state.
- Provide editor-friendly configuration for overview and dice-board streamed levels so designers can assign and adjust scenes without changing code.
- Expose a programmatic/Blueprint entrypoint to toggle the dice board as a streamed sublevel and add LogSkald diagnostics to aid debugging multiplayer transitions.

### Description
- Added `ConfigurePersistentSublevels(const TSoftObjectPtr<UWorld>&, const TSoftObjectPtr<UWorld>&)` to `USkaldBattleLevelManager` and stored `ConfiguredOverviewLevel` / `ConfiguredDiceBoardLevel` soft references so these persistent sublevels are editor-assignable.
- Implemented streamed dice-board activation API `SetDiceBoardActive(UWorld*, bool)` and introduced `ActiveDiceStreamingLevel` to track the dice sublevel; activation reuses existing streaming levels or issues a dynamic load and toggles visibility/load state while hiding non-battle persistent/sublevels.
- Added helper `ResolveOrStreamLevel(...)` to locate existing `ULevelStreaming` entries or request `ULevelStreamingDynamic::LoadLevelInstanceBySoftObjectPtr` with `LogSkald` diagnostics, and added stubs (`ApplyVisibilityForCurrentMode`, `IsStreamingLevelPartOfDiceBoard`) for follow-up visibility mode logic.
- Exposed designer/BP-facing properties and controls in `USkaldGameInstance`: `OverviewSublevel`, `DiceBoardSublevel`, wiring `BattleLevelStreamingManager->ConfigurePersistentSublevels(...)` in `Init()`, and added Blueprint-callable proxy `SetDiceBoardStreamedActive(bool)` that forwards to the manager and logs results.
- Added `UE_LOG(LogSkald, ...)` messages around configuration, streaming requests, activation/hide events, and error paths to aid runtime and multiplayer debugging.

### Testing
- No automated tests were executed as part of this change in this pass; integration/build verification was not run here and should be performed in CI or locally by running the project build and the relevant Unreal automation tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0d25c4883c83248458c4d048048bf0)