### PR TITLE
Schedule post-lock-in battle input reconcile for streamed battle maps

### DIFF
--- a/Source/Skald/Skald_PlayerController.cpp
+++ b/Source/Skald/Skald_PlayerController.cpp
@@ -1957,6 +1957,7 @@ void ASkaldPlayerController::EndPlay(const EEndPlayReason::Type EndPlayReason) {
     }
     World->GetTimerManager().ClearTimer(LobbyAutoInitHandle);
     World->GetTimerManager().ClearTimer(GameReferenceRetryHandle);
+    World->GetTimerManager().ClearTimer(PostLockInBattleInputRetryHandle);
   }
 
   if (BattleResultWidget) {
@@ -6056,6 +6057,61 @@ void ASkaldPlayerController::ReconcileBattleInputState(const TCHAR* Context) {
          Context ? Context : TEXT("Unknown"), *GetName(), bBattleMapActive ? 1 : 0);
 }
 
+void ASkaldPlayerController::SchedulePostLockInBattleInputReconcile() {
+  UWorld* World = GetWorld();
+  if (!World || !IsLocalController()) {
+    return;
+  }
+
+  PostLockInBattleInputRetryCount = 0;
+  World->GetTimerManager().ClearTimer(PostLockInBattleInputRetryHandle);
+  World->GetTimerManager().SetTimer(
+      PostLockInBattleInputRetryHandle, this,
+      &ASkaldPlayerController::HandlePostLockInBattleInputReconcileTick,
+      0.2f, true, 0.2f);
+}
+
+void ASkaldPlayerController::HandlePostLockInBattleInputReconcileTick() {
+  UWorld* World = GetWorld();
+  if (!World) {
+    return;
+  }
+
+  if (!CachedGameInstance) {
+    CachedGameInstance = GetGameInstance<USkaldGameInstance>();
+  }
+
+  bool bReady = false;
+  if (CachedGameInstance) {
+    if (const USkaldBattleLevelManager* BattleLevelManager =
+            CachedGameInstance->GetBattleLevelManager()) {
+      bReady = BattleLevelManager->IsBattleLevelFullyReady();
+    }
+
+    if (bReady && !CachedGameInstance->bIsInBattleMap) {
+      CachedGameInstance->SetBattleMapActive(true);
+      DetectBattleMap();
+      UE_LOG(LogSkaldBattle, Log,
+             TEXT("PostLockInReconcile: Promoted streamed battle-map active for %s"),
+             *GetName());
+    }
+  }
+
+  ReconcileBattleInputState(TEXT("PostLockInBattleInputRetry"));
+
+  const bool bBattleMapActive =
+      bIsBattleMap || (CachedGameInstance && CachedGameInstance->bIsInBattleMap);
+  constexpr int32 MaxRetries = 20;
+  ++PostLockInBattleInputRetryCount;
+
+  if (bBattleMapActive || PostLockInBattleInputRetryCount >= MaxRetries) {
+    World->GetTimerManager().ClearTimer(PostLockInBattleInputRetryHandle);
+    UE_LOG(LogSkaldBattle, Verbose,
+           TEXT("PostLockInReconcile: Completed for %s (BattleMapActive=%d Retries=%d)"),
+           *GetName(), bBattleMapActive ? 1 : 0, PostLockInBattleInputRetryCount);
+  }
+}
+
 void ASkaldPlayerController::HandleFighterSelectionLockedIn() {
   UE_LOG(LogSkaldUI, Log,
          TEXT("HandleFighterSelectionLockedIn: Controller=%s Local=%s Pawn=%s"),
@@ -6117,6 +6173,7 @@ void ASkaldPlayerController::HandleFighterSelectionLockedIn() {
   }
 
   ReconcileBattleInputState(TEXT("HandleFighterSelectionLockedIn"));
+  SchedulePostLockInBattleInputReconcile();
 
   if (CachedGameInstance && CachedGameInstance->GridBattleManager)
   {

--- a/Source/Skald/Skald_PlayerController.h
+++ b/Source/Skald/Skald_PlayerController.h
@@ -1094,6 +1094,8 @@ private:
 
   void RequestBattleStateIfNeeded();
   void ReconcileBattleInputState(const TCHAR* Context);
+  void SchedulePostLockInBattleInputReconcile();
+  void HandlePostLockInBattleInputReconcileTick();
 
   void BuildPlayerDataArray(TArray<FS_PlayerData> &OutPlayers) const;
 
@@ -1370,6 +1372,10 @@ private:
 
   /** Timer used to retry showing a pending prepare-for-battle prompt. */
   FTimerHandle PendingReadyPromptRetryHandle;
+
+  /** Timer that retries post-lock-in battle-map activation for streamed levels. */
+  FTimerHandle PostLockInBattleInputRetryHandle;
+  int32 PostLockInBattleInputRetryCount = 0;
 
   /** Timer that defers hiding the prepare prompt after an enemy retreat. */
   FTimerHandle EnemyRetreatHidePromptHandle;


### PR DESCRIPTION
### Motivation
- Ensure local controllers properly transition to battle input mode after a fighter selection lock-in when the battle level is streamed and the game-instance flag may not be set immediately.

### Description
- Added `SchedulePostLockInBattleInputReconcile()` and `HandlePostLockInBattleInputReconcileTick()` to poll and promote the battle-map state until the streamed level is fully ready, with retry counting and a timer interval of `0.2s`.
- Added `PostLockInBattleInputRetryHandle` and `PostLockInBattleInputRetryCount` members to the controller header for timer bookkeeping and retry limits.
- Invoke `SchedulePostLockInBattleInputReconcile()` from `HandleFighterSelectionLockedIn()` so post-lock-in input reconciliation is scheduled automatically.
- Clear the new timer in `EndPlay()` to avoid dangling timers on shutdown.
- Keep existing behavior of calling `ReconcileBattleInputState()` and promoting `bIsInBattleMap` when the battle level manager reports readiness.

### Testing
- Performed a project build to validate the changes compile successfully.
- Executed the existing automated test suite; all tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1839cabe488324be15affbaaaed4c2)