### PR TITLE
Respect active GameState payload and active-player flag in HandleHumanLockIn; improve logging

### DIFF
--- a/Source/Skald/Skald_BattleGameMode.cpp
+++ b/Source/Skald/Skald_BattleGameMode.cpp
@@ -2337,10 +2337,24 @@ void ASkald_BattleGameMode::HandleHumanLockIn(
     return;
   }
 
-  const FS_BattlePayload &Battle = GI->PendingBattle;
+  FS_BattlePayload Battle = GI->PendingBattle;
+  if (const ASkaldGameState* GS = GetGameState<ASkaldGameState>()) {
+    const FS_BattlePayload ActivePayload = GS->GetActiveBattlePayload();
+    if (ActivePayload.AttackerPlayerID > 0 && ActivePayload.DefenderPlayerID > 0) {
+      Battle = ActivePayload;
+    }
+  }
+
   const int32 PlayerId = ResolveBattlePlayerId(PS);
-  if (PlayerId != Battle.AttackerPlayerID &&
-      PlayerId != Battle.DefenderPlayerID) {
+  const bool bPlayerMatchesPayload =
+      (PlayerId == Battle.AttackerPlayerID || PlayerId == Battle.DefenderPlayerID);
+  const bool bPlayerMarkedParticipant = PS->bIsActiveBattlePlayer;
+
+  if (!bPlayerMatchesPayload && !bPlayerMarkedParticipant) {
+    UE_LOG(LogSkaldBattle, Warning,
+           TEXT("HandleHumanLockIn: rejecting lock-in for PlayerId=%d (Payload Attacker=%d Defender=%d ActiveFlag=%d)"),
+           PlayerId, Battle.AttackerPlayerID, Battle.DefenderPlayerID,
+           bPlayerMarkedParticipant ? 1 : 0);
     PC->Client_OnLockInResult(false, TEXT("Not part of pending battle"));
     return;
   }


### PR DESCRIPTION
### Motivation
- Ensure human lock-ins use the active battle payload from `ASkaldGameState` when present and allow players flagged as active battle participants to lock in even if they are not listed in the `GameInstance` pending payload.

### Description
- Replace `const FS_BattlePayload& Battle = GI->PendingBattle` with a local copy and override it with `GS->GetActiveBattlePayload()` when both attacker and defender IDs are set.
- Allow acceptance of a lock-in when either the resolved `PlayerId` matches the payload attacker/defender or when `PS->bIsActiveBattlePlayer` is true.
- Add a detailed `UE_LOG` message on rejection that includes `PlayerId`, payload attacker/defender IDs, and the active-player flag for better diagnostics.
- Keep the existing validation and `RegisterPlayerLockIn`/client result flows unchanged.

### Testing
- Project compiled successfully and the codebase built without errors.
- Existing automated unit tests covering battle flow were executed and passed.
- No new automated tests were added.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1372df329083249a72bdd915bb897c)