### PR TITLE
Gate post-lock-in battle setup on battle-map activation

### DIFF
--- a/Source/Skald/Skald_PlayerController.cpp
+++ b/Source/Skald/Skald_PlayerController.cpp
@@ -6107,6 +6107,30 @@ void ASkaldPlayerController::HandlePostLockInBattleInputReconcileTick() {
 
   const bool bBattleMapActive =
       bIsBattleMap || (CachedGameInstance && CachedGameInstance->bIsInBattleMap);
+
+  if (bBattleMapActive) {
+    InitializeBattleHUD();
+    if (CachedGameInstance && CachedGameInstance->GridBattleManager &&
+        !bBattleHUDVisible) {
+      EnsureBattleHUDVisible();
+    }
+    UpdateBattleCameraMode();
+    UpdateBattleHUDButtons();
+
+    UWidgetBlueprintLibrary::SetInputMode_GameOnly(this);
+    FocusGameViewport(this);
+    bShowMouseCursor = true;
+    bEnableClickEvents = true;
+    bEnableMouseOverEvents = true;
+    DefaultMouseCaptureMode = EMouseCaptureMode::CaptureDuringMouseDown;
+    if (UGameViewportClient* GameViewport =
+            World->GetGameViewport()) {
+      GameViewport->SetMouseCaptureMode(DefaultMouseCaptureMode);
+    }
+    SetIgnoreMoveInput(false);
+    SetIgnoreLookInput(false);
+  }
+
   constexpr int32 MaxRetries = 20;
   ++PostLockInBattleInputRetryCount;
 
@@ -6131,29 +6155,9 @@ void ASkaldPlayerController::HandleFighterSelectionLockedIn() {
 
   bBattleHUDReadyToShow = true;
 
-  // Ensure the HUD is initialized so the controller is bound to active-fighter
-  // updates even if no pawn has been selected yet.
-  InitializeBattleHUD();
-
   SelectedFighter = nullptr;
   LockedActiveFighter = nullptr;
   CancelCommandMode();
-  UpdateBattleHUDButtons();
-
-  // Lock-in closes the selection modal and hands control back to battle input.
-  // Use game-only input so camera drag/rotate works immediately, while still
-  // keeping cursor + click traces enabled for pawn selection.
-  UWidgetBlueprintLibrary::SetInputMode_GameOnly(this);
-  FocusGameViewport(this);
-  bShowMouseCursor = true;
-  bEnableClickEvents = true;
-  bEnableMouseOverEvents = true;
-  DefaultMouseCaptureMode = EMouseCaptureMode::CaptureDuringMouseDown;
-  if (UGameViewportClient* GameViewport = GetWorld() ? GetWorld()->GetGameViewport() : nullptr) {
-    GameViewport->SetMouseCaptureMode(DefaultMouseCaptureMode);
-  }
-  SetIgnoreMoveInput(false);
-  SetIgnoreLookInput(false);
 
   if (!CachedGameInstance) {
     CachedGameInstance = GetGameInstance<USkaldGameInstance>();
@@ -6173,12 +6177,44 @@ void ASkaldPlayerController::HandleFighterSelectionLockedIn() {
     }
   }
 
-  if (CachedGameInstance && CachedGameInstance->GridBattleManager &&
-      !bBattleHUDVisible) {
-    EnsureBattleHUDVisible();
+  DetectBattleMap();
+  const bool bBattleMapActive =
+      bIsBattleMap || (CachedGameInstance && CachedGameInstance->bIsInBattleMap);
+
+  if (bBattleMapActive) {
+    // Ensure the HUD/camera/input stack is initialized only after battle-map
+    // activation is visible on this controller.
+    InitializeBattleHUD();
+    if (CachedGameInstance && CachedGameInstance->GridBattleManager &&
+        !bBattleHUDVisible) {
+      EnsureBattleHUDVisible();
+    }
+    UpdateBattleHUDButtons();
+    UpdateBattleCameraMode();
+
+    // Lock-in closes the selection modal and hands control back to battle input.
+    // Use game-only input so camera drag/rotate works immediately, while still
+    // keeping cursor + click traces enabled for pawn selection.
+    UWidgetBlueprintLibrary::SetInputMode_GameOnly(this);
+    FocusGameViewport(this);
+    bShowMouseCursor = true;
+    bEnableClickEvents = true;
+    bEnableMouseOverEvents = true;
+    DefaultMouseCaptureMode = EMouseCaptureMode::CaptureDuringMouseDown;
+    if (UGameViewportClient* GameViewport =
+            GetWorld() ? GetWorld()->GetGameViewport() : nullptr) {
+      GameViewport->SetMouseCaptureMode(DefaultMouseCaptureMode);
+    }
+    SetIgnoreMoveInput(false);
+    SetIgnoreLookInput(false);
+
+    ReconcileBattleInputState(TEXT("HandleFighterSelectionLockedIn"));
+  } else {
+    UE_LOG(LogSkaldBattle, Verbose,
+           TEXT("HandleFighterSelectionLockedIn: Waiting for battle-map active flag before HUD/camera/input setup on %s"),
+           *GetName());
   }
 
-  ReconcileBattleInputState(TEXT("HandleFighterSelectionLockedIn"));
   SchedulePostLockInBattleInputReconcile();
 
   if (CachedGameInstance && CachedGameInstance->GridBattleManager)


### PR DESCRIPTION
### Motivation
- Streaming battle maps can delay when the canonical battle-map-active flag (`bIsInBattleMap`) is visible on a controller, which causes HUD/camera/input setup to occur too early after fighter lock-in. 
- The goal is to wait for the battle-map activation signal before wiring up player HUD, camera, and input so battle flow and player assignment remain synchronized.

### Description
- Modified `ASkaldPlayerController::HandleFighterSelectionLockedIn` to call `DetectBattleMap()` and then gate HUD/camera/input initialization behind a `bBattleMapActive` check (`bIsBattleMap || (CachedGameInstance && CachedGameInstance->bIsInBattleMap)`), performing initialization only when true and logging a verbose wait message otherwise. 
- Preserved the existing promotion path that calls `CachedGameInstance->SetBattleMapActive(true)` when `BattleLevelManager->IsBattleLevelFullyReady()` returns true. 
- Extended `ASkaldPlayerController::HandlePostLockInBattleInputReconcileTick` to perform the deferred HUD visibility, camera mode update, HUD button refresh, and game-only input / cursor setup once `bBattleMapActive` becomes true so the retry loop finishes remaining setup when streaming is delayed. 
- Ensured `SchedulePostLockInBattleInputReconcile()` continues to run so controllers that are not yet seeing the battle flag will complete setup when it arrives.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1840af092483248be8317af323defb)