### PR TITLE
Discard suppressed prepare-for-battle prompts before caching

### DIFF
--- a/Source/Skald/Skald_PlayerController.cpp
+++ b/Source/Skald/Skald_PlayerController.cpp
@@ -7550,15 +7550,15 @@ void ASkaldPlayerController::ShowPrepareForBattlePromptLocal_Internal(
 
   ShowMainHUD();
 
-  if (MainHUD) {
-    if (IsPrepareForBattlePromptSuppressed()) {
-      UE_LOG(LogSkaldReady, Verbose,
-             TEXT("Discarding prepare-for-battle prompt for %s because prompts are temporarily suppressed after retreat."),
-             *GetName());
-      ResetPendingReadyPromptState();
-      return;
-    }
+  if (IsPrepareForBattlePromptSuppressed()) {
+    UE_LOG(LogSkaldReady, Verbose,
+           TEXT("Discarding prepare-for-battle prompt for %s because prompts are temporarily suppressed after retreat."),
+           *GetName());
+    ResetPendingReadyPromptState();
+    return;
+  }
 
+  if (MainHUD) {
     if (!ShouldDisplayPrepareForBattlePrompt(PromptData)) {
       UE_LOG(LogSkaldReady, Log,
              TEXT("Discarding prepare-for-battle prompt for %s; ready state no longer requires confirmation."),


### PR DESCRIPTION
### Motivation
- Prompts arriving during the 2s post-retreat suppression window could be cached when `MainHUD` was still null and later displayed after the suppression expired, causing stale prepare-for-battle dialogs to appear.
- The intent is to ensure suppression is honored regardless of HUD initialization timing so suppressed prompt payloads are not stored for later display.

### Description
- Moved the suppression check into `ShowPrepareForBattlePromptLocal_Internal` so `IsPrepareForBattlePromptSuppressed()` is evaluated immediately after `ShowMainHUD()` and before any `MainHUD`-available branch.
- This short-circuits and drops suppressed prompts early, preventing the no-HUD fallback from setting `PendingReadyPrompt` and registering retries when suppression is active.
- Change is localized to `Source/Skald/Skald_PlayerController.cpp` inside `ShowPrepareForBattlePromptLocal_Internal`.

### Testing
- No automated unit or integration tests were executed for this change.
- Repository sanity commands (`git status` and the commit`) completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a183ec4b2ac8324add509cef2904f4f)