### PR TITLE
Add startup audit logs for player states, active player, turn ownership and initiative camera

### DIFF
--- a/Source/Skald/Skald_GameMode.cpp
+++ b/Source/Skald/Skald_GameMode.cpp
@@ -1388,6 +1388,23 @@ void ASkaldGameMode::NormalizePlayerStateIds() {
     }
   }
 
+  {
+    FString Snapshot;
+    for (APlayerState *PSBase : GS->PlayerArray) {
+      const ASkaldPlayerState *PS = Cast<ASkaldPlayerState>(PSBase);
+      if (!PS) {
+        continue;
+      }
+      Snapshot += FString::Printf(
+          TEXT("[Name=%s PlayerId=%d StableId=%d AI=%d Locked=%d] "),
+          *PS->GetResolvedPlayerName(TEXT("NormalizePlayerStateIds_Log")),
+          PS->GetPlayerId(), PS->GetStablePlayerId(), PS->bIsAI ? 1 : 0,
+          PS->bHasLockedIn ? 1 : 0);
+    }
+    UE_LOG(LogSkald, Log, TEXT("[StartupAudit] NormalizePlayerStateIds Snapshot %s"),
+           *Snapshot);
+  }
+
   auto RemoveFromPool = [](TArray<int32> &Pool, int32 Value) {
     const int32 Index = Pool.Find(Value);
     if (Index != INDEX_NONE) {

--- a/Source/Skald/Skald_GameState.cpp
+++ b/Source/Skald/Skald_GameState.cpp
@@ -283,6 +283,22 @@ void ASkaldGameState::SetActivePlayerId(int32 NewActivePlayerId)
 
     ActivePlayerId = NewActivePlayerId;
     UE_LOG(LogSkald, Log, TEXT("[TurnState] Active player set to %d"), ActivePlayerId);
+    FString TurnRoster;
+    for (APlayerState* PSBase : PlayerArray)
+    {
+        const ASkaldPlayerState* PS = Cast<ASkaldPlayerState>(PSBase);
+        if (!PS)
+        {
+            continue;
+        }
+        TurnRoster += FString::Printf(TEXT("[Name=%s PlayerId=%d StableId=%d AI=%d] "),
+                                      *PS->GetResolvedPlayerName(TEXT("SetActivePlayerId_Log")),
+                                      PS->GetPlayerId(),
+                                      PS->GetStablePlayerId(),
+                                      PS->bIsAI ? 1 : 0);
+    }
+    UE_LOG(LogSkald, Log, TEXT("[StartupAudit] ActivePlayerChange ActiveId=%d Roster=%s"),
+           ActivePlayerId, *TurnRoster);
     OnActivePlayerChanged.Broadcast(ActivePlayerId);
 
     // Listen servers won't receive OnRep callbacks, so proactively refresh

--- a/Source/Skald/Skald_PlayerController.cpp
+++ b/Source/Skald/Skald_PlayerController.cpp
@@ -5544,6 +5544,14 @@ void ASkaldPlayerController::HandleReplicatedTurnOwnership() {
            *GetName(), *UEnum::GetValueAsString(Phase), ReportedActiveId,
            bIsMyTurn ? TEXT("true") : TEXT("false"),
            bLocalTurnActive ? TEXT("true") : TEXT("false"));
+    UE_LOG(LogSkald, Log,
+           TEXT("[StartupAudit] TurnOwnership Controller=%s LocalStableId=%d CurrentPSStableId=%d ActiveId=%d Phase=%s BattlePhase=%s"),
+           *GetNameSafe(this), ResolveLocalStablePlayerId(),
+           GetPlayerState<ASkaldPlayerState>()
+               ? GetPlayerState<ASkaldPlayerState>()->GetStablePlayerId()
+               : INDEX_NONE,
+           ReportedActiveId, *UEnum::GetValueAsString(Phase),
+           *UEnum::GetValueAsString(BattlePhase));
   }
 
   if (MainHUD && !bTurnOwnershipStateUnchanged) {
@@ -6954,6 +6962,11 @@ void ASkaldPlayerController::ShowPendingStrategicInitiativeResult() {
   ASkald_PlayerCharacter *CameraPawn = Cast<ASkald_PlayerCharacter>(GetPawn());
   if (CameraPawn && !CameraPawn->IsBattleCameraActive() && CameraPawn->BeginStrategicInitiativeCameraView()) {
     bStrategicInitiativeCameraActive = true;
+    UE_LOG(LogSkald, Log,
+           TEXT("[StartupAudit] StrategicInitiativeCamera Begin Controller=%s Pawn=%s ActivePlayerId=%d LocalStableId=%d"),
+           *GetNameSafe(this), *GetNameSafe(CameraPawn),
+           CachedGameState ? CachedGameState->ActivePlayerId : INDEX_NONE,
+           ResolveLocalStablePlayerId());
     EnsureDiceManagerBindings();
   }
 
@@ -8706,6 +8719,11 @@ void ASkaldPlayerController::RestoreStrategicInitiativeCamera() {
   if (!bStrategicInitiativeCameraActive) {
     return;
   }
+  UE_LOG(LogSkald, Log,
+         TEXT("[StartupAudit] StrategicInitiativeCamera Restore Controller=%s ActivePlayerId=%d LocalStableId=%d"),
+         *GetNameSafe(this),
+         CachedGameState ? CachedGameState->ActivePlayerId : INDEX_NONE,
+         ResolveLocalStablePlayerId());
 
   bStrategicInitiativeCameraActive = false;
 


### PR DESCRIPTION
### Motivation
- Add detailed startup/runtime audit logging to help diagnose player ID/stable ID mismatches and turn ownership or camera issues during startup and strategic initiative flows.

### Description
- Add a player-state snapshot log in `ASkaldGameMode::NormalizePlayerStateIds` that prints resolved name, player id, stable id, AI flag and lock state for each `PlayerState`.
- Add a turn-roster audit log in `ASkaldGameState::SetActivePlayerId` that logs the new active id and a roster of resolved names with player id, stable id and AI flag.
- Add controller-side logs in `ASkaldPlayerController` to record turn ownership changes and strategic-initiative camera begin/restore events including controller/pawn names, active player id and local stable id.
- No gameplay logic or state mutations were changed; this PR only adds logging (`UE_LOG`) for diagnostic purposes.

### Testing
- Project compiled successfully after the changes.
- Automated unit/integration tests were executed and completed without regressions.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a151e6ca8108324899760a74a95bfed)