### PR TITLE
Consolidate retry timer setup and guard IsMyTurn during startup

### DIFF
--- a/Source/Skald/Skald_GameMode.cpp
+++ b/Source/Skald/Skald_GameMode.cpp
@@ -1510,6 +1510,13 @@ void ASkaldGameMode::NormalizePlayerStateIds() {
 }
 
 void ASkaldGameMode::TryInitializeWorldAndStart() {
+  auto ScheduleRetryInit = [this]() {
+    FTimerDelegate RetryInit = FTimerDelegate::CreateUObject(
+        this, &ASkaldGameMode::TryInitializeWorldAndStart);
+    GetWorldTimerManager().ClearTimer(RetryInitTimerHandle);
+    GetWorldTimerManager().SetTimer(RetryInitTimerHandle, RetryInit,
+                                    RetryInitDelay, false);
+  };
   ASkaldGameState *GS = GetGameState<ASkaldGameState>();
   if (!GS || !TurnManager) {
     return;
@@ -1607,12 +1614,7 @@ void ASkaldGameMode::TryInitializeWorldAndStart() {
           GI && (GI->bResumeTurns || GI->GetPendingTravelSnapshot().Num() > 0 ||
                  GI->CachedWorldMapTerritories.Num() > 0);
       if (bShouldRetryRestore) {
-        FTimerDelegate RetryInit = FTimerDelegate::CreateUObject(
-            this, &ASkaldGameMode::TryInitializeWorldAndStart);
-        GetWorldTimerManager().ClearTimer(RetryInitTimerHandle);
-        GetWorldTimerManager().SetTimer(RetryInitTimerHandle, RetryInit,
-                                        RetryInitDelay, false);
-        GetWorldTimerManager().SetTimerForNextTick(RetryInit);
+        ScheduleRetryInit();
         return;
       }
       bWantsResume = GI && GI->bResumeTurns;
@@ -1655,12 +1657,7 @@ void ASkaldGameMode::TryInitializeWorldAndStart() {
                           ExpectedControllerCount));
     }
 
-    FTimerDelegate RetryInit = FTimerDelegate::CreateUObject(
-        this, &ASkaldGameMode::TryInitializeWorldAndStart);
-    GetWorldTimerManager().ClearTimer(RetryInitTimerHandle);
-    GetWorldTimerManager().SetTimer(RetryInitTimerHandle, RetryInit,
-                                    RetryInitDelay, false);
-    GetWorldTimerManager().SetTimerForNextTick(RetryInit);
+    ScheduleRetryInit();
     return;
   }
   TSet<ASkaldPlayerController *> UniqueControllers;
@@ -1717,12 +1714,7 @@ void ASkaldGameMode::TryInitializeWorldAndStart() {
     FTimerDelegate RefreshDelegate =
         FTimerDelegate::CreateUObject(this, &ASkaldGameMode::RefreshHUDs);
     GetWorldTimerManager().SetTimerForNextTick(RefreshDelegate);
-    FTimerDelegate RetryInit = FTimerDelegate::CreateUObject(
-        this, &ASkaldGameMode::TryInitializeWorldAndStart);
-    GetWorldTimerManager().ClearTimer(RetryInitTimerHandle);
-    GetWorldTimerManager().SetTimer(RetryInitTimerHandle, RetryInit,
-                                    RetryInitDelay, false);
-    GetWorldTimerManager().SetTimerForNextTick(RetryInit);
+    ScheduleRetryInit();
     return;
   }
 
@@ -1730,12 +1722,7 @@ void ASkaldGameMode::TryInitializeWorldAndStart() {
     const bool bResumed =
         TurnManager && TurnManager->AttemptResumeSavedTurnState();
     if (!bResumed) {
-      FTimerDelegate RetryInit = FTimerDelegate::CreateUObject(
-          this, &ASkaldGameMode::TryInitializeWorldAndStart);
-      GetWorldTimerManager().ClearTimer(RetryInitTimerHandle);
-      GetWorldTimerManager().SetTimer(RetryInitTimerHandle, RetryInit,
-                                      RetryInitDelay, false);
-      GetWorldTimerManager().SetTimerForNextTick(RetryInit);
+      ScheduleRetryInit();
       return;
     }
 

--- a/Source/Skald/Skald_PlayerController.cpp
+++ b/Source/Skald/Skald_PlayerController.cpp
@@ -3769,6 +3769,21 @@ bool ASkaldPlayerController::IsMyTurn() const {
     return GameState->ActivePlayerId == MyStableId;
   }
 
+  // During startup, replicated active-id can transiently be INDEX_NONE while
+  // CurrentTurnIndex still points at a default roster entry. Treat this state
+  // as "no owner yet" so local HUD actions (e.g. initiative button paths) do
+  // not run optimistic local-turn logic that server authority can reject.
+  const ASkaldTurnManager* LocalTurnManager = TurnManager;
+  if (!LocalTurnManager && World) {
+    LocalTurnManager = World->GetAuthGameMode<ASkaldGameMode>()
+                           ? World->GetAuthGameMode<ASkaldGameMode>()
+                                 ->GetTurnManager()
+                           : nullptr;
+  }
+  if (LocalTurnManager && !LocalTurnManager->HasTurnsStarted()) {
+    return false;
+  }
+
   if (ASkaldPlayerState *Current = GameState->GetCurrentPlayer()) {
     return Current->GetStablePlayerId() == MyStableId;
   }


### PR DESCRIPTION
### Motivation
- Reduce duplicated timer setup logic in `ASkaldGameMode::TryInitializeWorldAndStart` by centralizing retry scheduling. 
- Avoid optimistic local-turn behavior on clients when the turn manager has not actually started during startup.

### Description
- Introduced a local helper `ScheduleRetryInit` lambda inside `ASkaldGameMode::TryInitializeWorldAndStart` that clears and sets the retry timer via `RetryInitTimerHandle` and `RetryInitDelay` and replaced multiple manual `FTimerDelegate`+`SetTimer` sequences with calls to `ScheduleRetryInit()`.
- Replaced several occurrences of duplicate retry scheduling and `SetTimerForNextTick` with the consolidated `ScheduleRetryInit()` invocation.
- In `ASkaldPlayerController::IsMyTurn` added a fallback to acquire a local `TurnManager` from the authoritative `ASkaldGameMode` and return `false` when `HasTurnsStarted()` is `false`, preventing clients from treating a transient `INDEX_NONE` active-id as an owned turn.

### Testing
- Project built successfully with the changes and no compilation errors reported.
- Executed the project's automated test suite and all tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1713c3bdb48324acf404449435ba06)