### PR TITLE
Expose streamed sublevel options in Skald_GameInstance Blueprint defaults

### DIFF
--- a/Source/Skald/Skald_GameInstance.h
+++ b/Source/Skald/Skald_GameInstance.h
@@ -184,9 +184,11 @@ public:
   /** Runtime helper responsible for streaming battle levels into the overworld. */
   UPROPERTY(Transient)
   TObjectPtr<USkaldBattleLevelManager> BattleLevelStreamingManager = nullptr;
-  UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category = "Streaming")
+  UPROPERTY(EditDefaultsOnly, BlueprintReadWrite, Category = "Streaming",
+            meta = (DisplayName = "Overview Streamed Sublevel"))
   TSoftObjectPtr<UWorld> OverviewSublevel;
-  UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category = "Streaming")
+  UPROPERTY(EditDefaultsOnly, BlueprintReadWrite, Category = "Streaming",
+            meta = (DisplayName = "Dice Board Streamed Sublevel"))
   TSoftObjectPtr<UWorld> DiceBoardSublevel;
 
   /** True when the game has travelled to a dedicated battle map. */


### PR DESCRIPTION
### Motivation
- Make the streaming sublevel references discoverable and editable in the Blueprint `Class Defaults` so designers can assign the overworld and dice-board streamed levels from the `USkaldGameInstance` BP.

### Description
- Change two properties in `USkaldGameInstance`: make `OverviewSublevel` and `DiceBoardSublevel` `BlueprintReadWrite` and add `meta=(DisplayName=...)` so they appear as `Overview Streamed Sublevel` and `Dice Board Streamed Sublevel` in the `Streaming` category of the editor.

### Testing
- No automated tests were run because this is an editor-exposure, UPROPERTY-metadata-only change; the header was updated to include the new metadata and access qualifiers for the two properties.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a12ee8ed0608324bd4d18837181a626)