### PR TITLE
Guard visual movement grid path reconstruction until grid init completes

### DIFF
--- a/Source/Skald/FighterPawn.cpp
+++ b/Source/Skald/FighterPawn.cpp
@@ -567,7 +567,7 @@ void AFighterPawn::RebuildVisualMovementPath(const FVector &Destination) {
   bool bConstructedFromGridPath = false;
 
   if (UGridOverlayComponent *Grid = GetGrid()) {
-    if (Grid != nullptr) {
+    if (Grid != nullptr && Grid->HasInitializedGrid()) {
       FIntPoint StartAnchor = MovementSourceCell;
       if (!Grid->IsCellInBounds(StartAnchor)) {
         StartAnchor = Grid->WorldToGrid(StartLocation);

--- a/Source/Skald/GridOverlayComponent.h
+++ b/Source/Skald/GridOverlayComponent.h
@@ -142,6 +142,10 @@ public:
   UFUNCTION(BlueprintCallable, BlueprintPure, Category = "Grid")
   bool IsCellInBounds(const FIntPoint &GridCoord) const;
 
+  /** Whether the grid has completed BeginPlay initialization and sampled data is ready. */
+  UFUNCTION(BlueprintCallable, BlueprintPure, Category = "Grid")
+  bool HasInitializedGrid() const { return bHasInitializedGrid; }
+
   /** Spawn a persistent trap marker at the supplied grid coordinate. */
   UFUNCTION(BlueprintCallable, Category = "Grid|Trap")
   UDecalComponent *AddTrapMarker(const FIntPoint &GridCoord);


### PR DESCRIPTION
### Motivation
- Prevent `AFighterPawn` from attempting grid-based visual path reconstruction before `UGridOverlayComponent::BeginPlay` has populated occupancy/obscurity data, which can produce invalid "clear" cell reads and incorrectly set `bConstructedFromGridPath`, suppressing fallback obstacle-avoidance during startup/streaming timing windows.

### Description
- Add a `HasInitializedGrid()` accessor to `UGridOverlayComponent` and gate `AFighterPawn::RebuildVisualMovementPath` so it only attempts grid-based path reconstruction when `Grid` exists and `Grid->HasInitializedGrid()` is true.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a135853efdc832497d8b2f395097a5c)