### PR TITLE
Fix canonical stable id resolution and preserve fighter selection UI across travel/load

### DIFF
--- a/Source/Skald/Skald_BattleGameMode.cpp
+++ b/Source/Skald/Skald_BattleGameMode.cpp
@@ -98,25 +98,33 @@ static int32 ResolveCanonicalStableId(AController* Controller,
   const int32 TravelDefender = TravelState ? TravelState->DefenderPlayerId : INDEX_NONE;
   const int32 CachedId = GetPlayerIdFrom(Controller);
   const bool bTravelIdsValid = TravelAttacker > 0 && TravelDefender > 0;
-  const bool bPlayerStateLooksAI = PlayerState ? PlayerState->bIsAI : IsAIController(Controller);
   int32 Chosen = PSId > 0 ? PSId : (CachedId > 0 ? CachedId : INDEX_NONE);
   OutReason = PSId > 0 ? TEXT("PlayerState") : (CachedId > 0 ? TEXT("ControllerCache") : TEXT("None"));
 
   // During travel bootstrapping, seamless-travel reassignment can temporarily
-  // surface a local PlayerState id that does not match the battle payload
-  // (e.g. transient 261 while payload expects 260). Prefer canonical travel
-  // identities when current ids are outside the active attacker/defender pair.
+  // surface ids outside the active attacker/defender pair. Only canonicalize
+  // when we have a concrete identity match; avoid role-based reassignment that
+  // can incorrectly map a human defender to the attacker id.
   if (bTravelIdsValid &&
       Chosen > 0 &&
       Chosen != TravelAttacker &&
       Chosen != TravelDefender) {
-    Chosen = bPlayerStateLooksAI ? TravelDefender : TravelAttacker;
-    OutReason = bPlayerStateLooksAI ? TEXT("TravelCanonicalDefender")
-                                    : TEXT("TravelCanonicalAttacker");
+    if (CachedId == TravelAttacker || CachedId == TravelDefender) {
+      Chosen = CachedId;
+      OutReason = TEXT("TravelCanonicalControllerCache");
+    } else if (PSId == TravelAttacker || PSId == TravelDefender) {
+      Chosen = PSId;
+      OutReason = TEXT("TravelCanonicalPlayerState");
+    } else {
+      UE_LOG(LogSkaldBattle, Warning,
+             TEXT("[StableIdAudit][WARN] Unmapped participant id (Controller=%s PSId=%d CachedId=%d TravelAttacker=%d TravelDefender=%d). Keeping current id to avoid incorrect role swap."),
+             *GetNameSafe(Controller), PSId, CachedId, TravelAttacker,
+             TravelDefender);
+    }
   }
 
-  if (Chosen <= 0 && TravelAttacker > 0) { Chosen = TravelAttacker; OutReason = TEXT("TravelAttacker"); }
-  if (Chosen <= 0 && TravelDefender > 0) { Chosen = TravelDefender; OutReason = TEXT("TravelDefender"); }
+  if (Chosen <= 0 && TravelAttacker > 0) { Chosen = TravelAttacker; OutReason = TEXT("TravelAttackerFallback"); }
+  if (Chosen <= 0 && TravelDefender > 0) { Chosen = TravelDefender; OutReason = TEXT("TravelDefenderFallback"); }
   UE_LOG(LogSkaldBattle, Log, TEXT("[StableIdAudit] Ctx=ResolveCanonicalStableId Controller=%s PSId=%d TravelId=%d CachedId=%d Chosen=%d Reason=%s"),
          *GetNameSafe(Controller), PSId, (TravelAttacker > 0 ? TravelAttacker : TravelDefender), CachedId, Chosen, *OutReason);
   return Chosen;

--- a/Source/Skald/Skald_PlayerController.cpp
+++ b/Source/Skald/Skald_PlayerController.cpp
@@ -2687,12 +2687,29 @@ void ASkaldPlayerController::InitializeFighterSelectionIfNeeded() {
     bIsParticipant = true;
   }
 
-  if (!bIsParticipant || PendingBudget <= 0 || !bInSelectionPhase) {
+  const bool bCanShowSelectionUI = bInSelectionPhase || bHasBattleContext;
+  if (!bIsParticipant || PendingBudget <= 0 || !bCanShowSelectionUI) {
     UE_LOG(LogSkaldBattle, Log,
-           TEXT("InitializeFighterSelectionIfNeeded: Skipping widget (Local=%s Participant=%d Phase=%d Budget=%d ActiveFlag=%d OnBattleMap=%d)"),
+           TEXT("InitializeFighterSelectionIfNeeded: Skipping widget (Local=%s Participant=%d Phase=%d Budget=%d ActiveFlag=%d OnBattleMap=%d HasContext=%d InSelectionPhase=%d)"),
            *GetNameSafe(this), bIsParticipant ? 1 : 0,
            CachedGameState ? static_cast<int32>(CachedGameState->BattlePhase) : -1, PendingBudget,
-           PS->bIsActiveBattlePlayer ? 1 : 0, bOnBattleMap ? 1 : 0);
+           PS->bIsActiveBattlePlayer ? 1 : 0, bOnBattleMap ? 1 : 0,
+           bHasBattleContext ? 1 : 0, bInSelectionPhase ? 1 : 0);
+
+    // Preserve cursor + UI input whenever the fighter-selection widget already
+    // exists. Replicated turn ownership updates can temporarily report a
+    // non-selection phase during travel/load, and forcing GameOnly in that
+    // window hides the cursor even though the selection UI is visible.
+    if (FighterSelectionWidget && FighterSelectionWidget->IsInViewport()) {
+      if (!bShowMouseCursor || !bEnableClickEvents || !bEnableMouseOverEvents) {
+        UWidgetBlueprintLibrary::SetInputMode_GameAndUIEx(
+            this, FighterSelectionWidget, EMouseLockMode::DoNotLock,
+            /*bHideCursorDuringCapture*/ false);
+      }
+      bShowMouseCursor = true;
+      bEnableClickEvents = true;
+      bEnableMouseOverEvents = true;
+    }
     return;
   }
 


### PR DESCRIPTION
### Motivation

- Prevent incorrect swapping of attacker/defender identities during seamless travel and transient PlayerState/controller mismatches. 
- Avoid hiding the fighter-selection UI and cursor when replicated turn ownership temporarily reports a non-selection phase during travel/load.

### Description

- Change canonical stable id resolution in `ResolveCanonicalStableId` to prefer concrete identity matches from the controller cache or `PlayerState` before attempting any role-based reassignment, and avoid using AI-role heuristics that could flip human roles. 
- Add detailed logging with `UE_LOG(LogSkaldBattle, Warning|Log, ...)` when an unmapped participant id is encountered and when fallback choices are used, and rename several `OutReason` strings to more explicit values (e.g. `TravelCanonicalControllerCache`, `TravelCanonicalPlayerState`, `TravelAttackerFallback`, `TravelDefenderFallback`).
- Remove the fragile `bPlayerStateLooksAI` heuristic and instead only canonicalize when `CachedId` or `PSId` explicitly matches `TravelAttacker` or `TravelDefender`.
- In `ASkaldPlayerController::InitializeFighterSelectionIfNeeded`, add `bHasBattleContext` to the UI-show condition, improve the debug log line, and preserve cursor/UI input when the fighter-selection widget is already visible by forcing `GameAndUI` input and enabling mouse events so transient phase flips do not hide the cursor.

### Testing

- No new automated tests were added for this change. 
- Ran the existing automated unit and integration tests for the project and they completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a13605449ac8324a798b9db1393cdf1)