### PR TITLE
Reuse in-level BattleGameMode to avoid duplicate instantiation

### DIFF
--- a/Source/Skald/Skald_BattleLevelManager.cpp
+++ b/Source/Skald/Skald_BattleLevelManager.cpp
@@ -363,6 +363,23 @@ void USkaldBattleLevelManager::HandleLevelLoaded() {
       UWorld *OwningWorld = ActiveStreamingLevel->GetWorld();
       ULevel *LoadedLevel = ActiveStreamingLevel->GetLoadedLevel();
       if (OwningWorld && LoadedLevel && OwningWorld->GetNetMode() != NM_Client) {
+        ASkald_BattleGameMode *ExistingBattleGM = nullptr;
+        for (AActor *LevelActor : LoadedLevel->Actors) {
+          ASkald_BattleGameMode *CandidateBattleGM = Cast<ASkald_BattleGameMode>(LevelActor);
+          if (CandidateBattleGM) {
+            ExistingBattleGM = CandidateBattleGM;
+            break;
+          }
+        }
+
+        if (ExistingBattleGM) {
+          ActiveBattleGameMode = ExistingBattleGM;
+          GI->SetActiveBattleGameMode(ExistingBattleGM);
+          UE_LOG(LogSkald, Log,
+                 TEXT("BattleLevelManager: Reusing existing battle game mode actor %s from streamed level."),
+                 *GetNameSafe(ExistingBattleGM));
+        }
+
         TSubclassOf<ASkald_BattleGameMode> BattleGameModeClass = nullptr;
         if (AWorldSettings *WorldSettings = LoadedLevel->GetWorldSettings()) {
           UClass *DefaultGameModeClass = nullptr;
@@ -415,7 +432,7 @@ void USkaldBattleLevelManager::HandleLevelLoaded() {
                  TEXT("BattleLevelManager: Falling back to native Skald_BattleGameMode for battle map."));
         }
 
-        if (BattleGameModeClass) {
+        if (BattleGameModeClass && !ExistingBattleGM) {
           const FTransform SpawnTransform = FTransform::Identity;
           FActorSpawnParameters SpawnParams;
           SpawnParams.SpawnCollisionHandlingOverride =


### PR DESCRIPTION
### Motivation
- Logs showed duplicated battle lifecycle objects and repeated ready/selection cycles when streaming a battle level, which is consistent with spawning a second `ASkald_BattleGameMode` on top of one already present in the streamed level. 
- The intent of the change is to avoid creating a second battle GameMode actor when the streamed level already contains one so the battle lifecycle is not re-entered unexpectedly. 
- This fix targets the streaming activation path in the battle level manager where the GameMode is currently spawned unconditionally.

### Description
- `USkaldBattleLevelManager::HandleLevelLoaded` now scans the streamed level's `Actors` for an existing `ASkald_BattleGameMode` instance and, if found, reuses it by assigning it to `ActiveBattleGameMode` and calling `GI->SetActiveBattleGameMode(...)`.
- Dynamic spawning of the battle GameMode is now guarded so the manager only spawns a new `ASkald_BattleGameMode` when no in-level instance was discovered (`if (BattleGameModeClass && !ExistingBattleGM)`).
- Added a log message when an in-level `ASkald_BattleGameMode` is detected and reused to aid debugging.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a14a5461c3883249bee034f001c7176)