### PR TITLE
Preserve fighter-selection cursor during battle travel

### DIFF
--- a/Source/Skald/Skald_PlayerController.cpp
+++ b/Source/Skald/Skald_PlayerController.cpp
@@ -2693,6 +2693,21 @@ void ASkaldPlayerController::InitializeFighterSelectionIfNeeded() {
            *GetNameSafe(this), bIsParticipant ? 1 : 0,
            CachedGameState ? static_cast<int32>(CachedGameState->BattlePhase) : -1, PendingBudget,
            PS->bIsActiveBattlePlayer ? 1 : 0, bOnBattleMap ? 1 : 0);
+
+    // Preserve cursor + UI input whenever the fighter-selection widget already
+    // exists. Replicated turn ownership updates can temporarily report a
+    // non-selection phase during travel/load, and forcing GameOnly in that
+    // window hides the cursor even though the selection UI is visible.
+    if (FighterSelectionWidget && FighterSelectionWidget->IsInViewport()) {
+      if (!bShowMouseCursor || !bEnableClickEvents || !bEnableMouseOverEvents) {
+        UWidgetBlueprintLibrary::SetInputMode_GameAndUIEx(
+            this, FighterSelectionWidget, EMouseLockMode::DoNotLock,
+            /*bHideCursorDuringCapture*/ false);
+      }
+      bShowMouseCursor = true;
+      bEnableClickEvents = true;
+      bEnableMouseOverEvents = true;
+    }
     return;
   }
 


### PR DESCRIPTION
### Motivation
- Fix a race where the fighter-selection UI is visible during overview->battle travel but the player's cursor/input is switched to GameOnly and becomes hidden due to transient replicated phase/context mismatches.

### Description
- Add a defensive input-mode restore in `ASkaldPlayerController::InitializeFighterSelectionIfNeeded` when the function skips creating the widget but `FighterSelectionWidget` is already in the viewport.
- Reapply `GameAndUI` input via `UWidgetBlueprintLibrary::SetInputMode_GameAndUIEx(this, FighterSelectionWidget, EMouseLockMode::DoNotLock, false)` and set `bShowMouseCursor`, `bEnableClickEvents`, and `bEnableMouseOverEvents` to true to preserve cursor and UI interaction.
- Change is localized to `Source/Skald/Skald_PlayerController.cpp` and targets the transient travel/load window that previously hid the cursor even though the selection UI was present.

### Testing
- Performed static code inspection and reviewed the diff to ensure the guard is applied in the correct skip path.
- No automated unit/integration tests or editor playtests were executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a13605449ac8324a798b9db1393cdf1)