### PR TITLE
Repair controller view-target and input on streamed battle transitions

### DIFF
--- a/Source/Skald/Skald_PlayerController.cpp
+++ b/Source/Skald/Skald_PlayerController.cpp
@@ -2447,6 +2447,15 @@ void ASkaldPlayerController::PlayerTick(float DeltaTime) {
     return;
   }
 
+  DetectBattleMap();
+  if (bIsBattleMap || (CachedGameInstance && CachedGameInstance->bIsInBattleMap)) {
+    APawn* ControlledPawn = GetPawn();
+    if (ControlledPawn && GetViewTarget() != ControlledPawn) {
+      SetViewTarget(ControlledPawn);
+      ReconcileBattleInputState(TEXT("PlayerTick.ViewTargetRepair"));
+    }
+  }
+
   // If the player has locked in their fighters and the battle manager became
   // available after the selection UI closed, ensure the battle HUD is
   // constructed and displayed.
@@ -5943,6 +5952,17 @@ void ASkaldPlayerController::ReconcileBattleInputState(const TCHAR* Context) {
   }
   SetIgnoreMoveInput(false);
   SetIgnoreLookInput(false);
+  APawn* ControlledPawn = GetPawn();
+  if (ControlledPawn) {
+    if (GetViewTarget() != ControlledPawn) {
+      SetViewTarget(ControlledPawn);
+    }
+  } else {
+    UE_LOG(LogSkaldBattle, Verbose,
+           TEXT("BattleInputReconciler[%s]: no possessed pawn yet for %s"),
+           Context ? Context : TEXT("Unknown"), *GetName());
+  }
+
   UpdateBattleCameraMode();
 
   UE_LOG(LogSkaldBattle, Verbose,


### PR DESCRIPTION
### Motivation
- Players were left able to interact with HUD (initiative roll) but unable to move the camera or control fighters after locking in and streaming into a battle, indicating the PlayerController had a stale view target or input mode after the streamed level handoff.
- The change aims to re-establish the controller→pawn camera binding and ensure battle input is re-applied reliably when a local player arrives on a streamed battle map.

### Description
- In `ASkaldPlayerController::PlayerTick` added a battle-mode check and a view-target repair so if the controller is on a battle map and its `ViewTarget` is not its possessed pawn the controller calls `SetViewTarget` and `ReconcileBattleInputState(TEXT("PlayerTick.ViewTargetRepair"))` to recover camera/input control.
- In `ASkaldPlayerController::ReconcileBattleInputState` added logic to re-assert the controller’s `ViewTarget` to the possessed pawn when re-applying battle input and emit a verbose diagnostic log when no pawn is yet possessed.
- Changes are localized to `Source/Skald/Skald_PlayerController.cpp` and only run for local controllers while battle map context is active.

### Testing
- Applied the patch and verified the diff with `git diff -- Source/Skald/Skald_PlayerController.cpp` and executed `git status --short`; both commands completed successfully.
- Committed the change with `git commit -m "Fix battle lock-in camera/input recovery after streamed battle transition"` which succeeded (commit created).
- Created the PR using the repository tooling (`make_pr`) which completed successfully; no automated unit/integration tests were run as part of this rollout.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1507a2b6ec8324af94a6ee42fe0402)