### PR TITLE
Harden HUD/world click arbitration so Deploy button clicks register reliably

### DIFF
--- a/Source/Skald/Skald_PlayerController.cpp
+++ b/Source/Skald/Skald_PlayerController.cpp
@@ -170,7 +170,7 @@ bool IsCursorOverInteractableSlateWidget() {
   FSlateApplication &SlateApp = FSlateApplication::Get();
   const FVector2D CursorPos = SlateApp.GetCursorPos();
 
-  TArray<TSharedRef<SWindow>> Windows = SlateApp.GetInteractiveTopLevelWindows();
+  TArray<TSharedRef<SWindow>> Windows = SlateApp.GetTopLevelWindows();
   if (Windows.Num() == 0) {
     return false;
   }
@@ -179,8 +179,19 @@ bool IsCursorOverInteractableSlateWidget() {
       SlateApp.LocateWindowUnderMouse(CursorPos, Windows);
 
   for (int32 Index = WidgetPath.Widgets.Num() - 1; Index >= 0; --Index) {
-    const FArrangedWidget &ArrangedWidget = WidgetPath.Widgets[Index];
-    if (ArrangedWidget.Widget->IsInteractable()) {
+    const TSharedRef<SWidget> Widget = WidgetPath.Widgets[Index].Widget;
+    if (!Widget->GetVisibility().IsHitTestVisible()) {
+      continue;
+    }
+
+    // Ignore the underlying viewport; everything else should block world
+    // clicks so UI buttons don't lose their press/release sequence.
+    if (Widget->GetTypeAsString() == TEXT("SViewport")) {
+      continue;
+    }
+
+    if (Widget->IsInteractable() || Widget->SupportsKeyboardFocus() ||
+        Widget->IsEnabled()) {
       return true;
     }
   }


### PR DESCRIPTION
### Motivation
- Recent regressions around input focus/capture caused HUD controls (notably the `Deploy` button) to sometimes lose their mouse press/release sequence to world click handlers, preventing clicks from firing correctly.
- The intent is to make the UI-vs-world hit-test gate more robust so UI surfaces under the cursor are consistently treated as UI even during PIE/modal/focus transitions.

### Description
- Updated `IsCursorOverInteractableSlateWidget()` in `Source/Skald/Skald_PlayerController.cpp` to use `FSlateApplication::GetTopLevelWindows()` instead of `GetInteractiveTopLevelWindows()`.
- Broadened the UI detection to treat any widget that is hit-test-visible and `IsInteractable()` or `SupportsKeyboardFocus()` or `IsEnabled()` as UI while explicitly ignoring the `SViewport` (game viewport) so it does not block HUD clicks.
- This change hardens the click arbitration used before `HandleGridClick` and other world-selection code so HUD button clicks are not stolen by the viewport.

### Testing
- Ran repository searches (`rg`) to locate relevant input/HUD call sites and confirm the changed function is used on the path to `HandleGridClick`, which succeeded.
- Inspected the diff with `git diff` and committed the change with `git commit`, both of which succeeded.
- Verified the edited function body and line numbers with `nl`/`sed` checks, which succeeded.
- No full compile or automated unit test suite was executed in this run; a full build and runtime playtest are recommended to validate the behavior in PIE and packaged runs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a179482f04c8324a3d0b9c25d4c43f1)