### PR TITLE
Fix battle setup timing gates

### DIFF
--- a/Source/Skald/Skald_BattleGameMode.cpp
+++ b/Source/Skald/Skald_BattleGameMode.cpp
@@ -984,35 +984,41 @@ void ASkald_BattleGameMode::BeginPreBattleSelection(ASkaldPlayerState *AttackerP
     AttackerPS->PendingArmyBudget = AttackerBudget;
     AttackerPS->PendingArmy.Reset();
     AttackerPS->bArmyLockedIn = false;
-
-    if (!AttackerPS->bIsAI) {
-      if (ASkaldPlayerController *APC =
-              Cast<ASkaldPlayerController>(AttackerPS->GetOwner())) {
-        if (!IsAIControllerIdentity(APC)) {
-          APC->Client_ShowFighterSelection(AttackerBudget, AttackerPS->Faction);
-        }
-      }
-    }
   }
 
   if (DefenderPS) {
     DefenderPS->PendingArmyBudget = DefenderBudget;
     DefenderPS->PendingArmy.Reset();
     DefenderPS->bArmyLockedIn = false;
-
-    if (!DefenderPS->bIsAI) {
-      if (ASkaldPlayerController *DPC =
-              Cast<ASkaldPlayerController>(DefenderPS->GetOwner())) {
-        if (!IsAIControllerIdentity(DPC)) {
-          DPC->Client_ShowFighterSelection(DefenderBudget, DefenderPS->Faction);
-        }
-      }
-    }
   }
+
+  // Replicate the final budgets/participant rows before clients react to the
+  // FighterSelection phase. The old ordering showed the widget first, then
+  // reset/upserted participants, which let InitializeFighterSelectionIfNeeded
+  // see Phase=None/Budget=0 and churn input flags during streamed-map startup.
+  SyncBattlePlayerEntry(AttackerPS);
+  SyncBattlePlayerEntry(DefenderPS);
 
   if (ASkaldGameState *GS = GetGameState<ASkaldGameState>()) {
     GS->SetBattlePhase(EBattlePhase::FighterSelection);
   }
+
+  auto ShowSelectionForHuman = [](ASkaldPlayerState *PlayerState,
+                                  int32 Budget) {
+    if (!PlayerState || PlayerState->bIsAI) {
+      return;
+    }
+
+    if (ASkaldPlayerController *PC =
+            Cast<ASkaldPlayerController>(PlayerState->GetOwner())) {
+      if (!IsAIControllerIdentity(PC)) {
+        PC->Client_ShowFighterSelection(Budget, PlayerState->Faction);
+      }
+    }
+  };
+
+  ShowSelectionForHuman(AttackerPS, AttackerBudget);
+  ShowSelectionForHuman(DefenderPS, DefenderBudget);
 
   LogParticipantLockState(TEXT("BeginPreBattleSelection"));
 }

