### PR TITLE
Gate streamed battle map activation until ready

### DIFF
--- a/Source/Skald/Skald_BattleLevelManager.cpp
+++ b/Source/Skald/Skald_BattleLevelManager.cpp
@@ -144,10 +144,14 @@ bool USkaldBattleLevelManager::RequestBattleLevel(
     const ULevelStreaming *StreamingLevel = ActiveStreamingLevel.Get();
     const bool bLevelAlreadyLoaded =
         StreamingLevel && StreamingLevel->IsLevelLoaded();
+    const bool bLevelAlreadyReady =
+        bLevelAlreadyLoaded && StreamingLevel->IsLevelVisible();
 
     if (USkaldGameInstance *GI = OwningInstance.Get()) {
-      GI->SetTravelPending(!bLevelAlreadyLoaded);
-      GI->SetBattleMapActive(true);
+      GI->SetTravelPending(!bLevelAlreadyReady);
+      if (bLevelAlreadyReady) {
+        GI->SetBattleMapActive(true);
+      }
     }
 
     RegisterStreamingTicker();
@@ -254,13 +258,10 @@ bool USkaldBattleLevelManager::RequestBattleLevel(
   bActiveLevelShouldBeLoaded = true;
 
   if (USkaldGameInstance *GI = OwningInstance.Get()) {
-    // A successful streaming request means the local world is entering tactical
-    // battle flow even before the level finishes becoming visible. Promote the
-    // battle-map flag here so player controllers bind battle input/camera state
-    // during the streamed sublevel load instead of waiting on a later callback
-    // that may be missed by pre-existing sublevels.
+    // Keep the battle-map flag false while the streamed sublevel is only
+    // requested/loading. HandleLevelLoaded promotes it after the level has been
+    // loaded, made visible, and non-battle levels have been hidden.
     GI->SetTravelPending(true);
-    GI->SetBattleMapActive(true);
   }
 
   RegisterWorldDelegates();

--- a/Source/Skald/Skald_PlayerController.cpp
+++ b/Source/Skald/Skald_PlayerController.cpp
@@ -3643,22 +3643,23 @@ void ASkaldPlayerController::DetectBattleMap() {
   }
   // Battle maps are streamed into the persistent world, so the current UWorld
   // name is not a reliable indicator. Prefer the game-instance battle flag, but
-  // recover if it was cleared by a persistent-world BeginPlay after the streamed
-  // battle level/manager was already initialized.
+  // only recover it once the streamed battle level is fully loaded and visible.
+  // TriggerGridBattle creates GridBattleManager before requesting the stream;
+  // treating that allocation (or a mere active streaming request) as proof that
+  // the battle map is active bypasses the loading guard and can switch clients
+  // into battle mode before the map is ready.
   if (CachedGameInstance) {
     bDetectedBattleMap = CachedGameInstance->bIsInBattleMap;
 
     if (!bDetectedBattleMap) {
       if (const USkaldBattleLevelManager* BattleLevelManager =
               CachedGameInstance->GetBattleLevelManager()) {
-        bDetectedBattleMap = BattleLevelManager->IsBattleLevelActive() ||
-                             BattleLevelManager->IsBattleLevelFullyReady();
+        bDetectedBattleMap = BattleLevelManager->IsBattleLevelFullyReady();
       }
     }
 
     if (!bDetectedBattleMap) {
-      bDetectedBattleMap = CachedGameInstance->GridBattleManager != nullptr ||
-                           CachedGameInstance->GetActiveBattleGameMode() != nullptr;
+      bDetectedBattleMap = CachedGameInstance->GetActiveBattleGameMode() != nullptr;
     }
 
     if (bDetectedBattleMap && !CachedGameInstance->bIsInBattleMap) {


### PR DESCRIPTION
### Motivation
- `ATurnManager::TriggerGridBattle` allocates `GridBattleManager` before requesting a streamed battle level, and some code used the mere presence of `GridBattleManager` (or an active streaming request) as a signal that the battle map was active, which can cause clients to transition into battle mode prematurely. 
- The intent is to ensure clients only flip into battle mode once the streamed battle level is actually loaded and visible (or a proper battle `GameMode` is present), preserving the existing loading guard and avoiding dropped/early RPCs or input state issues.

### Description
- Require the streaming manager to be fully ready before restoring the game-instance battle flag by changing `ASkaldPlayerController::DetectBattleMap()` to consult `BattleLevelManager->IsBattleLevelFullyReady()` or an active battle `GameMode` instead of treating `GridBattleManager != nullptr` or a pending stream as proof of an active battle map (`Source/Skald/Skald_PlayerController.cpp`).
- Adjust `USkaldBattleLevelManager::RequestBattleLevel()` so re-used streaming requests only call `SetBattleMapActive(true)` if the streaming level is both loaded and visible, and keep newly-requested streams from promoting the battle-map flag until `HandleLevelLoaded()` promotes it (`Source/Skald/Skald_BattleLevelManager.cpp`).
- Add clarifying comments where the early activation was removed and use a `bLevelAlreadyReady` check to distinguish loaded+visible from merely loaded.

### Testing
- Ran `git diff --check` to validate there are no whitespace/errors reported by the diff, and it completed with no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a186ccf12d48324b5320795b4cf433d)