### PR TITLE
Promote battle-map flag at fighter selection lock-in for streamed battles

### DIFF
--- a/Source/Skald/Skald_PlayerController.cpp
+++ b/Source/Skald/Skald_PlayerController.cpp
@@ -6092,6 +6092,21 @@ void ASkaldPlayerController::HandleFighterSelectionLockedIn() {
   if (!CachedGameInstance) {
     CachedGameInstance = GetGameInstance<USkaldGameInstance>();
   }
+
+  // Streamed battles can keep the game-instance battle-map flag false until
+  // the streaming manager reports the level as fully loaded/visible. Promote
+  // the flag at lock-in time so post-selection interaction (camera/click
+  // handling) can transition to battle mode reliably without waiting on
+  // unrelated world-travel style state changes.
+  if (CachedGameInstance && !CachedGameInstance->bIsInBattleMap) {
+    const USkaldBattleLevelManager* BattleLevelManager =
+        CachedGameInstance->GetBattleLevelManager();
+    if (BattleLevelManager && BattleLevelManager->IsBattleLevelFullyReady()) {
+      CachedGameInstance->SetBattleMapActive(true);
+      DetectBattleMap();
+    }
+  }
+
   if (CachedGameInstance && CachedGameInstance->GridBattleManager &&
       !bBattleHUDVisible) {
     EnsureBattleHUDVisible();


### PR DESCRIPTION
### Motivation
- Ensure streamed battle levels transition to battle mode immediately after the player locks in a fighter so camera and click interactions behave correctly without waiting for unrelated world-travel state changes.

### Description
- Add logic in `ASkaldPlayerController::HandleFighterSelectionLockedIn` to promote the game-instance battle-map flag when a `USkaldBattleLevelManager` reports the battle level as fully ready.
- The new code checks `CachedGameInstance->GetBattleLevelManager()->IsBattleLevelFullyReady()` and calls `CachedGameInstance->SetBattleMapActive(true)` followed by `DetectBattleMap()` when appropriate.
- Preserve existing input, HUD visibility, and logging behavior in `Skald_PlayerController.cpp` while ensuring streamed battles can enter battle mode at lock-in time.

### Testing
- Project built successfully with the change applied using the Unreal build pipeline and no compile errors were produced.
- Existing automated unit/integration tests were executed and reported success.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a182cf098808324ba3ee43ce1bbb69e)