### PR TITLE
Remove per-tick view-target repair and input-mode/cursor management from battle input reconciler

### DIFF
--- a/Source/Skald/Skald_PlayerController.cpp
+++ b/Source/Skald/Skald_PlayerController.cpp
@@ -2459,15 +2459,6 @@ void ASkaldPlayerController::PlayerTick(float DeltaTime) {
     return;
   }
 
-  DetectBattleMap();
-  if (bIsBattleMap || (CachedGameInstance && CachedGameInstance->bIsInBattleMap)) {
-    APawn* ControlledPawn = GetPawn();
-    if (ControlledPawn && GetViewTarget() != ControlledPawn) {
-      SetViewTarget(ControlledPawn);
-      ReconcileBattleInputState(TEXT("PlayerTick.ViewTargetRepair"));
-    }
-  }
-
   // If the player has locked in their fighters and the battle manager became
   // available after the selection UI closed, ensure the battle HUD is
   // constructed and displayed.
@@ -6052,52 +6043,11 @@ void ASkaldPlayerController::ReconcileBattleInputState(const TCHAR* Context) {
     return;
   }
 
-  UWidget* FocusWidget = nullptr;
-  if (FighterSelectionWidget && FighterSelectionWidget->IsInViewport()) {
-    FocusWidget = FighterSelectionWidget;
-  } else if (BattleHUD && BattleHUD->IsInViewport()) {
-    FocusWidget = BattleHUD;
-  } else if (MainHUD && MainHUD->IsInViewport()) {
-    FocusWidget = MainHUD;
-  }
-
-  UWidgetBlueprintLibrary::SetInputMode_GameAndUIEx(
-      this, FocusWidget, EMouseLockMode::DoNotLock,
-      /*bHideCursorDuringCapture*/ false);
-  if (!FocusWidget) {
-    FocusGameViewport(this);
-  }
-  bShowMouseCursor = true;
-  bEnableClickEvents = true;
-  bEnableMouseOverEvents = true;
-  DefaultMouseCaptureMode = EMouseCaptureMode::CaptureDuringMouseDown;
-  if (UGameViewportClient* GameViewport = GetWorld() ? GetWorld()->GetGameViewport() : nullptr) {
-    GameViewport->SetMouseCaptureMode(DefaultMouseCaptureMode);
-  }
-  SetIgnoreMoveInput(false);
-  SetIgnoreLookInput(false);
-  const bool bBattleUIActive =
-      (FighterSelectionWidget && FighterSelectionWidget->IsInViewport()) ||
-      (BattleHUD && BattleHUD->IsInViewport()) || bBattleHUDReadyToShow ||
-      bBattleHUDVisible;
-
-  APawn* ControlledPawn = GetPawn();
-  if (bBattleUIActive && ControlledPawn) {
-    if (GetViewTarget() != ControlledPawn) {
-      SetViewTarget(ControlledPawn);
-    }
-  } else if (bBattleUIActive && !ControlledPawn) {
-    UE_LOG(LogSkaldBattle, Verbose,
-           TEXT("BattleInputReconciler[%s]: no possessed pawn yet for %s"),
-           Context ? Context : TEXT("Unknown"), *GetName());
-  }
-
   UpdateBattleCameraMode();
 
   UE_LOG(LogSkaldBattle, Verbose,
-         TEXT("BattleInputReconciler[%s]: Controller=%s BattleMap=%d FocusWidget=%s"),
-         Context ? Context : TEXT("Unknown"), *GetName(), bBattleMapActive ? 1 : 0,
-         *GetNameSafe(FocusWidget));
+         TEXT("BattleInputReconciler[%s]: Controller=%s BattleMap=%d"),
+         Context ? Context : TEXT("Unknown"), *GetName(), bBattleMapActive ? 1 : 0);
 }
 
 void ASkaldPlayerController::HandleFighterSelectionLockedIn() {


### PR DESCRIPTION
### Motivation

- Reduce duplicated and intrusive behavior where `PlayerTick` forced the view target and `ReconcileBattleInputState` changed global input-mode and cursor state, which could interfere with other systems.
- Centralize camera/input responsibilities to avoid altering UI focus or input capture during ticks and reconciliation.
- Improve stability and clarity for local vs non-local controller handling by removing unnecessary UI state changes.

### Description

- Removed per-frame detection and forced `SetViewTarget` logic from `ASkaldPlayerController::PlayerTick`.
- Simplified `ASkaldPlayerController::ReconcileBattleInputState` by deleting focus-widget detection and all calls that set input mode, mouse cursor visibility, mouse capture mode, click/hover events, and ignore move/look input while keeping the battle-map check and camera update.
- Cleaned up the verbose logging in `ReconcileBattleInputState` to omit the removed `FocusWidget` detail.

### Testing

- Project compiled successfully after the changes with no compile errors.
- Ran automated unit and integration tests (editor/build test suite) and they passed.
- Verified that battle reconciliation still emits the simplified verbose log messages in automated runs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1820b1f378832480a31f07f8515c8e)