### PR TITLE
Remove forced view-target switch in ReconcileBattleInputState

### DIFF
--- a/Source/Skald/Skald_PlayerController.cpp
+++ b/Source/Skald/Skald_PlayerController.cpp
@@ -6076,22 +6076,6 @@ void ASkaldPlayerController::ReconcileBattleInputState(const TCHAR* Context) {
   }
   SetIgnoreMoveInput(false);
   SetIgnoreLookInput(false);
-  const bool bBattleUIActive =
-      (FighterSelectionWidget && FighterSelectionWidget->IsInViewport()) ||
-      (BattleHUD && BattleHUD->IsInViewport()) || bBattleHUDReadyToShow ||
-      bBattleHUDVisible;
-
-  APawn* ControlledPawn = GetPawn();
-  if (bBattleUIActive && ControlledPawn) {
-    if (GetViewTarget() != ControlledPawn) {
-      SetViewTarget(ControlledPawn);
-    }
-  } else if (bBattleUIActive && !ControlledPawn) {
-    UE_LOG(LogSkaldBattle, Verbose,
-           TEXT("BattleInputReconciler[%s]: no possessed pawn yet for %s"),
-           Context ? Context : TEXT("Unknown"), *GetName());
-  }
-
   UpdateBattleCameraMode();
 
   UE_LOG(LogSkaldBattle, Verbose,


### PR DESCRIPTION
### Motivation
- Prevent forcibly switching the view target to the possessed pawn when battle UI is active, avoiding redundant camera control and noisy logging when no pawn is present, since camera mode is handled by `UpdateBattleCameraMode()`.

### Description
- Remove the `bBattleUIActive` computation and the conditional block that retrieved `GetPawn()` and called `SetViewTarget()` or logged when no pawn existed inside `ASkaldPlayerController::ReconcileBattleInputState`, leaving `UpdateBattleCameraMode()` as the camera decision point.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1820b1f378832480a31f07f8515c8e)