### PR TITLE
Reconcile battle UI/input state on possession, map change, and payload handling

### DIFF
--- a/Source/Skald/Skald_PlayerController.cpp
+++ b/Source/Skald/Skald_PlayerController.cpp
@@ -2436,6 +2436,7 @@ void ASkaldPlayerController::OnPossess(APawn *InPawn) {
   }
 
   UpdateBattleCameraMode();
+  ReconcileBattleInputState(TEXT("OnPossess"));
 }
 
 void ASkaldPlayerController::PlayerTick(float DeltaTime) {
@@ -5490,6 +5491,7 @@ void ASkaldPlayerController::HandleReplicatedBattlePayload() {
   RefreshTurnDataFromState();
   HandleReplicatedTurnOwnership();
   HandleReplicatedTurnStart();
+  ReconcileBattleInputState(TEXT("HandleReplicatedBattlePayload"));
 }
 
 void ASkaldPlayerController::HandleReplicatedTurnOwnership() {
@@ -5745,6 +5747,7 @@ void ASkaldPlayerController::HandleBattleMapStateChanged(bool /*bInBattleMap*/) 
   // local player regains fighter selection, HUD, and camera context even if
   // the original travel RPC was missed.
   HandleReplicatedBattlePayload();
+  ReconcileBattleInputState(TEXT("HandleBattleMapStateChanged"));
 }
 
 void ASkaldPlayerController::HandleWorldStateChanged() {
@@ -5896,6 +5899,49 @@ void ASkaldPlayerController::UpdateBattleCameraMode() {
   }
 }
 
+void ASkaldPlayerController::ReconcileBattleInputState(const TCHAR* Context) {
+  if (!IsLocalController() || !CanCreateLocalUIWidget()) {
+    return;
+  }
+
+  if (!CachedGameInstance) {
+    CachedGameInstance = GetGameInstance<USkaldGameInstance>();
+  }
+
+  DetectBattleMap();
+  const bool bBattleMapActive =
+      bIsBattleMap || (CachedGameInstance && CachedGameInstance->bIsInBattleMap);
+  if (!bBattleMapActive) {
+    return;
+  }
+
+  UWidget* FocusWidget = nullptr;
+  if (FighterSelectionWidget && FighterSelectionWidget->IsInViewport()) {
+    FocusWidget = FighterSelectionWidget;
+  } else if (BattleHUD && BattleHUD->IsInViewport()) {
+    FocusWidget = BattleHUD;
+  } else if (MainHUD && MainHUD->IsInViewport()) {
+    FocusWidget = MainHUD;
+  }
+
+  UWidgetBlueprintLibrary::SetInputMode_GameAndUIEx(
+      this, FocusWidget, EMouseLockMode::DoNotLock,
+      /*bHideCursorDuringCapture*/ false);
+  FocusGameViewport(this);
+  bShowMouseCursor = true;
+  bEnableClickEvents = true;
+  bEnableMouseOverEvents = true;
+  DefaultMouseCaptureMode = EMouseCaptureMode::NoCapture;
+  SetIgnoreMoveInput(false);
+  SetIgnoreLookInput(false);
+  UpdateBattleCameraMode();
+
+  UE_LOG(LogSkaldBattle, Verbose,
+         TEXT("BattleInputReconciler[%s]: Controller=%s BattleMap=%d FocusWidget=%s"),
+         Context ? Context : TEXT("Unknown"), *GetName(), bBattleMapActive ? 1 : 0,
+         *GetNameSafe(FocusWidget));
+}
+
 void ASkaldPlayerController::HandleFighterSelectionLockedIn() {
   UE_LOG(LogSkaldUI, Log,
          TEXT("HandleFighterSelectionLockedIn: Controller=%s Local=%s Pawn=%s"),
@@ -5935,6 +5981,8 @@ void ASkaldPlayerController::HandleFighterSelectionLockedIn() {
       !bBattleHUDVisible) {
     EnsureBattleHUDVisible();
   }
+
+  ReconcileBattleInputState(TEXT("HandleFighterSelectionLockedIn"));
 
   if (CachedGameInstance && CachedGameInstance->GridBattleManager)
   {

--- a/Source/Skald/Skald_PlayerController.h
+++ b/Source/Skald/Skald_PlayerController.h
@@ -1090,6 +1090,7 @@ private:
   void DetectBattleMap();
 
   void RequestBattleStateIfNeeded();
+  void ReconcileBattleInputState(const TCHAR* Context);
 
   void BuildPlayerDataArray(TArray<FS_PlayerData> &OutPlayers) const;
 


### PR DESCRIPTION
### Motivation
- Ensure local players regain correct UI focus and input after possess, travel, or replicated battle payload events so HUD, cursor, and camera respond immediately. 
- Reduce race conditions where phase/turn updates or late-arriving battle state left clients without proper input mode or HUD focus. 
- Centralize input and UI reconciliation logic to avoid duplicated state-restoration across multiple handlers.

### Description
- Introduces `ReconcileBattleInputState(const TCHAR* Context)` in `ASkaldPlayerController` to detect battle map context and restore UI input mode, cursor visibility, click/mouse events, mouse capture, and pawn input (`SetIgnoreMoveInput`/`SetIgnoreLookInput`), and calls `UpdateBattleCameraMode` and `FocusGameViewport` as part of reconciliation. 
- Calls `ReconcileBattleInputState` from `OnPossess`, `HandleReplicatedBattlePayload`, `HandleBattleMapStateChanged`, and `HandleFighterSelectionLockedIn` to ensure input is reconciled after key transitions. 
- Adds declaration of `ReconcileBattleInputState` to the header and emits a verbose log entry to aid in diagnosing reconciliation events.

### Testing
- No automated tests were run for this change. 
- The change is implemented with defensive checks (`IsLocalController`, `CanCreateLocalUIWidget`, and cached `GameInstance`) to avoid affecting non-local or AI controllers during automated runs. 
- Logging (`UE_LOG(LogSkaldBattle, Verbose, ...)`) was added to assist manual verification during runtime.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a14e43c703883248390a32a68173692)