### PR TITLE
Promote streamed battle activation early and stabilize battle HUD/input handling

### DIFF
--- a/Source/Skald/Skald_BattleLevelManager.cpp
+++ b/Source/Skald/Skald_BattleLevelManager.cpp
@@ -146,11 +146,8 @@ bool USkaldBattleLevelManager::RequestBattleLevel(
         StreamingLevel && StreamingLevel->IsLevelLoaded();
 
     if (USkaldGameInstance *GI = OwningInstance.Get()) {
-      if (bLevelAlreadyLoaded) {
-        GI->SetTravelPending(false);
-      } else {
-        GI->SetTravelPending(true);
-      }
+      GI->SetTravelPending(!bLevelAlreadyLoaded);
+      GI->SetBattleMapActive(true);
     }
 
     RegisterStreamingTicker();
@@ -256,18 +253,25 @@ bool USkaldBattleLevelManager::RequestBattleLevel(
   ActiveStreamingLevel = StreamingLevel;
   bActiveLevelShouldBeLoaded = true;
 
+  if (USkaldGameInstance *GI = OwningInstance.Get()) {
+    // A successful streaming request means the local world is entering tactical
+    // battle flow even before the level finishes becoming visible. Promote the
+    // battle-map flag here so player controllers bind battle input/camera state
+    // during the streamed sublevel load instead of waiting on a later callback
+    // that may be missed by pre-existing sublevels.
+    GI->SetTravelPending(true);
+    GI->SetBattleMapActive(true);
+  }
+
   RegisterWorldDelegates();
   RegisterStreamingTicker();
 
   StreamingLevel->SetShouldBeVisible(false);
   StreamingLevel->SetShouldBeLoaded(true);
+  World->UpdateLevelStreaming();
 
   if (StreamingLevel->IsLevelLoaded()) {
     HandleLevelLoaded();
-  }
-
-  if (USkaldGameInstance *GI = OwningInstance.Get()) {
-    GI->SetTravelPending(true);
   }
 
   UE_LOG(LogSkald, Log,
@@ -352,6 +356,9 @@ void USkaldBattleLevelManager::HandleLevelLoaded() {
   }
 
   ActiveStreamingLevel->SetShouldBeVisible(true);
+  if (UWorld* World = ActiveStreamingLevel->GetWorld()) {
+    World->UpdateLevelStreaming();
+  }
   HideNonBattleLevels();
   UE_LOG(LogSkald, Log, TEXT("BattleLevelManager: Battle level streamed and visible"));
 

--- a/Source/Skald/Skald_GameInstance.cpp
+++ b/Source/Skald/Skald_GameInstance.cpp
@@ -933,14 +933,14 @@ void USkaldGameInstance::HandleWorldBeginPlay(UWorld *LoadedWorld) {
     }
   }
 
-  // Keep the battle-map state in sync with the actual level in case the travel
-  // RPC was missed (e.g. late-joining clients or failed multicast). This ensures
-  // PlayerControllers on the new map can immediately initialise their battle
-  // UI such as fighter selection. Only auto-promote into battle state when the
-  // default BattleMap is detected to avoid clearing an existing battle flag when
-  // travelling to named battle maps selected from the configured map lists.
-  if (bDetectedBattleMap != bIsInBattleMap) {
-    SetBattleMapActive(bDetectedBattleMap);
+  // Keep the battle-map state in sync if an actual standalone battle map loads,
+  // but do not demote an already-active streamed battle just because the
+  // persistent overview world began play. Streamed battles keep the same UWorld
+  // and level name, so using CurrentLevel as a negative signal here can clear
+  // bIsInBattleMap after the battle level manager already promoted it, leaving
+  // player controllers in overview input mode with no battle camera/grid clicks.
+  if (bDetectedBattleMap && !bIsInBattleMap) {
+    SetBattleMapActive(true);
   }
 
   SetTravelPending(false);
@@ -1169,6 +1169,8 @@ void USkaldGameInstance::SetBattleMapActive(bool bInBattleMap) {
   }
 
   bIsInBattleMap = bInBattleMap;
+  UE_LOG(LogSkald, Log, TEXT("GameInstance battle-map active -> %d"),
+         bIsInBattleMap ? 1 : 0);
   OnBattleMapStateChanged.Broadcast(bIsInBattleMap);
 
   if (bIsInBattleMap) {

--- a/Source/Skald/Skald_PlayerController.cpp
+++ b/Source/Skald/Skald_PlayerController.cpp
@@ -452,6 +452,10 @@ void ASkaldPlayerController::CacheGameReferences() {
         this, &ASkaldPlayerController::HandleBattleMapStateChanged);
     CachedGameInstance->OnBattleMapStateChanged.AddDynamic(
         this, &ASkaldPlayerController::HandleBattleMapStateChanged);
+
+    if (CachedGameInstance->bIsInBattleMap && !bIsBattleMap) {
+      HandleBattleMapStateChanged(true);
+    }
   } else {
     bNeedsRetry = true;
     UE_LOG(LogSkald, Verbose,
@@ -3265,17 +3269,17 @@ void ASkaldPlayerController::EnsureBattleHUDVisible() {
     return;
   }
 
-  BattleHudWidget->SetVisibility(ESlateVisibility::Visible);
+  // The battle HUD spans the viewport, so the widget itself must not be a
+  // hit-test target.  Keeping only its children hit-testable lets HUD buttons
+  // consume clicks while empty HUD space still falls through to grid/fighter
+  // traces.
+  BattleHudWidget->SetVisibility(ESlateVisibility::SelfHitTestInvisible);
   bBattleHUDVisible = true;
 
-  // Keep HUD focused so mouse interactions stay responsive while Game+UI
-  // input mode still allows camera controls.
-  UWidgetBlueprintLibrary::SetInputMode_GameAndUIEx(
-      this, BattleHudWidget, EMouseLockMode::DoNotLock, false);
-  bShowMouseCursor = true;
-  bEnableClickEvents = true;
-  bEnableMouseOverEvents = true;
-  DefaultMouseCaptureMode = EMouseCaptureMode::NoCapture;
+  // After selection lock-in/deploy, restore the battle input policy. This keeps
+  // Game+UI active for HUD buttons while allowing empty HUD space to fall through
+  // to grid/fighter traces and camera controls.
+  ApplyBattleInteractionInputState(TEXT("EnsureBattleHUDVisible"));
 }
 
 UGridOverlayComponent *ASkaldPlayerController::FindGridOverlay() const {
@@ -3637,12 +3641,32 @@ void ASkaldPlayerController::DetectBattleMap() {
   if (!CachedGameInstance) {
     CachedGameInstance = GetGameInstance<USkaldGameInstance>();
   }
-  // Battle maps are now streamed exclusively into the persistent world.
-  // Current level name and map-descriptor checks are no longer reliable
-  // indicators of battle context because the active UWorld does not switch.
-  // Treat the game-instance streamed-battle flag as the authoritative source.
+  // Battle maps are streamed into the persistent world, so the current UWorld
+  // name is not a reliable indicator. Prefer the game-instance battle flag, but
+  // recover if it was cleared by a persistent-world BeginPlay after the streamed
+  // battle level/manager was already initialized.
   if (CachedGameInstance) {
     bDetectedBattleMap = CachedGameInstance->bIsInBattleMap;
+
+    if (!bDetectedBattleMap) {
+      if (const USkaldBattleLevelManager* BattleLevelManager =
+              CachedGameInstance->GetBattleLevelManager()) {
+        bDetectedBattleMap = BattleLevelManager->IsBattleLevelActive() ||
+                             BattleLevelManager->IsBattleLevelFullyReady();
+      }
+    }
+
+    if (!bDetectedBattleMap) {
+      bDetectedBattleMap = CachedGameInstance->GridBattleManager != nullptr ||
+                           CachedGameInstance->GetActiveBattleGameMode() != nullptr;
+    }
+
+    if (bDetectedBattleMap && !CachedGameInstance->bIsInBattleMap) {
+      UE_LOG(LogSkaldBattle, Warning,
+             TEXT("DetectBattleMap: restoring streamed battle-map active flag for %s"),
+             *GetName());
+      CachedGameInstance->SetBattleMapActive(true);
+    }
   }
 
   bIsBattleMap = bDetectedBattleMap;
@@ -5694,11 +5718,24 @@ void ASkaldPlayerController::HandleReplicatedTurnOwnership() {
   // Battle preparation/selection controls are managed by battle flow. Avoid
   // having overworld turn ownership logic steal input mode or cursor state.
   if (bInBattleInputFlow) {
-    ApplyHudCapturePolicy(/*bModalUIActive*/ false);
+    const bool bOnBattleMapNow =
+        bIsBattleMap ||
+        (CachedGameInstance && CachedGameInstance->bIsInBattleMap);
+
+    if (bOnBattleMapNow) {
+      ApplyBattleInteractionInputState(
+          TEXT("HandleReplicatedTurnOwnershipBattleFlow"));
+    } else {
+      ApplyHudCapturePolicy(/*bModalUIActive*/ false);
+    }
+
     // Battle interaction (camera pan/rotate + world picks) must stay enabled
     // for both participants while streamed battle state settles. Without this
     // guard, a stale non-active-turn update can leave look/move input ignored
     // after lock-in and make the battle map appear frozen.
+    bShowMouseCursor = true;
+    bEnableClickEvents = true;
+    bEnableMouseOverEvents = true;
     SetIgnoreMoveInput(false);
     SetIgnoreLookInput(false);
     if (!bIsMyTurn && bLocalTurnActive) {
@@ -6125,11 +6162,16 @@ bool ASkaldPlayerController::ApplyBattleInteractionInputState(
     bEnableMouseOverEvents = true;
     DefaultMouseCaptureMode = EMouseCaptureMode::NoCapture;
   } else {
-    // Once modal battle setup UI is gone, explicitly return focus to the
-    // viewport and keep click traces enabled so camera axes plus grid/fighter
-    // picks recover after streamed map activation.
-    UWidgetBlueprintLibrary::SetInputMode_GameOnly(this);
-    FocusGameViewport(this);
+    // Normal battle play still needs a live Game+UI input mode: unhandled WASD,
+    // mouse-axis, and wheel input fall through to the camera pawn, while the
+    // visible UBattleHUDWidget buttons continue to receive UI clicks.  The HUD
+    // root is made SelfHitTestInvisible when shown, so empty HUD space still
+    // falls through to grid/fighter traces.
+    UWidget* BattleFocusWidget =
+        IsVisibleInViewport(BattleHudWidget) ? BattleHudWidget.Get() : nullptr;
+    UWidgetBlueprintLibrary::SetInputMode_GameAndUIEx(
+        this, BattleFocusWidget, EMouseLockMode::DoNotLock,
+        /*bHideCursorDuringCapture*/ false);
     bShowMouseCursor = true;
     bEnableClickEvents = true;
     bEnableMouseOverEvents = true;

--- a/Source/Skald/Skald_TurnManager.cpp
+++ b/Source/Skald/Skald_TurnManager.cpp
@@ -2866,10 +2866,9 @@ void ATurnManager::TriggerGridBattle(const FS_BattlePayload &Battle) {
         GI->SetTravelPending(true);
       }
 
-      // Do not mark the battle map as active until the streamed level is
-      // actually loaded/visible. Prematurely setting this flag keeps the
-      // overworld running while UI/state machines repeatedly try to enter
-      // ready-for-battle.
+      // Streamed battle-map activation is owned by the battle level manager as
+      // soon as its sublevel request is accepted. Non-streamed travel still
+      // needs the turn manager to publish the active battle-map flag directly.
       if (!bShouldStreamSelectedMap) {
         GI->SetBattleMapActive(true);
         if (World->GetNetMode() != NM_Standalone) {
@@ -3577,8 +3576,7 @@ void ATurnManager::MulticastStreamBattleLevel_Implementation(
 
   GI->SetTravelState(TravelState);
   GI->PendingBattle = BattlePayload;
-  // Keep this false until the battle streaming level is actually active.
-  GI->SetBattleMapActive(false);
+  GI->SetTravelPending(true);
 
   if (USkaldBattleLevelManager *BattleLevelManager =
           GI->GetBattleLevelManager()) {


### PR DESCRIPTION
### Motivation
- Avoid races where streamed battle sublevels or persistent-world BeginPlay clear the battle-map state and leave local controllers in the wrong input/camera mode.
- Ensure player controllers can bind battle input and camera state while a streamed sublevel is loading instead of waiting for later callbacks that may be missed.
- Make HUD hit-testing and input-mode restoration consistent for battle flow so camera and grid/fighter traces remain responsive during streamed battle setup and play.

### Description
- In `Skald_BattleLevelManager.cpp` promote battle activation earlier by setting `SetTravelPending` and `SetBattleMapActive` when a streaming request is accepted or reused, call `World->UpdateLevelStreaming()` after enabling load/visibility, and call `UpdateLevelStreaming()` when making the loaded sublevel visible.
- In `Skald_GameInstance.cpp` change `HandleWorldBeginPlay` to only auto-promote into battle-map state when a standalone battle map is detected (avoid demoting streamed battles) and add a log in `SetBattleMapActive`.
- In `Skald_PlayerController.cpp` make controllers eagerly recover streamed-battle state when binding to the `OnBattleMapStateChanged` delegate, prefer the game-instance/level-manager flags for `DetectBattleMap`, restore the game-instance flag when needed, make the battle HUD root use `SelfHitTestInvisible`, and centralize Battle input/mode handling through `ApplyBattleInteractionInputState` so Game+UI remains active while empty HUD space lets clicks fall through to the grid/fighter traces.
- In `Skald_TurnManager.cpp` remove client-side demotion of the battle flag in `MulticastStreamBattleLevel_Implementation` and let the `BattleLevelManager` own activation, while preserving non-streamed travel behavior that sets `SetBattleMapActive(true)`.

### Testing
- Performed a full project build/compile to validate API changes and compilation errors were resolved (build succeeded).
- Ran the project's automated unit/integration test suite and UI/input reconciliation tests (all automated tests passed).
- Verified streaming-path logging and controller input state transitions exercised by the existing automated replay/integration tests (no regressions observed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a18532fb3788324baded1eefeec9dbe)