### PR TITLE
Refresh cached GameState before turn ownership checks

### DIFF
--- a/Source/Skald/Skald_PlayerController.cpp
+++ b/Source/Skald/Skald_PlayerController.cpp
@@ -5558,6 +5558,8 @@ void ASkaldPlayerController::HandleReplicatedBattlePayload() {
 }
 
 void ASkaldPlayerController::HandleReplicatedTurnOwnership() {
+  CacheGameReferences();
+
   // Turn-ownership UI updates must never run on controllers without an attached
   // local player (notably AI controllers in PIE listen-server sessions).
   if (!Player || !GetLocalPlayer() || IsAIControllerIdentity_PlayerController(this) || !CanCreateLocalUIWidget()) {


### PR DESCRIPTION
### Motivation
- Replication/startup churn can leave controller-side cached references stale, causing `ActivePlayerId` and `IsMyTurn()` to disagree and leading to out-of-turn deploy rejections.

### Description
- Call `CacheGameReferences()` at the top of `ASkaldPlayerController::HandleReplicatedTurnOwnership()` in `Source/Skald/Skald_PlayerController.cpp` so HUD/input/turn-ownership logic runs against freshly cached `GameState`/`GameMode`/`TurnManager` before evaluating `IsMyTurn()`.

### Testing
- No automated tests were executed for this change (validation consisted of code inspection and a small targeted commit).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1831c634148324af3ad661ad57aac0)