### PR TITLE
Allow ArmyPlacement turn ownership during startup sync

### DIFF
--- a/Source/Skald/Skald_PlayerController.cpp
+++ b/Source/Skald/Skald_PlayerController.cpp
@@ -3780,7 +3780,8 @@ bool ASkaldPlayerController::IsMyTurn() const {
         LocalTurnManager = LocalGameMode->GetTurnManager();
       }
     }
-    if (LocalTurnManager && !LocalTurnManager->HasTurnsStarted()) {
+    if (LocalTurnManager && !LocalTurnManager->HasTurnsStarted() &&
+        LocalTurnManager->GetCurrentPhase() != ETurnPhase::ArmyPlacement) {
       return false;
     }
   }
@@ -3821,7 +3822,8 @@ bool ASkaldPlayerController::IsMyTurn() const {
         LocalTurnManager = LocalGameMode->GetTurnManager();
       }
     }
-    if (LocalTurnManager && !LocalTurnManager->HasTurnsStarted()) {
+    if (LocalTurnManager && !LocalTurnManager->HasTurnsStarted() &&
+        LocalTurnManager->GetCurrentPhase() != ETurnPhase::ArmyPlacement) {
       return false;
     }
   }


### PR DESCRIPTION
### Motivation
- Startup logs showed `ActivePlayerId` matching the local player but `IsMyTurn()` returning false, causing `ServerDeployUnits` to be rejected during the army placement phase. 
- The existing authority startup guard blocked all turn ownership until `TurnManager->HasTurnsStarted()`, which is too strict for the pre-`StartTurns()` ArmyPlacement window.

### Description
- Relaxed the startup authority guards in `ASkaldPlayerController::IsMyTurn()` to allow ownership checks when the `TurnManager` has not yet reported `HasTurnsStarted()` but the current phase is `ETurnPhase::ArmyPlacement`.
- Applied the conditional change in two places in `Source/Skald/Skald_PlayerController.cpp` by adding `&& LocalTurnManager->GetCurrentPhase() != ETurnPhase::ArmyPlacement` to the early-return checks.
- This enables local controllers to be recognized as turn owners during the initiative->army placement transition while preserving the guard for other phases.

### Testing
- No automated tests were executed for this change.
- Recommend running the project's automation/unit test suite (e.g. the `Source/Skald/Tests` automation tests) after merging to confirm runtime behavior in multiplayer/startup scenarios.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a183379b70c83248bcd6a5f01a04b2a)