### PR TITLE
Refactor GameMode retry scheduling and tighten PlayerController turn/input handling

### DIFF
--- a/Source/Skald/Skald_GameMode.cpp
+++ b/Source/Skald/Skald_GameMode.cpp
@@ -1510,6 +1510,13 @@ void ASkaldGameMode::NormalizePlayerStateIds() {
 }
 
 void ASkaldGameMode::TryInitializeWorldAndStart() {
+  auto ScheduleRetryInit = [this]() {
+    FTimerDelegate RetryInit = FTimerDelegate::CreateUObject(
+        this, &ASkaldGameMode::TryInitializeWorldAndStart);
+    GetWorldTimerManager().ClearTimer(RetryInitTimerHandle);
+    GetWorldTimerManager().SetTimer(RetryInitTimerHandle, RetryInit,
+                                    RetryInitDelay, false);
+  };
   ASkaldGameState *GS = GetGameState<ASkaldGameState>();
   if (!GS || !TurnManager) {
     return;
@@ -1607,12 +1614,7 @@ void ASkaldGameMode::TryInitializeWorldAndStart() {
           GI && (GI->bResumeTurns || GI->GetPendingTravelSnapshot().Num() > 0 ||
                  GI->CachedWorldMapTerritories.Num() > 0);
       if (bShouldRetryRestore) {
-        FTimerDelegate RetryInit = FTimerDelegate::CreateUObject(
-            this, &ASkaldGameMode::TryInitializeWorldAndStart);
-        GetWorldTimerManager().ClearTimer(RetryInitTimerHandle);
-        GetWorldTimerManager().SetTimer(RetryInitTimerHandle, RetryInit,
-                                        RetryInitDelay, false);
-        GetWorldTimerManager().SetTimerForNextTick(RetryInit);
+        ScheduleRetryInit();
         return;
       }
       bWantsResume = GI && GI->bResumeTurns;
@@ -1655,12 +1657,7 @@ void ASkaldGameMode::TryInitializeWorldAndStart() {
                           ExpectedControllerCount));
     }
 
-    FTimerDelegate RetryInit = FTimerDelegate::CreateUObject(
-        this, &ASkaldGameMode::TryInitializeWorldAndStart);
-    GetWorldTimerManager().ClearTimer(RetryInitTimerHandle);
-    GetWorldTimerManager().SetTimer(RetryInitTimerHandle, RetryInit,
-                                    RetryInitDelay, false);
-    GetWorldTimerManager().SetTimerForNextTick(RetryInit);
+    ScheduleRetryInit();
     return;
   }
   TSet<ASkaldPlayerController *> UniqueControllers;
@@ -1717,12 +1714,7 @@ void ASkaldGameMode::TryInitializeWorldAndStart() {
     FTimerDelegate RefreshDelegate =
         FTimerDelegate::CreateUObject(this, &ASkaldGameMode::RefreshHUDs);
     GetWorldTimerManager().SetTimerForNextTick(RefreshDelegate);
-    FTimerDelegate RetryInit = FTimerDelegate::CreateUObject(
-        this, &ASkaldGameMode::TryInitializeWorldAndStart);
-    GetWorldTimerManager().ClearTimer(RetryInitTimerHandle);
-    GetWorldTimerManager().SetTimer(RetryInitTimerHandle, RetryInit,
-                                    RetryInitDelay, false);
-    GetWorldTimerManager().SetTimerForNextTick(RetryInit);
+    ScheduleRetryInit();
     return;
   }
 
