### PR TITLE
Fix HUD input focus so UI buttons are clickable again

### DIFF
--- a/Source/Skald/Skald_PlayerController.cpp
+++ b/Source/Skald/Skald_PlayerController.cpp
@@ -1995,9 +1995,8 @@ void ASkaldPlayerController::ShowMainHUD() {
   }
 
   UWidgetBlueprintLibrary::SetInputMode_GameAndUIEx(
-      this, nullptr, EMouseLockMode::DoNotLock, /*bHideCursorDuringCapture*/
+      this, MainHUD, EMouseLockMode::DoNotLock, /*bHideCursorDuringCapture*/
       false);
-  FocusGameViewport(this);
   bShowMouseCursor = true;
   bEnableClickEvents = true;
   bEnableMouseOverEvents = true;
@@ -3260,11 +3259,10 @@ void ASkaldPlayerController::EnsureBattleHUDVisible() {
   BattleHudWidget->SetVisibility(ESlateVisibility::Visible);
   bBattleHUDVisible = true;
 
-  // Don't focus the HUD itself or it will consume keyboard input needed for
-  // camera controls; leave the viewport focused instead.
+  // Keep HUD focused so mouse interactions stay responsive while Game+UI
+  // input mode still allows camera controls.
   UWidgetBlueprintLibrary::SetInputMode_GameAndUIEx(
       this, BattleHudWidget, EMouseLockMode::DoNotLock, false);
-  FocusGameViewport(this);
   bShowMouseCursor = true;
   bEnableClickEvents = true;
   bEnableMouseOverEvents = true;
@@ -6053,7 +6051,9 @@ void ASkaldPlayerController::ReconcileBattleInputState(const TCHAR* Context) {
   UWidgetBlueprintLibrary::SetInputMode_GameAndUIEx(
       this, FocusWidget, EMouseLockMode::DoNotLock,
       /*bHideCursorDuringCapture*/ false);
-  FocusGameViewport(this);
+  if (!FocusWidget) {
+    FocusGameViewport(this);
+  }
   bShowMouseCursor = true;
   bEnableClickEvents = true;
   bEnableMouseOverEvents = true;


### PR DESCRIPTION
### Motivation
- The in-game HUD widgets were losing usable mouse focus because the controller repeatedly forced viewport focus, which prevented UI buttons from receiving clicks.

### Description
- Updated `Source/Skald/Skald_PlayerController.cpp` to pass the actual HUD widget to `UWidgetBlueprintLibrary::SetInputMode_GameAndUIEx` in `ShowMainHUD` so `MainHUD` receives focus instead of forcing viewport focus. 
- Kept `BattleHudWidget` focused in `EnsureBattleHUDVisible` and removed the unconditional `FocusGameViewport` call so battle HUD buttons remain clickable. 
- Modified `ReconcileBattleInputState` to call `FocusGameViewport` only when no UI `FocusWidget` is active, preserving camera input when appropriate and keeping UI interactions responsive otherwise. 
- Clarified the inline comment to reflect the new behavior where the HUD stays focused for mouse responsiveness.

### Testing
- Ran the automated patch script that applied the code replacements and it completed successfully (`patched`).
- Verified the modified source lines with `nl`/`sed` to ensure `SetInputMode_GameAndUIEx` now targets `MainHUD` and `BattleHudWidget` and that `FocusGameViewport` is conditional.
- Used `rg` to confirm the focus-related call sites were adjusted as intended.
- All automated verification steps succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1791cb40908324befd1603b7ecc50b)