### PR TITLE
Delay battle-map activation for streamed battles to fix ready-phase desync

### DIFF
--- a/Source/Skald/Skald_TurnManager.cpp
+++ b/Source/Skald/Skald_TurnManager.cpp
@@ -2838,10 +2838,16 @@ void ATurnManager::TriggerGridBattle(const FS_BattlePayload &Battle) {
       } else {
         GI->SetTravelPending(true);
       }
-      GI->SetBattleMapActive(true);
 
-      if (World->GetNetMode() != NM_Standalone) {
-        MulticastSetBattleMapActive(true);
+      // Do not mark the battle map as active until the streamed level is
+      // actually loaded/visible. Prematurely setting this flag keeps the
+      // overworld running while UI/state machines repeatedly try to enter
+      // ready-for-battle.
+      if (!bShouldStreamSelectedMap) {
+        GI->SetBattleMapActive(true);
+        if (World->GetNetMode() != NM_Standalone) {
+          MulticastSetBattleMapActive(true);
+        }
       }
     }
 
@@ -3544,7 +3550,8 @@ void ATurnManager::MulticastStreamBattleLevel_Implementation(
 
   GI->SetTravelState(TravelState);
   GI->PendingBattle = BattlePayload;
-  GI->SetBattleMapActive(true);
+  // Keep this false until the battle streaming level is actually active.
+  GI->SetBattleMapActive(false);
 
   if (USkaldBattleLevelManager *BattleLevelManager =
           GI->GetBattleLevelManager()) {


### PR DESCRIPTION
### Motivation
- Triggering streamed battle transitions marked the game as "in-battle" before the streamed level was loaded, allowing the overworld to remain active while UI/state machines repeatedly re-entered the prepare-for-battle flow.
- This produced the observed loop where the overview map never unloaded and turns continued in the overworld while a battle was expected.

### Description
- In `ATurnManager::TriggerGridBattle` the code now only calls `GI->SetBattleMapActive(true)` (and `MulticastSetBattleMapActive`) immediately for the non-streamed (fallback travel) path, avoiding premature activation for streamed transitions in `Source/Skald/Skald_TurnManager.cpp`.
- In `ATurnManager::MulticastStreamBattleLevel_Implementation` the client-side handler now keeps the game instance battle flag false (`GI->SetBattleMapActive(false)`) until the battle level manager actually reports the streamed level is active, ensuring level-manager activation (`HandleLevelLoaded`) remains authoritative.
- Added clarifying comments around the guarded activation logic to explain the desync risk and intent.

### Testing
- Ran the included validation script `bash Build/validate.sh`, which executed and reported Unreal tooling was unavailable so compile and automation tests were skipped; the script completed without further errors.
- Performed a repository-level audit of relevant call sites and streaming flow (`TriggerGridBattle`, `MulticastStreamBattleLevel`, and `USkaldBattleLevelManager` handlers) to ensure the change aligns with existing `HandleLevelLoaded`/`HandleLevelUnloaded` activation points.
- Changes were committed to the working branch with the message `Fix premature battle-map activation during streamed battle travel`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a14b7cd5f708324814f4af395425e09)