--- a/Source/Skald/Skald_PlayerController.cpp
+++ b/Source/Skald/Skald_PlayerController.cpp
@@ -2625,10 +2625,14 @@ void ASkaldPlayerController::InitializeFighterSelectionIfNeeded() {
                                                   ? CachedGameInstance->PendingBattle
                                                   : FS_BattlePayload();
 
+  // Only the replicated battle phase (or the authoritative Client_Show RPC)
+  // may open fighter selection. Treating a generic pending battle context as
+  // selection-ready lets the local controller display and interact with the
+  // widget before the streamed BattleGameMode has reset participants/budgets,
+  // which races with setup and causes duplicate UI/input-mode churn.
   const bool bInSelectionPhase =
-      !CachedGameState ||
-      CachedGameState->BattlePhase == EBattlePhase::FighterSelection ||
-      (CachedGameState->BattlePhase == EBattlePhase::None && bHasBattleContext);
+      CachedGameState &&
+      CachedGameState->BattlePhase == EBattlePhase::FighterSelection;
 
   ASkaldPlayerState *SelectionPS = GetPlayerState<ASkaldPlayerState>();
   int32 LocalPlayerId = SelectionPS ? ResolveStablePlayerId(SelectionPS) : INDEX_NONE;
@@ -2714,14 +2718,13 @@ void ASkaldPlayerController::InitializeFighterSelectionIfNeeded() {
       CachedGameInstance ? CachedGameInstance->GetBattleLevelManager() : nullptr;
   const bool bBattleStreamReady =
       !BattleLevelManager || BattleLevelManager->IsBattleLevelFullyReady();
-  // Streaming readiness can occasionally lag a frame behind map activation.
-  // Once the local controller is on the battle map, treat streaming as ready so
-  // we don't permanently gate fighter selection / input behind a stale flag.
-  const bool bEffectiveStreamReady = bBattleStreamReady || bOnBattleMap;
-  const bool bLikelyBattleContextReady =
-      bOnBattleMap || (bHasBattleContext && bInSelectionPhase && bEffectiveStreamReady);
+  // Streaming readiness can occasionally lag a frame behind the server phase
+  // transition, but do not use bOnBattleMap alone as readiness: GameInstance
+  // marks the map active before BattleGameMode setup has reset participants and
+  // assigned final budgets. The direct Client_Show RPC remains the immediate
+  // authority path; this self-heal path waits for both phase and stream-ready.
   const bool bCanShowSelectionUI =
-      bLikelyBattleContextReady && bInSelectionPhase && bEffectiveStreamReady &&
+      bInSelectionPhase && bBattleStreamReady &&
       !CachedGameInstance->IsTravelPending();
   if (!bIsParticipant || PendingBudget <= 0 || !bCanShowSelectionUI) {
     UE_LOG(LogSkaldBattle, Log,

--- a/Source/Skald/Skald_TurnManager.cpp
+++ b/Source/Skald/Skald_TurnManager.cpp
@@ -1047,6 +1047,28 @@ void ATurnManager::SyncGameStateTurnIndex() {
       }
     }
 
+    if (const USkaldGameInstance *GI = GetGameInstance<USkaldGameInstance>()) {
+      const FSkaldTravelState &TravelState = GI->GetTravelState();
+      const bool bBattleTurnStateFrozen =
+          GI->bTurnStateFrozenForTravel || GI->IsTravelPending() ||
+          GI->bIsInBattleMap || GS->BattlePhase != EBattlePhase::None;
+      const int32 FrozenActivePlayerId =
+          TravelState.AttackerPlayerId > 0 ? TravelState.AttackerPlayerId
+                                           : GS->ActivePlayerId;
+
+      if (bBattleTurnStateFrozen && FrozenActivePlayerId > 0 &&
+          NewActivePlayerId != FrozenActivePlayerId) {
+        GS->CurrentTurnIndex = GS->FindTurnIndexForStableId(FrozenActivePlayerId);
+        GS->SetActivePlayerId(FrozenActivePlayerId);
+        UE_LOG(LogSkald, Log,
+               TEXT("[TurnFreeze] Ctx=SyncGameStateTurnIndex Frozen=1 PreserveActiveId=%d SuppressedActiveId=%d Phase=%s BattlePhase=%s"),
+               FrozenActivePlayerId, NewActivePlayerId,
+               *UEnum::GetValueAsString(CurrentPhase),
+               *UEnum::GetValueAsString(GS->BattlePhase));
+        return;
+      }
+    }
+
     // Avoid thrashing the replicated ActivePlayerId while players reconnect to
     // the overview map after travel. If we previously had a valid active
     // player, keep broadcasting that stable value until the controllers have


### PR DESCRIPTION
### Motivation
- The logs showed fighter-selection UI and input mode toggles firing before the streamed battle `GameMode` finished bootstrapping, causing `Budget=0` / `Phase=None` churn and duplicate widget/input changes.
- Turn ownership could flip to the AI during battle bootstrap because `SyncGameStateTurnIndex` overwrote `ActivePlayerId` while travel/battle state was still settling.

### Description
- Tighten fighter-selection gating in `ASkaldPlayerController::InitializeFighterSelectionIfNeeded` so the widget is only shown when the replicated `BattlePhase` is `FighterSelection` (or via the authoritative `Client_ShowFighterSelection` RPC) and when the battle level manager reports fully ready; remove the prior shortcut that treated `bOnBattleMap` as sufficient readiness.
- Reorder `ASkald_BattleGameMode::BeginPreBattleSelection` to reset participant budgets, call `SyncBattlePlayerEntry` for participants, set `BattlePhase` to `FighterSelection`, and only then invoke `Client_ShowFighterSelection` for human controllers to avoid racey client-side selection/UI churn.
- Protect replicated active-turn updates in `ATurnManager::SyncGameStateTurnIndex` by preserving the attacker/travel active player while travel/battle state is active (using `bTurnStateFrozenForTravel`, `IsTravelPending()`, `bIsInBattleMap`, and `GS->BattlePhase`), preventing premature flips to AI ownership during bootstrap.
- Added targeted log lines to help diagnose preserved/suppressed active-player cases and the selection gating path. Files changed: `Source/Skald/Skald_PlayerController.cpp`, `Source/Skald/Skald_BattleGameMode.cpp`, `Source/Skald/Skald_TurnManager.cpp`.

### Testing
- Ran `git diff --check` to ensure no whitespace/format issues, which passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a18721b71b48324b81592c9cfd904a8)