### PR TITLE
Reconcile battle input/cursor state and guard battle-map checks

### DIFF
--- a/Source/Skald/Skald_PlayerController.cpp
+++ b/Source/Skald/Skald_PlayerController.cpp
@@ -2436,6 +2436,7 @@ void ASkaldPlayerController::OnPossess(APawn *InPawn) {
   }
 
   UpdateBattleCameraMode();
+  ReconcileBattleInputState(TEXT("OnPossess"));
 }
 
 void ASkaldPlayerController::PlayerTick(float DeltaTime) {
@@ -5490,6 +5491,7 @@ void ASkaldPlayerController::HandleReplicatedBattlePayload() {
   RefreshTurnDataFromState();
   HandleReplicatedTurnOwnership();
   HandleReplicatedTurnStart();
+  ReconcileBattleInputState(TEXT("HandleReplicatedBattlePayload"));
 }
 
 void ASkaldPlayerController::HandleReplicatedTurnOwnership() {
@@ -5745,6 +5747,7 @@ void ASkaldPlayerController::HandleBattleMapStateChanged(bool /*bInBattleMap*/) 
   // local player regains fighter selection, HUD, and camera context even if
   // the original travel RPC was missed.
   HandleReplicatedBattlePayload();
+  ReconcileBattleInputState(TEXT("HandleBattleMapStateChanged"));
 }
 
 void ASkaldPlayerController::HandleWorldStateChanged() {
@@ -5896,6 +5899,49 @@ void ASkaldPlayerController::UpdateBattleCameraMode() {
   }
 }
 
+void ASkaldPlayerController::ReconcileBattleInputState(const TCHAR* Context) {
+  if (!IsLocalController() || !CanCreateLocalUIWidget()) {
+    return;
+  }
+
+  if (!CachedGameInstance) {
+    CachedGameInstance = GetGameInstance<USkaldGameInstance>();
+  }
+
+  DetectBattleMap();
+  const bool bBattleMapActive =
+      bIsBattleMap || (CachedGameInstance && CachedGameInstance->bIsInBattleMap);
+  if (!bBattleMapActive) {
+    return;
+  }
+
+  UWidget* FocusWidget = nullptr;
+  if (FighterSelectionWidget && FighterSelectionWidget->IsInViewport()) {
+    FocusWidget = FighterSelectionWidget;
+  } else if (BattleHUD && BattleHUD->IsInViewport()) {
+    FocusWidget = BattleHUD;
+  } else if (MainHUD && MainHUD->IsInViewport()) {
+    FocusWidget = MainHUD;
+  }
+
+  UWidgetBlueprintLibrary::SetInputMode_GameAndUIEx(
+      this, FocusWidget, EMouseLockMode::DoNotLock,
+      /*bHideCursorDuringCapture*/ false);
+  FocusGameViewport(this);
+  bShowMouseCursor = true;
+  bEnableClickEvents = true;
+  bEnableMouseOverEvents = true;
+  DefaultMouseCaptureMode = EMouseCaptureMode::NoCapture;
+  SetIgnoreMoveInput(false);
+  SetIgnoreLookInput(false);
+  UpdateBattleCameraMode();
+
+  UE_LOG(LogSkaldBattle, Verbose,
+         TEXT("BattleInputReconciler[%s]: Controller=%s BattleMap=%d FocusWidget=%s"),
+         Context ? Context : TEXT("Unknown"), *GetName(), bBattleMapActive ? 1 : 0,
+         *GetNameSafe(FocusWidget));
+}
+
 void ASkaldPlayerController::HandleFighterSelectionLockedIn() {
   UE_LOG(LogSkaldUI, Log,
          TEXT("HandleFighterSelectionLockedIn: Controller=%s Local=%s Pawn=%s"),
@@ -5935,6 +5981,8 @@ void ASkaldPlayerController::HandleFighterSelectionLockedIn() {
       !bBattleHUDVisible) {
     EnsureBattleHUDVisible();
   }
+
+  ReconcileBattleInputState(TEXT("HandleFighterSelectionLockedIn"));
 
   if (CachedGameInstance && CachedGameInstance->GridBattleManager)
   {
@@ -6035,13 +6083,17 @@ void ASkaldPlayerController::HandleGridClick() {
   if (!IsLocalController())
     return;
 
+  DetectBattleMap();
+  const bool bBattleMapActive =
+      bIsBattleMap || (CachedGameInstance && CachedGameInstance->bIsInBattleMap);
+
   if (IsCursorOverInteractableSlateWidget()) {
     return;
   }
 
   // Non-battle map handling
   FHitResult Hit;
-  if (!bIsBattleMap) {
+  if (!bBattleMapActive) {
     if (!HasResolvedLocalPlayerId()) {
       UE_LOG(LogSkald, Verbose,
              TEXT("HandleGridClick ignoring world map click until the controller finishes registration."));
@@ -6462,7 +6514,7 @@ void ASkaldPlayerController::HandleGridClick() {
 
     SetSelectedFighter(CellFighter);
 
-    if (!IsFriendlyFighter(CellFighter) && IsLocalController() && bIsBattleMap) {
+    if (!IsFriendlyFighter(CellFighter) && IsLocalController() && bBattleMapActive) {
       if (ASkald_PlayerCharacter *CameraPawn = Cast<ASkald_PlayerCharacter>(GetPawn())) {
         CameraPawn->FocusCameraOnActor(CellFighter);
       }
@@ -6610,7 +6662,10 @@ void ASkaldPlayerController::HandleClearSelectionPressed() {
     return;
   }
 
-  if (!bIsBattleMap) {
+  DetectBattleMap();
+  const bool bBattleMapActive =
+      bIsBattleMap || (CachedGameInstance && CachedGameInstance->bIsInBattleMap);
+  if (!bBattleMapActive) {
     if (!HasResolvedLocalPlayerId()) {
       UE_LOG(LogSkald, Verbose,
              TEXT("HandleClearSelectionPressed ignoring deselect until the controller finishes registration."));
@@ -6629,7 +6684,10 @@ void ASkaldPlayerController::HandleRightClick() {
     return;
   }
 
-  if (!bIsBattleMap) {
+  DetectBattleMap();
+  const bool bBattleMapActive =
+      bIsBattleMap || (CachedGameInstance && CachedGameInstance->bIsInBattleMap);
+  if (!bBattleMapActive) {
     return;
   }
 

--- a/Source/Skald/Skald_PlayerController.h
+++ b/Source/Skald/Skald_PlayerController.h
@@ -1090,6 +1090,7 @@ private:
   void DetectBattleMap();
 
   void RequestBattleStateIfNeeded();
+  void ReconcileBattleInputState(const TCHAR* Context);
 
   void BuildPlayerDataArray(TArray<FS_PlayerData> &OutPlayers) const;
 


### PR DESCRIPTION
### Motivation
- Fix race conditions where clients arrive on or restore a battle map but HUD/input/camera remain out of sync, causing lost mouse/camera control or stalled UI after possession, travel, or replicated payloads.

### Description
- Add `ReconcileBattleInputState(const TCHAR*)` to centralize enabling UI/input/cursor state, focusing the appropriate widget, setting input modes, and updating the battle camera, with verbose logging.\n- Call `ReconcileBattleInputState` from `OnPossess`, `HandleReplicatedBattlePayload`, `HandleBattleMapStateChanged`, and `HandleFighterSelectionLockedIn` to ensure input is reconciled after possession, payload replication, map travel, and selection flow completion.\n- Replace several direct `bIsBattleMap` checks with a computed `bBattleMapActive` (via `DetectBattleMap()` and `CachedGameInstance->bIsInBattleMap`) in `HandleGridClick`, `HandleClearSelectionPressed`, `HandleRightClick`, and selection logic to avoid using stale map state.\n- Expose the new `ReconcileBattleInputState` declaration in the header (`Skald_PlayerController.h`).

### Testing
- Project compiled successfully with the changes (automated build).\n- Automated unit/integration tests covering player controller, battle UI and input flows were executed and passed without regressions.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a14e43c703883248390a32a68173692)