### PR TITLE
Defer PlayerState removal on startup and add startup/turn ownership audit logs

### DIFF
--- a/Source/Skald/Skald_GameMode.cpp
+++ b/Source/Skald/Skald_GameMode.cpp
@@ -1388,6 +1388,23 @@ void ASkaldGameMode::NormalizePlayerStateIds() {
     }
   }
 
+  {
+    FString Snapshot;
+    for (APlayerState *PSBase : GS->PlayerArray) {
+      const ASkaldPlayerState *PS = Cast<ASkaldPlayerState>(PSBase);
+      if (!PS) {
+        continue;
+      }
+      Snapshot += FString::Printf(
+          TEXT("[Name=%s PlayerId=%d StableId=%d AI=%d Locked=%d] "),
+          *PS->GetResolvedPlayerName(TEXT("NormalizePlayerStateIds_Log")),
+          PS->GetPlayerId(), PS->GetStablePlayerId(), PS->bIsAI ? 1 : 0,
+          PS->bHasLockedIn ? 1 : 0);
+    }
+    UE_LOG(LogSkald, Log, TEXT("[StartupAudit] NormalizePlayerStateIds Snapshot %s"),
+           *Snapshot);
+  }
+
   auto RemoveFromPool = [](TArray<int32> &Pool, int32 Value) {
     const int32 Index = Pool.Find(Value);
     if (Index != INDEX_NONE) {
@@ -1654,14 +1671,14 @@ void ASkaldGameMode::TryInitializeWorldAndStart() {
     ASkaldPlayerController *OwningController =
         PS ? Cast<ASkaldPlayerController>(PS->GetOwner()) : nullptr;
     if (!IsValid(OwningController)) {
+      // During map transitions and early startup, PlayerState ownership can lag
+      // behind controller registration for a short period. Removing these
+      // PlayerStates here can incorrectly drop the local human entry and allow
+      // AI ownership to become the only remaining active participant.
       UE_LOG(LogSkald, Warning,
-             TEXT("TryInitializeWorldAndStart: Removing PlayerState %s with no "
-                  "controller"),
+             TEXT("TryInitializeWorldAndStart: Deferring PlayerState %s with no "
+                  "controller (will retry)"),
              *GetNameSafe(PS));
-      GS->RemovePlayerState(PS);
-      PlayerDataArray.RemoveAll([PS](const FS_PlayerData &Data) {
-        return Data.PlayerID == PS->GetPlayerId();
-      });
       bNeedsRetry = true;
       continue;
     }

--- a/Source/Skald/Skald_GameState.cpp
+++ b/Source/Skald/Skald_GameState.cpp
@@ -283,6 +283,22 @@ void ASkaldGameState::SetActivePlayerId(int32 NewActivePlayerId)
 
     ActivePlayerId = NewActivePlayerId;
     UE_LOG(LogSkald, Log, TEXT("[TurnState] Active player set to %d"), ActivePlayerId);
+    FString TurnRoster;
+    for (APlayerState* PSBase : PlayerArray)
+    {
+        const ASkaldPlayerState* PS = Cast<ASkaldPlayerState>(PSBase);
+        if (!PS)
+        {
+            continue;
+        }
+        TurnRoster += FString::Printf(TEXT("[Name=%s PlayerId=%d StableId=%d AI=%d] "),
+                                      *PS->GetResolvedPlayerName(TEXT("SetActivePlayerId_Log")),
+                                      PS->GetPlayerId(),
+                                      PS->GetStablePlayerId(),
+                                      PS->bIsAI ? 1 : 0);
+    }
+    UE_LOG(LogSkald, Log, TEXT("[StartupAudit] ActivePlayerChange ActiveId=%d Roster=%s"),
+           ActivePlayerId, *TurnRoster);
     OnActivePlayerChanged.Broadcast(ActivePlayerId);
 
     // Listen servers won't receive OnRep callbacks, so proactively refresh

--- a/Source/Skald/Skald_PlayerController.cpp
+++ b/Source/Skald/Skald_PlayerController.cpp
@@ -5544,6 +5544,14 @@ void ASkaldPlayerController::HandleReplicatedTurnOwnership() {
            *GetName(), *UEnum::GetValueAsString(Phase), ReportedActiveId,
            bIsMyTurn ? TEXT("true") : TEXT("false"),
            bLocalTurnActive ? TEXT("true") : TEXT("false"));
+    UE_LOG(LogSkald, Log,
+           TEXT("[StartupAudit] TurnOwnership Controller=%s LocalStableId=%d CurrentPSStableId=%d ActiveId=%d Phase=%s BattlePhase=%s"),
+           *GetNameSafe(this), GetResolvedLocalPlayerId(),
+           GetPlayerState<ASkaldPlayerState>()
+               ? GetPlayerState<ASkaldPlayerState>()->GetStablePlayerId()
+               : INDEX_NONE,
+           ReportedActiveId, *UEnum::GetValueAsString(Phase),
+           *UEnum::GetValueAsString(BattlePhase));
   }
 
   if (MainHUD && !bTurnOwnershipStateUnchanged) {
@@ -6954,6 +6962,11 @@ void ASkaldPlayerController::ShowPendingStrategicInitiativeResult() {
   ASkald_PlayerCharacter *CameraPawn = Cast<ASkald_PlayerCharacter>(GetPawn());
   if (CameraPawn && !CameraPawn->IsBattleCameraActive() && CameraPawn->BeginStrategicInitiativeCameraView()) {
     bStrategicInitiativeCameraActive = true;
+    UE_LOG(LogSkald, Log,
+           TEXT("[StartupAudit] StrategicInitiativeCamera Begin Controller=%s Pawn=%s ActivePlayerId=%d LocalStableId=%d"),
+           *GetNameSafe(this), *GetNameSafe(CameraPawn),
+           CachedGameState ? CachedGameState->ActivePlayerId : INDEX_NONE,
+           GetResolvedLocalPlayerId());
     EnsureDiceManagerBindings();
   }
 
@@ -8706,6 +8719,11 @@ void ASkaldPlayerController::RestoreStrategicInitiativeCamera() {
   if (!bStrategicInitiativeCameraActive) {
     return;
   }
+  UE_LOG(LogSkald, Log,
+         TEXT("[StartupAudit] StrategicInitiativeCamera Restore Controller=%s ActivePlayerId=%d LocalStableId=%d"),
+         *GetNameSafe(this),
+         CachedGameState ? CachedGameState->ActivePlayerId : INDEX_NONE,
+         GetResolvedLocalPlayerId());
 
   bStrategicInitiativeCameraActive = false;
 


### PR DESCRIPTION
### Motivation

- Improve observability of player/controller ownership and turn assignment during startup and turn changes to aid debugging of transient ownership races.
- Avoid prematurely removing `PlayerState` instances that temporarily lack an owning controller during map transitions, which could drop the local human entry and leave only AI participants.

### Description

- In `ASkaldGameMode::NormalizePlayerStateIds` add a `StartupAudit` log that snapshots all `PlayerArray` entries showing resolved name, `PlayerId`, `StableId`, AI and locked flags.
- In `ASkaldGameMode::TryInitializeWorldAndStart` change the behavior when a `PlayerState` has no valid controller to defer initialization instead of removing the `PlayerState`, set `bNeedsRetry = true`, and update the log message to indicate deferral; a comment explains the ownership lag rationale.
- In `ASkaldGameState::SetActivePlayerId` add a `StartupAudit` log that emits the current turn roster (name, `PlayerId`, `StableId`, AI) whenever the active player is changed.
- In `ASkaldPlayerController` add `StartupAudit` logs in `HandleReplicatedTurnOwnership` and strategic-initiative camera methods to report controller name, local stable id, current `PlayerState` stable id, active player id, and phase/battle phase when relevant.

### Testing

- Built the project successfully with no compile errors after the changes to `Skald_GameMode.cpp`, `Skald_GameState.cpp`, and `Skald_PlayerController.cpp`.
- Ran the existing automated test suite and engine startup smoke checks and observed no failures related to these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a151e6ca8108324899760a74a95bfed)