### PR TITLE
Stabilize pre-battle fighter selection, camera behavior, and turn state across travel

### DIFF
--- a/Source/Skald/Skald_BattleGameMode.cpp
+++ b/Source/Skald/Skald_BattleGameMode.cpp
@@ -984,35 +984,41 @@ void ASkald_BattleGameMode::BeginPreBattleSelection(ASkaldPlayerState *AttackerP
     AttackerPS->PendingArmyBudget = AttackerBudget;
     AttackerPS->PendingArmy.Reset();
     AttackerPS->bArmyLockedIn = false;
-
-    if (!AttackerPS->bIsAI) {
-      if (ASkaldPlayerController *APC =
-              Cast<ASkaldPlayerController>(AttackerPS->GetOwner())) {
-        if (!IsAIControllerIdentity(APC)) {
-          APC->Client_ShowFighterSelection(AttackerBudget, AttackerPS->Faction);
-        }
-      }
-    }
   }
 
   if (DefenderPS) {
     DefenderPS->PendingArmyBudget = DefenderBudget;
     DefenderPS->PendingArmy.Reset();
     DefenderPS->bArmyLockedIn = false;
-
-    if (!DefenderPS->bIsAI) {
-      if (ASkaldPlayerController *DPC =
-              Cast<ASkaldPlayerController>(DefenderPS->GetOwner())) {
-        if (!IsAIControllerIdentity(DPC)) {
-          DPC->Client_ShowFighterSelection(DefenderBudget, DefenderPS->Faction);
-        }
-      }
-    }
   }
+
+  // Replicate the final budgets/participant rows before clients react to the
+  // FighterSelection phase. The old ordering showed the widget first, then
+  // reset/upserted participants, which let InitializeFighterSelectionIfNeeded
+  // see Phase=None/Budget=0 and churn input flags during streamed-map startup.
+  SyncBattlePlayerEntry(AttackerPS);
+  SyncBattlePlayerEntry(DefenderPS);
 
   if (ASkaldGameState *GS = GetGameState<ASkaldGameState>()) {
     GS->SetBattlePhase(EBattlePhase::FighterSelection);
   }
+
+  auto ShowSelectionForHuman = [](ASkaldPlayerState *PlayerState,
+                                  int32 Budget) {
+    if (!PlayerState || PlayerState->bIsAI) {
+      return;
+    }
+
+    if (ASkaldPlayerController *PC =
+            Cast<ASkaldPlayerController>(PlayerState->GetOwner())) {
+      if (!IsAIControllerIdentity(PC)) {
+        PC->Client_ShowFighterSelection(Budget, PlayerState->Faction);
+      }
+    }
+  };
+
+  ShowSelectionForHuman(AttackerPS, AttackerBudget);
+  ShowSelectionForHuman(DefenderPS, DefenderBudget);
 
   LogParticipantLockState(TEXT("BeginPreBattleSelection"));
 }

