### PR TITLE
Fix battle input lock during streamed battle phase transitions

### DIFF
--- a/Source/Skald/Skald_PlayerController.cpp
+++ b/Source/Skald/Skald_PlayerController.cpp
@@ -5677,6 +5677,12 @@ void ASkaldPlayerController::HandleReplicatedTurnOwnership() {
   // having overworld turn ownership logic steal input mode or cursor state.
   if (bInBattleInputFlow) {
     ApplyHudCapturePolicy(/*bModalUIActive*/ false);
+    // Battle interaction (camera pan/rotate + world picks) must stay enabled
+    // for both participants while streamed battle state settles. Without this
+    // guard, a stale non-active-turn update can leave look/move input ignored
+    // after lock-in and make the battle map appear frozen.
+    SetIgnoreMoveInput(false);
+    SetIgnoreLookInput(false);
     if (!bIsMyTurn && bLocalTurnActive) {
       UE_LOG(LogSkald, Verbose,
              TEXT("[TurnState] Controller %s clearing stale local turn while battle flow is active."),


### PR DESCRIPTION
### Motivation
- Prevent the battle map from becoming non-interactive after fighter lock-in when streamed battle state and replicated turn ownership updates can leave look/move input disabled.

### Description
- When `bInBattleInputFlow` is true in `HandleReplicatedTurnOwnership`, explicitly call `SetIgnoreMoveInput(false)` and `SetIgnoreLookInput(false)` so camera pan/rotate and world picks remain enabled while battle state settles.

### Testing
- No automated tests were executed for this change; the patch is a small runtime input-policy fix and was committed after local inspection of relevant logs and source locations (`ASkaldPlayerController::HandleReplicatedTurnOwnership`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a183dcb938483248816db61995b1138)