### PR TITLE
Prevent TriggerGridBattle from starting when battle map is already active

### DIFF
--- a/Source/Skald/Skald_TurnManager.cpp
+++ b/Source/Skald/Skald_TurnManager.cpp
@@ -2342,6 +2342,14 @@ void ATurnManager::TriggerGridBattle(const FS_BattlePayload &Battle) {
   SeededBattle.RandomSeed = FMath::Rand();
 
   USkaldGameInstance *GI = GetGameInstance<USkaldGameInstance>();
+  if (GI && GI->bIsInBattleMap) {
+    UE_LOG(LogSkald, Warning,
+           TEXT("TriggerGridBattle ignored: battle map already active (Token=%s From=%d To=%d)."),
+           *GCurrentTravelSessionToken, Battle.FromTerritoryID,
+           Battle.TargetTerritoryID);
+    return;
+  }
+
   if (GI && (GI->bTravelPending || GI->bPendingBattleResolution)) {
     UE_LOG(LogSkald, Verbose,
            TEXT("TriggerGridBattle deferred: travel/resolution in progress (TravelPending=%s PendingResolution=%s)"),


### PR DESCRIPTION
### Motivation
- Avoid attempting to start a new grid battle while the battle map is already active to prevent conflicting state and redundant transitions.

### Description
- Add an early check in `ATurnManager::TriggerGridBattle` that logs a warning and returns when `GI->bIsInBattleMap` is true, including the current travel session token and involved territory IDs in the log message.

### Testing
- Project build and automated test suite executed after the change, and all automated tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a14a08dab1c83249cf6f64117d27124)