### PR TITLE
Always set view target to possessed pawn in ReconcileBattleInputState

### DIFF
--- a/Source/Skald/Skald_PlayerController.cpp
+++ b/Source/Skald/Skald_PlayerController.cpp
@@ -6076,17 +6076,12 @@ void ASkaldPlayerController::ReconcileBattleInputState(const TCHAR* Context) {
   }
   SetIgnoreMoveInput(false);
   SetIgnoreLookInput(false);
-  const bool bBattleUIActive =
-      (FighterSelectionWidget && FighterSelectionWidget->IsInViewport()) ||
-      (BattleHUD && BattleHUD->IsInViewport()) || bBattleHUDReadyToShow ||
-      bBattleHUDVisible;
-
   APawn* ControlledPawn = GetPawn();
-  if (bBattleUIActive && ControlledPawn) {
+  if (ControlledPawn) {
     if (GetViewTarget() != ControlledPawn) {
       SetViewTarget(ControlledPawn);
     }
-  } else if (bBattleUIActive && !ControlledPawn) {
+  } else {
     UE_LOG(LogSkaldBattle, Verbose,
            TEXT("BattleInputReconciler[%s]: no possessed pawn yet for %s"),
            Context ? Context : TEXT("Unknown"), *GetName());


### PR DESCRIPTION
### Motivation
- Ensure the controller always switches the camera to the possessed pawn during input reconciliation so the view isn't left on an incorrect target when possession occurs, independent of battle UI state.

### Description
- Removed the local `bBattleUIActive` flag and simplified `ASkaldPlayerController::ReconcileBattleInputState` to set the view target whenever `GetPawn()` returns a valid pawn and to log when no pawn is present.

### Testing
- Ran the existing automated test suite after the change and all tests passed; no new tests were added.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1820b1f378832480a31f07f8515c8e)