### PR TITLE
Use travel attacker id as canonical fallback during seamless travel

### DIFF
--- a/Source/Skald/Skald_BattleGameMode.cpp
+++ b/Source/Skald/Skald_BattleGameMode.cpp
@@ -116,8 +116,10 @@ static int32 ResolveCanonicalStableId(AController* Controller,
       Chosen = PSId;
       OutReason = TEXT("TravelCanonicalPlayerState");
     } else {
+      Chosen = TravelAttacker;
+      OutReason = TEXT("TravelCanonicalFallbackAttacker");
       UE_LOG(LogSkaldBattle, Warning,
-             TEXT("[StableIdAudit][WARN] Unmapped participant id (Controller=%s PSId=%d CachedId=%d TravelAttacker=%d TravelDefender=%d). Keeping current id to avoid incorrect role swap."),
+             TEXT("[StableIdAudit][WARN] Unmapped participant id (Controller=%s PSId=%d CachedId=%d TravelAttacker=%d TravelDefender=%d). Falling back to attacker travel id to avoid persisting a transient mapping."),
              *GetNameSafe(Controller), PSId, CachedId, TravelAttacker,
              TravelDefender);
     }


### PR DESCRIPTION
### Motivation
- Prevent persisting transient, non-canonical participant IDs during seamless-travel remap windows which can cause `GetBattleEntryForPlayer` lookups to miss and UI/ownership state to desync.

### Description
- Update `ResolveCanonicalStableId` in `Source/Skald/Skald_BattleGameMode.cpp` to set `Chosen = TravelAttacker` and `OutReason = TEXT("TravelCanonicalFallbackAttacker")` when both `PSId` and `CachedId` are outside the active travel participant IDs and travel IDs are valid, and adjust the warning log to reflect the fallback behavior. 

### Testing
- Verified the change by inspecting the working tree (`git status --short`), viewing the diff (`git diff -- Source/Skald/Skald_BattleGameMode.cpp`), committing the change, and printing the modified range of `Skald_BattleGameMode.cpp` (all commands completed successfully).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a136669f89c832487a46e4e54c307f6)