### PR TITLE
Prevent duplicate/parallel SetupPendingBattle by tracking in-progress token

### DIFF
--- a/Source/Skald/Skald_BattleGameMode.cpp
+++ b/Source/Skald/Skald_BattleGameMode.cpp
@@ -1021,7 +1021,14 @@ void ASkald_BattleGameMode::SetupPendingBattle() {
   ++SetupAttemptCounter;
   const FString Token = GetGameInstance<USkaldGameInstance>() ? GetGameInstance<USkaldGameInstance>()->GetTravelSessionToken() : FString();
   UE_LOG(LogSkaldBattle, Log, TEXT("[SetupTrace] Token=%s Attempt=%d Source=direct AlreadyComplete=%d"), *Token, SetupAttemptCounter, bSetupCompleted ? 1 : 0);
-  if (bSetupCompleted && SetupCompleteToken == Token) { UE_LOG(LogSkaldBattle, Warning, TEXT("[SetupTrace][WARN] Duplicate setup entry")); }
+  if (bSetupCompleted && SetupCompleteToken == Token) {
+    UE_LOG(LogSkaldBattle, Warning, TEXT("[SetupTrace][WARN] Duplicate setup entry"));
+    return;
+  }
+  if (!Token.IsEmpty() && SetupInProgressToken == Token) {
+    UE_LOG(LogSkaldBattle, Verbose, TEXT("[SetupTrace] Token=%s duplicate in-progress entry ignored"), *Token);
+    return;
+  }
   if (!HasAuthority()) {
     return;
   }
@@ -1036,7 +1043,10 @@ void ASkald_BattleGameMode::SetupPendingBattle() {
     bSetupStarted = false;
     GBattleSetupTriggered = false;
     ActiveSetupSignature = 0;
+    SetupInProgressToken.Reset();
   };
+
+  SetupInProgressToken = Token;
 
   USkaldGameInstance *GI = GetGameInstance<USkaldGameInstance>();
   if (!GI || !GI->GridBattleManager) {
@@ -1098,6 +1108,7 @@ void ASkald_BattleGameMode::SetupPendingBattle() {
     bSetupCompleted = true; SetupCompleteToken = Token; if (USkaldGameInstance* LocalGI = GetGameInstance<USkaldGameInstance>()) { LocalGI->bTurnStateFrozenForTravel = false; UE_LOG(LogSkald, Log, TEXT("[TurnFreeze] Ctx=SetupPendingBattle Frozen=0 ActiveId=%d LocalTurnActive=0 Action=evaluate"), LocalGI->GetTravelState().AttackerPlayerId); } UE_LOG(LogSkaldBattle, Log, TEXT("[TravelSummary] Token=%s Expected=%d ParticipantCount=%d SetupAttempts=%d"), *Token, ExpectedControllers, GS ? GS->GetBattleEntries().Num() : 0, SetupAttemptCounter);
     bSetupStarted = false;
     GBattleSetupTriggered = false;
+    SetupInProgressToken.Reset();
     return;
   }
 
@@ -1441,6 +1452,7 @@ void ASkald_BattleGameMode::SetupPendingBattle() {
   }
 
   bSetupCompleted = true; SetupCompleteToken = Token; if (USkaldGameInstance* LocalGI = GetGameInstance<USkaldGameInstance>()) { LocalGI->bTurnStateFrozenForTravel = false; UE_LOG(LogSkald, Log, TEXT("[TurnFreeze] Ctx=SetupPendingBattle Frozen=0 ActiveId=%d LocalTurnActive=0 Action=evaluate"), LocalGI->GetTravelState().AttackerPlayerId); } UE_LOG(LogSkaldBattle, Log, TEXT("[TravelSummary] Token=%s Expected=%d ParticipantCount=%d SetupAttempts=%d"), *Token, ExpectedControllers, GS ? GS->GetBattleEntries().Num() : 0, SetupAttemptCounter);
+  SetupInProgressToken.Reset();
   LastCompletedSetupSignature = SetupSignature;
   ActiveSetupSignature = 0;
   GI->PendingBattle = Battle;

--- a/Source/Skald/Skald_BattleGameMode.h
+++ b/Source/Skald/Skald_BattleGameMode.h
@@ -132,5 +132,7 @@ private:
   uint32 ActiveSetupSignature = 0;
   int32 SetupAttemptCounter = 0;
   FString SetupCompleteToken;
+  /** Travel token currently being processed by SetupPendingBattle. */
+  FString SetupInProgressToken;
   TMap<FString, TSet<FString>> RegisteredControllers;
 };


### PR DESCRIPTION
### Motivation
- Prevent duplicate or parallel execution of `SetupPendingBattle` when the same travel session token is processed multiple times. 
- Ensure idempotency and avoid drifting state when a previously-completed or currently-in-progress setup is re-triggered. 
- Provide clearer logging and state cleanup for interrupted or ignored setup attempts.

### Description
- Add a new member `SetupInProgressToken` to track the travel token currently being processed by `SetupPendingBattle`.
- Early-return and log a warning if `bSetupCompleted` matches the incoming token to avoid re-running a completed setup. 
- Early-return and log verbose if the incoming token equals `SetupInProgressToken` to ignore duplicate in-progress entries. 
- Set `SetupInProgressToken` at start of processing and clear it in `ResetSetupAttempt`, when skipping duplicate completed setups, and after successful setup completion.

### Testing
- Built the project (Unreal build) successfully with the change applied. 
- Ran the project's automated unit test suite and observed no failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a14b267c5a08324b38358a69448f33f)