### PR TITLE
Do not defer prepare-for-battle prompts while waiting on AI opponent decision

### DIFF
--- a/Source/Skald/Skald_TurnManager.cpp
+++ b/Source/Skald/Skald_TurnManager.cpp
@@ -3132,47 +3132,6 @@ void ATurnManager::BroadcastPrepareForBattlePrompt(
     return;
   }
 
-  auto ShouldDeferForOpponentAIDecision =
-      [&](ASkaldPlayerController *Participant, bool bParticipantIsAttacker) {
-        if (!bHasAuthority || !Participant) {
-          return false;
-        }
-
-        const bool bOpponentIsAI = bParticipantIsAttacker
-                                        ? PendingBattleReadyState.bDefenderIsAI
-                                        : PendingBattleReadyState.bAttackerIsAI;
-
-        if (!bOpponentIsAI) {
-          return false;
-        }
-
-        const int32 OpponentPlayerId = bParticipantIsAttacker
-                                           ? PendingBattleReadyState.DefenderPlayerID
-                                           : PendingBattleReadyState.AttackerPlayerID;
-
-        if (OpponentPlayerId == INDEX_NONE) {
-          return false;
-        }
-
-        const bool bOpponentReady = bParticipantIsAttacker
-                                        ? PendingBattleReadyState.bDefenderReady
-                                        : PendingBattleReadyState.bAttackerReady;
-
-        if (bOpponentReady) {
-          return false;
-        }
-
-        const TCHAR *WaitingOnRole = bParticipantIsAttacker ? TEXT("defender")
-                                                            : TEXT("attacker");
-        UE_LOG(LogSkaldReady, Verbose,
-               TEXT("%s: deferring prepare prompt for %s while AI %s resolves decision."),
-               ResolvedLogContext, *GetNameSafe(Participant), WaitingOnRole);
-        return true;
-      };
-
-  bool bAttackerDeferred = false;
-  bool bDefenderDeferred = false;
-
   UWorld *World = GetWorld();
   ASkaldGameState *GameState =
       World ? World->GetGameState<ASkaldGameState>() : nullptr;
@@ -3401,14 +3360,6 @@ void ATurnManager::BroadcastPrepareForBattlePrompt(
                  TEXT("%s: participant flagged as AI but controller %s is not ASkaldAIController."),
                  LogContext, *Controller->GetName());
         }
-      } else if (ShouldDeferForOpponentAIDecision(Controller, bIsAttacker)) {
-        if (bIsAttacker) {
-          bAttackerDeferred = true;
-        }
-        if (bIsDefender) {
-          bDefenderDeferred = true;
-        }
-        continue;
       } else {
         UE_LOG(LogSkaldReady, Log,
                TEXT("WidgetSpawned PC=%s Role=%s Battle=%d->%d"),
@@ -3448,15 +3399,13 @@ void ATurnManager::BroadcastPrepareForBattlePrompt(
     }
   }
 
-  if (bNeedsAttackerConfirmation && !bAttackerMatched &&
-      !bAttackerDeferred) {
+  if (bNeedsAttackerConfirmation && !bAttackerMatched) {
     UE_LOG(LogSkald, Warning,
            TEXT("%s: pending attacker PlayerID %d has no registered controller."),
            LogContext, PendingBattleReadyState.AttackerPlayerID);
   }
 
-  if (bNeedsDefenderConfirmation && !bDefenderMatched &&
-      !bDefenderDeferred) {
+  if (bNeedsDefenderConfirmation && !bDefenderMatched) {
     UE_LOG(LogSkald, Warning,
            TEXT("%s: pending defender PlayerID %d has no registered controller."),
            LogContext, PendingBattleReadyState.DefenderPlayerID);


### PR DESCRIPTION
### Motivation
- Remove deferral behavior that withheld prepare-for-battle prompts for human participants while an AI opponent's readiness decision was unresolved, which could leave players waiting and skip prompt delivery.

### Description
- Deleted the `ShouldDeferForOpponentAIDecision` lambda and the `bAttackerDeferred`/`bDefenderDeferred` flags from `ATurnManager::BroadcastPrepareForBattlePrompt`.
- Removed the branch that continued without showing prompts when an opponent AI had not yet resolved its decision so controllers are now shown prompts immediately even if the opponent is AI.
- Updated final warning checks to always report missing controllers (removed checks against deferred flags).

### Testing
- Project compiled successfully after the change using the normal build pipeline.
- Ran the automated unit test suite and related game-state tests and they passed.
- Observed logs during automated runs confirming prompts are now emitted immediately rather than deferred.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a148ae2aef08324b4f21f29da56bce4)