### PR TITLE
Improve battle spawn placement checks and clear camera lock on manual input

### DIFF
--- a/Source/Skald/Skald_BattleGameMode.cpp
+++ b/Source/Skald/Skald_BattleGameMode.cpp
@@ -1775,6 +1775,11 @@ void ASkald_BattleGameMode::SpawnFighterSide(const TArray<FFighterDefinition> &R
 
   UGridOverlayComponent *Grid =
       Skald::GridOverlay::FindActiveGridOverlay(GetWorld());
+  if (!Grid) {
+    UE_LOG(LogSkaldBattle, Warning,
+           TEXT("SpawnFighterSide: No active grid overlay found; aborting spawn to avoid invalid world placement."));
+    return;
+  }
 
   const int32 Edge = BattleSpawnEdgeColumns;
   int32 GridWidth = Grid ? Grid->GetWidth() : UGridBattleManager::GridSize;
@@ -1819,11 +1824,53 @@ void ASkald_BattleGameMode::SpawnFighterSide(const TArray<FFighterDefinition> &R
                                 : MaxAnchorX;
     const int32 ClampedMaxSpawnX = FMath::Max(MinSpawnX, MaxSpawnX);
 
-    Cell.X = GI->CombatRandomStream.RandRange(MinSpawnX, ClampedMaxSpawnX);
-    Cell.Y = GI->CombatRandomStream.RandRange(0, MaxAnchorY);
+    const int32 MinSpawnY = 0;
+    const int32 MaxSpawnY = MaxAnchorY;
 
-    FVector TerrainLocation =
-        Grid ? Grid->GridToWorld(Cell) : FVector::ZeroVector;
+    TArray<FIntPoint> CandidateCells;
+    CandidateCells.Reserve((ClampedMaxSpawnX - MinSpawnX + 1) *
+                           (MaxSpawnY - MinSpawnY + 1));
+    for (int32 CandidateX = MinSpawnX; CandidateX <= ClampedMaxSpawnX; ++CandidateX) {
+      for (int32 CandidateY = MinSpawnY; CandidateY <= MaxSpawnY; ++CandidateY) {
+        CandidateCells.Emplace(CandidateX, CandidateY);
+      }
+    }
+
+    for (int32 Index = CandidateCells.Num() - 1; Index > 0; --Index) {
+      const int32 SwapIndex = GI->CombatRandomStream.RandRange(0, Index);
+      CandidateCells.Swap(Index, SwapIndex);
+    }
+
+    bool bFoundValidCell = false;
+    for (const FIntPoint &CandidateCell : CandidateCells) {
+      bool bBlocked = false;
+      const TArray<FIntPoint> CandidateFootprint =
+          DefaultPawn ? DefaultPawn->GetOccupiedCells(CandidateCell)
+                      : TArray<FIntPoint>{CandidateCell};
+
+      for (const FIntPoint &OccupiedCell : CandidateFootprint) {
+        if (!Grid->IsCellInBounds(OccupiedCell) || Grid->IsOccupied(OccupiedCell) ||
+            Grid->IsObscured(OccupiedCell)) {
+          bBlocked = true;
+          break;
+        }
+      }
+
+      if (!bBlocked) {
+        Cell = CandidateCell;
+        bFoundValidCell = true;
+        break;
+      }
+    }
+
+    if (!bFoundValidCell) {
+      UE_LOG(LogSkaldBattle, Warning,
+             TEXT("SpawnFighterSide: Could not find open grid cell for fighter %s on %s side."),
+             *Def.Id.ToString(), bAsAttacker ? TEXT("attacker") : TEXT("defender"));
+      continue;
+    }
+
+    FVector TerrainLocation = Grid->GridToWorld(Cell);
     float RequestedHalfHeight = 0.f;
     if (DefaultPawn) {
       RequestedHalfHeight = DefaultPawn->GetSimpleCollisionHalfHeight();
@@ -1929,6 +1976,17 @@ void ASkald_BattleGameMode::TryLaunchBattle() {
   if (!AreBothParticipantsLocked()) {
     UE_LOG(LogSkaldBattle, Verbose,
            TEXT("BattleGM TryLaunchBattle: waiting for participants to confirm lock-in"));
+    return;
+  }
+
+  UGridOverlayComponent *ActiveGrid =
+      Skald::GridOverlay::FindActiveGridOverlay(World);
+  if (!ActiveGrid) {
+    UE_LOG(LogSkaldBattle, Verbose,
+           TEXT("BattleGM TryLaunchBattle: Active grid overlay not ready yet; retrying launch next tick."));
+    FTimerDelegate RetryLaunch =
+        FTimerDelegate::CreateUObject(this, &ASkald_BattleGameMode::TryLaunchBattle);
+    GetWorldTimerManager().SetTimerForNextTick(RetryLaunch);
     return;
   }
 

--- a/Source/Skald/Skald_PlayerCharacter.cpp
+++ b/Source/Skald/Skald_PlayerCharacter.cpp
@@ -293,18 +293,9 @@ void ASkald_PlayerCharacter::MoveForward(float Value)
 {
 	if (bBattleCameraActive)
         {
-                if (bBattleCameraLocked)
+                if (bBattleCameraLocked && !FMath::IsNearlyZero(Value))
                 {
-                        if (!FMath::IsNearlyZero(Value))
-                        {
-                                bHasManuallyRotatedWhileLocked = true;
-
-                                const float DeltaTime = GetWorld() ? GetWorld()->GetDeltaSeconds() : 0.f;
-                                const float PitchDelta = Value * BattleKeyboardPitchSpeed * DeltaTime;
-                                const float NewPitch = DesiredBattleRotation.Pitch + PitchDelta;
-                                DesiredBattleRotation.Pitch = FMath::Clamp(NewPitch, MinBattlePitch, MaxBattlePitch);
-                        }
-                        return;
+                        ClearBattleCameraLock();
                 }
 
                 BattleMoveInput.X = Value;
@@ -336,17 +327,9 @@ void ASkald_PlayerCharacter::MoveRight(float Value)
 {
 	if (bBattleCameraActive)
         {
-                if (bBattleCameraLocked)
+                if (bBattleCameraLocked && !FMath::IsNearlyZero(Value))
                 {
-                        if (!FMath::IsNearlyZero(Value))
-                        {
-                                bHasManuallyRotatedWhileLocked = true;
-
-                                const float DeltaTime = GetWorld() ? GetWorld()->GetDeltaSeconds() : 0.f;
-                                const float YawDelta = Value * BattleKeyboardYawSpeed * DeltaTime;
-                                DesiredBattleRotation.Yaw = FRotator::NormalizeAxis(DesiredBattleRotation.Yaw + YawDelta);
-                        }
-                        return;
+                        ClearBattleCameraLock();
                 }
 
                 BattleMoveInput.Y = Value;


### PR DESCRIPTION
### Motivation
- Ensure fighters are only spawned into valid grid cells and avoid invalid world placement when the grid overlay is not yet available.
- Prevent battles from launching before the active grid overlay is ready to avoid placement errors.
- Make battle camera lock behavior more intuitive by clearing the lock when the player provides manual input.

### Description
- In `ASkald_BattleGameMode::SpawnFighterSide` early-return with a warning if no active grid overlay is found to avoid invalid placement.
- Replace the single random cell selection with building a shuffled list of candidate cells and validate each candidate footprint with `Grid->IsCellInBounds`, `Grid->IsOccupied`, and `Grid->IsObscured`, skipping and logging a warning when no valid cell can be found for a fighter.
- Use `Grid->GridToWorld` for computing `TerrainLocation`, averaging across footprint cells when necessary instead of falling back to a zero vector.
- In `TryLaunchBattle` check for the active grid overlay and, if missing, log and schedule a retry on the next tick via `GetWorldTimerManager().SetTimerForNextTick` rather than proceeding.
- In `ASkald_PlayerCharacter::MoveForward` and `MoveRight` call `ClearBattleCameraLock()` when the battle camera is locked and non-zero input is received, removing the previous manual-rotation-while-locked code path.

### Testing
- The project compiled successfully in-editor and a runtime smoke test was performed to verify that battle launch defers until the grid overlay is present and that spawning respects occupancy/obscuration checks.
- Existing automated unit tests were executed and passed with no regressions observed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a14d44cdae883248d18e49e2d2d92d7)