### PR TITLE
Gate battle readiness on actual streamed level visibility

### DIFF
--- a/Source/Skald/Skald_BattleLevelManager.cpp
+++ b/Source/Skald/Skald_BattleLevelManager.cpp
@@ -246,6 +246,8 @@ bool USkaldBattleLevelManager::RequestBattleLevel(
   PendingPayload = BattlePayload;
   ActiveStreamingLevel = StreamingLevel;
   bActiveLevelShouldBeLoaded = true;
+  bActiveLevelVisibilityRequested = false;
+  bActiveLevelActivationComplete = false;
 
   if (USkaldGameInstance *GI = OwningInstance.Get()) {
     // Keep the battle-map flag false while the streamed sublevel is only
@@ -273,6 +275,9 @@ void USkaldBattleLevelManager::ReleaseBattleLevel() {
     UnregisterWorldDelegates();
     UnregisterStreamingTicker();
     RestoreNonBattleLevels();
+    bActiveLevelShouldBeLoaded = false;
+    bActiveLevelVisibilityRequested = false;
+    bActiveLevelActivationComplete = false;
     return;
   }
 
@@ -286,6 +291,8 @@ void USkaldBattleLevelManager::ReleaseBattleLevel() {
   }
 
   bActiveLevelShouldBeLoaded = false;
+  bActiveLevelVisibilityRequested = false;
+  bActiveLevelActivationComplete = false;
 
   UE_LOG(LogSkald, Log, TEXT("BattleLevelManager: Unloading battle level"));
 
@@ -344,11 +351,29 @@ void USkaldBattleLevelManager::HandleLevelLoaded() {
     LevelAddedToWorldHandle.Reset();
   }
 
-  ActiveStreamingLevel->SetShouldBeVisible(true);
-  if (UWorld* World = ActiveStreamingLevel->GetWorld()) {
-    World->UpdateLevelStreaming();
+  ULevelStreaming *StreamingLevel = ActiveStreamingLevel.Get();
+  if (!StreamingLevel) {
+    return;
   }
-  HideNonBattleLevels();
+
+  if (!bActiveLevelVisibilityRequested) {
+    StreamingLevel->SetShouldBeVisible(true);
+    bActiveLevelVisibilityRequested = true;
+    if (UWorld* World = StreamingLevel->GetWorld()) {
+      World->UpdateLevelStreaming();
+    }
+    HideNonBattleLevels();
+    UE_LOG(LogSkald, Log, TEXT("BattleLevelManager: Battle level streamed; visibility requested"));
+  }
+
+  if (!StreamingLevel->IsLevelVisible()) {
+    return;
+  }
+
+  if (bActiveLevelActivationComplete) {
+    return;
+  }
+
   UE_LOG(LogSkald, Log, TEXT("BattleLevelManager: Battle level streamed and visible"));
 
   if (USkaldGameInstance *GI = OwningInstance.Get()) {
@@ -484,6 +509,8 @@ void USkaldBattleLevelManager::HandleLevelLoaded() {
       }
     }
   }
+
+  bActiveLevelActivationComplete = true;
 }
 
 void USkaldBattleLevelManager::HandleLevelUnloaded() {
@@ -494,6 +521,8 @@ void USkaldBattleLevelManager::HandleLevelUnloaded() {
   RestoreNonBattleLevels();
 
   bActiveLevelShouldBeLoaded = false;
+  bActiveLevelVisibilityRequested = false;
+  bActiveLevelActivationComplete = false;
   bLastKnownLoadedState = false;
   ActiveStreamingLevel.Reset();
   RequestedBattleLevel.Reset();
@@ -679,8 +708,8 @@ bool USkaldBattleLevelManager::IsBattleLevelFullyReady() const {
     return false;
   }
 
-  return bActiveLevelShouldBeLoaded && IsActiveStreamingLevelLoaded() &&
-         (StreamingLevel->IsLevelVisible() || StreamingLevel->ShouldBeVisible());
+  return bActiveLevelShouldBeLoaded && bActiveLevelActivationComplete &&
+         IsActiveStreamingLevelLoaded() && StreamingLevel->IsLevelVisible();
 }
 
 void USkaldBattleLevelManager::HideNonBattleLevels() {

--- a/Source/Skald/Skald_BattleLevelManager.h
+++ b/Source/Skald/Skald_BattleLevelManager.h
@@ -77,6 +77,8 @@ private:
   FTSTicker::FDelegateHandle StreamingStatusTickerHandle;
   FS_BattlePayload PendingPayload;
   bool bActiveLevelShouldBeLoaded = false;
+  bool bActiveLevelVisibilityRequested = false;
+  bool bActiveLevelActivationComplete = false;
   bool bLastKnownLoadedState = false;
   TWeakObjectPtr<ASkald_BattleGameMode> ActiveBattleGameMode;
 


### PR DESCRIPTION
### Motivation
- Prevent callers from treating a streamed battle level as fully ready when `SetShouldBeVisible(true)` has been requested but Unreal has not yet made the level actually visible.
- Close the race where UI/input transitions to battle mode during the gap between requesting visibility and the level becoming visible.

### Description
- Add two explicit state flags `bActiveLevelVisibilityRequested` and `bActiveLevelActivationComplete` to `USkaldBattleLevelManager` to track the visibility-requested and activation-complete phases (`Source/Skald/Skald_BattleLevelManager.h`).
- Initialize and reset the new flags when starting or releasing a streamed level in `RequestBattleLevel` and `ReleaseBattleLevel` (`Source/Skald/Skald_BattleLevelManager.cpp`).
- Update `HandleLevelLoaded()` to: request visibility only once (set `ShouldBeVisible` and mark `bActiveLevelVisibilityRequested`), return until `IsLevelVisible()` becomes true, and only then perform battle activation and set `bActiveLevelActivationComplete` (`Source/Skald/Skald_BattleLevelManager.cpp`).
- Change `IsBattleLevelFullyReady()` to require `bActiveLevelActivationComplete` and `IsLevelVisible()` instead of treating `ShouldBeVisible()` as sufficient readiness (`Source/Skald/Skald_BattleLevelManager.cpp`).

### Testing
- Ran `git diff --check` to validate whitespace/patch issues, which passed.
- Searched for the previous `ShouldBeVisible()` fallback with `rg` to ensure readiness gating no longer relies on `ShouldBeVisible()`, which returned no problematic matches.
- Verified compilation-local edits (file diffs) to ensure the new flags are set/cleared on all relevant code paths by inspecting the modified `RequestBattleLevel`, `HandleLevelLoaded`, and `HandleLevelUnloaded` flows.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a186fdbb6448324b40c7df141fecbc1)