### PR TITLE
Prefer streaming retry over travel fallback in TriggerGridBattle

### DIFF
--- a/Source/Skald/Skald_TurnManager.cpp
+++ b/Source/Skald/Skald_TurnManager.cpp
@@ -2835,6 +2835,13 @@ void ATurnManager::TriggerGridBattle(const FS_BattlePayload &Battle) {
       UE_LOG(LogSkald, Warning,
              TEXT("TriggerGridBattle: battle level streaming failed for %s; scheduling retry instead of map travel."),
              *SelectedBattleMap.ToSoftObjectPath().ToString());
+      if (GI) {
+        // Clear the in-flight travel gate before scheduling a retry. Streaming
+        // failure marks travel pending earlier in this function to block
+        // premature battle flow, but leaving it set would cause the retry path
+        // to immediately defer again at the TriggerGridBattle guard.
+        GI->SetTravelPending(false);
+      }
       DeferredPendingBattle = PendingPayload;
       if (World &&
           !World->GetTimerManager().IsTimerActive(PendingBattleTravelRetryHandle)) {

--- a/Source/Skald/Skald_TurnManager.cpp
+++ b/Source/Skald/Skald_TurnManager.cpp
@@ -2831,7 +2831,20 @@ void ATurnManager::TriggerGridBattle(const FS_BattlePayload &Battle) {
            TravelState.HumanOwnedTerritories.Num(),
            TravelState.CachedTerritories.Num());
 
-    if (!bShouldStreamSelectedMap || !bStreamingBattle) {
+    if (bShouldStreamSelectedMap && !bStreamingBattle) {
+      UE_LOG(LogSkald, Warning,
+             TEXT("TriggerGridBattle: battle level streaming failed for %s; scheduling retry instead of map travel."),
+             *SelectedBattleMap.ToSoftObjectPath().ToString());
+      DeferredPendingBattle = PendingPayload;
+      if (World &&
+          !World->GetTimerManager().IsTimerActive(PendingBattleTravelRetryHandle)) {
+        FTimerDelegate RetryDelegate = FTimerDelegate::CreateUObject(
+            this, &ATurnManager::RetryPendingBattleTravel);
+        constexpr float RetryDelaySeconds = 0.15f;
+        World->GetTimerManager().SetTimer(PendingBattleTravelRetryHandle,
+                                          RetryDelegate, RetryDelaySeconds, false);
+      }
+    } else if (!bShouldStreamSelectedMap) {
       if (World->GetNetMode() != NM_Standalone) {
         MulticastPrepareBattleTravel(TravelState, PendingPayload);
       }


### PR DESCRIPTION
### Motivation
- Integrate the new battle level streaming flow by removing the outdated immediate `ServerTravel`/`OpenLevel` fallback when a streaming request fails, to avoid disruptive map reloads during battle preparation. 
- Prefer a recovery and retry strategy that preserves game flow and lets the streaming manager attempt to load the battle level cleanly. 

### Description
- Updated `ATurnManager::TriggerGridBattle` so that when `bShouldStreamSelectedMap` is true and the streaming request did not succeed, the code now logs a warning and caches the pending payload in `DeferredPendingBattle` instead of initiating map travel. 
- Scheduled a retry by setting a timer that calls `RetryPendingBattleTravel` via the existing `PendingBattleTravelRetryHandle` and an `FTimerDelegate`, with a short retry delay. 
- Preserved the legacy travel path (`MulticastPrepareBattleTravel` / `World->ServerTravel` / `UGameplayStatics::OpenLevel`) only for the case where streaming is explicitly disabled (`!bShouldStreamSelectedMap`). 

### Testing
- Ran `./Build/validate.sh`, which completed; the script reported that `UnrealBuildTool` and `UnrealEditor` were not present so compile and automation tests were skipped in this environment. 
- No other automated tests were executed as part of this change in the current environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1219c2d840832495c867b4eb9e3a4b)