### PR TITLE
Fix missing Battle HUD after lock-in when entering Deploy phase

### DIFF
--- a/Source/Skald/Skald_PlayerController.cpp
+++ b/Source/Skald/Skald_PlayerController.cpp
@@ -2982,11 +2982,17 @@ void ASkaldPlayerController::HandleBattlePhaseChanged() {
                   " spawned automatically."),
              *GetName());
 
-      if (bBattleHUDReadyToShow && !bBattleHUDVisible) {
+      if (!bBattleHUDVisible) {
+        // Battle HUD visibility can be reset by intermediate UI transitions
+        // (e.g. overworld HUD teardown) between lock-in and deploy. Always
+        // force a local re-show when entering deploy so initiative controls are
+        // guaranteed to appear.
+        bBattleHUDReadyToShow = true;
         EnsureBattleHUDVisible();
       }
     } else if (SGS->BattlePhase != EBattlePhase::FighterSelection &&
-               bBattleHUDReadyToShow && !bBattleHUDVisible) {
+               !bBattleHUDVisible) {
+      bBattleHUDReadyToShow = true;
       EnsureBattleHUDVisible();
     }
   }


### PR DESCRIPTION
### Motivation
- Players could lock in fighters and transition to the Deploy phase while the battle HUD remained hidden, preventing initiative controls and stalling the battle start. 
- The hidden HUD was caused by intermediate UI teardown clearing `bBattleHUDReadyToShow`, so the local controller did not re-show the HUD on phase change.

### Description
- Changed `ASkaldPlayerController::HandleBattlePhaseChanged` to always re-show the battle HUD when entering `EBattlePhase::Deploy` if the HUD is not visible by checking `!bBattleHUDVisible` and calling `EnsureBattleHUDVisible()`.
- Explicitly re-sets `bBattleHUDReadyToShow = true` before forcing visibility so intermediate UI transitions cannot prevent HUD recovery. 
- Applied the same readiness re-arm in the non-`FighterSelection` fallback path so any hidden HUD in other battle phases is also recovered.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a14d2be12d4832482361ddbc078707a)