### PR TITLE
Expose streamed sublevel settings in GameInstance defaults

### DIFF
--- a/Source/Skald/Skald_GameInstance.h
+++ b/Source/Skald/Skald_GameInstance.h
@@ -184,11 +184,11 @@ public:
   /** Runtime helper responsible for streaming battle levels into the overworld. */
   UPROPERTY(Transient)
   TObjectPtr<USkaldBattleLevelManager> BattleLevelStreamingManager = nullptr;
-  UPROPERTY(EditDefaultsOnly, BlueprintReadWrite, Category = "Streaming",
-            meta = (DisplayName = "Overview Streamed Sublevel"))
+  UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Streaming",
+            meta = (DisplayName = "Overview Streamed Sublevel", AllowedClasses = "/Script/Engine.World"))
   TSoftObjectPtr<UWorld> OverviewSublevel;
-  UPROPERTY(EditDefaultsOnly, BlueprintReadWrite, Category = "Streaming",
-            meta = (DisplayName = "Dice Board Streamed Sublevel"))
+  UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Streaming",
+            meta = (DisplayName = "Dice Board Streamed Sublevel", AllowedClasses = "/Script/Engine.World"))
   TSoftObjectPtr<UWorld> DiceBoardSublevel;
 
   /** True when the game has travelled to a dedicated battle map. */


### PR DESCRIPTION
### Motivation
- Make the two streamed sublevel properties on `USkaldGameInstance` editable from Blueprint Class Defaults so they can be assigned inside the Unreal Editor (UE 5.5.4).

### Description
- Changed `OverviewSublevel` and `DiceBoardSublevel` `UPROPERTY` qualifiers from `EditDefaultsOnly` to `EditAnywhere` in `Source/Skald/Skald_GameInstance.h` so they are visible in `BP_Skald_GameInstance` Class Defaults.
- Added `AllowedClasses = "/Script/Engine.World"` metadata to both properties so the editor shows an appropriate world/level asset picker for these `TSoftObjectPtr<UWorld>` fields.

### Testing
- No automated tests were run for this small header change; please rebuild the project and open `BP_Skald_GameInstance` Class Defaults in the editor to verify the fields appear and are assignable.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a12f4ef4b908324ae85847b07222eec)