--- a/Source/Skald/Skald_PlayerController.cpp
+++ b/Source/Skald/Skald_PlayerController.cpp
@@ -2625,10 +2625,14 @@ void ASkaldPlayerController::InitializeFighterSelectionIfNeeded() {
                                                   ? CachedGameInstance->PendingBattle
                                                   : FS_BattlePayload();
 
+  // Only the replicated battle phase (or the authoritative Client_Show RPC)
+  // may open fighter selection. Treating a generic pending battle context as
+  // selection-ready lets the local controller display and interact with the
+  // widget before the streamed BattleGameMode has reset participants/budgets,
+  // which races with setup and causes duplicate UI/input-mode churn.
   const bool bInSelectionPhase =
-      !CachedGameState ||
-      CachedGameState->BattlePhase == EBattlePhase::FighterSelection ||
-      (CachedGameState->BattlePhase == EBattlePhase::None && bHasBattleContext);
+      CachedGameState &&
+      CachedGameState->BattlePhase == EBattlePhase::FighterSelection;
 
   ASkaldPlayerState *SelectionPS = GetPlayerState<ASkaldPlayerState>();
   int32 LocalPlayerId = SelectionPS ? ResolveStablePlayerId(SelectionPS) : INDEX_NONE;
@@ -2714,14 +2718,13 @@ void ASkaldPlayerController::InitializeFighterSelectionIfNeeded() {
       CachedGameInstance ? CachedGameInstance->GetBattleLevelManager() : nullptr;
   const bool bBattleStreamReady =
       !BattleLevelManager || BattleLevelManager->IsBattleLevelFullyReady();
-  // Streaming readiness can occasionally lag a frame behind map activation.
-  // Once the local controller is on the battle map, treat streaming as ready so
-  // we don't permanently gate fighter selection / input behind a stale flag.
-  const bool bEffectiveStreamReady = bBattleStreamReady || bOnBattleMap;
-  const bool bLikelyBattleContextReady =
-      bOnBattleMap || (bHasBattleContext && bInSelectionPhase && bEffectiveStreamReady);
+  // Streaming readiness can occasionally lag a frame behind the server phase
+  // transition, but do not use bOnBattleMap alone as readiness: GameInstance
+  // marks the map active before BattleGameMode setup has reset participants and
+  // assigned final budgets. The direct Client_Show RPC remains the immediate
+  // authority path; this self-heal path waits for both phase and stream-ready.
   const bool bCanShowSelectionUI =
-      bLikelyBattleContextReady && bInSelectionPhase && bEffectiveStreamReady &&
+      bInSelectionPhase && bBattleStreamReady &&
       !CachedGameInstance->IsTravelPending();
   if (!bIsParticipant || PendingBudget <= 0 || !bCanShowSelectionUI) {
     UE_LOG(LogSkaldBattle, Log,
@@ -6076,8 +6079,27 @@ void ASkaldPlayerController::UpdateBattleCameraMode() {
     return;
   }
 
+  if (!CachedGameInstance) {
+    CachedGameInstance = GetGameInstance<USkaldGameInstance>();
+  }
+
   ASkald_PlayerCharacter *CameraPawn = Cast<ASkald_PlayerCharacter>(GetPawn());
   if (!CameraPawn) {
+    return;
+  }
+
+  const ASkaldPlayerState *LocalPS = GetPlayerState<ASkaldPlayerState>();
+  const bool bSelectionWidgetActive =
+      FighterSelectionWidget && FighterSelectionWidget->IsInViewport();
+  const bool bSelectionLockedIn =
+      bBattleHUDReadyToShow || bBattleHUDVisible ||
+      (LocalPS && LocalPS->bArmyLockedIn);
+
+  // Do not let battle replication/setup callbacks lock or unlock the camera
+  // while the player is still choosing fighters. The overview camera should
+  // continue naturally until lock-in; after lock-in, battle camera focus can
+  // follow the normal active-fighter flow without stream/phase gates.
+  if (bSelectionWidgetActive && !bSelectionLockedIn) {
     return;
   }
 
@@ -6087,13 +6109,12 @@ void ASkaldPlayerController::UpdateBattleCameraMode() {
   CameraPawn->SetBattleCameraActive(bBattleMapActive);
 
   if (!bBattleMapActive) {
-    CameraPawn->ClearCameraFocus();
     return;
   }
 
   if (LockedActiveFighter && LockedActiveFighter->IsAlive()) {
     CameraPawn->FocusCameraOnActor(LockedActiveFighter.Get());
-  } else {
+  } else if (bSelectionLockedIn) {
     CameraPawn->ClearCameraFocus();
   }
 }
@@ -6230,20 +6251,12 @@ void ASkaldPlayerController::HandlePostLockInBattleInputReconcileTick() {
     CachedGameInstance = GetGameInstance<USkaldGameInstance>();
   }
 
-  bool bReady = false;
-  if (CachedGameInstance) {
-    if (const USkaldBattleLevelManager* BattleLevelManager =
-            CachedGameInstance->GetBattleLevelManager()) {
-      bReady = BattleLevelManager->IsBattleLevelFullyReady();
-    }
-
-    if (bReady && !CachedGameInstance->bIsInBattleMap) {
-      CachedGameInstance->SetBattleMapActive(true);
-      DetectBattleMap();
-      UE_LOG(LogSkaldBattle, Log,
-             TEXT("PostLockInReconcile: Promoted streamed battle-map active for %s"),
-             *GetName());
-    }
+  if (CachedGameInstance && !CachedGameInstance->bIsInBattleMap) {
+    CachedGameInstance->SetBattleMapActive(true);
+    DetectBattleMap();
+    UE_LOG(LogSkaldBattle, Log,
+           TEXT("PostLockInReconcile: Promoted battle-map active after lock-in for %s"),
+           *GetName());
   }
 
   const bool bBattleMapActive =
@@ -6295,18 +6308,12 @@ void ASkaldPlayerController::HandleFighterSelectionLockedIn() {
     CachedGameInstance = GetGameInstance<USkaldGameInstance>();
   }
 
-  // Streamed battles can keep the game-instance battle-map flag false until
-  // the streaming manager reports the level as fully loaded/visible. Promote
-  // the flag at lock-in time so post-selection interaction (camera/click
-  // handling) can transition to battle mode reliably without waiting on
-  // unrelated world-travel style state changes.
+  // Fighter lock-in is the only local gate for transitioning camera/input to
+  // battle mode. Do not wait on streamed-level readiness here; the overview
+  // camera has already carried the player into the battle context, and
+  // post-lock-in reconciliation will settle HUD/input as actors arrive.
   if (CachedGameInstance && !CachedGameInstance->bIsInBattleMap) {
-    const USkaldBattleLevelManager* BattleLevelManager =
-        CachedGameInstance->GetBattleLevelManager();
-    if (BattleLevelManager && BattleLevelManager->IsBattleLevelFullyReady()) {
-      CachedGameInstance->SetBattleMapActive(true);
-      DetectBattleMap();
-    }
+    CachedGameInstance->SetBattleMapActive(true);
   }
 
   DetectBattleMap();

--- a/Source/Skald/Skald_TurnManager.cpp
+++ b/Source/Skald/Skald_TurnManager.cpp
@@ -1047,6 +1047,27 @@ void ATurnManager::SyncGameStateTurnIndex() {
       }
     }
 
+    if (const USkaldGameInstance *GI = GetGameInstance<USkaldGameInstance>()) {
+      const FSkaldTravelState &TravelState = GI->GetTravelState();
+      const bool bBattleTurnStateFrozen =
+          GI->bTurnStateFrozenForTravel || GI->IsTravelPending();
+      const int32 FrozenActivePlayerId =
+          TravelState.AttackerPlayerId > 0 ? TravelState.AttackerPlayerId
+                                           : GS->ActivePlayerId;
+
+      if (bBattleTurnStateFrozen && FrozenActivePlayerId > 0 &&
+          NewActivePlayerId != FrozenActivePlayerId) {
+        GS->CurrentTurnIndex = GS->FindTurnIndexForStableId(FrozenActivePlayerId);
+        GS->SetActivePlayerId(FrozenActivePlayerId);
+        UE_LOG(LogSkald, Log,
+               TEXT("[TurnFreeze] Ctx=SyncGameStateTurnIndex Frozen=1 PreserveActiveId=%d SuppressedActiveId=%d Phase=%s BattlePhase=%s"),
+               FrozenActivePlayerId, NewActivePlayerId,
+               *UEnum::GetValueAsString(CurrentPhase),
+               *UEnum::GetValueAsString(GS->BattlePhase));
+        return;
+      }
+    }
+
     // Avoid thrashing the replicated ActivePlayerId while players reconnect to
     // the overview map after travel. If we previously had a valid active
     // player, keep broadcasting that stable value until the controllers have


### PR DESCRIPTION
### Motivation
- Prevent client-side races where fighter-selection UI and input modes appear before the server has reset/replicated participant rows and final budgets, causing duplicate UI churn and dropped RPCs.  
- Avoid camera focus or battle-mode transitions while the local player is still choosing fighters.  
- Preserve the active turn owner during travel/resume so replicated turn ownership does not flip while controllers re-register.

### Description
- Reordered `BeginPreBattleSelection` to replicate participant entries via `SyncBattlePlayerEntry` and set the battle phase before showing fighter-selection UI, and moved per-player `Client_ShowFighterSelection` calls into a shared `ShowSelectionForHuman` helper so the widget is displayed only after server state is synced.  
- Tightened selection gating in `ASkaldPlayerController::InitializeFighterSelectionIfNeeded` to require a replicated `CachedGameState` with `BattlePhase == EBattlePhase::FighterSelection` (instead of inferring from travel context) and require the battle level to be stream-ready before creating the selection UI.  
- Prevented camera mode/camera-focus transitions while the fighter-selection widget is active by short-circuiting `UpdateBattleCameraMode` until lock-in, and adjusted camera unlock behavior to clear focus only after lock-in.  
- Simplified post-lock-in reconciliation and promoted the game-instance battle-map active flag at lock-in time so HUD/input settle reliably after player lock-in.  
- In `ATurnManager::SyncGameStateTurnIndex`, added logic to detect travel/turn-freeze (`bTurnStateFrozenForTravel` / `IsTravelPending`) and preserve the frozen active player id from `FSkaldTravelState` to avoid broadcasting transient active-player changes during controller re-registration.  

### Testing
- Project compiled successfully after changes.  
- Ran the automated unit/integration tests in the repository CI suite and all tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a18721b71b48324b81592c9cfd904a8)