### PR TITLE
Fix stale ActivePlayerId at army placement phase start

### DIFF
--- a/Source/Skald/Skald_TurnManager.cpp
+++ b/Source/Skald/Skald_TurnManager.cpp
@@ -969,6 +969,12 @@ void ATurnManager::StartArmyPlacementPhase() {
   CurrentIndex = 0;
   bHasTurnsStarted = false;
 
+  // Army placement must begin from the initiative-sorted roster leader.
+  // Re-sync replicated turn ownership immediately so ActivePlayerId reflects
+  // Controllers[0] for this phase instead of any stale value left from prior
+  // startup/travel state.
+  SyncGameStateTurnIndex();
+
   for (const TWeakObjectPtr<ASkaldPlayerController> &ControllerPtr :
        Controllers) {
     if (ASkaldPlayerController *Controller = ControllerPtr.Get()) {


### PR DESCRIPTION
### Motivation
- Prevent clients from observing a stale `GameState.ActivePlayerId` (and briefly believing it is their turn) when Army Placement begins due to startup/travel state carryover.

### Description
- Call `SyncGameStateTurnIndex()` immediately after `CurrentIndex = 0` inside `ATurnManager::StartArmyPlacementPhase()` so `GameState.ActivePlayerId` is re-synchronized to the initiative-sorted `Controllers[0]` before phase broadcast (file: `Source/Skald/Skald_TurnManager.cpp`).

### Testing
- No automated tests were executed for this change; the modification is a small, deterministic initialization fix verified by code inspection and local file/commit checks.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a183a89f13083249e59ee7cb6190a97)