### PR TITLE
Fix battle HUD persistence after fighter lock-in

### DIFF
--- a/Source/Skald/Skald_PlayerController.cpp
+++ b/Source/Skald/Skald_PlayerController.cpp
@@ -3238,10 +3238,12 @@ void ASkaldPlayerController::ShowOverworldHUD() {
 void ASkaldPlayerController::HideOverworldHUDForBattle() {
   HideMainHUD();
 
-  bBattleHUDVisible = false;
-  if (BattleHudWidget) {
-    BattleHudWidget->SetVisibility(ESlateVisibility::Collapsed);
-  }
+  // Only tear down overworld presentation here. This function is called by
+  // battle-map detection/reconciliation paths after fighter lock-in, so
+  // collapsing the battle HUD here races with EnsureBattleHUDVisible() and can
+  // leave the local player with no battle HUD or camera input once streaming
+  // finishes. Battle HUD lifetime/visibility is managed by
+  // EnsureBattleHUDVisible(), ShowOverworldHUD(), and battle-end cleanup.
 
   if (UWorld *World = GetWorld()) {
     if (AWorldMap *WorldMap = Cast<AWorldMap>(
@@ -3659,8 +3661,22 @@ void ASkaldPlayerController::DetectBattleMap() {
 
   if (bIsBattleMap) {
     HideOverworldHUDForBattle();
+
+    const bool bSelectionVisible =
+        FighterSelectionWidget && FighterSelectionWidget->IsInViewport() &&
+        FighterSelectionWidget->GetVisibility() != ESlateVisibility::Collapsed &&
+        FighterSelectionWidget->GetVisibility() != ESlateVisibility::Hidden;
+    const bool bBattlePhaseAllowsHud =
+        !CachedGameState ||
+        CachedGameState->BattlePhase != EBattlePhase::FighterSelection;
+
+    // The battle manager is created after Deploy/TryLaunchBattle, while
+    // streamed level callbacks can re-run DetectBattleMap in between. If a
+    // previous pass already consumed bBattleHUDReadyToShow, still restore the
+    // HUD once there is an active battle manager and no modal selection widget.
     if (CachedGameInstance && CachedGameInstance->GridBattleManager &&
-        bBattleHUDReadyToShow) {
+        !bSelectionVisible && bBattlePhaseAllowsHud &&
+        (bBattleHUDReadyToShow || !bBattleHUDVisible)) {
       EnsureBattleHUDVisible();
     }
   } else {


### PR DESCRIPTION
### Motivation
- Players could lose the battle HUD and camera input after locking in fighters because the overworld teardown path collapsed the battle HUD during streamed map transitions, creating a race with HUD show logic.
- `DetectBattleMap()` could fail to restore the battle HUD when the `GridBattleManager` arrived after a streaming pass had already cleared the ready-to-show flag, leaving local players without controls.

### Description
- Stop collapsing `BattleHudWidget` in `HideOverworldHUDForBattle()` so the function only tears down overworld presentation and does not race with battle HUD initialization.
- In `DetectBattleMap()` add logic to restore the battle HUD once `CachedGameInstance->GridBattleManager` exists, only if no fighter-selection modal is visible and the phase is not `FighterSelection`, and allow restoration even when `bBattleHUDReadyToShow` was previously consumed.
- Add explanatory comments describing the race condition and the rationale for leaving battle HUD lifetime management to battle-specific paths.

### Testing
- Ran `git diff --check` to validate the workspace diff and style check which reported no issues and completed successfully.
- Attempted an automated build check but a local `UnrealBuildTool` was not available in the environment so a full compile/test run could not be executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a185137352883249cbd4aeb2a68455c)