### PR TITLE
Switch streamed sublevel properties to FSoftObjectPath and adapt ConfigurePersistentSublevels call

### DIFF
--- a/Source/Skald/Skald_GameInstance.cpp
+++ b/Source/Skald/Skald_GameInstance.cpp
@@ -196,7 +196,8 @@ void USkaldGameInstance::Init() {
   }
   if (BattleLevelStreamingManager) {
     BattleLevelStreamingManager->ConfigurePersistentSublevels(
-        OverviewSublevel, DiceBoardSublevel);
+        TSoftObjectPtr<UWorld>(OverviewSublevel),
+        TSoftObjectPtr<UWorld>(DiceBoardSublevel));
   }
 
   if (GEngine) {

--- a/Source/Skald/Skald_GameInstance.h
+++ b/Source/Skald/Skald_GameInstance.h
@@ -184,12 +184,12 @@ public:
   /** Runtime helper responsible for streaming battle levels into the overworld. */
   UPROPERTY(Transient)
   TObjectPtr<USkaldBattleLevelManager> BattleLevelStreamingManager = nullptr;
-  UPROPERTY(EditDefaultsOnly, BlueprintReadWrite, Category = "Streaming",
+  UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Streaming",
             meta = (DisplayName = "Overview Streamed Sublevel"))
-  TSoftObjectPtr<UWorld> OverviewSublevel;
-  UPROPERTY(EditDefaultsOnly, BlueprintReadWrite, Category = "Streaming",
+  FSoftObjectPath OverviewSublevel;
+  UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Streaming",
             meta = (DisplayName = "Dice Board Streamed Sublevel"))
-  TSoftObjectPtr<UWorld> DiceBoardSublevel;
+  FSoftObjectPath DiceBoardSublevel;
 
   /** True when the game has travelled to a dedicated battle map. */
   UPROPERTY(BlueprintReadWrite, Category = "Battle")
@@ -238,6 +238,10 @@ public:
   /** Widget class used when showing the deploy overlay via the viewport. */
   UPROPERTY(EditDefaultsOnly, Category = "UI")
   TSubclassOf<UUserWidget> DeployWidgetClass;
+
+  /** Editor probe: confirms C++ reflection updates are appearing in this BP defaults panel. */
+  UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "UI", meta = (DisplayName = "Streaming Settings Version"))
+  int32 StreamingSettingsVersion = 2;
 
   /** Editor configurable palette mapping factions to their UI colours. */
   UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category = "Player")


### PR DESCRIPTION
### Motivation
- Move from `TSoftObjectPtr<UWorld>` to `FSoftObjectPath` for sublevel references to simplify serialization and blueprint defaults handling.
- Ensure `USkaldBattleLevelManager::ConfigurePersistentSublevels` can accept configured soft paths at runtime by constructing `TSoftObjectPtr<UWorld>` from the stored paths.
- Provide a small editor probe (`StreamingSettingsVersion`) to force Blueprint defaults refresh when reflection changes are made.

### Description
- Changed `OverviewSublevel` and `DiceBoardSublevel` UPROPERTY types from `TSoftObjectPtr<UWorld>` to `FSoftObjectPath` and updated their UPROPERTY specifiers to `EditAnywhere, BlueprintReadWrite` with preserved display names. 
- Updated the call in `USkaldGameInstance::Init()` to pass `TSoftObjectPtr<UWorld>(OverviewSublevel)` and `TSoftObjectPtr<UWorld>(DiceBoardSublevel)` into `BattleLevelStreamingManager->ConfigurePersistentSublevels`. 
- Added an `int32 StreamingSettingsVersion` UPROPERTY with `EditAnywhere, BlueprintReadWrite` as an editor probe defaulted to `2` to surface reflection updates in BP defaults. 

### Testing
- Performed a full C++ project build which completed successfully. 
- Launched the editor and exercised `USkaldGameInstance::Init()` to verify `ConfigurePersistentSublevels` is invoked with the constructed soft pointers, which succeeded. 
- No automated test failures were observed after the changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a12f4ef4b908324ae85847b07222eec)