### PR TITLE
DetectBattleMap: rely on game-instance streamed-battle flag

### DIFF
--- a/Source/Skald/Skald_PlayerController.cpp
+++ b/Source/Skald/Skald_PlayerController.cpp
@@ -3609,58 +3609,12 @@ void ASkaldPlayerController::DetectBattleMap() {
   if (!CachedGameInstance) {
     CachedGameInstance = GetGameInstance<USkaldGameInstance>();
   }
-  if (CachedGameInstance && CachedGameInstance->bIsInBattleMap) {
-    bDetectedBattleMap = true;
-  }
-
-  FString CurrentMap;
-  if (!bDetectedBattleMap) {
-    CurrentMap = UGameplayStatics::GetCurrentLevelName(this, true);
-    if (CurrentMap.Equals(TEXT("BattleMap"), ESearchCase::IgnoreCase)) {
-      bDetectedBattleMap = true;
-    }
-  }
-
-  if (!bDetectedBattleMap) {
-    ATurnManager *TM = TurnManager;
-    if (!TM) {
-      if (!CachedGameMode) {
-        CachedGameMode = GetWorld()->GetAuthGameMode<ASkaldGameMode>();
-      }
-      if (CachedGameMode) {
-        TM = CachedGameMode->GetTurnManager();
-      }
-      if (!TM) {
-        TM = FindTurnManagerActor();
-      }
-    }
-
-    if (TM) {
-      if (CurrentMap.IsEmpty()) {
-        CurrentMap = UGameplayStatics::GetCurrentLevelName(this, true);
-      }
-
-      auto MatchesCurrentMap = [&](const TSoftObjectPtr<UWorld> &MapPtr) {
-        return CurrentMap.Equals(MapPtr.ToSoftObjectPath().GetAssetName(),
-                                 ESearchCase::IgnoreCase);
-      };
-
-      for (const TSoftObjectPtr<UWorld> &Map : TM->BattleMaps) {
-        if (MatchesCurrentMap(Map)) {
-          bDetectedBattleMap = true;
-          break;
-        }
-      }
-
-      if (!bDetectedBattleMap) {
-        for (const FBattleMapDescriptor &Entry : TM->BattleMapEntries) {
-          if (MatchesCurrentMap(Entry.Map)) {
-            bDetectedBattleMap = true;
-            break;
-          }
-        }
-      }
-    }
+  // Battle maps are now streamed exclusively into the persistent world.
+  // Current level name and map-descriptor checks are no longer reliable
+  // indicators of battle context because the active UWorld does not switch.
+  // Treat the game-instance streamed-battle flag as the authoritative source.
+  if (CachedGameInstance) {
+    bDetectedBattleMap = CachedGameInstance->bIsInBattleMap;
   }
 
   bIsBattleMap = bDetectedBattleMap;


### PR DESCRIPTION
### Motivation
- Battle maps are now streamed into the persistent world which makes current level name and map-descriptor checks unreliable for determining battle context.
- Use the game-instance streamed-battle indicator as the authoritative source to simplify and harden detection logic.

### Description
- Removed legacy detection logic that inspected the current level name and iterated `TurnManager` `BattleMaps` and `BattleMapEntries` to infer battle context.
- Updated `DetectBattleMap` to set `bDetectedBattleMap = CachedGameInstance->bIsInBattleMap` when `CachedGameInstance` is available, and added a clarifying comment about streamed battle maps.
- Kept subsequent behavior intact, including setting `bIsBattleMap`, calling `UpdateBattleCameraMode`, and toggling HUD visibility and battle sound/reset state handling.

### Testing
- Project was compiled with the updated `DetectBattleMap` implementation and the build completed successfully.
- Existing automated tests were executed and completed without failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a14d9bc05d483248c57e84c49cbe86c)