### PR TITLE
Use FSoftObjectPath for Overview/DiceBoard sublevel references and adapt streaming manager call

### DIFF
--- a/Source/Skald/Skald_GameInstance.cpp
+++ b/Source/Skald/Skald_GameInstance.cpp
@@ -196,7 +196,8 @@ void USkaldGameInstance::Init() {
   }
   if (BattleLevelStreamingManager) {
     BattleLevelStreamingManager->ConfigurePersistentSublevels(
-        OverviewSublevel, DiceBoardSublevel);
+        TSoftObjectPtr<UWorld>(OverviewSublevel),
+        TSoftObjectPtr<UWorld>(DiceBoardSublevel));
   }
 
   if (GEngine) {

--- a/Source/Skald/Skald_GameInstance.h
+++ b/Source/Skald/Skald_GameInstance.h
@@ -184,12 +184,12 @@ public:
   /** Runtime helper responsible for streaming battle levels into the overworld. */
   UPROPERTY(Transient)
   TObjectPtr<USkaldBattleLevelManager> BattleLevelStreamingManager = nullptr;
-  UPROPERTY(EditDefaultsOnly, BlueprintReadWrite, Category = "Streaming",
-            meta = (DisplayName = "Overview Streamed Sublevel"))
-  TSoftObjectPtr<UWorld> OverviewSublevel;
-  UPROPERTY(EditDefaultsOnly, BlueprintReadWrite, Category = "Streaming",
-            meta = (DisplayName = "Dice Board Streamed Sublevel"))
-  TSoftObjectPtr<UWorld> DiceBoardSublevel;
+  UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Streaming",
+            meta = (DisplayName = "Overview Streamed Sublevel", AllowedClasses = "/Script/Engine.World"))
+  FSoftObjectPath OverviewSublevel;
+  UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Streaming",
+            meta = (DisplayName = "Dice Board Streamed Sublevel", AllowedClasses = "/Script/Engine.World"))
+  FSoftObjectPath DiceBoardSublevel;
 
   /** True when the game has travelled to a dedicated battle map. */
   UPROPERTY(BlueprintReadWrite, Category = "Battle")


### PR DESCRIPTION
### Motivation

- Update how streamed battle sublevels are stored so references are represented as asset paths rather than typed `TSoftObjectPtr<UWorld>` pointers to improve editor compatibility and serialization.
- Ensure the battle level streaming manager still receives `TSoftObjectPtr<UWorld>` when configuring persistent sublevels after the field type change.

### Description

- Changed `OverviewSublevel` and `DiceBoardSublevel` properties from `TSoftObjectPtr<UWorld>` to `FSoftObjectPath` and set `AllowedClasses = "/Script/Engine.World"` with `EditAnywhere` and display names.
- Wrapped the new `FSoftObjectPath` fields with `TSoftObjectPtr<UWorld>(...)` when calling `BattleLevelStreamingManager->ConfigurePersistentSublevels(...)` to preserve the previous API contract.
- Kept transient/runtime members and initialization logic unchanged outside of the type adaptation.

### Testing

- Performed a full project build which completed successfully and validated the code compiles with the updated property types.
- Ran the existing automated test suite and editor startup smoke checks; all executed checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a12f4ef4b908324ae85847b07222eec)