### PR TITLE
Force strategic initiative prompt on startup; fix input capture and controller counting

### DIFF
--- a/Source/Skald/Skald_GameMode.cpp
+++ b/Source/Skald/Skald_GameMode.cpp
@@ -1864,6 +1864,32 @@ void ASkaldGameMode::TryInitializeWorldAndStart() {
     bTurnsStarted = true;
   }
 
+  // If startup state drifts into an initialized-but-not-started path without
+  // any initiative rolls recorded, force the strategic initiative prompt before
+  // StartTurns. This prevents default controller ordering (often AI first) from
+  // silently starting the match and leaving overview UI actions as no-ops.
+  bool bAnyInitiativeRollRecorded = false;
+  for (APlayerState *PSBase : GS->PlayerArray) {
+    if (const ASkaldPlayerState *PS = Cast<ASkaldPlayerState>(PSBase)) {
+      if (PS->InitiativeRoll > 0) {
+        bAnyInitiativeRollRecorded = true;
+        break;
+      }
+    }
+  }
+
+  const bool bShouldForceStrategicInitiative =
+      bReadyToStart && !bTurnsStarted && TurnManager &&
+      !TurnManager->HasTurnsStarted() && !bAwaitingStrategicInitiativeInput &&
+      !bStrategicInitiativePromptIssued && !bAnyInitiativeRollRecorded;
+
+  if (bShouldForceStrategicInitiative) {
+    UE_LOG(LogSkald, Warning,
+           TEXT("TryInitializeWorldAndStart: forcing strategic initiative before StartTurns (no recorded initiative rolls)."));
+    BeginStrategicInitiativePhase();
+    return;
+  }
+
   if (bWorldInitialized && bReadyToStart && !bTurnsStarted && TurnManager &&
       !TurnManager->HasTurnsStarted() &&
       TurnManager->GetCurrentPhase() != ETurnPhase::ArmyPlacement &&
@@ -3346,16 +3372,29 @@ int32 ASkaldGameMode::ResolveExpectedControllerCount() const {
 
   if (const ASkaldGameState *GS = GetGameState<ASkaldGameState>()) {
     TSet<const ASkaldPlayerController *> UniqueControllers;
+    TSet<int32> UniqueStableIds;
     for (const APlayerState *PlayerStateBase : GS->PlayerArray) {
       const ASkaldPlayerState *PS =
           Cast<ASkaldPlayerState>(PlayerStateBase);
+      if (!PS) {
+        continue;
+      }
+
+      const int32 StableId = PS->GetStablePlayerId();
+      if (StableId != INDEX_NONE) {
+        UniqueStableIds.Add(StableId);
+      }
+
       const ASkaldPlayerController *ControllerOwner =
-          PS ? Cast<ASkaldPlayerController>(PS->GetOwner()) : nullptr;
+          Cast<ASkaldPlayerController>(PS->GetOwner());
       if (ControllerOwner) {
         UniqueControllers.Add(ControllerOwner);
       }
     }
-    ExpectedCount = UniqueControllers.Num();
+    // During seamless travel startup a PlayerState can exist briefly without
+    // an owning controller. Count stable IDs too so army placement waits for
+    // those controllers instead of starting with an incomplete roster.
+    ExpectedCount = FMath::Max(UniqueControllers.Num(), UniqueStableIds.Num());
   }
 
   const USkaldGameInstance *GI =

--- a/Source/Skald/Skald_PlayerController.cpp
+++ b/Source/Skald/Skald_PlayerController.cpp
@@ -5624,12 +5624,27 @@ void ASkaldPlayerController::HandleReplicatedTurnOwnership() {
       }
     }
 
-    if (bNeedsBattlePrepUI) {
-      if (!bShowMouseCursor || !bEnableClickEvents || !bEnableMouseOverEvents) {
-        UWidgetBlueprintLibrary::SetInputMode_GameAndUIEx(
-            this, nullptr, EMouseLockMode::DoNotLock,
-            /*bHideCursorDuringCapture*/ false);
+    const bool bHudAwaitingStrategicInitiative =
+        MainHUD && MainHUD->IsAwaitingStrategicInitiative();
+    const bool bNeedsStrategicInitiativeUI =
+        bAwaitingStrategicInitiativeRoll || PendingStrategicInitiativeRoll > 0 ||
+        bHudAwaitingStrategicInitiative;
+    if (bNeedsBattlePrepUI || bNeedsStrategicInitiativeUI) {
+      // Keep focus anchored to the active UI surface when strategic initiative
+      // is awaiting input. Passing nullptr can leave focus on the viewport and
+      // make clicks appear to register (SFX) without driving widget actions
+      // until OS focus is toggled (e.g. Win key).
+      UWidget* InputFocusWidget = nullptr;
+      if (bNeedsStrategicInitiativeUI && MainHUD && MainHUD->IsInViewport()) {
+        InputFocusWidget = MainHUD;
+      } else if (FighterSelectionWidget && FighterSelectionWidget->IsInViewport()) {
+        InputFocusWidget = FighterSelectionWidget;
+      } else if (BattleHUD && BattleHUD->IsInViewport()) {
+        InputFocusWidget = BattleHUD;
       }
+      UWidgetBlueprintLibrary::SetInputMode_GameAndUIEx(
+          this, InputFocusWidget, EMouseLockMode::DoNotLock,
+          /*bHideCursorDuringCapture*/ false);
       bShowMouseCursor = true;
       bEnableClickEvents = true;
       bEnableMouseOverEvents = true;
@@ -5874,8 +5889,9 @@ void ASkaldPlayerController::HandleFactionLockedIn() {
   bShowMouseCursor = true;
   bEnableClickEvents = true;
   bEnableMouseOverEvents = true;
-  DefaultMouseCaptureMode =
-      EMouseCaptureMode::CapturePermanently_IncludingInitialMouseDown;
+  // Never permanently capture in overview; that can trap focus/clicks in PIE
+  // and block interaction with initiative UI and even the editor window.
+  DefaultMouseCaptureMode = EMouseCaptureMode::NoCapture;
   if (UGameViewportClient* GameViewport = GetWorld() ? GetWorld()->GetGameViewport() : nullptr) {
     GameViewport->SetMouseCaptureMode(DefaultMouseCaptureMode);
   }
@@ -5953,8 +5969,7 @@ void ASkaldPlayerController::ReconcileBattleInputState(const TCHAR* Context) {
   bShowMouseCursor = true;
   bEnableClickEvents = true;
   bEnableMouseOverEvents = true;
-  DefaultMouseCaptureMode =
-      EMouseCaptureMode::CapturePermanently_IncludingInitialMouseDown;
+  DefaultMouseCaptureMode = EMouseCaptureMode::CaptureDuringMouseDown;
   if (UGameViewportClient* GameViewport = GetWorld() ? GetWorld()->GetGameViewport() : nullptr) {
     GameViewport->SetMouseCaptureMode(DefaultMouseCaptureMode);
   }
@@ -6932,11 +6947,10 @@ void ASkaldPlayerController::HandleAttackRollRequested() {
 }
 
 void ASkaldPlayerController::HandleStrategicInitiativeRollRequested() {
-  bAwaitingStrategicInitiativeRoll = false;
-
+  // Keep the local prompt active until the authoritative server response
+  // arrives; clearing too early can strand the player in a stale UI state if
+  // the request races with replicated startup updates.
   if (MainHUD) {
-    MainHUD->HideStrategicInitiativePrompt();
-
     const FText RollingText =
         NSLOCTEXT("Skald", "StrategicInitiativeRolling",
                   "Rolling for initiative...");
@@ -7032,6 +7046,22 @@ void ASkaldPlayerController::ClientPromptStrategicInitiative_Implementation(
     MainHUD->ShowStrategicInitiativePrompt(PromptText);
     MainHUD->SetAwaitingStrategicInitiative(true);
   }
+
+  // Strategic-initiative prompt is a pure UI interaction in overview. Release
+  // viewport capture so clicks do not get trapped in PIE and editor controls
+  // (including Stop) remain reachable.
+  UWidgetBlueprintLibrary::SetInputMode_GameAndUIEx(
+      this, MainHUD, EMouseLockMode::DoNotLock, false);
+  DefaultMouseCaptureMode = EMouseCaptureMode::NoCapture;
+  if (UGameViewportClient *GameViewport =
+          GetWorld() ? GetWorld()->GetGameViewport() : nullptr) {
+    GameViewport->SetMouseCaptureMode(DefaultMouseCaptureMode);
+  }
+  bShowMouseCursor = true;
+  bEnableClickEvents = true;
+  bEnableMouseOverEvents = true;
+  SetIgnoreMoveInput(false);
+  SetIgnoreLookInput(false);
 }
 
 void ASkaldPlayerController::ServerConfirmStrategicInitiativeRollReady_Implementation() {

--- a/Source/Skald/UI/SkaldMainHUDWidget.h
+++ b/Source/Skald/UI/SkaldMainHUDWidget.h
@@ -272,6 +272,9 @@ public:
   /** Toggle the HUD state while awaiting the strategic initiative roll. */
   UFUNCTION(BlueprintCallable, Category = "Skald|HUD|Initiative")
   void SetAwaitingStrategicInitiative(bool bAwaiting);
+  bool IsAwaitingStrategicInitiative() const {
+    return bAwaitingStrategicInitiative;
+  }
 
   /** Show an in-progress enemy turn message without auto-hiding. */
   UFUNCTION(BlueprintCallable, Category = "Skald|HUD")


### PR DESCRIPTION
### Motivation

- Prevent the match from silently starting with default controller ordering when the world becomes initialized but no initiative rolls have been recorded.  
- Ensure UI clicks and editor/PIE controls remain usable when strategic initiative or battle-prep UI is displayed.  
- Make army-placement/controller readiness detection robust during seamless travel when `PlayerState` may exist without an owning controller.

### Description

- Added logic in `ASkaldGameMode::TryInitializeWorldAndStart` to detect when the world is ready-to-start but no initiative rolls exist and to force `BeginStrategicInitiativePhase()` before starting turns.  
- Added a scan of `GameState->PlayerArray` for any recorded `ASkaldPlayerState::InitiativeRoll` and early-return after forcing the strategic initiative prompt.  
- Improved `ResolveExpectedControllerCount` to also count distinct stable player IDs via `GetStablePlayerId()` so army placement waits for controllers that are represented by `PlayerState` during seamless travel.  
- Adjusted input-mode handling in `ASkaldPlayerController::HandleReplicatedTurnOwnership` to keep focus on active UI surfaces when strategic-initiative input is awaited and to prefer a specific `InputFocusWidget` instead of passing `nullptr`.  
- Changed mouse capture defaults: use `NoCapture` for overview/strategic-initiative UI and `CaptureDuringMouseDown` for battle UI, and ensure viewport capture is updated accordingly.  
- Kept the strategic-initiative prompt active locally until the authoritative server response by not clearing the prompt early in `HandleStrategicInitiativeRollRequested`.  
- When showing the strategic initiative prompt (`ClientPromptStrategicInitiative`), explicitly release viewport capture and set UI input so clicks reach the HUD and editor/PIE controls.  
- Added `IsAwaitingStrategicInitiative()` accessor to `SkaldMainHUDWidget` to let controllers query HUD state.

### Testing

- Built the project and ran the existing automated test suite; all tests completed successfully.  
- Executed automated startup/PIE smoke tests that exercise the strategic-initiative prompt and mouse-capture transitions; those checks passed.  
- No new automated tests were added in this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a152f53068483249dcd0713355a362d)