### PR TITLE
Reconcile battle input and mouse capture when entering battles and on possession

### DIFF
--- a/Source/Skald/Skald_PlayerController.cpp
+++ b/Source/Skald/Skald_PlayerController.cpp
@@ -2436,6 +2436,7 @@ void ASkaldPlayerController::OnPossess(APawn *InPawn) {
   }
 
   UpdateBattleCameraMode();
+  ReconcileBattleInputState(TEXT("OnPossess"));
 }
 
 void ASkaldPlayerController::PlayerTick(float DeltaTime) {
@@ -5490,6 +5491,7 @@ void ASkaldPlayerController::HandleReplicatedBattlePayload() {
   RefreshTurnDataFromState();
   HandleReplicatedTurnOwnership();
   HandleReplicatedTurnStart();
+  ReconcileBattleInputState(TEXT("HandleReplicatedBattlePayload"));
 }
 
 void ASkaldPlayerController::HandleReplicatedTurnOwnership() {
@@ -5745,6 +5747,7 @@ void ASkaldPlayerController::HandleBattleMapStateChanged(bool /*bInBattleMap*/) 
   // local player regains fighter selection, HUD, and camera context even if
   // the original travel RPC was missed.
   HandleReplicatedBattlePayload();
+  ReconcileBattleInputState(TEXT("HandleBattleMapStateChanged"));
 }
 
 void ASkaldPlayerController::HandleWorldStateChanged() {
@@ -5853,7 +5856,9 @@ void ASkaldPlayerController::HandleFactionLockedIn() {
   bShowMouseCursor = true;
   bEnableClickEvents = true;
   bEnableMouseOverEvents = true;
-  DefaultMouseCaptureMode = EMouseCaptureMode::NoCapture;
+  DefaultMouseCaptureMode =
+      EMouseCaptureMode::CapturePermanently_IncludingInitialMouseDown;
+  SetMouseCaptureMode(DefaultMouseCaptureMode);
   SetIgnoreMoveInput(false);
   SetIgnoreLookInput(false);
   RefreshFactionCursorFromState();
@@ -5896,6 +5901,51 @@ void ASkaldPlayerController::UpdateBattleCameraMode() {
   }
 }
 
+void ASkaldPlayerController::ReconcileBattleInputState(const TCHAR* Context) {
+  if (!IsLocalController() || !CanCreateLocalUIWidget()) {
+    return;
+  }
+
+  if (!CachedGameInstance) {
+    CachedGameInstance = GetGameInstance<USkaldGameInstance>();
+  }
+
+  DetectBattleMap();
+  const bool bBattleMapActive =
+      bIsBattleMap || (CachedGameInstance && CachedGameInstance->bIsInBattleMap);
+  if (!bBattleMapActive) {
+    return;
+  }
+
+  UWidget* FocusWidget = nullptr;
+  if (FighterSelectionWidget && FighterSelectionWidget->IsInViewport()) {
+    FocusWidget = FighterSelectionWidget;
+  } else if (BattleHUD && BattleHUD->IsInViewport()) {
+    FocusWidget = BattleHUD;
+  } else if (MainHUD && MainHUD->IsInViewport()) {
+    FocusWidget = MainHUD;
+  }
+
+  UWidgetBlueprintLibrary::SetInputMode_GameAndUIEx(
+      this, FocusWidget, EMouseLockMode::DoNotLock,
+      /*bHideCursorDuringCapture*/ false);
+  FocusGameViewport(this);
+  bShowMouseCursor = true;
+  bEnableClickEvents = true;
+  bEnableMouseOverEvents = true;
+  DefaultMouseCaptureMode =
+      EMouseCaptureMode::CapturePermanently_IncludingInitialMouseDown;
+  SetMouseCaptureMode(DefaultMouseCaptureMode);
+  SetIgnoreMoveInput(false);
+  SetIgnoreLookInput(false);
+  UpdateBattleCameraMode();
+
+  UE_LOG(LogSkaldBattle, Verbose,
+         TEXT("BattleInputReconciler[%s]: Controller=%s BattleMap=%d FocusWidget=%s"),
+         Context ? Context : TEXT("Unknown"), *GetName(), bBattleMapActive ? 1 : 0,
+         *GetNameSafe(FocusWidget));
+}
+
 void ASkaldPlayerController::HandleFighterSelectionLockedIn() {
   UE_LOG(LogSkaldUI, Log,
          TEXT("HandleFighterSelectionLockedIn: Controller=%s Local=%s Pawn=%s"),
@@ -5935,6 +5985,8 @@ void ASkaldPlayerController::HandleFighterSelectionLockedIn() {
       !bBattleHUDVisible) {
     EnsureBattleHUDVisible();
   }
+
+  ReconcileBattleInputState(TEXT("HandleFighterSelectionLockedIn"));
 
   if (CachedGameInstance && CachedGameInstance->GridBattleManager)
   {
@@ -6035,13 +6087,17 @@ void ASkaldPlayerController::HandleGridClick() {
   if (!IsLocalController())
     return;
 
+  DetectBattleMap();
+  const bool bBattleMapActive =
+      bIsBattleMap || (CachedGameInstance && CachedGameInstance->bIsInBattleMap);
+
   if (IsCursorOverInteractableSlateWidget()) {
     return;
   }
 
   // Non-battle map handling
   FHitResult Hit;
-  if (!bIsBattleMap) {
+  if (!bBattleMapActive) {
     if (!HasResolvedLocalPlayerId()) {
       UE_LOG(LogSkald, Verbose,
              TEXT("HandleGridClick ignoring world map click until the controller finishes registration."));
@@ -6462,7 +6518,7 @@ void ASkaldPlayerController::HandleGridClick() {
 
     SetSelectedFighter(CellFighter);
 
-    if (!IsFriendlyFighter(CellFighter) && IsLocalController() && bIsBattleMap) {
+    if (!IsFriendlyFighter(CellFighter) && IsLocalController() && bBattleMapActive) {
       if (ASkald_PlayerCharacter *CameraPawn = Cast<ASkald_PlayerCharacter>(GetPawn())) {
         CameraPawn->FocusCameraOnActor(CellFighter);
       }
@@ -6610,7 +6666,10 @@ void ASkaldPlayerController::HandleClearSelectionPressed() {
     return;
   }
 
-  if (!bIsBattleMap) {
+  DetectBattleMap();
+  const bool bBattleMapActive =
+      bIsBattleMap || (CachedGameInstance && CachedGameInstance->bIsInBattleMap);
+  if (!bBattleMapActive) {
     if (!HasResolvedLocalPlayerId()) {
       UE_LOG(LogSkald, Verbose,
              TEXT("HandleClearSelectionPressed ignoring deselect until the controller finishes registration."));
@@ -6629,7 +6688,10 @@ void ASkaldPlayerController::HandleRightClick() {
     return;
   }
 
-  if (!bIsBattleMap) {
+  DetectBattleMap();
+  const bool bBattleMapActive =
+      bIsBattleMap || (CachedGameInstance && CachedGameInstance->bIsInBattleMap);
+  if (!bBattleMapActive) {
     return;
   }
 

--- a/Source/Skald/Skald_PlayerController.h
+++ b/Source/Skald/Skald_PlayerController.h
@@ -1090,6 +1090,7 @@ private:
   void DetectBattleMap();
 
   void RequestBattleStateIfNeeded();
+  void ReconcileBattleInputState(const TCHAR* Context);
 
   void BuildPlayerDataArray(TArray<FS_PlayerData> &OutPlayers) const;
 


### PR DESCRIPTION
### Motivation
- Ensure the local player's input mode, mouse capture, and HUD focus are consistently restored when a controller possesses a pawn, arrives on a battle map, or receives replicated battle/turn payloads so clients regain control without waiting for host-driven prompts.
- Fix cases where input/mouse state or UI focus could be left inconsistent after travel, replication, or widget transitions.

### Description
- Added `ReconcileBattleInputState(const TCHAR* Context)` to centralize restoring input mode, mouse cursor visibility, click/hover events, mouse capture via `SetMouseCaptureMode`, viewport focus via `FocusGameViewport`, and camera update through `UpdateBattleCameraMode` with verbose logging.  
- Call `ReconcileBattleInputState` from `OnPossess`, `HandleReplicatedBattlePayload`, `HandleBattleMapStateChanged`, and `HandleFighterSelectionLockedIn` to proactively repair input/UI state after key lifecycle events.  
- Use `DetectBattleMap()` and compute a `bBattleMapActive` local flag in several handlers and input methods (`HandleGridClick`, `HandleClearSelectionPressed`, `HandleRightClick`) to replace direct `bIsBattleMap` checks and ensure the controller considers `CachedGameInstance->bIsInBattleMap`.  
- Change default mouse capture behavior in `HandleWorldStateChanged` to `EMouseCaptureMode::CapturePermanently_IncludingInitialMouseDown` and call `SetMouseCaptureMode` to apply it immediately.  
- Exposed `ReconcileBattleInputState` declaration in the header and added a verbose `UE_LOG` for the new reconciler for diagnostics.

### Testing
- Compiled the project and editor build successfully after the changes.  
- Ran the project's automated test/automation suites and UI-focused automation checks; all executed tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a14e43c703883248390a32a68173692)