### PR TITLE
Fix EBattlePhase forward-declaration compile failure in player controller

### DIFF
--- a/Source/Skald/Skald_PlayerController.cpp
+++ b/Source/Skald/Skald_PlayerController.cpp
@@ -325,6 +325,7 @@ ASkaldPlayerController::ASkaldPlayerController() {
   bBattleHUDVisible = false;
   bBattleHUDReadyToShow = false;
   bPendingLocalSelectionRefresh = false;
+  LastTurnOwnershipBattlePhase = EBattlePhase::None;
 
   static ConstructorHelpers::FClassFinder<UChoosePlayerWidget> ChooseBP(
       TEXT("/Game/Blueprints/UI/Skald_ChoosePlayerWidget"));

--- a/Source/Skald/Skald_PlayerController.h
+++ b/Source/Skald/Skald_PlayerController.h
@@ -1077,7 +1077,7 @@ private:
   /** Debounce redundant turn-ownership refreshes for identical replicated state. */
   int32 LastTurnOwnershipActivePlayerId = INDEX_NONE;
   ETurnPhase LastTurnOwnershipPhase = ETurnPhase::Reinforcement;
-  EBattlePhase LastTurnOwnershipBattlePhase = EBattlePhase::None;
+  EBattlePhase LastTurnOwnershipBattlePhase;
   bool bLastTurnOwnershipIsMyTurn = false;
   bool bLastTurnOwnershipBattleTravelPending = false;
 


### PR DESCRIPTION
### Motivation
- A header-side default initializer referenced `EBattlePhase::None` while `EBattlePhase` was only forward-declared in the header, causing MSVC errors (`C2027` / `C2065`) during compilation.

### Description
- Removed the in-header default initializer for `LastTurnOwnershipBattlePhase` in `Source/Skald/Skald_PlayerController.h` so the forward declaration is no longer used with an enum value.
- Added initialization of `LastTurnOwnershipBattlePhase = EBattlePhase::None;` in the `ASkaldPlayerController` constructor in `Source/Skald/Skald_PlayerController.cpp` where the full enum definition is available.
- Changes are limited to the player controller declaration and constructor and avoid requiring the enum definition in the header.

### Testing
- Located enum declarations with `rg -n "enum class EBattlePhase" Source/Skald` to confirm the forward declaration and full definition locations, which informed the fix.
- Inspected the modified lines with `nl -ba`/`sed` to verify the header no longer contains the enum value initializer and the constructor now performs the initialization, both checks succeeded.
- No full project build was performed as part of this change; running a complete compile is recommended to validate the fix in the build environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0d28ecaa588324ba5281e945504f4b)