### PR TITLE
Preserve fighter-selection UI and cursor when battle phase briefly changes

### DIFF
--- a/Source/Skald/Skald_PlayerController.cpp
+++ b/Source/Skald/Skald_PlayerController.cpp
@@ -2687,12 +2687,29 @@ void ASkaldPlayerController::InitializeFighterSelectionIfNeeded() {
     bIsParticipant = true;
   }
 
-  if (!bIsParticipant || PendingBudget <= 0 || !bInSelectionPhase) {
+  const bool bCanShowSelectionUI = bInSelectionPhase || bHasBattleContext;
+  if (!bIsParticipant || PendingBudget <= 0 || !bCanShowSelectionUI) {
     UE_LOG(LogSkaldBattle, Log,
-           TEXT("InitializeFighterSelectionIfNeeded: Skipping widget (Local=%s Participant=%d Phase=%d Budget=%d ActiveFlag=%d OnBattleMap=%d)"),
+           TEXT("InitializeFighterSelectionIfNeeded: Skipping widget (Local=%s Participant=%d Phase=%d Budget=%d ActiveFlag=%d OnBattleMap=%d HasContext=%d InSelectionPhase=%d)"),
            *GetNameSafe(this), bIsParticipant ? 1 : 0,
            CachedGameState ? static_cast<int32>(CachedGameState->BattlePhase) : -1, PendingBudget,
-           PS->bIsActiveBattlePlayer ? 1 : 0, bOnBattleMap ? 1 : 0);
+           PS->bIsActiveBattlePlayer ? 1 : 0, bOnBattleMap ? 1 : 0,
+           bHasBattleContext ? 1 : 0, bInSelectionPhase ? 1 : 0);
+
+    // Preserve cursor + UI input whenever the fighter-selection widget already
+    // exists. Replicated turn ownership updates can temporarily report a
+    // non-selection phase during travel/load, and forcing GameOnly in that
+    // window hides the cursor even though the selection UI is visible.
+    if (FighterSelectionWidget && FighterSelectionWidget->IsInViewport()) {
+      if (!bShowMouseCursor || !bEnableClickEvents || !bEnableMouseOverEvents) {
+        UWidgetBlueprintLibrary::SetInputMode_GameAndUIEx(
+            this, FighterSelectionWidget, EMouseLockMode::DoNotLock,
+            /*bHideCursorDuringCapture*/ false);
+      }
+      bShowMouseCursor = true;
+      bEnableClickEvents = true;
+      bEnableMouseOverEvents = true;
+    }
     return;
   }
 


### PR DESCRIPTION
### Motivation

- Prevent the fighter-selection UI from being hidden and the mouse cursor from being lost when replicated turn ownership updates briefly report a non-selection phase during travel/load while the selection widget is still visible.

### Description

- Add `bCanShowSelectionUI` to allow showing selection UI when either `bInSelectionPhase` or `bHasBattleContext` is true.
- Expand the debug log to include `HasContext` and `InSelectionPhase` fields for better diagnostics.
- When skipping initialization, preserve UI input if `FighterSelectionWidget` is visible by calling `UWidgetBlueprintLibrary::SetInputMode_GameAndUIEx` and re-enabling `bShowMouseCursor`, `bEnableClickEvents`, and `bEnableMouseOverEvents`.
- Maintain existing early-return behavior for non-participants or zero budget cases while ensuring visible selection UI remains interactive.

### Testing

- No automated tests were added or run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a13605449ac8324a798b9db1393cdf1)