### PR TITLE
Fix battle camera/input handoff after fighter lock-in

### DIFF
--- a/Source/Skald/Skald_PlayerController.cpp
+++ b/Source/Skald/Skald_PlayerController.cpp
@@ -6072,13 +6072,19 @@ void ASkaldPlayerController::HandleFighterSelectionLockedIn() {
   CancelCommandMode();
   UpdateBattleHUDButtons();
 
-  UWidgetBlueprintLibrary::SetInputMode_GameAndUIEx(
-      this, nullptr, EMouseLockMode::DoNotLock, false);
+  // Lock-in closes the selection modal and hands control back to battle input.
+  // Use game-only input so camera drag/rotate works immediately, while still
+  // keeping cursor + click traces enabled for pawn selection.
+  UWidgetBlueprintLibrary::SetInputMode_GameOnly(this);
   FocusGameViewport(this);
   bShowMouseCursor = true;
   bEnableClickEvents = true;
   bEnableMouseOverEvents = true;
-  DefaultMouseCaptureMode = EMouseCaptureMode::NoCapture;
+  DefaultMouseCaptureMode = EMouseCaptureMode::CaptureDuringMouseDown;
+  if (UGameViewportClient* GameViewport = GetWorld() ? GetWorld()->GetGameViewport() : nullptr) {
+    GameViewport->SetMouseCaptureMode(DefaultMouseCaptureMode);
+    GameViewport->SetMouseLockMode(EMouseLockMode::LockOnCapture);
+  }
   SetIgnoreMoveInput(false);
   SetIgnoreLookInput(false);
 


### PR DESCRIPTION
### Motivation
- Players lost camera rotation and pawn selection responsiveness immediately after committing fighter lock-in because the controller remained in a UI-focused input configuration.

### Description
- Changed `ASkaldPlayerController::HandleFighterSelectionLockedIn` to call `UWidgetBlueprintLibrary::SetInputMode_GameOnly(this)` so control is returned to the game world when the fighter selection modal closes.
- Restored cursor/click traces while enabling world input by setting `bShowMouseCursor`, `bEnableClickEvents`, and `bEnableMouseOverEvents` to true and re-enabling move/look input via `SetIgnoreMoveInput(false)` and `SetIgnoreLookInput(false)`.
- Switched the post-lock-in capture policy from `NoCapture` to `CaptureDuringMouseDown` and explicitly applied viewport capture and mouse lock (`GameViewport->SetMouseCaptureMode(...)` and `GameViewport->SetMouseLockMode(EMouseLockMode::LockOnCapture)`) so camera drag/rotate works immediately while clicks still select pawns.
- Change is limited to `Source/Skald/Skald_PlayerController.cpp` within `HandleFighterSelectionLockedIn` and leaves the rest of the battle input reconciliation logic intact.

### Testing
- Applied the patch programmatically (python edit) and verified the file was updated successfully with `git diff` showing the intended changes.
- Committed the change with `git commit` which completed successfully.
- Ran repository inspections (`rg`/`sed` lookups) to confirm the modified lines and surrounding logic; these commands completed without error.
- No automated unit or gameplay regression tests were executed in this rollout.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1828a14d748324b5a2fe1f900e4c19)