### PR TITLE
Centralize battle input/camera/UI focus handling and add HUD prompt visibility helpers

### DIFF
--- a/Source/Skald/Skald_PlayerController.cpp
+++ b/Source/Skald/Skald_PlayerController.cpp
@@ -5579,7 +5579,9 @@ void ASkaldPlayerController::HandleReplicatedTurnOwnership() {
   const bool bBattleTravelPending =
       CachedGameInstance && CachedGameInstance->IsTravelPending();
   const bool bInBattleInputFlow =
-      bIsBattleMap || BattlePhase != EBattlePhase::None || bBattleTravelPending;
+      bIsBattleMap ||
+      (CachedGameInstance && CachedGameInstance->bIsInBattleMap) ||
+      BattlePhase != EBattlePhase::None || bBattleTravelPending;
   const int32 ReportedActiveId =
       CachedGameState ? CachedGameState->ActivePlayerId : INDEX_NONE;
 
@@ -6040,9 +6042,10 @@ void ASkaldPlayerController::UpdateBattleCameraMode() {
   }
 }
 
-void ASkaldPlayerController::ReconcileBattleInputState(const TCHAR* Context) {
+bool ASkaldPlayerController::ApplyBattleInteractionInputState(
+    const TCHAR* Context) {
   if (!IsLocalController() || !CanCreateLocalUIWidget()) {
-    return;
+    return false;
   }
 
   if (!CachedGameInstance) {
@@ -6053,14 +6056,93 @@ void ASkaldPlayerController::ReconcileBattleInputState(const TCHAR* Context) {
   const bool bBattleMapActive =
       bIsBattleMap || (CachedGameInstance && CachedGameInstance->bIsInBattleMap);
   if (!bBattleMapActive) {
-    return;
+    return false;
   }
 
   UpdateBattleCameraMode();
 
+  const ASkald_PlayerCharacter* CameraPawn =
+      Cast<ASkald_PlayerCharacter>(GetPawn());
+  const bool bCameraReady =
+      CameraPawn && CameraPawn->IsBattleCameraActive();
+
+  auto IsVisibleInViewport = [](const UUserWidget* Widget) {
+    return Widget && Widget->IsInViewport() &&
+           Widget->GetVisibility() != ESlateVisibility::Collapsed &&
+           Widget->GetVisibility() != ESlateVisibility::Hidden;
+  };
+
+  UUserWidget* ModalFocusWidget = nullptr;
+  const TCHAR* ModalReason = TEXT("None");
+  if (IsVisibleInViewport(FighterSelectionWidget)) {
+    ModalFocusWidget = FighterSelectionWidget;
+    ModalReason = TEXT("FighterSelection");
+  } else if (IsVisibleInViewport(InGameMenuWidget)) {
+    ModalFocusWidget = InGameMenuWidget;
+    ModalReason = TEXT("InGameMenu");
+  } else if (IsVisibleInViewport(BattleResultWidget)) {
+    ModalFocusWidget = BattleResultWidget;
+    ModalReason = TEXT("BattleResult");
+  } else if (IsVisibleInViewport(MainHUD) &&
+             (MainHUD->IsAwaitingStrategicInitiative() ||
+              MainHUD->HasActivePrepareForBattlePrompt())) {
+    ModalFocusWidget = MainHUD;
+    ModalReason = MainHUD->HasActivePrepareForBattlePrompt()
+                      ? TEXT("PrepareForBattle")
+                      : TEXT("StrategicInitiative");
+  } else if (IsVisibleInViewport(BattleHudWidget) &&
+             BattleHudWidget->IsInitiativePromptActive()) {
+    ModalFocusWidget = BattleHudWidget;
+    ModalReason = TEXT("BattleInitiative");
+  }
+
+  if (ModalFocusWidget) {
+    // Replicated battle payloads/map-state changes can show a modal battle UI
+    // and then immediately reconcile input in the same frame. Preserve Game+UI
+    // focus for that modal instead of switching to GameOnly and starving normal
+    // widget input before the player can lock in or respond to the prompt.
+    UWidgetBlueprintLibrary::SetInputMode_GameAndUIEx(
+        this, ModalFocusWidget, EMouseLockMode::DoNotLock,
+        /*bHideCursorDuringCapture*/ false);
+    bShowMouseCursor = true;
+    bEnableClickEvents = true;
+    bEnableMouseOverEvents = true;
+    DefaultMouseCaptureMode = EMouseCaptureMode::NoCapture;
+  } else {
+    // Once modal battle setup UI is gone, explicitly return focus to the
+    // viewport and keep click traces enabled so camera axes plus grid/fighter
+    // picks recover after streamed map activation.
+    UWidgetBlueprintLibrary::SetInputMode_GameOnly(this);
+    FocusGameViewport(this);
+    bShowMouseCursor = true;
+    bEnableClickEvents = true;
+    bEnableMouseOverEvents = true;
+    DefaultMouseCaptureMode = EMouseCaptureMode::CaptureDuringMouseDown;
+  }
+
+  if (UGameViewportClient* GameViewport =
+          GetWorld() ? GetWorld()->GetGameViewport() : nullptr) {
+    GameViewport->SetMouseCaptureMode(DefaultMouseCaptureMode);
+  }
+  SetIgnoreMoveInput(false);
+  SetIgnoreLookInput(false);
+
+  const bool bInputReady =
+      bShowMouseCursor && bEnableClickEvents && bEnableMouseOverEvents &&
+      !IsMoveInputIgnored() && !IsLookInputIgnored();
+
   UE_LOG(LogSkaldBattle, Verbose,
-         TEXT("BattleInputReconciler[%s]: Controller=%s BattleMap=%d"),
-         Context ? Context : TEXT("Unknown"), *GetName(), bBattleMapActive ? 1 : 0);
+         TEXT("BattleInputReconciler[%s]: Controller=%s BattleMap=%d CameraReady=%d InputReady=%d Modal=%s Pawn=%s"),
+         Context ? Context : TEXT("Unknown"), *GetName(),
+         bBattleMapActive ? 1 : 0, bCameraReady ? 1 : 0,
+         bInputReady ? 1 : 0, ModalReason,
+         GetPawn() ? *GetPawn()->GetName() : TEXT("null"));
+
+  return bCameraReady && bInputReady;
+}
+
+void ASkaldPlayerController::ReconcileBattleInputState(const TCHAR* Context) {
+  ApplyBattleInteractionInputState(Context);
 }
 
 void ASkaldPlayerController::SchedulePostLockInBattleInputReconcile() {
@@ -6103,18 +6185,31 @@ void ASkaldPlayerController::HandlePostLockInBattleInputReconcileTick() {
     }
   }
 
-  ReconcileBattleInputState(TEXT("PostLockInBattleInputRetry"));
-
   const bool bBattleMapActive =
       bIsBattleMap || (CachedGameInstance && CachedGameInstance->bIsInBattleMap);
+
+  if (bBattleMapActive) {
+    InitializeBattleHUD();
+    if (CachedGameInstance && CachedGameInstance->GridBattleManager &&
+        !bBattleHUDVisible) {
+      EnsureBattleHUDVisible();
+    }
+    UpdateBattleHUDButtons();
+  }
+
+  const bool bBattleInteractionReady =
+      ApplyBattleInteractionInputState(TEXT("PostLockInBattleInputRetry"));
+
   constexpr int32 MaxRetries = 20;
   ++PostLockInBattleInputRetryCount;
 
-  if (bBattleMapActive || PostLockInBattleInputRetryCount >= MaxRetries) {
+  if ((bBattleMapActive && bBattleInteractionReady) ||
+      PostLockInBattleInputRetryCount >= MaxRetries) {
     World->GetTimerManager().ClearTimer(PostLockInBattleInputRetryHandle);
     UE_LOG(LogSkaldBattle, Verbose,
-           TEXT("PostLockInReconcile: Completed for %s (BattleMapActive=%d Retries=%d)"),
-           *GetName(), bBattleMapActive ? 1 : 0, PostLockInBattleInputRetryCount);
+           TEXT("PostLockInReconcile: Completed for %s (BattleMapActive=%d InteractionReady=%d Retries=%d)"),
+           *GetName(), bBattleMapActive ? 1 : 0,
+           bBattleInteractionReady ? 1 : 0, PostLockInBattleInputRetryCount);
   }
 }
 
@@ -6131,29 +6226,9 @@ void ASkaldPlayerController::HandleFighterSelectionLockedIn() {
 
   bBattleHUDReadyToShow = true;
 
-  // Ensure the HUD is initialized so the controller is bound to active-fighter
-  // updates even if no pawn has been selected yet.
-  InitializeBattleHUD();
-
   SelectedFighter = nullptr;
   LockedActiveFighter = nullptr;
   CancelCommandMode();
-  UpdateBattleHUDButtons();
-
-  // Lock-in closes the selection modal and hands control back to battle input.
-  // Use game-only input so camera drag/rotate works immediately, while still
-  // keeping cursor + click traces enabled for pawn selection.
-  UWidgetBlueprintLibrary::SetInputMode_GameOnly(this);
-  FocusGameViewport(this);
-  bShowMouseCursor = true;
-  bEnableClickEvents = true;
-  bEnableMouseOverEvents = true;
-  DefaultMouseCaptureMode = EMouseCaptureMode::CaptureDuringMouseDown;
-  if (UGameViewportClient* GameViewport = GetWorld() ? GetWorld()->GetGameViewport() : nullptr) {
-    GameViewport->SetMouseCaptureMode(DefaultMouseCaptureMode);
-  }
-  SetIgnoreMoveInput(false);
-  SetIgnoreLookInput(false);
 
   if (!CachedGameInstance) {
     CachedGameInstance = GetGameInstance<USkaldGameInstance>();
@@ -6173,12 +6248,26 @@ void ASkaldPlayerController::HandleFighterSelectionLockedIn() {
     }
   }
 
-  if (CachedGameInstance && CachedGameInstance->GridBattleManager &&
-      !bBattleHUDVisible) {
-    EnsureBattleHUDVisible();
+  DetectBattleMap();
+  const bool bBattleMapActive =
+      bIsBattleMap || (CachedGameInstance && CachedGameInstance->bIsInBattleMap);
+
+  if (bBattleMapActive) {
+    // Ensure the HUD/camera/input stack is initialized only after battle-map
+    // activation is visible on this controller.
+    InitializeBattleHUD();
+    if (CachedGameInstance && CachedGameInstance->GridBattleManager &&
+        !bBattleHUDVisible) {
+      EnsureBattleHUDVisible();
+    }
+    UpdateBattleHUDButtons();
+    ApplyBattleInteractionInputState(TEXT("HandleFighterSelectionLockedIn"));
+  } else {
+    UE_LOG(LogSkaldBattle, Verbose,
+           TEXT("HandleFighterSelectionLockedIn: Waiting for battle-map active flag before HUD/camera/input setup on %s"),
+           *GetName());
   }
 
-  ReconcileBattleInputState(TEXT("HandleFighterSelectionLockedIn"));
   SchedulePostLockInBattleInputReconcile();
 
   if (CachedGameInstance && CachedGameInstance->GridBattleManager)

--- a/Source/Skald/Skald_PlayerController.h
+++ b/Source/Skald/Skald_PlayerController.h
@@ -1094,6 +1094,7 @@ private:
   void DetectBattleMap();
 
   void RequestBattleStateIfNeeded();
+  bool ApplyBattleInteractionInputState(const TCHAR* Context);
   void ReconcileBattleInputState(const TCHAR* Context);
   void SchedulePostLockInBattleInputReconcile();
   void HandlePostLockInBattleInputReconcileTick();

--- a/Source/Skald/UI/BattleHUDWidget.cpp
+++ b/Source/Skald/UI/BattleHUDWidget.cpp
@@ -892,6 +892,18 @@ void UBattleHUDWidget::HideInitiativePrompt() {
   }
 }
 
+bool UBattleHUDWidget::IsInitiativePromptActive() const {
+  const bool bPromptVisible =
+      InitiativePromptText &&
+      InitiativePromptText->GetVisibility() != ESlateVisibility::Collapsed &&
+      InitiativePromptText->GetVisibility() != ESlateVisibility::Hidden;
+  const bool bRollButtonVisible =
+      RollInitiativeButton &&
+      RollInitiativeButton->GetVisibility() != ESlateVisibility::Collapsed &&
+      RollInitiativeButton->GetVisibility() != ESlateVisibility::Hidden;
+  return bPromptVisible || bRollButtonVisible;
+}
+
 void UBattleHUDWidget::RefreshStats() { UpdateStatPanel(); }
 
 void UBattleHUDWidget::BindToFighter(AFighterPawn *Fighter) {

--- a/Source/Skald/UI/BattleHUDWidget.h
+++ b/Source/Skald/UI/BattleHUDWidget.h
@@ -519,6 +519,8 @@ public:
   /** Hide the initiative prompt and roll button. */
   void HideInitiativePrompt();
 
+  bool IsInitiativePromptActive() const;
+
   /** Update the round and initiative labels. */
   void SetRoundInfo(const FText &RoundLabel, const FText &InitiativeLabel);
 

--- a/Source/Skald/UI/SkaldMainHUDWidget.h
+++ b/Source/Skald/UI/SkaldMainHUDWidget.h
@@ -277,6 +277,10 @@ public:
     return bAwaitingStrategicInitiative;
   }
 
+  bool HasActivePrepareForBattlePrompt() const {
+    return bHasActivePreparePrompt;
+  }
+
   /** Show an in-progress enemy turn message without auto-hiding. */
   UFUNCTION(BlueprintCallable, Category = "Skald|HUD")
   void ShowEnemyTurnInProgress(const FString &Message);


### PR DESCRIPTION
### Motivation
- Prevent race-conditions and input/camera focus regressions when replicated battle payloads or streamed battle-maps become active by preserving modal UI focus and ensuring input is only considered ready when camera+click state are valid.
- Provide HUD-level visibility queries to let the controller decide when prepare/initiative prompts are active so input handling can respect modal prompts.

### Description
- Introduced `ApplyBattleInteractionInputState(const TCHAR*)` which centralizes input-mode, cursor, mouse-capture, camera readiness and modal-widget detection and returns a boolean indicating whether battle interaction is ready; `ReconcileBattleInputState` now delegates to this helper.
- Use `CachedGameInstance->bIsInBattleMap` alongside `bIsBattleMap` when determining battle-map state in multiple controller paths (`HandleReplicatedTurnOwnership`, `UpdateBattleCameraMode`, `HandleFighterSelectionLockedIn`, post-lock-in reconcile, etc.).
- Update post-lock-in reconcile flow to call `ApplyBattleInteractionInputState` and stop retrying only when the battle interaction stack (camera + click traces + modal state) is actually ready, and improve verbose logging to include camera/input readiness and the detected modal reason.
- Move HUD/camera/input setup to be gated on battle-map activation and driven by the new helper; added `UBattleHUDWidget::IsInitiativePromptActive()` and `USkaldMainHUDWidget::HasActivePrepareForBattlePrompt()` accessors used to detect modal prompts.
- Added function declaration for `ApplyBattleInteractionInputState` in the controller header and updated related call sites and logging.

### Testing
- Built the project (Editor configuration) and ensured the modified modules compile without errors.
- Executed existing automated test suite and UI-related checks locally; no regressions or test failures were observed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1840af092483248be8317af323defb)