### PR TITLE
Fix battle travel loading overlay and map-state detection

### DIFF
--- a/Source/Skald/Skald_GameInstance.cpp
+++ b/Source/Skald/Skald_GameInstance.cpp
@@ -348,7 +348,9 @@ void USkaldGameInstance::SetTravelPending(bool bInPending) {
                                            .HAlign(HAlign_Center)
                                            .VAlign(VAlign_Center)[SNew(STextBlock)
                                                                      .Justification(ETextJustify::Center)
-                                                                     .Text(NSLOCTEXT("Skald", "TravelLoadingText", "Loading overworld..."))
+                                                                     .Text(HasPendingBattleTravelContext()
+                                                                               ? NSLOCTEXT("Skald", "TravelLoadingBattleText", "Loading battle map...")
+                                                                               : NSLOCTEXT("Skald", "TravelLoadingText", "Loading overworld..."))
                                                                      .Font(FCoreStyle::GetDefaultFontStyle("Bold", 32))
                                                                      .ColorAndOpacity(FLinearColor::White)]];
 
@@ -895,8 +897,18 @@ void USkaldGameInstance::HandleWorldBeginPlay(UWorld *LoadedWorld) {
 
   const FString CurrentLevel =
       UGameplayStatics::GetCurrentLevelName(this, /*bRemovePrefixString=*/true);
-  const bool bDetectedBattleMap =
-      CurrentLevel.Equals(TEXT("BattleMap"), ESearchCase::IgnoreCase);
+
+  bool bDetectedBattleMap =
+      CurrentLevel.Equals(TEXT("BattleMap"), ESearchCase::IgnoreCase) ||
+      CurrentLevel.StartsWith(TEXT("Battle"), ESearchCase::IgnoreCase);
+
+  if (!bDetectedBattleMap) {
+    if (const AGameModeBase *GM = LoadedWorld->GetAuthGameMode()) {
+      const FString GMClassName = GM->GetClass()->GetName();
+      bDetectedBattleMap = GMClassName.Contains(TEXT("BattleGameMode"),
+                                                ESearchCase::IgnoreCase);
+    }
+  }
 
   // Keep the battle-map state in sync with the actual level in case the travel
   // RPC was missed (e.g. late-joining clients or failed multicast). This ensures
@@ -904,8 +916,8 @@ void USkaldGameInstance::HandleWorldBeginPlay(UWorld *LoadedWorld) {
   // UI such as fighter selection. Only auto-promote into battle state when the
   // default BattleMap is detected to avoid clearing an existing battle flag when
   // travelling to named battle maps selected from the configured map lists.
-  if (bDetectedBattleMap && !bIsInBattleMap) {
-    SetBattleMapActive(true);
+  if (bDetectedBattleMap != bIsInBattleMap) {
+    SetBattleMapActive(bDetectedBattleMap);
   }
 
   SetTravelPending(false);


### PR DESCRIPTION
### Motivation
- The travel loading overlay always showed an overworld message and battle/map detection was too narrow, causing the UI to display "Loading Overview Map..." during battle transitions and leaving stale overview state active after travel. 

### Description
- Update `USkaldGameInstance::SetTravelPending` to display a battle-specific message when a battle travel context exists by using `HasPendingBattleTravelContext()` and `NSLOCTEXT("Skald","TravelLoadingBattleText","Loading battle map...")` instead of always showing the overworld text. 
- Harden `HandleWorldBeginPlay` detection to mark battle maps when the level name equals `BattleMap` or `StartsWith("Battle")`, and add a fallback that inspects the authoritative `GameMode` class name for `BattleGameMode`. 
- Ensure world/battle state is synchronized in both directions by calling `SetBattleMapActive(bDetectedBattleMap)` when detection changes instead of only setting it true on detection. 
- All modifications are contained in `Source/Skald/Skald_GameInstance.cpp` and committed with the message `Fix battle travel loading overlay and map-state detection`.

### Testing
- Verified the code edits with `git diff` to confirm the intended changes were applied, which succeeded. 
- Committed the change with `git commit`, which succeeded. 
- No automated test suite was executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a14b013bfc48324be9f1a1372161f71)