### PR TITLE
Preserve travel state on partial updates and accept legacy BattleGameMode blueprint name

### DIFF
--- a/Source/Skald/Skald_BattleLevelManager.cpp
+++ b/Source/Skald/Skald_BattleLevelManager.cpp
@@ -395,9 +395,13 @@ void USkaldBattleLevelManager::HandleLevelLoaded() {
                    *GetNameSafe(LoadedLevel), *GetNameSafe(DefaultGameModeClass),
                    *DefaultClassPath);
 
-            if (!DefaultClassPath.Contains(TEXT("Skald_BattleGameMode_SC"))) {
+            const bool bMatchesCanonicalBlueprint =
+                DefaultClassPath.Contains(TEXT("Skald_BattleGameMode_SC"));
+            const bool bMatchesLegacyTypoBlueprint =
+                DefaultClassPath.Contains(TEXT("Skald_BatlleGameMode_SC"));
+            if (!bMatchesCanonicalBlueprint && !bMatchesLegacyTypoBlueprint) {
               UE_LOG(LogSkald, Warning,
-                     TEXT("BattleLevelManager: Expected Skald_BattleGameMode_SC as the default battle GameMode for streamed maps."));
+                     TEXT("BattleLevelManager: Expected Skald_BattleGameMode_SC (or legacy Skald_BatlleGameMode_SC) as the default battle GameMode for streamed maps."));
             }
 
             if (DefaultGameModeClass->IsChildOf(

--- a/Source/Skald/Skald_GameInstance.cpp
+++ b/Source/Skald/Skald_GameInstance.cpp
@@ -239,8 +239,31 @@ USkaldGameInstance::GetFactionEmblem(ESkaldFaction InFaction) const {
 }
 
 void USkaldGameInstance::SetTravelState(const FSkaldTravelState &InState) {
+  const FSkaldTravelState PreviousState = TravelState;
   TravelState = InState;
   TravelState.bValid = true;
+
+  // Replicated travel-state updates can arrive in multiple passes. Preserve
+  // the previously issued travel token when the incoming state omits it so
+  // all setup stages remain correlated to the same battle session.
+  if (TravelState.TravelSessionToken.IsEmpty() &&
+      !PreviousState.TravelSessionToken.IsEmpty()) {
+    TravelState.TravelSessionToken = PreviousState.TravelSessionToken;
+  }
+
+  // Keep established participant/controller fields when a partial update has
+  // not filled them yet. This avoids temporarily regressing to an "invalid"
+  // travel state between replication passes.
+  if (TravelState.ExpectedControllers <= 0 &&
+      PreviousState.ExpectedControllers > 0) {
+    TravelState.ExpectedControllers = PreviousState.ExpectedControllers;
+  }
+  if (TravelState.AttackerPlayerId <= 0 && PreviousState.AttackerPlayerId > 0) {
+    TravelState.AttackerPlayerId = PreviousState.AttackerPlayerId;
+  }
+  if (TravelState.DefenderPlayerId <= 0 && PreviousState.DefenderPlayerId > 0) {
+    TravelState.DefenderPlayerId = PreviousState.DefenderPlayerId;
+  }
   if (TravelState.CachedTerritories.Num() == 0 &&
       CachedWorldMapTerritories.Num() > 0) {
     TravelState.CachedTerritories = CachedWorldMapTerritories;


### PR DESCRIPTION
### Motivation
- Prevent transient regressions when replicated travel-state updates arrive in multiple passes by retaining previously established fields.
- Accept a legacy/typo GameMode blueprint name so streamed levels using the older asset name don't produce misleading warnings.

### Description
- In `USkaldGameInstance::SetTravelState` record the previous `FSkaldTravelState` and preserve `TravelSessionToken` when the incoming state omits it to keep setup stages correlated to the same battle session.
- In `USkaldGameInstance::SetTravelState` also retain `ExpectedControllers`, `AttackerPlayerId`, and `DefenderPlayerId` from the previous state when the incoming values are non-positive, avoiding temporary regressions to an "invalid" travel state.
- In `USkaldBattleLevelManager::HandleLevelLoaded` add detection for the legacy/typo blueprint name `Skald_BatlleGameMode_SC` in addition to the canonical `Skald_BattleGameMode_SC`, and update the warning message accordingly.

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a14baa2d91c8324a8aea1d732f0af75)