### PR TITLE
Tear down prepare-for-battle UI on retreat and add defender success message

### DIFF
--- a/Source/Skald/Skald_PlayerController.cpp
+++ b/Source/Skald/Skald_PlayerController.cpp
@@ -7280,28 +7280,30 @@ void ASkaldPlayerController::NotifyEnemyRetreated() {
     InitializeHUDWidget();
   }
 
-  const bool bDisplayedStatus = MainHUD && MainHUD->ShowEnemyRetreatedMessage();
+  HidePrepareForBattlePromptLocal();
 
-  if (bDisplayedStatus) {
-    if (UWorld *World = GetWorld()) {
-      FTimerManager &TimerManager = World->GetTimerManager();
-      TimerManager.ClearTimer(EnemyRetreatHidePromptHandle);
+  if (UWorld *World = GetWorld()) {
+    World->GetTimerManager().ClearTimer(EnemyRetreatHidePromptHandle);
+  }
 
-      const TWeakObjectPtr<ASkaldPlayerController> WeakThis(this);
-      FTimerDelegate TimerDelegate;
-      TimerDelegate.BindLambda([WeakThis]() {
-        if (WeakThis.IsValid()) {
-          WeakThis->HidePrepareForBattlePromptLocal();
-        }
-      });
+  if (MainHUD) {
+    MainHUD->ShowEnemyRetreatedMessage();
+  }
+}
 
-      TimerManager.SetTimer(EnemyRetreatHidePromptHandle, TimerDelegate, 2.f,
-                            false);
-    } else {
-      HidePrepareForBattlePromptLocal();
-    }
-  } else {
-    HidePrepareForBattlePromptLocal();
+void ASkaldPlayerController::NotifyRetreatSuccessful() {
+  HidePrepareForBattlePromptLocal();
+
+  if (UWorld *World = GetWorld()) {
+    World->GetTimerManager().ClearTimer(EnemyRetreatHidePromptHandle);
+  }
+
+  if (!MainHUD) {
+    InitializeHUDWidget();
+  }
+
+  if (MainHUD) {
+    MainHUD->ShowRetreatSuccessfulMessage();
   }
 }
 
@@ -7514,6 +7516,10 @@ void ASkaldPlayerController::ClientRetreatFailed_Implementation(
 
 void ASkaldPlayerController::ClientEnemyRetreated_Implementation() {
   NotifyEnemyRetreated();
+}
+
+void ASkaldPlayerController::ClientRetreatSuccessful_Implementation() {
+  NotifyRetreatSuccessful();
 }
 
 void ASkaldPlayerController::ClientShowPrepareForBattle_Implementation(

--- a/Source/Skald/Skald_PlayerController.h
+++ b/Source/Skald/Skald_PlayerController.h
@@ -833,6 +833,8 @@ public:
 
   UFUNCTION(Client, Reliable)
   void ClientEnemyRetreated();
+  UFUNCTION(Client, Reliable)
+  void ClientRetreatSuccessful();
 
   UFUNCTION(Client, Reliable)
   void ClientShowTurnAnnouncement(const FString &PlayerName, bool bIsMyTurn);
@@ -994,6 +996,7 @@ public:
   void CompleteRetreatSelectionLocal();
   virtual void NotifyRetreatFailed(const FText &Message);
   void NotifyEnemyRetreated();
+  void NotifyRetreatSuccessful();
 private:
   /** Display the stored strategic initiative roll if one is pending. */
   void ShowPendingStrategicInitiativeResult();

--- a/Source/Skald/Skald_TurnManager.cpp
+++ b/Source/Skald/Skald_TurnManager.cpp
@@ -1919,6 +1919,15 @@ void ATurnManager::ConfirmDefenderRetreatDestination(
   DispatchToControllerConfirm(
       RequestingController,
       [](ASkaldPlayerController *LocalController) {
+        LocalController->NotifyRetreatSuccessful();
+      },
+      [](ASkaldPlayerController *RemoteController) {
+        RemoteController->ClientRetreatSuccessful();
+      });
+
+  DispatchToControllerConfirm(
+      RequestingController,
+      [](ASkaldPlayerController *LocalController) {
         LocalController->HandleWorldStateChanged();
       },
       [](ASkaldPlayerController *RemoteController) {

--- a/Source/Skald/UI/SkaldMainHUDWidget.cpp
+++ b/Source/Skald/UI/SkaldMainHUDWidget.cpp
@@ -1130,8 +1130,7 @@ bool USkaldMainHUDWidget::ShowEnemyRetreatedMessage() {
 
   if (ActivePrepareForBattleWidget) {
     const FText RetreatMessage = NSLOCTEXT(
-        "SkaldHUD", "PrepareEnemyRetreatedStatus",
-        "Enemy retreated. Returning to map...");
+        "SkaldHUD", "PrepareEnemyRetreatedStatus", "Enemy Retreated");
     ActivePrepareForBattleWidget->ShowRetreatStatus(RetreatMessage, 0.f);
 
     ActivePrepareForBattleWidget->SetRetreatButtonVisibility(
@@ -1186,6 +1185,32 @@ bool USkaldMainHUDWidget::ShowEnemyRetreatedMessage() {
   }
 
   return bDisplayedRetreatStatus;
+}
+
+void USkaldMainHUDWidget::ShowRetreatSuccessfulMessage() {
+  if (!EndingTurnText) {
+    return;
+  }
+
+  ApplyBroadcastStyle(true);
+  EndingTurnText->SetText(
+      NSLOCTEXT("SkaldHUD", "RetreatSuccessfulMessage", "Retreat successful."));
+  EndingTurnText->SetVisibility(ESlateVisibility::Visible);
+
+  if (UWorld *World = GetWorld()) {
+    FTimerManager &TimerManager = World->GetTimerManager();
+    TimerManager.ClearTimer(TurnMessageTimerHandle);
+
+    const TWeakObjectPtr<USkaldMainHUDWidget> WeakThis(this);
+    FTimerDelegate TimerDelegate;
+    TimerDelegate.BindLambda([WeakThis]() {
+      if (WeakThis.IsValid()) {
+        WeakThis->HideEndingTurn();
+      }
+    });
+
+    TimerManager.SetTimer(TurnMessageTimerHandle, TimerDelegate, 2.f, false);
+  }
 }
 
 void USkaldMainHUDWidget::HandleRetreatClicked() {

--- a/Source/Skald/UI/SkaldMainHUDWidget.h
+++ b/Source/Skald/UI/SkaldMainHUDWidget.h
@@ -264,6 +264,7 @@ public:
    * after the message has been visible for a short duration.
    */
   bool ShowEnemyRetreatedMessage();
+  void ShowRetreatSuccessfulMessage();
 
   /** Display the rolled initiative value using the configured dice visuals. */
   UFUNCTION(BlueprintCallable, Category = "Skald|HUD|Initiative")


### PR DESCRIPTION
### Motivation
- The prepare-for-battle widget could remain active after a retreat, leaving a stale "Ready for Battle" interaction blocking the player; the prompt must be removed immediately when a retreat occurs. 
- Both the defender (who initiated the retreat) and other players need clear, brief feedback: the opponent should see "Enemy Retreated" and the retreating defender should see "Retreat successful." for 2 seconds. 
- The behavior must work correctly for local controllers and over the network via client RPCs so multiplayer flow is consistent.

### Description
- Added a new HUD API `ShowRetreatSuccessfulMessage()` and implemented it in `Source/Skald/UI/SkaldMainHUDWidget.{h,cpp}` to display the defender-facing message `"Retreat successful."` for 2 seconds. 
- Adjusted the existing enemy-facing message text to `"Enemy Retreated"` in `SkaldMainHUDWidget.cpp` and ensured the prepare-for-battle dialog is torn down via a teardown timer when showing that message. 
- Updated `ASkaldPlayerController` (`Source/Skald/Skald_PlayerController.{h,cpp}`) to immediately call `HidePrepareForBattlePromptLocal()` when retreats occur, to clear timers, and to route HUD messages via `NotifyEnemyRetreated()` and the new `NotifyRetreatSuccessful()` local method tied to new `ClientRetreatSuccessful` RPC. 
- Wired the retreat-success notification into the server-side confirmation flow by calling `NotifyRetreatSuccessful()` / `ClientRetreatSuccessful()` from `ATurnManager::ConfirmDefenderRetreatDestination` (`Source/Skald/Skald_TurnManager.cpp`) so the defender receives the success message once the retreat is confirmed.

### Testing
- Ran `git diff --check` which produced no style/whitespace errors and passed locally.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1835f4be488324ae8ebd1dbd83e501)