### PR TITLE
Suppress duplicate TriggerGridBattle launches and relax fighter-selection UI gating

### DIFF
--- a/Source/Skald/Skald_PlayerController.cpp
+++ b/Source/Skald/Skald_PlayerController.cpp
@@ -2695,8 +2695,10 @@ void ASkaldPlayerController::InitializeFighterSelectionIfNeeded() {
       CachedGameInstance ? CachedGameInstance->GetBattleLevelManager() : nullptr;
   const bool bBattleStreamReady =
       !BattleLevelManager || BattleLevelManager->IsBattleLevelFullyReady();
+  const bool bLikelyBattleContextReady =
+      bOnBattleMap || (bHasBattleContext && bInSelectionPhase && bBattleStreamReady);
   const bool bCanShowSelectionUI =
-      bOnBattleMap && bInSelectionPhase && bBattleStreamReady &&
+      bLikelyBattleContextReady && bInSelectionPhase && bBattleStreamReady &&
       !CachedGameInstance->IsTravelPending();
   if (!bIsParticipant || PendingBudget <= 0 || !bCanShowSelectionUI) {
     UE_LOG(LogSkaldBattle, Log,

--- a/Source/Skald/Skald_TurnManager.cpp
+++ b/Source/Skald/Skald_TurnManager.cpp
@@ -2340,8 +2340,17 @@ void ATurnManager::BeginReadyPhase(const FS_BattlePayload &Battle,
 void ATurnManager::TriggerGridBattle(const FS_BattlePayload &Battle) {
   FS_BattlePayload SeededBattle = Battle;
   SeededBattle.RandomSeed = FMath::Rand();
+  const uint32 BattlePayloadHash = GetTypeHash(Battle);
 
   USkaldGameInstance *GI = GetGameInstance<USkaldGameInstance>();
+  if (GI && GI->IsTravelPending() && LastTriggeredBattlePayloadHash != 0 &&
+      LastTriggeredBattlePayloadHash == BattlePayloadHash) {
+    UE_LOG(LogSkald, Warning,
+           TEXT("TriggerGridBattle ignored duplicate while travel pending (Hash=%u From=%d To=%d Attacker=%d Defender=%d)."),
+           BattlePayloadHash, Battle.FromTerritoryID, Battle.TargetTerritoryID,
+           Battle.AttackerPlayerID, Battle.DefenderPlayerID);
+    return;
+  }
   if (GI && GI->bIsInBattleMap) {
     UE_LOG(LogSkald, Warning,
            TEXT("TriggerGridBattle ignored: battle map already active (Token=%s From=%d To=%d)."),
@@ -2415,6 +2424,7 @@ void ATurnManager::TriggerGridBattle(const FS_BattlePayload &Battle) {
   }
   PendingBattle = SeededBattle;
   DeferredPendingBattle = FS_BattlePayload();
+  LastTriggeredBattlePayloadHash = BattlePayloadHash;
 
   if (GI) {
     GI->SeedCombatRandomStream(SeededBattle.RandomSeed);

--- a/Source/Skald/Skald_TurnManager.h
+++ b/Source/Skald/Skald_TurnManager.h
@@ -279,6 +279,8 @@ protected:
   void ClearActiveRetreatContext();
   /** Payload for the next battle waiting on travel/resolution to finish. */
   FS_BattlePayload DeferredPendingBattle;
+  /** Last battle payload hash processed by TriggerGridBattle for duplicate suppression. */
+  uint32 LastTriggeredBattlePayloadHash = 0;
 
   UPROPERTY()
   AWorldMap *CachedWorldMap;


### PR DESCRIPTION
### Motivation
- Logs showed duplicated battle travel/ready-phase sequences that spawned overlapping battle setup and duplicate visuals, indicating re-entrant `TriggerGridBattle` calls during travel handoff. 
- The fighter-selection UI was sometimes not shown (cursor hidden and initiative roll not presented) because `bOnBattleMap` could lag even when battle context and streaming readiness were present.

### Description
- Added a `LastTriggeredBattlePayloadHash` field to `ATurnManager` and compute `BattlePayloadHash = GetTypeHash(Battle)` to deterministically detect duplicate `TriggerGridBattle` requests. 
- Early-return from `ATurnManager::TriggerGridBattle` when a matching payload hash is already pending to suppress duplicate launches during travel handoff and log a warning. 
- Relaxed the selection UI gating in `ASkaldPlayerController::InitializeFighterSelectionIfNeeded` by introducing `bLikelyBattleContextReady` and allowing the fighter-selection UI to initialize when battle context + selection phase + stream readiness are satisfied even if `bOnBattleMap` is not yet true.

### Testing
- No automated tests or Unreal builds were executed in this environment; changes were code-reviewed and committed locally.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a14c86503ac832481d9acc1b59f3219)