### PR TITLE
Restore battle interaction after streamed map activation

### DIFF
--- a/Source/Skald/Skald_PlayerController.cpp
+++ b/Source/Skald/Skald_PlayerController.cpp
@@ -5579,7 +5579,9 @@ void ASkaldPlayerController::HandleReplicatedTurnOwnership() {
   const bool bBattleTravelPending =
       CachedGameInstance && CachedGameInstance->IsTravelPending();
   const bool bInBattleInputFlow =
-      bIsBattleMap || BattlePhase != EBattlePhase::None || bBattleTravelPending;
+      bIsBattleMap ||
+      (CachedGameInstance && CachedGameInstance->bIsInBattleMap) ||
+      BattlePhase != EBattlePhase::None || bBattleTravelPending;
   const int32 ReportedActiveId =
       CachedGameState ? CachedGameState->ActivePlayerId : INDEX_NONE;
 
@@ -6040,9 +6042,10 @@ void ASkaldPlayerController::UpdateBattleCameraMode() {
   }
 }
 
-void ASkaldPlayerController::ReconcileBattleInputState(const TCHAR* Context) {
+bool ASkaldPlayerController::ApplyBattleInteractionInputState(
+    const TCHAR* Context) {
   if (!IsLocalController() || !CanCreateLocalUIWidget()) {
-    return;
+    return false;
   }
 
   if (!CachedGameInstance) {
@@ -6053,14 +6056,49 @@ void ASkaldPlayerController::ReconcileBattleInputState(const TCHAR* Context) {
   const bool bBattleMapActive =
       bIsBattleMap || (CachedGameInstance && CachedGameInstance->bIsInBattleMap);
   if (!bBattleMapActive) {
-    return;
+    return false;
   }
 
   UpdateBattleCameraMode();
 
+  const ASkald_PlayerCharacter* CameraPawn =
+      Cast<ASkald_PlayerCharacter>(GetPawn());
+  const bool bCameraReady =
+      CameraPawn && CameraPawn->IsBattleCameraActive();
+
+  // Fighter selection uses Game+UI with a modal widget. Once that modal closes
+  // and the streamed battle-map flag is visible, explicitly return focus to the
+  // viewport and keep click traces enabled. This prevents the removed selection
+  // widget (or a later turn-ownership refresh) from leaving camera axes and
+  // grid/fighter picks starved even though the HUD is visible.
+  UWidgetBlueprintLibrary::SetInputMode_GameOnly(this);
+  FocusGameViewport(this);
+  bShowMouseCursor = true;
+  bEnableClickEvents = true;
+  bEnableMouseOverEvents = true;
+  DefaultMouseCaptureMode = EMouseCaptureMode::CaptureDuringMouseDown;
+  if (UGameViewportClient* GameViewport =
+          GetWorld() ? GetWorld()->GetGameViewport() : nullptr) {
+    GameViewport->SetMouseCaptureMode(DefaultMouseCaptureMode);
+  }
+  SetIgnoreMoveInput(false);
+  SetIgnoreLookInput(false);
+
+  const bool bInputReady =
+      bShowMouseCursor && bEnableClickEvents && bEnableMouseOverEvents &&
+      !IsMoveInputIgnored() && !IsLookInputIgnored();
+
   UE_LOG(LogSkaldBattle, Verbose,
-         TEXT("BattleInputReconciler[%s]: Controller=%s BattleMap=%d"),
-         Context ? Context : TEXT("Unknown"), *GetName(), bBattleMapActive ? 1 : 0);
+         TEXT("BattleInputReconciler[%s]: Controller=%s BattleMap=%d CameraReady=%d InputReady=%d Pawn=%s"),
+         Context ? Context : TEXT("Unknown"), *GetName(),
+         bBattleMapActive ? 1 : 0, bCameraReady ? 1 : 0,
+         bInputReady ? 1 : 0, GetPawn() ? *GetPawn()->GetName() : TEXT("null"));
+
+  return bCameraReady && bInputReady;
+}
+
+void ASkaldPlayerController::ReconcileBattleInputState(const TCHAR* Context) {
+  ApplyBattleInteractionInputState(Context);
 }
 
 void ASkaldPlayerController::SchedulePostLockInBattleInputReconcile() {
@@ -6103,18 +6141,31 @@ void ASkaldPlayerController::HandlePostLockInBattleInputReconcileTick() {
     }
   }
 
-  ReconcileBattleInputState(TEXT("PostLockInBattleInputRetry"));
-
   const bool bBattleMapActive =
       bIsBattleMap || (CachedGameInstance && CachedGameInstance->bIsInBattleMap);
+
+  if (bBattleMapActive) {
+    InitializeBattleHUD();
+    if (CachedGameInstance && CachedGameInstance->GridBattleManager &&
+        !bBattleHUDVisible) {
+      EnsureBattleHUDVisible();
+    }
+    UpdateBattleHUDButtons();
+  }
+
+  const bool bBattleInteractionReady =
+      ApplyBattleInteractionInputState(TEXT("PostLockInBattleInputRetry"));
+
   constexpr int32 MaxRetries = 20;
   ++PostLockInBattleInputRetryCount;
 
-  if (bBattleMapActive || PostLockInBattleInputRetryCount >= MaxRetries) {
+  if ((bBattleMapActive && bBattleInteractionReady) ||
+      PostLockInBattleInputRetryCount >= MaxRetries) {
     World->GetTimerManager().ClearTimer(PostLockInBattleInputRetryHandle);
     UE_LOG(LogSkaldBattle, Verbose,
-           TEXT("PostLockInReconcile: Completed for %s (BattleMapActive=%d Retries=%d)"),
-           *GetName(), bBattleMapActive ? 1 : 0, PostLockInBattleInputRetryCount);
+           TEXT("PostLockInReconcile: Completed for %s (BattleMapActive=%d InteractionReady=%d Retries=%d)"),
+           *GetName(), bBattleMapActive ? 1 : 0,
+           bBattleInteractionReady ? 1 : 0, PostLockInBattleInputRetryCount);
   }
 }
 
@@ -6131,29 +6182,9 @@ void ASkaldPlayerController::HandleFighterSelectionLockedIn() {
 
   bBattleHUDReadyToShow = true;
 
-  // Ensure the HUD is initialized so the controller is bound to active-fighter
-  // updates even if no pawn has been selected yet.
-  InitializeBattleHUD();
-
   SelectedFighter = nullptr;
   LockedActiveFighter = nullptr;
   CancelCommandMode();
-  UpdateBattleHUDButtons();
-
-  // Lock-in closes the selection modal and hands control back to battle input.
-  // Use game-only input so camera drag/rotate works immediately, while still
-  // keeping cursor + click traces enabled for pawn selection.
-  UWidgetBlueprintLibrary::SetInputMode_GameOnly(this);
-  FocusGameViewport(this);
-  bShowMouseCursor = true;
-  bEnableClickEvents = true;
-  bEnableMouseOverEvents = true;
-  DefaultMouseCaptureMode = EMouseCaptureMode::CaptureDuringMouseDown;
-  if (UGameViewportClient* GameViewport = GetWorld() ? GetWorld()->GetGameViewport() : nullptr) {
-    GameViewport->SetMouseCaptureMode(DefaultMouseCaptureMode);
-  }
-  SetIgnoreMoveInput(false);
-  SetIgnoreLookInput(false);
 
   if (!CachedGameInstance) {
     CachedGameInstance = GetGameInstance<USkaldGameInstance>();
@@ -6173,12 +6204,26 @@ void ASkaldPlayerController::HandleFighterSelectionLockedIn() {
     }
   }
 
-  if (CachedGameInstance && CachedGameInstance->GridBattleManager &&
-      !bBattleHUDVisible) {
-    EnsureBattleHUDVisible();
+  DetectBattleMap();
+  const bool bBattleMapActive =
+      bIsBattleMap || (CachedGameInstance && CachedGameInstance->bIsInBattleMap);
+
+  if (bBattleMapActive) {
+    // Ensure the HUD/camera/input stack is initialized only after battle-map
+    // activation is visible on this controller.
+    InitializeBattleHUD();
+    if (CachedGameInstance && CachedGameInstance->GridBattleManager &&
+        !bBattleHUDVisible) {
+      EnsureBattleHUDVisible();
+    }
+    UpdateBattleHUDButtons();
+    ApplyBattleInteractionInputState(TEXT("HandleFighterSelectionLockedIn"));
+  } else {
+    UE_LOG(LogSkaldBattle, Verbose,
+           TEXT("HandleFighterSelectionLockedIn: Waiting for battle-map active flag before HUD/camera/input setup on %s"),
+           *GetName());
   }
 
-  ReconcileBattleInputState(TEXT("HandleFighterSelectionLockedIn"));
   SchedulePostLockInBattleInputReconcile();
 
   if (CachedGameInstance && CachedGameInstance->GridBattleManager)

--- a/Source/Skald/Skald_PlayerController.h
+++ b/Source/Skald/Skald_PlayerController.h
@@ -1094,6 +1094,7 @@ private:
   void DetectBattleMap();
 
   void RequestBattleStateIfNeeded();
+  bool ApplyBattleInteractionInputState(const TCHAR* Context);
   void ReconcileBattleInputState(const TCHAR* Context);
   void SchedulePostLockInBattleInputReconcile();
   void HandlePostLockInBattleInputReconcileTick();


### PR DESCRIPTION
### Motivation
- Streamed battle maps can delay when `bIsInBattleMap` becomes visible to controllers, which previously left HUD/camera/input setup racing and sometimes left camera/picking unresponsive after lock-in; the change ensures we wait for both the map flag and local camera/input readiness before finishing post-lock-in work.

### Description
- Added `ApplyBattleInteractionInputState(const TCHAR* Context)` to centralize restoring game/viewport input, enabling cursor/click/mouse-over events, applying mouse-capture policy, clearing ignored move/look input, and verifying the possessed battle camera is active.
- Replaced ad-hoc input restores with calls to `ApplyBattleInteractionInputState` from `HandleFighterSelectionLockedIn` so immediate and deferred paths use the same reconciler.
- Modified `HandlePostLockInBattleInputReconcileTick` to require both the battle-map active flag and `ApplyBattleInteractionInputState` success before clearing the retry timer so retries continue until camera/input are actually ready.
- Tightened turn/ownership battle-flow detection in `HandleReplicatedTurnOwnership` to consider `CachedGameInstance->bIsInBattleMap`, preventing overworld input policies from stealing focus during streamed battle transitions.
- Added the new method declaration to the header and updated verbose logging to include camera/input readiness for easier debugging.

### Testing
- Ran source checks: `git diff --check` succeeded and code compiled changes were committed locally (no full Unreal build executed in this environment). 
- Environment check: `test -n "$(command -v UnrealEditor)"` returned negative so no local Unreal/Editor compile or runtime tests were run here.
- No automated engine/automation tests were executed as part of this change in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1840af092483248be8317af323defb)