### PR TITLE
Fix replicated battle payload travel-state reconstruction

### DIFF
--- a/Source/Skald/Skald_GameState.cpp
+++ b/Source/Skald/Skald_GameState.cpp
@@ -433,6 +433,20 @@ void ASkaldGameState::OnRep_BattlePayload()
             bUpdatedTravel = true;
         }
 
+        if (ActiveBattlePayload.FromTerritoryID > 0 &&
+            TravelState.AttackerTerritory != ActiveBattlePayload.FromTerritoryID)
+        {
+            TravelState.AttackerTerritory = ActiveBattlePayload.FromTerritoryID;
+            bUpdatedTravel = true;
+        }
+
+        if (ActiveBattlePayload.TargetTerritoryID > 0 &&
+            TravelState.DefenderTerritory != ActiveBattlePayload.TargetTerritoryID)
+        {
+            TravelState.DefenderTerritory = ActiveBattlePayload.TargetTerritoryID;
+            bUpdatedTravel = true;
+        }
+
         if (ActiveBattlePayload.ArmyCountSent > 0 &&
             TravelState.AttackerArmyBudget != ActiveBattlePayload.ArmyCountSent)
         {
@@ -448,6 +462,12 @@ void ASkaldGameState::OnRep_BattlePayload()
             TravelState.DefenderArmyBudget != ReplicatedDefenderBudget)
         {
             TravelState.DefenderArmyBudget = ReplicatedDefenderBudget;
+            bUpdatedTravel = true;
+        }
+
+        if (TravelState.ExpectedControllers <= 0)
+        {
+            TravelState.ExpectedControllers = 1;
             bUpdatedTravel = true;
         }
 


### PR DESCRIPTION
### Motivation
- Replicated battle payloads on late-joining clients were updating player IDs and budgets but leaving travel territory IDs and expected-controller counts unset, producing partial/invalid travel state and causing battle-prep/fighter-selection gating to fail. 

### Description
- Update `ASkaldGameState::OnRep_BattlePayload()` to copy `ActiveBattlePayload.FromTerritoryID` and `ActiveBattlePayload.TargetTerritoryID` into `TravelState.AttackerTerritory` and `TravelState.DefenderTerritory` respectively. 
- Add a defensive fallback to set `TravelState.ExpectedControllers = 1` when the reconstructed travel state reports `<= 0` controllers. 
- Preserve existing propagation of player IDs and budgets and only call `GI->SetTravelState(TravelState)` when `bUpdatedTravel` indicates a change. 
- Change is in `Source/Skald/Skald_GameState.cpp` (updates around `OnRep_BattlePayload`).

### Testing
- Ran `git diff` to verify the patch touched `Source/Skald/Skald_GameState.cpp` and inspected the diff, which succeeded. 
- Ran `git status --short` to confirm the working tree state after the change, which succeeded. 
- Committed the change with `git commit -m "Fix replicated battle payload travel-state reconstruction"`, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a136a5b0c3c83249277529efbabdddf)