### PR TITLE
Restore camera/grid input during streamed battle preparation

### DIFF
--- a/Source/Skald/Skald_PlayerController.cpp
+++ b/Source/Skald/Skald_PlayerController.cpp
@@ -5609,6 +5609,13 @@ void ASkaldPlayerController::HandleReplicatedTurnOwnership() {
       bShowMouseCursor = true;
       bEnableClickEvents = true;
       bEnableMouseOverEvents = true;
+      // Battle prep UI (fighter lock-in, streamed battle travel, etc.) still
+      // needs world interaction for camera movement and grid picks. If input
+      // was previously suppressed by a UI-only flow, explicitly re-enable it
+      // here so replicated turn ownership updates cannot strand the local
+      // player in a non-interactive state.
+      SetIgnoreMoveInput(false);
+      SetIgnoreLookInput(false);
     } else {
       // Ensure non-active players fully release world input and phase buttons
       // instead of inheriting the host's UI state.


### PR DESCRIPTION
### Motivation
- Prevent players on streamed battlemaps from being able to click HUD fighter entries while camera movement and grid selection remain unresponsive after replicated turn-ownership updates.

### Description
- In `Source/Skald/Skald_PlayerController.cpp` inside `ASkaldPlayerController::HandleReplicatedTurnOwnership`, when `bNeedsBattlePrepUI` is true the controller now calls `SetIgnoreMoveInput(false)` and `SetIgnoreLookInput(false)` and adds a clarifying comment so battle-prep UI retains required world interaction (camera and grid picks).

### Testing
- No automated tests were executed; the patch applied and was committed successfully (`git` operations and diff verification completed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a14e05bd24483249f656d117719552e)