### PR TITLE
Fix premature fighter lock-in before battle map is ready

### DIFF
--- a/Source/Skald/Skald_PlayerController.cpp
+++ b/Source/Skald/Skald_PlayerController.cpp
@@ -2687,7 +2687,10 @@ void ASkaldPlayerController::InitializeFighterSelectionIfNeeded() {
     bIsParticipant = true;
   }
 
-  const bool bCanShowSelectionUI = bInSelectionPhase || bHasBattleContext;
+  // Only allow lock-in UI once we're actually on the battle map.
+  // Showing it during travel can let clients submit lock-in before a battle
+  // GameMode exists, which drops the selection RPC on the floor.
+  const bool bCanShowSelectionUI = bOnBattleMap && bInSelectionPhase;
   if (!bIsParticipant || PendingBudget <= 0 || !bCanShowSelectionUI) {
     UE_LOG(LogSkaldBattle, Log,
            TEXT("InitializeFighterSelectionIfNeeded: Skipping widget (Local=%s Participant=%d Phase=%d Budget=%d ActiveFlag=%d OnBattleMap=%d HasContext=%d InSelectionPhase=%d)"),
@@ -2886,6 +2889,9 @@ void ASkaldPlayerController::Server_LockInSelection_Implementation(
     UE_LOG(LogSkaldBattle, Warning,
            TEXT("Server_LockInSelection: BattleGameMode not resolved for %s"),
            *GetName());
+    Client_OnLockInResult(
+        false,
+        TEXT("Battle is still loading. Please wait a moment and lock in again."));
   }
 }
 


### PR DESCRIPTION
### Motivation
- Playtest logs showed the fighter-selection UI appearing while `OnBattleMap=0`, which allowed clients to call `Server_LockInSelection` before an `ASkald_BattleGameMode` existed and produced `BattleGameMode not resolved` warnings.
- The goal is to prevent lock-in RPCs from being dropped during map/travel transitions and to give the user clear feedback when a lock-in races the battle-mode load.

### Description
- Require the client to be actually on the battle map before presenting the lock-in UI by changing the selection condition to `bOnBattleMap && bInSelectionPhase` in `ASkaldPlayerController::InitializeFighterSelectionIfNeeded` (file: `Source/Skald/Skald_PlayerController.cpp`).
- Add an explicit client notification in `Server_LockInSelection_Implementation` that calls `Client_OnLockInResult(false, "Battle is still loading...")` when `ResolveBattleGameMode()` returns `nullptr` so failures are surfaced and the client can retry.
- Add a short comment explaining the rationale for requiring the battle map to avoid submitting lock-ins before the battle `GameMode` exists.

### Testing
- Performed repository checks and code inspection using `rg` and `sed` to locate log occurrences and verify the changed logic, and reviewed the diff with `git diff`, which all completed successfully.
- Committed the change with `git commit` which succeeded. No automated unit or integration tests were run as none were invoked in this workflow.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a149ca6df4483248d0497d9f8ac7864)