### PR TITLE
Fix FighterPawn visual path rebuild compile errors

### DIFF
--- a/Source/Skald/FighterPawn.cpp
+++ b/Source/Skald/FighterPawn.cpp
@@ -567,12 +567,6 @@ void AFighterPawn::RebuildVisualMovementPath(const FVector &Destination) {
   bool bConstructedFromGridPath = false;
 
   if (UGridOverlayComponent *Grid = GetGrid()) {
-    if (!Grid->IsInitialized()) {
-      UE_LOG(LogSkald, Verbose,
-             TEXT("RebuildVisualMovementPath fallback: grid not initialized for fighter %s"),
-             *GetNameSafe(this));
-      Grid = nullptr;
-    }
     if (Grid != nullptr) {
       FIntPoint StartAnchor = MovementSourceCell;
       if (!Grid->IsCellInBounds(StartAnchor)) {
@@ -776,6 +770,7 @@ void AFighterPawn::RebuildVisualMovementPath(const FVector &Destination) {
     }
   }
 
+  }
   const bool bCanAttemptAvoidance = !bConstructedFromGridPath &&
                                     bUseVisualObstacleAvoidance &&
                                     VisualAvoidanceProbeRadius > KINDA_SMALL_NUMBER &&


### PR DESCRIPTION
### Motivation
- The `RebuildVisualMovementPath` implementation referenced a non-existent `UGridOverlayComponent::IsInitialized()` API and an undeclared `LogSkald` category, which produced compile errors. 
- A missing closing brace in the same function corrupted scope and produced cascading `C2601 local function definitions are illegal` compiler errors.

### Description
- Removed the invalid `IsInitialized()` guard and the associated `UE_LOG(LogSkald, ...)` call from `AFighterPawn::RebuildVisualMovementPath` in `Source/Skald/FighterPawn.cpp` to avoid referring to unavailable APIs and undeclared log categories. 
- Inserted the missing closing brace to correctly terminate the grid-path construction block and restore proper function scope. 
- Adjusted surrounding formatting so the avoidance-path logic (`bCanAttemptAvoidance` block) remains intact and executes as intended when no grid path was constructed. 
- Changes are localized to `Source/Skald/FighterPawn.cpp` and do not introduce new APIs.

### Testing
- Ran a brace-balance check with `python -c` to verify that the number of `{` and `}` in `Source/Skald/FighterPawn.cpp` are balanced, and the script reported success. 
- Inspected the affected source region with `nl`/`sed` to confirm the `IsInitialized`/`UE_LOG` lines were removed and the closing brace was inserted before the avoidance block, and these inspections matched expectations. 
- No automated full project build was run in this patch; the edits specifically address the compile errors reported in the rollout and the above automated checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a13549beed48324999661b907a59fa2)