### PR TITLE
Wait for controller-less PlayerStates during startup to fix initiative/placement regression

### DIFF
--- a/Source/Skald/Skald_GameMode.cpp
+++ b/Source/Skald/Skald_GameMode.cpp
@@ -3346,16 +3346,29 @@ int32 ASkaldGameMode::ResolveExpectedControllerCount() const {
 
   if (const ASkaldGameState *GS = GetGameState<ASkaldGameState>()) {
     TSet<const ASkaldPlayerController *> UniqueControllers;
+    TSet<int32> UniqueStableIds;
     for (const APlayerState *PlayerStateBase : GS->PlayerArray) {
       const ASkaldPlayerState *PS =
           Cast<ASkaldPlayerState>(PlayerStateBase);
+      if (!PS) {
+        continue;
+      }
+
+      const int32 StableId = PS->GetStablePlayerId();
+      if (StableId != INDEX_NONE) {
+        UniqueStableIds.Add(StableId);
+      }
+
       const ASkaldPlayerController *ControllerOwner =
-          PS ? Cast<ASkaldPlayerController>(PS->GetOwner()) : nullptr;
+          Cast<ASkaldPlayerController>(PS->GetOwner());
       if (ControllerOwner) {
         UniqueControllers.Add(ControllerOwner);
       }
     }
-    ExpectedCount = UniqueControllers.Num();
+    // During seamless travel startup a PlayerState can exist briefly without
+    // an owning controller. Count stable IDs too so army placement waits for
+    // those controllers instead of starting with an incomplete roster.
+    ExpectedCount = FMath::Max(UniqueControllers.Num(), UniqueStableIds.Num());
   }
 
   const USkaldGameInstance *GI =


### PR DESCRIPTION
### Motivation
- A transient startup/seamless-travel window could leave `PlayerState` objects without an attached controller, which led to undercounting expected players and starting army placement too early causing initiative/turn/camera desyncs introduced around PR#1809. 

### Description
- Update `ASkaldGameMode::ResolveExpectedControllerCount()` to collect both unique owning controllers and unique stable player IDs from `GameState->PlayerArray`. 
- Add a `TSet<int32> UniqueStableIds`, skip null `PlayerState` entries, insert `GetStablePlayerId()` when valid, and compute `ExpectedCount` as `FMath::Max(UniqueControllers.Num(), UniqueStableIds.Num())`. 
- This ensures startup/army-placement waits for controller attachment even when `PlayerState` objects exist before their owners. The change is in `Source/Skald/Skald_GameMode.cpp`.

### Testing
- Ran repository searches for initiative/army-placement related symbols to inspect affected code paths and confirm the update location with `rg` (success). 
- Performed local static checks on the modified file and ensured the change is syntactically correct at file level (no compile errors introduced). 
- No automated runtime tests were available in this environment; recommend in-engine verification across seamless travel and match start scenarios with mixed host/client readiness.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a152f53068483249dcd0713355a362d)