### PR TITLE
Add GetTypeHash for FS_BattlePayload to fix build error

### DIFF
--- a/Source/Skald/SkaldTypes.h
+++ b/Source/Skald/SkaldTypes.h
@@ -192,6 +192,39 @@ struct SKALD_API FS_BattlePayload
     FString ReturnMap;
 };
 
+inline uint32 GetTypeHash(const FS_BattlePayload& Payload)
+{
+    uint32 Hash = 0;
+    Hash = HashCombine(Hash, ::GetTypeHash(Payload.AttackerPlayerID));
+    Hash = HashCombine(Hash, ::GetTypeHash(Payload.DefenderPlayerID));
+    Hash = HashCombine(Hash, ::GetTypeHash(Payload.FromTerritoryID));
+    Hash = HashCombine(Hash, ::GetTypeHash(Payload.TargetTerritoryID));
+    Hash = HashCombine(Hash, ::GetTypeHash(Payload.ArmyCountSent));
+    Hash = HashCombine(Hash, ::GetTypeHash(Payload.DefenderArmyCount));
+    Hash = HashCombine(Hash, ::GetTypeHash(Payload.AttackerTerritoryName));
+    Hash = HashCombine(Hash, ::GetTypeHash(Payload.DefenderTerritoryName));
+    Hash = HashCombine(Hash, ::GetTypeHash(Payload.AttackerDisplayName));
+    Hash = HashCombine(Hash, ::GetTypeHash(Payload.DefenderDisplayName));
+    Hash = HashCombine(Hash, ::GetTypeHash(Payload.AttackerFaction));
+    Hash = HashCombine(Hash, ::GetTypeHash(Payload.DefenderFaction));
+    Hash = HashCombine(Hash, ::GetTypeHash(Payload.bAttackerIsAI));
+    Hash = HashCombine(Hash, ::GetTypeHash(Payload.bDefenderIsAI));
+    Hash = HashCombine(Hash, ::GetTypeHash(Payload.IsCapitalAttack));
+    Hash = HashCombine(Hash, ::GetTypeHash(Payload.TreasureFlag));
+    Hash = HashCombine(Hash, ::GetTypeHash(Payload.TurnNumber));
+    Hash = HashCombine(Hash, ::GetTypeHash(Payload.RandomSeed));
+    Hash = HashCombine(Hash, ::GetTypeHash(Payload.ReturnMap));
+    Hash = HashCombine(Hash, ::GetTypeHash(Payload.AttackerFactionEmblem));
+    Hash = HashCombine(Hash, ::GetTypeHash(Payload.DefenderFactionEmblem));
+
+    for (const int32 SiegeId : Payload.AssignedSiegeIDs)
+    {
+        Hash = HashCombine(Hash, ::GetTypeHash(SiegeId));
+    }
+
+    return Hash;
+}
+
 USTRUCT(BlueprintType)
 struct SKALD_API FBattlePlayerEntry
 {


### PR DESCRIPTION
### Motivation
- Calling `GetTypeHash(Battle)` in `ATurnManager::TriggerGridBattle` caused MSVC error C2665 because there was no `GetTypeHash` overload for `FS_BattlePayload`, blocking the Windows/UE build.

### Description
- Added an inline `GetTypeHash(const FS_BattlePayload&)` implementation to `Source/Skald/SkaldTypes.h` that combines the payload’s key scalar, string, enum, bool, soft-object, and `AssignedSiegeIDs` entries into a stable uint32 hash using `HashCombine` and `::GetTypeHash`.
- The new overload is defined immediately after the `FS_BattlePayload` struct so calls like `GetTypeHash(Battle)` resolve correctly for duplicate-battle suppression logic.
- Committed the change with the message `Fix FS_BattlePayload hashing for battle dedupe`.

### Testing
- Ran repository checks and verified the header change via `git diff` and a commit, and confirmed the new function appears in `Source/Skald/SkaldTypes.h` as expected (succeeded).
- No full Unreal/Windows build or automated CI was executed in this environment, so the platform-specific compile that originally failed was not run here (not executed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a14c9700e44832488ce1275f9ef645a)