### PR TITLE
Guard strategic initiative roll button against unbound HUD delegate

### DIFF
--- a/Source/Skald/UI/SkaldMainHUDWidget.cpp
+++ b/Source/Skald/UI/SkaldMainHUDWidget.cpp
@@ -1310,6 +1310,15 @@ void USkaldMainHUDWidget::ShowStrategicInitiativeRoll(int32 RollValue,
 }
 
 void USkaldMainHUDWidget::HandleStrategicInitiativeRollPressed() {
+  if (!OnStrategicInitiativeRollRequested.IsBound()) {
+    UE_LOG(LogSkaldUI, Warning,
+           TEXT("Strategic initiative roll button pressed but no listeners are bound; ignoring click to avoid losing the prompt."));
+    if (RollInitiativeButton) {
+      RollInitiativeButton->SetIsEnabled(true);
+    }
+    return;
+  }
+
   if (RollInitiativeButton) {
     RollInitiativeButton->SetIsEnabled(false);
   }


### PR DESCRIPTION
### Motivation
- The startup log showed the initiative button click produced SFX but did not progress the game when the UI had no handler bound, so the change prevents dismissing the prompt and trapping the user after a dead click.

### Description
- Added a defensive check in `USkaldMainHUDWidget::HandleStrategicInitiativeRollPressed()` (file `Source/Skald/UI/SkaldMainHUDWidget.cpp`) that logs a warning and re-enables the `RollInitiativeButton` if `OnStrategicInitiativeRollRequested` is not bound, and otherwise preserves the existing flow of disabling the button, hiding the prompt, and broadcasting the delegate.

### Testing
- No automated tests were executed in this environment; the change was committed (`git commit`) and is limited to the single HUD source file edit.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a181e2d75488324bcedd61a8bf305a9)