### PR TITLE
Fix FS_BattlePayload hashing for FString fields

### DIFF
--- a/Source/Skald/SkaldTypes.h
+++ b/Source/Skald/SkaldTypes.h
@@ -201,10 +201,10 @@ inline uint32 GetTypeHash(const FS_BattlePayload& Payload)
     Hash = HashCombine(Hash, ::GetTypeHash(Payload.TargetTerritoryID));
     Hash = HashCombine(Hash, ::GetTypeHash(Payload.ArmyCountSent));
     Hash = HashCombine(Hash, ::GetTypeHash(Payload.DefenderArmyCount));
-    Hash = HashCombine(Hash, ::GetTypeHash(Payload.AttackerTerritoryName));
-    Hash = HashCombine(Hash, ::GetTypeHash(Payload.DefenderTerritoryName));
-    Hash = HashCombine(Hash, ::GetTypeHash(Payload.AttackerDisplayName));
-    Hash = HashCombine(Hash, ::GetTypeHash(Payload.DefenderDisplayName));
+    Hash = HashCombine(Hash, FCrc::StrCrc32(*Payload.AttackerTerritoryName));
+    Hash = HashCombine(Hash, FCrc::StrCrc32(*Payload.DefenderTerritoryName));
+    Hash = HashCombine(Hash, FCrc::StrCrc32(*Payload.AttackerDisplayName));
+    Hash = HashCombine(Hash, FCrc::StrCrc32(*Payload.DefenderDisplayName));
     Hash = HashCombine(Hash, ::GetTypeHash(Payload.AttackerFaction));
     Hash = HashCombine(Hash, ::GetTypeHash(Payload.DefenderFaction));
     Hash = HashCombine(Hash, ::GetTypeHash(Payload.bAttackerIsAI));
@@ -213,7 +213,7 @@ inline uint32 GetTypeHash(const FS_BattlePayload& Payload)
     Hash = HashCombine(Hash, ::GetTypeHash(Payload.TreasureFlag));
     Hash = HashCombine(Hash, ::GetTypeHash(Payload.TurnNumber));
     Hash = HashCombine(Hash, ::GetTypeHash(Payload.RandomSeed));
-    Hash = HashCombine(Hash, ::GetTypeHash(Payload.ReturnMap));
+    Hash = HashCombine(Hash, FCrc::StrCrc32(*Payload.ReturnMap));
     Hash = HashCombine(Hash, ::GetTypeHash(Payload.AttackerFactionEmblem));
     Hash = HashCombine(Hash, ::GetTypeHash(Payload.DefenderFactionEmblem));
 


### PR DESCRIPTION
### Motivation
- Fix compile failures caused by `::GetTypeHash` template deduction errors when called with `FString` members inside `GetTypeHash(const FS_BattlePayload&)` (e.g. the `ReturnMap` error seen during builds). 

### Description
- Replace `::GetTypeHash` calls for `AttackerTerritoryName`, `DefenderTerritoryName`, `AttackerDisplayName`, `DefenderDisplayName`, and `ReturnMap` with explicit string CRC hashing using `FCrc::StrCrc32(*Payload.Field)` in `Source/Skald/SkaldTypes.h`.

### Testing
- No automated tests were run as part of this change; please run a full project rebuild/CI to verify the compiler errors are resolved.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a14cafa26208324972bc8a51246e141)