### PR TITLE
Fix battle camera lock-in compile error

### DIFF
--- a/Source/Skald/Skald_PlayerController.cpp
+++ b/Source/Skald/Skald_PlayerController.cpp
@@ -6148,7 +6148,8 @@ void ASkaldPlayerController::UpdateBattleCameraMode() {
 
   if (LockedActiveFighter && LockedActiveFighter->IsAlive()) {
     CameraPawn->FocusCameraOnActor(LockedActiveFighter.Get());
-  } else if (bSelectionLockedIn) {
+  } else if (bBattleHUDReadyToShow || bBattleHUDVisible ||
+             (BattleHudWidget && BattleHudWidget->IsInViewport())) {
     CameraPawn->ClearCameraFocus();
   }
 }


### PR DESCRIPTION
### Motivation
- The `UpdateBattleCameraMode` function referenced an undefined variable `bSelectionLockedIn`, which produced a compile error.

### Description
- Replace the `bSelectionLockedIn` check with existing HUD state checks `bBattleHUDReadyToShow`, `bBattleHUDVisible`, and `(BattleHudWidget && BattleHudWidget->IsInViewport())` in `ASkaldPlayerController::UpdateBattleCameraMode` (file `Source/Skald/Skald_PlayerController.cpp`).

### Testing
- Ran `rg "bSelectionLockedIn" Source/Skald; test $? -eq 1` to verify no remaining references, which succeeded.
- Ran `git diff --check` to validate the patch for whitespace/error issues, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1878c6d2588324a5a3c82516e2ceca)