### PR TITLE
Only set view target when battle UI is active in ReconcileBattleInputState

### DIFF
--- a/Source/Skald/Skald_PlayerController.cpp
+++ b/Source/Skald/Skald_PlayerController.cpp
@@ -5952,12 +5952,17 @@ void ASkaldPlayerController::ReconcileBattleInputState(const TCHAR* Context) {
   }
   SetIgnoreMoveInput(false);
   SetIgnoreLookInput(false);
+  const bool bBattleUIActive =
+      (FighterSelectionWidget && FighterSelectionWidget->IsInViewport()) ||
+      (BattleHUD && BattleHUD->IsInViewport()) || bBattleHUDReadyToShow ||
+      bBattleHUDVisible;
+
   APawn* ControlledPawn = GetPawn();
-  if (ControlledPawn) {
+  if (bBattleUIActive && ControlledPawn) {
     if (GetViewTarget() != ControlledPawn) {
       SetViewTarget(ControlledPawn);
     }
-  } else {
+  } else if (bBattleUIActive && !ControlledPawn) {
     UE_LOG(LogSkaldBattle, Verbose,
            TEXT("BattleInputReconciler[%s]: no possessed pawn yet for %s"),
            Context ? Context : TEXT("Unknown"), *GetName());


### PR DESCRIPTION
### Motivation
- Avoid changing the camera/view target unless the battle UI is actually active and surface a clear log when the UI is active but no pawn is possessed.

### Description
- Add `bBattleUIActive` in `ASkaldPlayerController::ReconcileBattleInputState` (checks `FighterSelectionWidget`, `BattleHUD`, `bBattleHUDReadyToShow`, and `bBattleHUDVisible`) and restrict `SetViewTarget(ControlledPawn)` to run only when `bBattleUIActive` is true, and log a verbose message when the UI is active but there is no possessed pawn.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a151ce815088324a53a28bf879d0251)