### PR TITLE
Ensure camera focuses on possessed pawn when battle UI is active

### DIFF
--- a/Source/Skald/Skald_PlayerController.cpp
+++ b/Source/Skald/Skald_PlayerController.cpp
@@ -5943,6 +5943,22 @@ void ASkaldPlayerController::ReconcileBattleInputState(const TCHAR* Context) {
   }
   SetIgnoreMoveInput(false);
   SetIgnoreLookInput(false);
+  const bool bBattleUIActive =
+      (FighterSelectionWidget && FighterSelectionWidget->IsInViewport()) ||
+      (BattleHUD && BattleHUD->IsInViewport()) || bBattleHUDReadyToShow ||
+      bBattleHUDVisible;
+
+  APawn* ControlledPawn = GetPawn();
+  if (bBattleUIActive && ControlledPawn) {
+    if (GetViewTarget() != ControlledPawn) {
+      SetViewTarget(ControlledPawn);
+    }
+  } else if (bBattleUIActive && !ControlledPawn) {
+    UE_LOG(LogSkaldBattle, Verbose,
+           TEXT("BattleInputReconciler[%s]: no possessed pawn yet for %s"),
+           Context ? Context : TEXT("Unknown"), *GetName());
+  }
+
   UpdateBattleCameraMode();
 
   UE_LOG(LogSkaldBattle, Verbose,


### PR DESCRIPTION
### Motivation
- Ensure that when battle UI (fighter selection / battle HUD) is active the controller's camera is focused on the possessed pawn to avoid incorrect view targets during HUD transitions or fighter selection.

### Description
- In `ReconcileBattleInputState` add `bBattleUIActive` to consolidate UI visibility flags and, when active, set the view target to the possessed pawn via `SetViewTarget(ControlledPawn)` if a pawn exists, and emit a verbose log via `UE_LOG` when no pawn is possessed.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1507a2b6ec8324af94a6ee42fe0402)