### PR TITLE
Add `cpp.hint` with Visual Studio IntelliSense macros for Unreal Engine

### DIFF
--- a/cpp.hint
+++ b/cpp.hint
@@ -1,0 +1,29 @@
+// Visual Studio IntelliSense macro hints for Unreal Engine projects.
+// This file is consumed by VS/C++ browsing to reduce false diagnostics.
+
+#define UCLASS(...)
+#define USTRUCT(...)
+#define UENUM(...)
+#define UINTERFACE(...)
+#define UFUNCTION(...)
+#define UPROPERTY(...)
+#define UDELEGATE(...)
+#define GENERATED_BODY(...)
+#define GENERATED_UCLASS_BODY(...)
+#define GENERATED_USTRUCT_BODY(...)
+#define GENERATED_IINTERFACE_BODY(...)
+
+// Keep delegate type names visible to IntelliSense by declaring placeholders.
+#define DECLARE_DYNAMIC_MULTICAST_DELEGATE(DelegateName) struct DelegateName {};
+#define DECLARE_DYNAMIC_MULTICAST_DELEGATE_OneParam(DelegateName, ...) struct DelegateName {};
+#define DECLARE_DYNAMIC_MULTICAST_DELEGATE_TwoParams(DelegateName, ...) struct DelegateName {};
+#define DECLARE_DYNAMIC_MULTICAST_DELEGATE_ThreeParams(DelegateName, ...) struct DelegateName {};
+#define DECLARE_DYNAMIC_MULTICAST_DELEGATE_FourParams(DelegateName, ...) struct DelegateName {};
+#define DECLARE_DYNAMIC_MULTICAST_DELEGATE_FiveParams(DelegateName, ...) struct DelegateName {};
+#define DECLARE_DYNAMIC_DELEGATE(DelegateName) struct DelegateName {};
+#define DECLARE_DYNAMIC_DELEGATE_OneParam(DelegateName, ...) struct DelegateName {};
+#define DECLARE_DYNAMIC_DELEGATE_TwoParams(DelegateName, ...) struct DelegateName {};
+#define DECLARE_DYNAMIC_DELEGATE_ThreeParams(DelegateName, ...) struct DelegateName {};
+
+#define SKALD_API
+#define SKALDDICE_API


### PR DESCRIPTION
### Motivation
- Add an IntelliSense hint file to reduce false diagnostics in Visual Studio when editing Unreal Engine code by providing no-op definitions for common Unreal macros and delegate types.

### Description
- Add `cpp.hint` that defines no-op macros for `UCLASS`, `USTRUCT`, `UENUM`, `UINTERFACE`, `UFUNCTION`, `UPROPERTY`, `UDELEGATE`, `GENERATED_BODY`, and related generated macros.
- Provide placeholder `struct` declarations for various `DECLARE_DYNAMIC_*_DELEGATE` variants so delegate type names remain visible to IntelliSense.
- Define project API macros `SKALD_API` and `SKALDDICE_API` as empty to silence linkage attribute warnings in header parsing.

### Testing
- No automated tests were required or executed for this non-functional IntelliSense helper file.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a136e1bd4e4832499cdbea0f3913f9a)