### PR TITLE
Narrow Slate hover blocker to interactive widgets

### DIFF
--- a/Source/Skald/Skald_PlayerController.cpp
+++ b/Source/Skald/Skald_PlayerController.cpp
@@ -190,8 +190,10 @@ bool IsCursorOverInteractableSlateWidget() {
       continue;
     }
 
-    if (Widget->IsInteractable() || Widget->SupportsKeyboardFocus() ||
-        Widget->IsEnabled()) {
+    // Treat only interactive/focusable widgets as input blockers. Using
+    // IsEnabled() here is too broad because many layout-only Slate widgets are
+    // enabled by default, which can incorrectly swallow world-map/battle clicks.
+    if (Widget->IsInteractable() || Widget->SupportsKeyboardFocus()) {
       return true;
     }
   }


### PR DESCRIPTION
### Motivation
- Prevent layout-only Slate widgets from incorrectly blocking world and battle clicks by narrowing the input-blocking predicate in `IsCursorOverInteractableSlateWidget()`.

### Description
- Removed the `Widget->IsEnabled()` check and limited the blocker condition to `Widget->IsInteractable()` or `Widget->SupportsKeyboardFocus()`, and added a comment explaining why `IsEnabled()` was too broad.

### Testing
- Ran repository inspection and verification commands (`rg`, `sed`, `git diff`, `git commit`) to validate the change and recorded a successful commit; no compile or unit tests were run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a17963214b08324a24796950f630edd)