### PR TITLE
Use GameViewportClient::SetMouseCaptureMode in SkaldPlayerController (UE5.5)

### DIFF
--- a/Source/Skald/Skald_PlayerController.cpp
+++ b/Source/Skald/Skald_PlayerController.cpp
@@ -9,6 +9,7 @@
 #include "Components/InputComponent.h"
 #include "Engine/EngineTypes.h"
 #include "Engine/LocalPlayer.h"
+#include "Engine/GameViewportClient.h"
 #include "Engine/Level.h"
 #include "EngineUtils.h"
 #include "FighterDataLibrary.h"
@@ -5858,7 +5859,9 @@ void ASkaldPlayerController::HandleFactionLockedIn() {
   bEnableMouseOverEvents = true;
   DefaultMouseCaptureMode =
       EMouseCaptureMode::CapturePermanently_IncludingInitialMouseDown;
-  SetMouseCaptureMode(DefaultMouseCaptureMode);
+  if (UGameViewportClient* GameViewport = GetWorld() ? GetWorld()->GetGameViewport() : nullptr) {
+    GameViewport->SetMouseCaptureMode(DefaultMouseCaptureMode);
+  }
   SetIgnoreMoveInput(false);
   SetIgnoreLookInput(false);
   RefreshFactionCursorFromState();
@@ -5935,7 +5938,9 @@ void ASkaldPlayerController::ReconcileBattleInputState(const TCHAR* Context) {
   bEnableMouseOverEvents = true;
   DefaultMouseCaptureMode =
       EMouseCaptureMode::CapturePermanently_IncludingInitialMouseDown;
-  SetMouseCaptureMode(DefaultMouseCaptureMode);
+  if (UGameViewportClient* GameViewport = GetWorld() ? GetWorld()->GetGameViewport() : nullptr) {
+    GameViewport->SetMouseCaptureMode(DefaultMouseCaptureMode);
+  }
   SetIgnoreMoveInput(false);
   SetIgnoreLookInput(false);
   UpdateBattleCameraMode();


### PR DESCRIPTION
### Motivation
- Fix a UE 5.5 compile break caused by `error C3861: 'SetMouseCaptureMode': identifier not found` after the `APlayerController` API changed.

### Description
- Replace direct calls to `SetMouseCaptureMode(DefaultMouseCaptureMode)` with `GetWorld()->GetGameViewport()->SetMouseCaptureMode(DefaultMouseCaptureMode)` guarded by a null check on `UGameViewportClient` in the two affected code paths.
- Add `#include "Engine/GameViewportClient.h"` to enable the viewport API.
- Apply the change where mouse capture is set during faction lock-in and during battle input reconciliation.

### Testing
- Ran `rg -n "GameViewportClient|SetMouseCaptureMode\(|SetMouseCaptureMode" Source/Skald/Skald_PlayerController.cpp` to verify the direct `SetMouseCaptureMode(...)` calls were replaced and the new `GameViewportClient` usage is present, which succeeded.
- Inspected the modified file ranges with `nl` to confirm the include and guarded calls are at the intended locations, which succeeded.
- A Windows UE build was not executed in this environment, so please run the project build (`Build.bat SkaldEditor ...`) in your Windows UE5.5 environment to fully validate compilation and runtime behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a14f79d719c83248be5db1e7907fcbf)