@@ -1730,12 +1722,7 @@ void ASkaldGameMode::TryInitializeWorldAndStart() {
     const bool bResumed =
         TurnManager && TurnManager->AttemptResumeSavedTurnState();
     if (!bResumed) {
-      FTimerDelegate RetryInit = FTimerDelegate::CreateUObject(
-          this, &ASkaldGameMode::TryInitializeWorldAndStart);
-      GetWorldTimerManager().ClearTimer(RetryInitTimerHandle);
-      GetWorldTimerManager().SetTimer(RetryInitTimerHandle, RetryInit,
-                                      RetryInitDelay, false);
-      GetWorldTimerManager().SetTimerForNextTick(RetryInit);
+      ScheduleRetryInit();
       return;
     }
 

--- a/Source/Skald/Skald_PlayerController.cpp
+++ b/Source/Skald/Skald_PlayerController.cpp
@@ -3764,6 +3764,23 @@ bool ASkaldPlayerController::IsMyTurn() const {
     return false;
   }
 
+  // Startup guard for authority: block local-turn ownership until turns have
+  // officially started. This must run before active-player/current-player
+  // ownership checks; otherwise startup ordering can mark a host as active
+  // while StartTurns has not run yet.
+  if (HasAuthority()) {
+    const ATurnManager* LocalTurnManager = TurnManager;
+    if (!LocalTurnManager && World) {
+      if (const ASkaldGameMode* LocalGameMode =
+              World->GetAuthGameMode<ASkaldGameMode>()) {
+        LocalTurnManager = LocalGameMode->GetTurnManager();
+      }
+    }
+    if (LocalTurnManager && !LocalTurnManager->HasTurnsStarted()) {
+      return false;
+    }
+  }
+
   const int32 MyStableId = MyPlayerState->GetStablePlayerId();
   if (GameState->ActivePlayerId != INDEX_NONE) {
     return GameState->ActivePlayerId == MyStableId;
@@ -5558,12 +5575,53 @@ void ASkaldPlayerController::HandleReplicatedTurnOwnership() {
     MainHUD->SyncPhaseButtons(bIsMyTurn);
   }
 
+  const bool bHudAwaitingStrategicInitiative =
+      MainHUD && MainHUD->IsAwaitingStrategicInitiative();
+  const bool bNeedsStrategicInitiativeUI =
+      bAwaitingStrategicInitiativeRoll || PendingStrategicInitiativeRoll > 0 ||
+      bHudAwaitingStrategicInitiative;
+  auto ApplyHudCapturePolicy = [this](bool bModalUIActive) {
+    const EMouseCaptureMode DesiredCaptureMode =
+        bModalUIActive ? EMouseCaptureMode::NoCapture
+                       : EMouseCaptureMode::CaptureDuringMouseDown;
+    if (DefaultMouseCaptureMode != DesiredCaptureMode) {
+      DefaultMouseCaptureMode = DesiredCaptureMode;
+      UE_LOG(LogSkald, Verbose,
+             TEXT("[InputPolicy] %s capture mode -> %s"),
+             *GetName(),
+             DesiredCaptureMode == EMouseCaptureMode::NoCapture
+                 ? TEXT("NoCapture")
+                 : TEXT("CaptureDuringMouseDown"));
+    }
+    if (UGameViewportClient* GameViewport =
+            GetWorld() ? GetWorld()->GetGameViewport() : nullptr) {
+      GameViewport->SetMouseCaptureMode(DefaultMouseCaptureMode);
+    }
+  };
+
+  // Strategic initiative can become active while turn ownership is still
+  // settling. Force UI-focused input mode whenever that overlay is visible so
+  // the first click is consumed by the button action instead of just restoring
+  // focus/capture to the PIE viewport.
+  if (bNeedsStrategicInitiativeUI && MainHUD && MainHUD->IsInViewport()) {
+    ApplyHudCapturePolicy(/*bModalUIActive*/ true);
+    UWidgetBlueprintLibrary::SetInputMode_GameAndUIEx(
+        this, MainHUD, EMouseLockMode::DoNotLock,
+        /*bHideCursorDuringCapture*/ false);
+    bShowMouseCursor = true;
+    bEnableClickEvents = true;
+    bEnableMouseOverEvents = true;
+    SetIgnoreMoveInput(false);
+    SetIgnoreLookInput(false);
+  }
+
   // Keep fighter-selection interaction stable even if replicated turn/battle
   // flags momentarily lag. Without this guard, turn-ownership refreshes can
   // fall through to the non-active-player branch and force GameOnly input,
   // which hides the cursor on click until focus changes.
   if (FighterSelectionWidget && FighterSelectionWidget->IsInViewport()) {
     if (!bShowMouseCursor || !bEnableClickEvents || !bEnableMouseOverEvents) {
+      ApplyHudCapturePolicy(/*bModalUIActive*/ true);
       UWidgetBlueprintLibrary::SetInputMode_GameAndUIEx(
           this, FighterSelectionWidget, EMouseLockMode::DoNotLock,
           /*bHideCursorDuringCapture*/ false);
@@ -5577,6 +5635,7 @@ void ASkaldPlayerController::HandleReplicatedTurnOwnership() {
   // Battle preparation/selection controls are managed by battle flow. Avoid
   // having overworld turn ownership logic steal input mode or cursor state.
   if (bInBattleInputFlow) {
+    ApplyHudCapturePolicy(/*bModalUIActive*/ false);
     if (!bIsMyTurn && bLocalTurnActive) {
       UE_LOG(LogSkald, Verbose,
              TEXT("[TurnState] Controller %s clearing stale local turn while battle flow is active."),
@@ -5624,11 +5683,6 @@ void ASkaldPlayerController::HandleReplicatedTurnOwnership() {
       }
     }
 
-    const bool bHudAwaitingStrategicInitiative =
-        MainHUD && MainHUD->IsAwaitingStrategicInitiative();
-    const bool bNeedsStrategicInitiativeUI =
-        bAwaitingStrategicInitiativeRoll || PendingStrategicInitiativeRoll > 0 ||
-        bHudAwaitingStrategicInitiative;
     if (bNeedsBattlePrepUI || bNeedsStrategicInitiativeUI) {
       // Keep focus anchored to the active UI surface when strategic initiative
       // is awaiting input. Passing nullptr can leave focus on the viewport and
@@ -5645,6 +5699,7 @@ void ASkaldPlayerController::HandleReplicatedTurnOwnership() {
       UWidgetBlueprintLibrary::SetInputMode_GameAndUIEx(
           this, InputFocusWidget, EMouseLockMode::DoNotLock,
           /*bHideCursorDuringCapture*/ false);
+      ApplyHudCapturePolicy(/*bModalUIActive*/ true);
       bShowMouseCursor = true;
       bEnableClickEvents = true;
       bEnableMouseOverEvents = true;
@@ -5656,6 +5711,7 @@ void ASkaldPlayerController::HandleReplicatedTurnOwnership() {
       SetIgnoreMoveInput(false);
       SetIgnoreLookInput(false);
     } else {
+      ApplyHudCapturePolicy(/*bModalUIActive*/ false);
       // Ensure non-active players fully release world input and phase buttons
       // instead of inheriting the host's UI state.
       if (bShowMouseCursor || bEnableClickEvents || bEnableMouseOverEvents) {


### PR DESCRIPTION
### Motivation
- Reduce duplication and stabilize world initialization retry logic in `ASkaldGameMode::TryInitializeWorldAndStart`.
- Prevent premature host-local turn ownership during startup and ensure consistent mouse capture/input behavior while strategic and battle UI overlays are active.

### Description
- Extracted retry timer setup into a `ScheduleRetryInit` lambda and replaced repeated `FTimerDelegate`/`SetTimer` blocks inside `ASkaldGameMode::TryInitializeWorldAndStart` with calls to `ScheduleRetryInit`.
- Added an authority-side startup guard in `ASkaldPlayerController::IsMyTurn` to return false until the `TurnManager->HasTurnsStarted()` is true.
- Introduced `ApplyHudCapturePolicy` in `ASkaldPlayerController::HandleReplicatedTurnOwnership` to centralize setting `DefaultMouseCaptureMode` and invoke `GameViewport->SetMouseCaptureMode` when HUD modal state changes.
- Updated replicated turn ownership handling to force proper `GameAndUI` input mode, cursor visibility, and mouse capture behavior for strategic initiative overlays, fighter selection, battle prep flows, and to ensure world input is re-enabled when needed.

### Testing
- Project compiled successfully after the changes (`UE build`).
- Exercised existing automated turn-management and input-related editor/UI automation tests; the exercised tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1713c3bdb48324acf404449435ba06)