### PR TITLE
Fix misplaced UPROPERTY in Skald_AIController.h

### DIFF
--- a/Source/Skald/Skald_AIController.h
+++ b/Source/Skald/Skald_AIController.h
@@ -352,7 +352,8 @@ private:
 
   /** PlayerState associated with the current animated placement sequence. */
   TWeakObjectPtr<ASkaldPlayerState> AnimatedPlacementPlayerState;
-};
+
   /** Optional data-driven mapping from ability id to AI decision category. */
   UPROPERTY(EditDefaultsOnly, Category = "AI|Data")
   UDataTable *AbilityCategoryTable = nullptr;
+};


### PR DESCRIPTION
### Motivation
- Fix an Unreal Header Tool parse error caused by a `UPROPERTY` macro appearing outside of class/struct scope which blocked the build.

### Description
- Move the `AbilityCategoryTable` declaration with `UPROPERTY(EditDefaultsOnly, Category = "AI|Data")` back inside the `ASkaldAIController` class so it appears before the final `};` in `Source/Skald/Skald_AIController.h`.

### Testing
- No automated tests were executed; the header was inspected to confirm the `UPROPERTY` now resides inside the class scope.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a135d1ced808324be6bfbf5156bbede)