### PR TITLE
Forward-declare EBattlePhase in Skald_PlayerController.h to fix compile error

### DIFF
--- a/Source/Skald/Skald_PlayerController.h
+++ b/Source/Skald/Skald_PlayerController.h
@@ -54,6 +54,7 @@ class UImage;
 class UCanvasPanel;
 class UFactionCursorWidget;
 struct FSkaldTravelState;
+enum class EBattlePhase : uint8;
 
 /** Command issued by the player during a battle. */
 UENUM()


### PR DESCRIPTION
### Motivation
- The header referenced `EBattlePhase` for the member `LastTurnOwnershipBattlePhase` but `EBattlePhase` was not declared in this header, causing compiler errors during parsing and member declaration.

### Description
- Add a forward declaration `enum class EBattlePhase : uint8;` to `Source/Skald/Skald_PlayerController.h` to make the type visible at the declaration site without changing runtime behavior.

### Testing
- No automated tests were run in this environment; this is a minimal, compile-time header-visibility fix validated by static inspection.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0d27ab606083248a8665708ad68fb4)