### PR TITLE
Fix battle camera focus for streamed battle fighter selections

### DIFF
--- a/Source/Skald/Skald_PlayerController.cpp
+++ b/Source/Skald/Skald_PlayerController.cpp
@@ -3566,7 +3566,10 @@ void ASkaldPlayerController::HandleLockedInEntrySelected(AFighterPawn *Fighter) 
   }
   UpdateLockedInSelectionHighlight();
 
-  if (IsLocalController() && bIsBattleMap) {
+  const bool bBattleMapActive =
+      bIsBattleMap || (CachedGameInstance && CachedGameInstance->bIsInBattleMap);
+
+  if (IsLocalController() && bBattleMapActive) {
     if (Fighter->IsAlive()) {
       if (ASkald_PlayerCharacter *CameraPawn = Cast<ASkald_PlayerCharacter>(GetPawn())) {
         CameraPawn->FocusCameraOnActor(Fighter);
@@ -3592,7 +3595,10 @@ void ASkaldPlayerController::HandleEnemyLockedInEntrySelected(
   }
   UpdateLockedInSelectionHighlight();
 
-  if (IsLocalController() && bIsBattleMap) {
+  const bool bBattleMapActive =
+      bIsBattleMap || (CachedGameInstance && CachedGameInstance->bIsInBattleMap);
+
+  if (IsLocalController() && bBattleMapActive) {
     if (Fighter->IsAlive()) {
       if (ASkald_PlayerCharacter *CameraPawn = Cast<ASkald_PlayerCharacter>(GetPawn())) {
         CameraPawn->FocusCameraOnActor(Fighter);
@@ -5862,9 +5868,12 @@ void ASkaldPlayerController::UpdateBattleCameraMode() {
     return;
   }
 
-  CameraPawn->SetBattleCameraActive(bIsBattleMap);
+  const bool bBattleMapActive =
+      bIsBattleMap || (CachedGameInstance && CachedGameInstance->bIsInBattleMap);
 
-  if (!bIsBattleMap) {
+  CameraPawn->SetBattleCameraActive(bBattleMapActive);
+
+  if (!bBattleMapActive) {
     CameraPawn->ClearCameraFocus();
     return;
   }


### PR DESCRIPTION
### Motivation
- Streamed battle maps can make `bIsBattleMap` lag behind the authoritative game-instance flag, causing the tactical camera to remain inactive so UI fighter selections no longer changed camera focus.

### Description
- Introduced a streamed-aware `bBattleMapActive = bIsBattleMap || (CachedGameInstance && CachedGameInstance->bIsInBattleMap)` and applied it in `UpdateBattleCameraMode` to drive `CameraPawn->SetBattleCameraActive(...)` and avoid clearing focus prematurely.
- Updated `HandleLockedInEntrySelected` and `HandleEnemyLockedInEntrySelected` to use the same `bBattleMapActive` check so UI-driven fighter selections re-focus the camera during streaming transitions.
- Modified file: `Source/Skald/Skald_PlayerController.cpp`.

### Testing
- Verified the source diff with `git diff` to confirm the intended changes were applied successfully.
- Committed the change with `git commit`, which completed without error.
- Inspected the updated selection and camera code paths to ensure the streamed-battle-aware condition is used consistently.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a14de10f57883249f5c2e93cb03fab1)