### PR TITLE
Hide stale prepare-for-battle prompts when defender retreats

### DIFF
--- a/Source/Skald/Skald_TurnManager.cpp
+++ b/Source/Skald/Skald_TurnManager.cpp
@@ -1709,6 +1709,7 @@ void ATurnManager::RequestDefenderRetreat(
   HidePreparePrompt(RequestingController);
 
   if (AttackerController) {
+    HidePreparePrompt(AttackerController);
     NotifyEnemyRetreated(AttackerController);
   }
 
@@ -1720,6 +1721,7 @@ void ATurnManager::RequestDefenderRetreat(
       continue;
     }
 
+    HidePreparePrompt(Controller);
     NotifyEnemyRetreated(Controller);
   }
 


### PR DESCRIPTION
### Motivation
- Prevent clients from being left with a stale "Ready for Battle" prompt after a defender (especially an AI) auto-retreats, which caused clicks to be consumed but no battle to start because pending battle state had been cleared.

### Description
- Explicitly hide the prepare-for-battle prompt for the attacker and any observing controllers in `ATurnManager::RequestDefenderRetreat` by adding `HidePreparePrompt` calls for the attacker and observers (file: `Source/Skald/Skald_TurnManager.cpp`).

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a18279d0ba08324941a9e63d4c9686c)