### PR TITLE
Fix battle input after fighter lock-in

### DIFF
--- a/Source/Skald/Skald_PlayerController.cpp
+++ b/Source/Skald/Skald_PlayerController.cpp
@@ -3265,17 +3265,18 @@ void ASkaldPlayerController::EnsureBattleHUDVisible() {
     return;
   }
 
-  BattleHudWidget->SetVisibility(ESlateVisibility::Visible);
+  // The battle HUD spans the viewport, so the widget itself must not be a
+  // hit-test target.  Keeping only its children hit-testable lets HUD buttons
+  // consume clicks while empty HUD space still falls through to grid/fighter
+  // traces.
+  BattleHudWidget->SetVisibility(ESlateVisibility::SelfHitTestInvisible);
   bBattleHUDVisible = true;
 
-  // Keep HUD focused so mouse interactions stay responsive while Game+UI
-  // input mode still allows camera controls.
-  UWidgetBlueprintLibrary::SetInputMode_GameAndUIEx(
-      this, BattleHudWidget, EMouseLockMode::DoNotLock, false);
-  bShowMouseCursor = true;
-  bEnableClickEvents = true;
-  bEnableMouseOverEvents = true;
-  DefaultMouseCaptureMode = EMouseCaptureMode::NoCapture;
+  // After selection lock-in/deploy, the player is in world interaction mode:
+  // camera axes should reach the possessed camera pawn and mouse clicks should
+  // still trace the battle grid.  Modal battle prompts are handled inside the
+  // reconciler and will keep Game+UI focus only while they are actually active.
+  ApplyBattleInteractionInputState(TEXT("EnsureBattleHUDVisible"));
 }
 
 UGridOverlayComponent *ASkaldPlayerController::FindGridOverlay() const {


### PR DESCRIPTION
### Motivation
- After fighter selection/lock-in and battle initialization the player must retain camera control (WASD/rotation/zoom) and be able to click the grid and fighter pawns, but the full-screen battle HUD root was blocking those traces.

### Description
- Change `EnsureBattleHUDVisible()` to set the HUD root widget visibility to `ESlateVisibility::SelfHitTestInvisible` so empty HUD space does not block world click traces while child HUD controls remain interactive.
- Invoke the existing reconciler by calling `ApplyBattleInteractionInputState(TEXT("EnsureBattleHUDVisible"))` when showing the HUD so camera axes and world picking are restored after lock-in/deploy unless a modal prompt is actively required.
- Add explanatory comments clarifying the intent to keep HUD controls clickable while allowing clicks to fall through to the grid when appropriate.

### Testing
- Executed `./Build/validate.sh`, which ran but could not perform the compile and engine automation steps because `UnrealBuildTool` and `UnrealEditor` were not available in this environment (script exited successfully with those steps skipped).
- Ran `git diff --check` to verify no trailing-whitespace or diff-check issues, which passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a18532fb3788324baded1eefeec9dbe)