### PR TITLE
Fix C4456 shadowing in BeginArmyPlacementPhase

### DIFF
--- a/Source/Skald/Skald_GameMode.cpp
+++ b/Source/Skald/Skald_GameMode.cpp
@@ -3130,9 +3130,9 @@ void ASkaldGameMode::BeginArmyPlacementPhase() {
   if (ASkaldGameState* GS = GetGameState<ASkaldGameState>()) {
     const int32 ActiveStableId = GS->ActivePlayerId;
     if (ActiveStableId != INDEX_NONE) {
-      const TArray<ASkaldPlayerController*> Controllers = TurnManager->GetControllers();
-      for (int32 Index = 0; Index < Controllers.Num(); ++Index) {
-        ASkaldPlayerController* PC = Controllers[Index];
+      const TArray<ASkaldPlayerController*> OrderedControllers = TurnManager->GetControllers();
+      for (int32 Index = 0; Index < OrderedControllers.Num(); ++Index) {
+        ASkaldPlayerController* PC = OrderedControllers[Index];
         ASkaldPlayerState* PS = PC ? PC->GetPlayerState<ASkaldPlayerState>() : nullptr;
         if (PS && PS->GetStablePlayerId() == ActiveStableId) {
           // AdvanceArmyPlacement pre-increments PlacementIndex, so store


### PR DESCRIPTION
### Motivation
- Remove a local-variable shadowing that triggered `error C4456` during compilation by ensuring the inner controller array does not hide an earlier `Controllers` declaration.

### Description
- Renamed the inner `Controllers` variable in `ASkaldGameMode::BeginArmyPlacementPhase` to `OrderedControllers` and updated the loop to iterate `OrderedControllers` instead of `Controllers`.

### Testing
- Committed the change (`git commit`) and verified the file update and commit hash (`c923383`) succeeded; no automated UBT build was executed in this environment so full compilation remains pending and should be run on the Windows/UE toolchain.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1529a2a428832486fd86797eb79f0d)