### PR TITLE
Defer PlayerState removal during init, preserve initiative order, and add startup audit logs

### DIFF
--- a/Source/Skald/Skald_GameMode.cpp
+++ b/Source/Skald/Skald_GameMode.cpp
@@ -1388,6 +1388,23 @@ void ASkaldGameMode::NormalizePlayerStateIds() {
     }
   }
 
+  {
+    FString Snapshot;
+    for (APlayerState *PSBase : GS->PlayerArray) {
+      const ASkaldPlayerState *PS = Cast<ASkaldPlayerState>(PSBase);
+      if (!PS) {
+        continue;
+      }
+      Snapshot += FString::Printf(
+          TEXT("[Name=%s PlayerId=%d StableId=%d AI=%d Locked=%d] "),
+          *PS->GetResolvedPlayerName(TEXT("NormalizePlayerStateIds_Log")),
+          PS->GetPlayerId(), PS->GetStablePlayerId(), PS->bIsAI ? 1 : 0,
+          PS->bHasLockedIn ? 1 : 0);
+    }
+    UE_LOG(LogSkald, Log, TEXT("[StartupAudit] NormalizePlayerStateIds Snapshot %s"),
+           *Snapshot);
+  }
+
   auto RemoveFromPool = [](TArray<int32> &Pool, int32 Value) {
     const int32 Index = Pool.Find(Value);
     if (Index != INDEX_NONE) {
@@ -1654,14 +1671,14 @@ void ASkaldGameMode::TryInitializeWorldAndStart() {
     ASkaldPlayerController *OwningController =
         PS ? Cast<ASkaldPlayerController>(PS->GetOwner()) : nullptr;
     if (!IsValid(OwningController)) {
+      // During map transitions and early startup, PlayerState ownership can lag
+      // behind controller registration for a short period. Removing these
+      // PlayerStates here can incorrectly drop the local human entry and allow
+      // AI ownership to become the only remaining active participant.
       UE_LOG(LogSkald, Warning,
-             TEXT("TryInitializeWorldAndStart: Removing PlayerState %s with no "
-                  "controller"),
+             TEXT("TryInitializeWorldAndStart: Deferring PlayerState %s with no "
+                  "controller (will retry)"),
              *GetNameSafe(PS));
-      GS->RemovePlayerState(PS);
-      PlayerDataArray.RemoveAll([PS](const FS_PlayerData &Data) {
-        return Data.PlayerID == PS->GetPlayerId();
-      });
       bNeedsRetry = true;
       continue;
     }
@@ -3110,6 +3127,25 @@ void ASkaldGameMode::BeginArmyPlacementPhase() {
   ArmyPlacementLeader.Reset();
   PendingArmyPlacementAIController.Reset();
   PlacementIndex = -1;
+  if (ASkaldGameState* GS = GetGameState<ASkaldGameState>()) {
+    const int32 ActiveStableId = GS->ActivePlayerId;
+    if (ActiveStableId != INDEX_NONE) {
+      const TArray<ASkaldPlayerController*> Controllers = TurnManager->GetControllers();
+      for (int32 Index = 0; Index < Controllers.Num(); ++Index) {
+        ASkaldPlayerController* PC = Controllers[Index];
+        ASkaldPlayerState* PS = PC ? PC->GetPlayerState<ASkaldPlayerState>() : nullptr;
+        if (PS && PS->GetStablePlayerId() == ActiveStableId) {
+          // AdvanceArmyPlacement pre-increments PlacementIndex, so store
+          // previous slot to start with the active initiative winner.
+          PlacementIndex = Index - 1;
+          UE_LOG(LogSkald, Log,
+                 TEXT("BeginArmyPlacementPhase: preserving initiative leader StableId=%d Index=%d Controller=%s"),
+                 ActiveStableId, Index, *GetNameSafe(PC));
+          break;
+        }
+      }
+    }
+  }
   AdvanceArmyPlacement();
 }
 

--- a/Source/Skald/Skald_GameState.cpp
+++ b/Source/Skald/Skald_GameState.cpp
@@ -283,6 +283,22 @@ void ASkaldGameState::SetActivePlayerId(int32 NewActivePlayerId)
 
     ActivePlayerId = NewActivePlayerId;
     UE_LOG(LogSkald, Log, TEXT("[TurnState] Active player set to %d"), ActivePlayerId);
+    FString TurnRoster;
+    for (APlayerState* PSBase : PlayerArray)
+    {
+        const ASkaldPlayerState* PS = Cast<ASkaldPlayerState>(PSBase);
+        if (!PS)
+        {
+            continue;
+        }
+        TurnRoster += FString::Printf(TEXT("[Name=%s PlayerId=%d StableId=%d AI=%d] "),
+                                      *PS->GetResolvedPlayerName(TEXT("SetActivePlayerId_Log")),
+                                      PS->GetPlayerId(),
+                                      PS->GetStablePlayerId(),
+                                      PS->bIsAI ? 1 : 0);
+    }
+    UE_LOG(LogSkald, Log, TEXT("[StartupAudit] ActivePlayerChange ActiveId=%d Roster=%s"),
+           ActivePlayerId, *TurnRoster);
     OnActivePlayerChanged.Broadcast(ActivePlayerId);
 
     // Listen servers won't receive OnRep callbacks, so proactively refresh

--- a/Source/Skald/Skald_PlayerController.cpp
+++ b/Source/Skald/Skald_PlayerController.cpp
@@ -5544,6 +5544,14 @@ void ASkaldPlayerController::HandleReplicatedTurnOwnership() {
            *GetName(), *UEnum::GetValueAsString(Phase), ReportedActiveId,
            bIsMyTurn ? TEXT("true") : TEXT("false"),
            bLocalTurnActive ? TEXT("true") : TEXT("false"));
+    UE_LOG(LogSkald, Log,
+           TEXT("[StartupAudit] TurnOwnership Controller=%s LocalStableId=%d CurrentPSStableId=%d ActiveId=%d Phase=%s BattlePhase=%s"),
+           *GetNameSafe(this), GetResolvedLocalPlayerId(),
+           GetPlayerState<ASkaldPlayerState>()
+               ? GetPlayerState<ASkaldPlayerState>()->GetStablePlayerId()
+               : INDEX_NONE,
+           ReportedActiveId, *UEnum::GetValueAsString(Phase),
+           *UEnum::GetValueAsString(BattlePhase));
   }
 
   if (MainHUD && !bTurnOwnershipStateUnchanged) {
@@ -6954,6 +6962,11 @@ void ASkaldPlayerController::ShowPendingStrategicInitiativeResult() {
   ASkald_PlayerCharacter *CameraPawn = Cast<ASkald_PlayerCharacter>(GetPawn());
   if (CameraPawn && !CameraPawn->IsBattleCameraActive() && CameraPawn->BeginStrategicInitiativeCameraView()) {
     bStrategicInitiativeCameraActive = true;
+    UE_LOG(LogSkald, Log,
+           TEXT("[StartupAudit] StrategicInitiativeCamera Begin Controller=%s Pawn=%s ActivePlayerId=%d LocalStableId=%d"),
+           *GetNameSafe(this), *GetNameSafe(CameraPawn),
+           CachedGameState ? CachedGameState->ActivePlayerId : INDEX_NONE,
+           GetResolvedLocalPlayerId());
     EnsureDiceManagerBindings();
   }
 
@@ -8706,6 +8719,11 @@ void ASkaldPlayerController::RestoreStrategicInitiativeCamera() {
   if (!bStrategicInitiativeCameraActive) {
     return;
   }
+  UE_LOG(LogSkald, Log,
+         TEXT("[StartupAudit] StrategicInitiativeCamera Restore Controller=%s ActivePlayerId=%d LocalStableId=%d"),
+         *GetNameSafe(this),
+         CachedGameState ? CachedGameState->ActivePlayerId : INDEX_NONE,
+         GetResolvedLocalPlayerId());
 
   bStrategicInitiativeCameraActive = false;
 


### PR DESCRIPTION
### Motivation
- Improve reliability of startup and turn-init flows by avoiding premature removal of PlayerStates that temporarily lack controllers and by capturing more diagnostic information for startup/turn ownership issues.
- Ensure army placement begins with the previously active initiative winner when transitioning phases.

### Description
- Replace immediate removal of PlayerState entries with a deferred retry when a PlayerState has no valid controller in `TryInitializeWorldAndStart`, and log a warning indicating the deferral.
- Add detailed `[StartupAudit]` UE_LOG entries in `NormalizePlayerStateIds`, `ASkaldGameState::SetActivePlayerId`, and several places in `ASkaldPlayerController` (`HandleReplicatedTurnOwnership`, `ShowPendingStrategicInitiativeResult`, `RestoreStrategicInitiativeCamera`) to record player/turn/camera state snapshots for diagnostics.
- In `BeginArmyPlacementPhase`, preserve the initiative leader by locating the controller whose PlayerState `GetStablePlayerId()` matches `ASkaldGameState::ActivePlayerId` and pre-adjusting `PlacementIndex` so placement starts with the active initiative winner, with a log entry when preserved.

### Testing
- Compiled the project and executed the existing automated unit/integration test suite; all tests passed.
- Exercised startup/controller-lag and initiative flows in runtime smoke tests to verify PlayerStates are not dropped prematurely and army placement preserves the active leader (no regressions observed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a151e6ca8108324899760a74a95bfed)