### PR TITLE
Fix local variable shadowing in IsMyTurn

### DIFF
--- a/Source/Skald/Skald_PlayerController.cpp
+++ b/Source/Skald/Skald_PlayerController.cpp
@@ -3790,14 +3790,14 @@ bool ASkaldPlayerController::IsMyTurn() const {
   // CurrentTurnIndex still points at a default roster entry. Treat this state
   // as "no owner yet" so local HUD actions (e.g. initiative button paths) do
   // not run optimistic local-turn logic that server authority can reject.
-  const ATurnManager* LocalTurnManager = TurnManager;
-  if (!LocalTurnManager && World) {
-    LocalTurnManager = World->GetAuthGameMode<ASkaldGameMode>()
+  const ATurnManager* StartupTurnManager = TurnManager;
+  if (!StartupTurnManager && World) {
+    StartupTurnManager = World->GetAuthGameMode<ASkaldGameMode>()
                            ? World->GetAuthGameMode<ASkaldGameMode>()
                                  ->GetTurnManager()
                            : nullptr;
   }
-  if (LocalTurnManager && !LocalTurnManager->HasTurnsStarted()) {
+  if (StartupTurnManager && !StartupTurnManager->HasTurnsStarted()) {
     return false;
   }
 


### PR DESCRIPTION
### Motivation
- Prevent a Windows MSVC compile error `C4456` caused by a `LocalTurnManager` local variable being re-declared in `ASkaldPlayerController::IsMyTurn()` by renaming the startup-phase variable to avoid shadowing.

### Description
- Renamed the startup-scope `ATurnManager` local from `LocalTurnManager` to `StartupTurnManager` in `Source/Skald/Skald_PlayerController.cpp` to eliminate the duplicate declaration while keeping the original control flow and checks unchanged.

### Testing
- Verified the change with repository checks using `git diff` and `nl -ba` and committed the change successfully, and no build was executed in this environment due to the absence of the UE/MSVC toolchain (please run the Unreal build on CI or a developer machine to confirm compile success).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a17900390548324bf9b987e207a15cb)