### PR TITLE
Revert "Ensure camera focuses on possessed pawn when battle UI is active"

### DIFF
--- a/Source/Skald/Skald_PlayerController.cpp
+++ b/Source/Skald/Skald_PlayerController.cpp
@@ -5952,17 +5952,12 @@ void ASkaldPlayerController::ReconcileBattleInputState(const TCHAR* Context) {
   }
   SetIgnoreMoveInput(false);
   SetIgnoreLookInput(false);
-  const bool bBattleUIActive =
-      (FighterSelectionWidget && FighterSelectionWidget->IsInViewport()) ||
-      (BattleHUD && BattleHUD->IsInViewport()) || bBattleHUDReadyToShow ||
-      bBattleHUDVisible;
-
   APawn* ControlledPawn = GetPawn();
-  if (bBattleUIActive && ControlledPawn) {
+  if (ControlledPawn) {
     if (GetViewTarget() != ControlledPawn) {
       SetViewTarget(ControlledPawn);
     }
-  } else if (bBattleUIActive && !ControlledPawn) {
+  } else {
     UE_LOG(LogSkaldBattle, Verbose,
            TEXT("BattleInputReconciler[%s]: no possessed pawn yet for %s"),
            Context ? Context : TEXT("Unknown"), *GetName());


### PR DESCRIPTION
Reverts Matrocoles/Skald_TurnBasedStrategy_Code#1809