### PR TITLE
Fix fighter-selection/input lock when battle stream readiness lags

### DIFF
--- a/Source/Skald/Skald_PlayerController.cpp
+++ b/Source/Skald/Skald_PlayerController.cpp
@@ -2695,10 +2695,14 @@ void ASkaldPlayerController::InitializeFighterSelectionIfNeeded() {
       CachedGameInstance ? CachedGameInstance->GetBattleLevelManager() : nullptr;
   const bool bBattleStreamReady =
       !BattleLevelManager || BattleLevelManager->IsBattleLevelFullyReady();
+  // Streaming readiness can occasionally lag a frame behind map activation.
+  // Once the local controller is on the battle map, treat streaming as ready so
+  // we don't permanently gate fighter selection / input behind a stale flag.
+  const bool bEffectiveStreamReady = bBattleStreamReady || bOnBattleMap;
   const bool bLikelyBattleContextReady =
-      bOnBattleMap || (bHasBattleContext && bInSelectionPhase && bBattleStreamReady);
+      bOnBattleMap || (bHasBattleContext && bInSelectionPhase && bEffectiveStreamReady);
   const bool bCanShowSelectionUI =
-      bLikelyBattleContextReady && bInSelectionPhase && bBattleStreamReady &&
+      bLikelyBattleContextReady && bInSelectionPhase && bEffectiveStreamReady &&
       !CachedGameInstance->IsTravelPending();
   if (!bIsParticipant || PendingBudget <= 0 || !bCanShowSelectionUI) {
     UE_LOG(LogSkaldBattle, Log,


### PR DESCRIPTION
### Motivation
- Logs showed repeated skips with `OnBattleMap=1` and `StreamReady=0` that prevented the fighter-selection UI and input from initializing, effectively leaving the local player unable to act after the battle map became visible.

### Description
- In `Source/Skald/Skald_PlayerController.cpp` updated `ASkaldPlayerController::InitializeFighterSelectionIfNeeded` to compute `bEffectiveStreamReady = bBattleStreamReady || bOnBattleMap` and use it when evaluating `bLikelyBattleContextReady` and `bCanShowSelectionUI`, while preserving the existing travel/participant/budget guards.

### Testing
- Committed the change (`git commit`) and verified the updated lines with `nl`/`sed` and the PR metadata was generated with `make_pr`, all of which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a14e23bb24c832481f90f6e4588531a)