### PR TITLE
Fix UE_LOG format arg mismatch in fighter selection init

### DIFF
--- a/Source/Skald/Skald_PlayerController.cpp
+++ b/Source/Skald/Skald_PlayerController.cpp
@@ -2693,7 +2693,8 @@ void ASkaldPlayerController::InitializeFighterSelectionIfNeeded() {
            TEXT("InitializeFighterSelectionIfNeeded: Skipping widget (Local=%s Participant=%d Phase=%d Budget=%d ActiveFlag=%d OnBattleMap=%d HasContext=%d InSelectionPhase=%d)"),
            *GetNameSafe(this), bIsParticipant ? 1 : 0,
            CachedGameState ? static_cast<int32>(CachedGameState->BattlePhase) : -1, PendingBudget,
-           PS->bIsActiveBattlePlayer ? 1 : 0, bOnBattleMap ? 1 : 0);
+           PS->bIsActiveBattlePlayer ? 1 : 0, bOnBattleMap ? 1 : 0,
+           bHasBattleContext ? 1 : 0, bInSelectionPhase ? 1 : 0);
 
     // Preserve cursor + UI input whenever the fighter-selection widget already
     // exists. Replicated turn ownership updates can temporarily report a


### PR DESCRIPTION
### Motivation
- Resolve a compile-time `FormatStringSan` static assert caused by a mismatch between the `UE_LOG` format string placeholders and the number of provided arguments in `ASkaldPlayerController::InitializeFighterSelectionIfNeeded`.

### Description
- Add the missing `bHasBattleContext ? 1 : 0` and `bInSelectionPhase ? 1 : 0` arguments to the `UE_LOG` call so the placeholder count matches the supplied values.

### Testing
- Verified the corrected source line with `nl -ba Source/Skald/Skald_PlayerController.cpp | sed -n '2688,2702p'` to ensure the new arguments are present; committed the change; a full Unreal build was not executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a13661a7cf483249910e58f4376d399)