### PR TITLE
Count stable player IDs for expected controllers and adjust input/mouse capture for UI flows

### DIFF
--- a/Source/Skald/Skald_GameMode.cpp
+++ b/Source/Skald/Skald_GameMode.cpp
@@ -3346,16 +3346,29 @@ int32 ASkaldGameMode::ResolveExpectedControllerCount() const {
 
   if (const ASkaldGameState *GS = GetGameState<ASkaldGameState>()) {
     TSet<const ASkaldPlayerController *> UniqueControllers;
+    TSet<int32> UniqueStableIds;
     for (const APlayerState *PlayerStateBase : GS->PlayerArray) {
       const ASkaldPlayerState *PS =
           Cast<ASkaldPlayerState>(PlayerStateBase);
+      if (!PS) {
+        continue;
+      }
+
+      const int32 StableId = PS->GetStablePlayerId();
+      if (StableId != INDEX_NONE) {
+        UniqueStableIds.Add(StableId);
+      }
+
       const ASkaldPlayerController *ControllerOwner =
-          PS ? Cast<ASkaldPlayerController>(PS->GetOwner()) : nullptr;
+          Cast<ASkaldPlayerController>(PS->GetOwner());
       if (ControllerOwner) {
         UniqueControllers.Add(ControllerOwner);
       }
     }
-    ExpectedCount = UniqueControllers.Num();
+    // During seamless travel startup a PlayerState can exist briefly without
+    // an owning controller. Count stable IDs too so army placement waits for
+    // those controllers instead of starting with an incomplete roster.
+    ExpectedCount = FMath::Max(UniqueControllers.Num(), UniqueStableIds.Num());
   }
 
   const USkaldGameInstance *GI =

--- a/Source/Skald/Skald_PlayerController.cpp
+++ b/Source/Skald/Skald_PlayerController.cpp
@@ -5624,7 +5624,9 @@ void ASkaldPlayerController::HandleReplicatedTurnOwnership() {
       }
     }
 
-    if (bNeedsBattlePrepUI) {
+    const bool bNeedsStrategicInitiativeUI =
+        bAwaitingStrategicInitiativeRoll || PendingStrategicInitiativeRoll > 0;
+    if (bNeedsBattlePrepUI || bNeedsStrategicInitiativeUI) {
       if (!bShowMouseCursor || !bEnableClickEvents || !bEnableMouseOverEvents) {
         UWidgetBlueprintLibrary::SetInputMode_GameAndUIEx(
             this, nullptr, EMouseLockMode::DoNotLock,
@@ -5874,8 +5876,9 @@ void ASkaldPlayerController::HandleFactionLockedIn() {
   bShowMouseCursor = true;
   bEnableClickEvents = true;
   bEnableMouseOverEvents = true;
-  DefaultMouseCaptureMode =
-      EMouseCaptureMode::CapturePermanently_IncludingInitialMouseDown;
+  // Never permanently capture in overview; that can trap focus/clicks in PIE
+  // and block interaction with initiative UI and even the editor window.
+  DefaultMouseCaptureMode = EMouseCaptureMode::NoCapture;
   if (UGameViewportClient* GameViewport = GetWorld() ? GetWorld()->GetGameViewport() : nullptr) {
     GameViewport->SetMouseCaptureMode(DefaultMouseCaptureMode);
   }
@@ -5953,8 +5956,7 @@ void ASkaldPlayerController::ReconcileBattleInputState(const TCHAR* Context) {
   bShowMouseCursor = true;
   bEnableClickEvents = true;
   bEnableMouseOverEvents = true;
-  DefaultMouseCaptureMode =
-      EMouseCaptureMode::CapturePermanently_IncludingInitialMouseDown;
+  DefaultMouseCaptureMode = EMouseCaptureMode::CaptureDuringMouseDown;
   if (UGameViewportClient* GameViewport = GetWorld() ? GetWorld()->GetGameViewport() : nullptr) {
     GameViewport->SetMouseCaptureMode(DefaultMouseCaptureMode);
   }


### PR DESCRIPTION
### Motivation

- Ensure army placement and turn startup wait for players that have a `PlayerState` but not yet an owning controller (common during seamless travel). 
- Make UI input activation include strategic-initiative flows so initiative roll UI doesn’t leave players unable to interact. 
- Prevent permanent mouse capture from trapping focus in PIE/editor or blocking initiative/editor interactions. 

### Description

- Update `ResolveExpectedControllerCount` to collect stable player IDs via `PS->GetStablePlayerId()` into `UniqueStableIds` and use `FMath::Max` of controller-count and stable-ID-count when computing `ExpectedCount`. 
- Add `bNeedsStrategicInitiativeUI` (based on `bAwaitingStrategicInitiativeRoll` / `PendingStrategicInitiativeRoll`) and include it in the input-mode branch in `HandleReplicatedTurnOwnership` so strategic initiative UI requests enable game+UI input and world input. 
- Change default mouse capture behavior: set `DefaultMouseCaptureMode` to `EMouseCaptureMode::NoCapture` in overview HUD setup and to `EMouseCaptureMode::CaptureDuringMouseDown` in battle input handling, and apply the mode to the `GameViewport`. 
- Minor control-flow cleanup when iterating `PlayerArray` to skip null `PlayerState` entries before inspecting owners and stable IDs. 

### Testing

- Project builds were produced for editor and server configurations and the codebase compiled successfully. 
- Automated unit and engine tests were executed and reported no regressions. 
- Multiplayer startup and UI input flows were exercised by automated integration checks and the strategic-initiative and army-placement behaviors behaved as expected in those tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a152f53068483249dcd0713355a362d)