### PR TITLE
Gate fighter-selection on battle-stream readiness and fully unload non-battle sublevels

### DIFF
--- a/Source/Skald/Skald_BattleLevelManager.cpp
+++ b/Source/Skald/Skald_BattleLevelManager.cpp
@@ -632,6 +632,16 @@ bool USkaldBattleLevelManager::TickStreamingStatus(float DeltaTime) {
   return ActiveStreamingLevel.IsValid();
 }
 
+bool USkaldBattleLevelManager::IsBattleLevelFullyReady() const {
+  const ULevelStreaming* StreamingLevel = ActiveStreamingLevel.Get();
+  if (!StreamingLevel) {
+    return false;
+  }
+
+  return bActiveLevelShouldBeLoaded && StreamingLevel->IsLevelLoaded() &&
+         StreamingLevel->IsLevelVisible();
+}
+
 void USkaldBattleLevelManager::HideNonBattleLevels() {
   RestoreNonBattleLevels();
 
@@ -666,13 +676,15 @@ void USkaldBattleLevelManager::HideNonBattleLevels() {
     }
 
     const bool bWasVisible = OtherLevel->IsLevelVisible();
-    if (!bWasVisible) {
+    const bool bWasLoaded = OtherLevel->ShouldBeLoaded();
+    if (!bWasVisible && !bWasLoaded) {
       continue;
     }
 
     FHiddenStreamingLevelState State;
     State.Level = OtherLevel;
     State.bWasVisible = bWasVisible;
+    State.bWasLoaded = bWasLoaded;
     HiddenStreamingLevels.Add(State);
 
     FString LevelLabel = OtherLevel->GetWorldAssetPackageName();
@@ -680,6 +692,7 @@ void USkaldBattleLevelManager::HideNonBattleLevels() {
       LevelLabel = OtherLevel->GetWorldAsset().ToSoftObjectPath().ToString();
     }
 
+    OtherLevel->SetShouldBeLoaded(false);
     OtherLevel->SetShouldBeVisible(false);
     UE_LOG(LogSkald, Verbose,
            TEXT("BattleLevelManager: Hiding streaming level %s while battle map active"),
@@ -747,6 +760,7 @@ void USkaldBattleLevelManager::RestoreNonBattleLevels() {
 
   for (const FHiddenStreamingLevelState &State : HiddenStreamingLevels) {
     if (ULevelStreaming *Level = State.Level.Get()) {
+      Level->SetShouldBeLoaded(State.bWasLoaded);
       Level->SetShouldBeVisible(State.bWasVisible);
       if (State.bWasVisible) {
         FString LevelLabel = Level->GetWorldAssetPackageName();

--- a/Source/Skald/Skald_BattleLevelManager.h
+++ b/Source/Skald/Skald_BattleLevelManager.h
@@ -40,6 +40,7 @@ public:
 
   /** Returns whether a streamed battle level is currently active. */
   bool IsBattleLevelActive() const { return ActiveStreamingLevel.IsValid(); }
+  bool IsBattleLevelFullyReady() const;
 
 private:
   void HideNonBattleLevels();
@@ -78,6 +79,7 @@ private:
   struct FHiddenStreamingLevelState {
     TWeakObjectPtr<ULevelStreaming> Level;
     bool bWasVisible = false;
+    bool bWasLoaded = false;
   };
 
   struct FHiddenPersistentActorState {

--- a/Source/Skald/Skald_PlayerController.cpp
+++ b/Source/Skald/Skald_PlayerController.cpp
@@ -30,6 +30,7 @@
 #include "Skald_GameInstance.h"
 #include "Skald_GameMode.h"
 #include "Skald_BattleGameMode.h"
+#include "Skald_BattleLevelManager.h"
 #include "SkaldLogging.h"
 #include "Skald_GameState.h"
 #include "Skald_PlayerState.h"
@@ -2690,14 +2691,22 @@ void ASkaldPlayerController::InitializeFighterSelectionIfNeeded() {
   // Only allow lock-in UI once we're actually on the battle map.
   // Showing it during travel can let clients submit lock-in before a battle
   // GameMode exists, which drops the selection RPC on the floor.
-  const bool bCanShowSelectionUI = bOnBattleMap && bInSelectionPhase;
+  const USkaldBattleLevelManager* BattleLevelManager =
+      CachedGameInstance ? CachedGameInstance->GetBattleLevelManager() : nullptr;
+  const bool bBattleStreamReady =
+      !BattleLevelManager || BattleLevelManager->IsBattleLevelFullyReady();
+  const bool bCanShowSelectionUI =
+      bOnBattleMap && bInSelectionPhase && bBattleStreamReady &&
+      !CachedGameInstance->IsTravelPending();
   if (!bIsParticipant || PendingBudget <= 0 || !bCanShowSelectionUI) {
     UE_LOG(LogSkaldBattle, Log,
-           TEXT("InitializeFighterSelectionIfNeeded: Skipping widget (Local=%s Participant=%d Phase=%d Budget=%d ActiveFlag=%d OnBattleMap=%d HasContext=%d InSelectionPhase=%d)"),
+           TEXT("InitializeFighterSelectionIfNeeded: Skipping widget (Local=%s Participant=%d Phase=%d Budget=%d ActiveFlag=%d OnBattleMap=%d HasContext=%d InSelectionPhase=%d StreamReady=%d TravelPending=%d)"),
            *GetNameSafe(this), bIsParticipant ? 1 : 0,
            CachedGameState ? static_cast<int32>(CachedGameState->BattlePhase) : -1, PendingBudget,
            PS->bIsActiveBattlePlayer ? 1 : 0, bOnBattleMap ? 1 : 0,
-           bHasBattleContext ? 1 : 0, bInSelectionPhase ? 1 : 0);
+           bHasBattleContext ? 1 : 0, bInSelectionPhase ? 1 : 0,
+           bBattleStreamReady ? 1 : 0,
+           CachedGameInstance->IsTravelPending() ? 1 : 0);
 
     // Preserve cursor + UI input whenever the fighter-selection widget already
     // exists. Replicated turn ownership updates can temporarily report a


### PR DESCRIPTION
### Motivation
- Prevent fighter selection UI and overworld systems (duplicate player states, camera managers, etc.) from activating before a streamed battle sublevel is fully loaded and visible. 
- Ensure the overview map and other non-battle streamed sublevels are actually unloaded (not just hidden) while a battle sublevel is active to avoid background tick/collision/state leaks. 

### Description
- Added `IsBattleLevelFullyReady()` to `USkaldBattleLevelManager` to expose a readiness check that requires the active streaming level to be requested, loaded and visible. (Updated `Skald_BattleLevelManager.h/cpp`.)
- Extended hidden-streamed-level bookkeeping with a `bWasLoaded` flag and changed `HideNonBattleLevels()` to set `SetShouldBeLoaded(false)` for non-battle sublevels, and `RestoreNonBattleLevels()` to restore the previous `ShouldBeLoaded` state so levels are truly unloaded and then restored. (Updated `Skald_BattleLevelManager.cpp`/header.)
- Tightened fighter-selection gating in `ASkaldPlayerController::InitializeFighterSelectionIfNeeded()` so the selection UI is only shown when on the battle map, in the selection phase, the battle stream is fully ready (`IsBattleLevelFullyReady()`), and travel is not pending; added diagnostic logging for stream-ready and travel-pending state. (Updated `Skald_PlayerController.cpp`.)

### Testing
- No automated tests were executed as part of this change; changes were code-reviewed and compiled as part of the local edit cycle.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a14aa4be6e083249b937955b1baabe9)