### PR TITLE
Always stream battle maps as sublevels; remove travel fallback and fix camera

### DIFF
--- a/Source/Skald/SkaldTypes.h
+++ b/Source/Skald/SkaldTypes.h
@@ -139,11 +139,11 @@ struct SKALD_API FS_BattlePayload
     UPROPERTY(BlueprintReadWrite, EditAnywhere)
     int32 DefenderArmyCount = 0;
 
-    /** Cached display name for the attacking player when travelling to the battle map. */
+    /** Cached display name for the attacking player when streaming the battle map. */
     UPROPERTY(BlueprintReadWrite, EditAnywhere)
     FString AttackerDisplayName;
 
-    /** Cached display name for the defending player when travelling to the battle map. */
+    /** Cached display name for the defending player when streaming the battle map. */
     UPROPERTY(BlueprintReadWrite, EditAnywhere)
     FString DefenderDisplayName;
 
@@ -187,7 +187,7 @@ struct SKALD_API FS_BattlePayload
     UPROPERTY(BlueprintReadWrite, EditAnywhere)
     int32 RandomSeed = 0;
 
-    /** Map name to travel back to once the battle concludes. */
+    /** Overview map name associated with the streamed battle context. */
     UPROPERTY(BlueprintReadWrite, EditAnywhere)
     FString ReturnMap;
 };

--- a/Source/Skald/Skald_BattleLevelManager.cpp
+++ b/Source/Skald/Skald_BattleLevelManager.cpp
@@ -9,10 +9,14 @@
 #include "Engine/LevelStreamingDynamic.h"
 #include "Misc/PackageName.h"
 #include "GameFramework/Actor.h"
+#include "GameFramework/Controller.h"
 #include "GameFramework/GameModeBase.h"
+#include "GameFramework/Pawn.h"
+#include "GameFramework/PlayerController.h"
 #include "GameFramework/WorldSettings.h"
 #include "Skald_BattleGameMode.h"
 #include "Skald_GameInstance.h"
+#include "Skald_PlayerCharacter.h"
 #include "SkaldLogging.h"
 #include "UObject/Package.h"
 #include "UObject/SoftObjectPath.h"
@@ -38,21 +42,6 @@ static ULevelStreaming *FindStreamingLevelFor(ULevel *Level)
   }
 
   return nullptr;
-}
-
-static void SetPersistentLevelVisibility(UWorld *World, ULevel *PersistentLevel,
-                                         bool bShouldBeVisible)
-{
-  if (!PersistentLevel) {
-    return;
-  }
-
-  if (ULevelStreaming *StreamingLevel = FindStreamingLevelFor(PersistentLevel)) {
-    StreamingLevel->SetShouldBeVisible(bShouldBeVisible);
-    if (World) {
-      World->UpdateLevelStreaming();
-    }
-  }
 }
 
 static FString ResolveStreamingLevelPackageName(const ULevelStreaming *Level)
@@ -499,6 +488,8 @@ void USkaldBattleLevelManager::HandleLevelLoaded() {
       }
     }
     ASkald_BattleGameMode *BattleGM = ActiveBattleGameMode.Get();
+    RecenterLocalBattleCameras();
+
     if (BattleGM) {
       BattleGM->NotifyBattleLevelActivated();
     } else {
@@ -783,9 +774,9 @@ void USkaldBattleLevelManager::HideNonBattleLevels() {
           continue;
         }
 
-        // Skip world settings so the world retains its authoritative
-        // configuration while the overworld is hidden.
-        if (Actor->IsA<AWorldSettings>()) {
+        // Skip world settings and player-owned camera pawns/controllers so the
+        // persistent player view keeps ticking while only the battle map is visible.
+        if (ShouldKeepPersistentActorForBattle(Actor)) {
           continue;
         }
 
@@ -807,9 +798,8 @@ void USkaldBattleLevelManager::HideNonBattleLevels() {
         }
       }
 
-      SetPersistentLevelVisibility(StreamingWorld, PersistentLevel, false);
       UE_LOG(LogSkald, Verbose,
-             TEXT("BattleLevelManager: Hiding persistent level %s"),
+             TEXT("BattleLevelManager: Hid persistent overworld actors in %s while keeping camera actors active"),
              *PersistentLevel->GetOutermost()->GetName());
     }
   }
@@ -852,12 +842,9 @@ void USkaldBattleLevelManager::RestoreNonBattleLevels() {
         StreamingWorld = PersistentLevel->GetWorld();
       }
 
-      SetPersistentLevelVisibility(StreamingWorld, PersistentLevel,
-                                   bPersistentLevelWasVisible);
-
       if (bPersistentLevelWasVisible) {
         UE_LOG(LogSkald, Verbose,
-               TEXT("BattleLevelManager: Restored persistent level %s"),
+               TEXT("BattleLevelManager: Restored persistent overworld actors in %s"),
                *PersistentLevel->GetOutermost()->GetName());
       }
     }
@@ -928,6 +915,81 @@ bool USkaldBattleLevelManager::IsStreamingLevelPartOfBattleMap(
   }
 
   return false;
+}
+
+bool USkaldBattleLevelManager::ShouldKeepPersistentActorForBattle(AActor* Actor) const {
+  if (!Actor) {
+    return false;
+  }
+
+  if (Actor->IsA<AWorldSettings>() || Actor->IsA<ASkald_PlayerCharacter>()) {
+    return true;
+  }
+
+  const APawn* Pawn = Cast<APawn>(Actor);
+  if (Pawn && Pawn->GetController()) {
+    return true;
+  }
+
+  return Actor->IsA<AController>();
+}
+
+bool USkaldBattleLevelManager::CalculateActiveBattleLevelBounds(FBox& OutBounds) const {
+  OutBounds.Init();
+
+  const ULevelStreaming* StreamingLevel = ActiveStreamingLevel.Get();
+  ULevel* LoadedLevel = StreamingLevel ? StreamingLevel->GetLoadedLevel() : nullptr;
+  if (!LoadedLevel) {
+    return false;
+  }
+
+  for (AActor* Actor : LoadedLevel->Actors) {
+    if (!Actor || Actor->IsA<AWorldSettings>() || Actor->IsA<AGameModeBase>()) {
+      continue;
+    }
+
+    const FBox ActorBounds = Actor->GetComponentsBoundingBox(/*bNonColliding=*/true);
+    if (ActorBounds.IsValid) {
+      OutBounds += ActorBounds;
+    }
+  }
+
+  return OutBounds.IsValid;
+}
+
+void USkaldBattleLevelManager::RecenterLocalBattleCameras() {
+  UWorld* World = nullptr;
+  if (ULevelStreaming* StreamingLevel = ActiveStreamingLevel.Get()) {
+    World = StreamingLevel->GetWorld();
+  }
+  if (!World) {
+    return;
+  }
+
+  FBox BattleBounds;
+  const bool bHasBounds = CalculateActiveBattleLevelBounds(BattleBounds);
+  const FVector BattleCenter = bHasBounds ? BattleBounds.GetCenter() : FVector::ZeroVector;
+  const FVector CameraLocation(BattleCenter.X, BattleCenter.Y,
+                               bHasBounds ? FMath::Max(BattleCenter.Z, BattleBounds.Max.Z) : BattleCenter.Z);
+
+  for (FConstPlayerControllerIterator It = World->GetPlayerControllerIterator(); It; ++It) {
+    APlayerController* PC = It->Get();
+    if (!PC || !PC->IsLocalController()) {
+      continue;
+    }
+
+    ASkald_PlayerCharacter* CameraPawn = Cast<ASkald_PlayerCharacter>(PC->GetPawn());
+    if (!CameraPawn) {
+      CameraPawn = Cast<ASkald_PlayerCharacter>(PC->GetViewTarget());
+    }
+    if (!CameraPawn) {
+      continue;
+    }
+
+    CameraPawn->SetBattleCameraActive(true);
+    CameraPawn->SetActorLocation(CameraLocation);
+    PC->SetViewTarget(CameraPawn);
+  }
 }
 
 bool USkaldBattleLevelManager::ResolveOrStreamLevel(

--- a/Source/Skald/Skald_BattleLevelManager.h
+++ b/Source/Skald/Skald_BattleLevelManager.h
@@ -53,6 +53,9 @@ private:
                             ULevelStreaming*& OutStreamingLevel, const TCHAR* ContextLabel);
   void ApplyVisibilityForCurrentMode();
   bool IsStreamingLevelPartOfDiceBoard(ULevelStreaming* Level) const;
+  bool ShouldKeepPersistentActorForBattle(AActor* Actor) const;
+  void RecenterLocalBattleCameras();
+  bool CalculateActiveBattleLevelBounds(FBox& OutBounds) const;
 
   void HandleLevelLoaded();
   void HandleLevelUnloaded();

--- a/Source/Skald/Skald_GameInstance.h
+++ b/Source/Skald/Skald_GameInstance.h
@@ -56,7 +56,7 @@ struct FSkaldTravelState
   UPROPERTY(BlueprintReadWrite, EditAnywhere)
   int32 DefenderTerritory = -1;
 
-  /** Canonical map to return to once battle travel completes. */
+  /** Canonical overview map associated with the active streamed battle. */
   UPROPERTY(BlueprintReadWrite, EditAnywhere)
   FString ReturnMap;
 
@@ -191,11 +191,11 @@ public:
             meta = (DisplayName = "Dice Board Streamed Sublevel", AllowedClasses = "/Script/Engine.World"))
   TSoftObjectPtr<UWorld> DiceBoardSublevel;
 
-  /** True when the game has travelled to a dedicated battle map. */
+  /** True when a streamed battle sublevel is active. */
   UPROPERTY(BlueprintReadWrite, Category = "Battle")
   bool bIsInBattleMap = false;
 
-  /** True while a ServerTravel call is in flight. */
+  /** True while a battle/overworld streaming transition is in flight. */
   UPROPERTY(Transient)
   bool bTravelPending = false;
 
@@ -206,12 +206,12 @@ public:
   UPROPERTY(Transient)
   TWeakObjectPtr<ASkald_BattleGameMode> ActiveBattleGameMode;
 
-  /** Snapshot of the overworld territories captured before travelling. */
+  /** Snapshot of the overworld territories captured before battle streaming. */
   UPROPERTY(BlueprintReadWrite, Category = "Battle")
   TArray<FS_Territory> CachedWorldMapTerritories;
 
-  /** Snapshot captured immediately before travelling so the overworld can be
-   *  restored when returning from a battle map. */
+  /** Snapshot captured immediately before battle streaming so the overworld can be
+   *  restored after unloading a battle sublevel. */
   UPROPERTY(BlueprintReadWrite, Category = "Battle")
   TArray<FS_Territory> PendingTravelTerritories;
 
@@ -227,7 +227,7 @@ public:
   UPROPERTY(BlueprintReadWrite, Category = "Turn")
   int32 SavedTurnPlayerId = 0;
 
-  /** Phase of the turn cycle that was active before travelling. */
+  /** Phase of the turn cycle that was active before battle streaming. */
   UPROPERTY(BlueprintReadWrite, Category = "Turn")
   ETurnPhase SavedTurnPhase = ETurnPhase::Reinforcement;
 
@@ -315,21 +315,20 @@ public:
     return PendingTravelTerritories;
   }
 
-  /** Store the canonical map path we should travel back to once combat
-   *  concludes. */
+  /** Store the canonical overview map path associated with combat cleanup. */
   void SetPendingReturnMap(const FString &InReturnMap);
 
-  /** Return the currently cached travel destination, if any. */
+  /** Return the currently cached overview map path, if any. */
   const FString &GetPendingReturnMap() const { return PendingReturnMap; }
 
-  /** Clear any cached return destination once travel has completed. */
+  /** Clear any cached overview map path once battle cleanup has completed. */
   void ClearPendingReturnMap();
 
-  /** Toggle the travel pending guard and log the change. */
+  /** Toggle the streaming pending guard and log the change. */
   UFUNCTION(BlueprintCallable)
   void SetTravelPending(bool bInPending);
 
-  /** Whether the game instance currently expects a travel to complete. */
+  /** Whether the game instance currently expects streaming to complete. */
   UFUNCTION(BlueprintCallable, BlueprintPure)
   bool IsTravelPending() const;
 

--- a/Source/Skald/Skald_TurnManager.cpp
+++ b/Source/Skald/Skald_TurnManager.cpp
@@ -492,7 +492,7 @@ void ATurnManager::BeginPlay() {
       ResolveGridBattleResult();
     }
 
-    // On the battle map, listen for battle end and travel back on event
+    // While the streamed battle map is active, listen for its battle-end event.
     if (!bOnWorldMap) {
       AttemptBindBattleEnd(GI);
     }
@@ -524,12 +524,12 @@ void ATurnManager::EndPlay(const EEndPlayReason::Type EndPlayReason) {
 
   if (UWorld *World = GetWorld()) {
     FTimerManager &TimerManager = World->GetTimerManager();
-    TimerManager.ClearTimer(BattleReturnDelayHandle);
+    TimerManager.ClearTimer(BattleConclusionDelayHandle);
     TimerManager.ClearTimer(BattleEndBindingRetryHandle);
     TimerManager.ClearTimer(PhaseBroadcastRetryHandle);
   }
   bPhaseBroadcastRetryActive = false;
-  bBattleReturnPending = false;
+  bBattleConclusionPending = false;
 
   Super::EndPlay(EndPlayReason);
 }
@@ -546,20 +546,20 @@ void ATurnManager::HandleGridBattleEnded(ESkaldFaction /*WinningFaction*/, int32
     ClearBattleEndBinding(GI);
   }
 
-  if (bBattleReturnPending) {
+  if (bBattleConclusionPending) {
     return;
   }
 
   UWorld *World = GetWorld();
   if (World) {
-    World->GetTimerManager().ClearTimer(BattleReturnDelayHandle);
+    World->GetTimerManager().ClearTimer(BattleConclusionDelayHandle);
   }
 
-  bBattleReturnPending = true;
+  bBattleConclusionPending = true;
 
   if (World && BattleResultReturnDelaySeconds > 0.f) {
     World->GetTimerManager().SetTimer(
-        BattleReturnDelayHandle, this, &ATurnManager::CompleteBattleConclusion,
+        BattleConclusionDelayHandle, this, &ATurnManager::CompleteBattleConclusion,
         BattleResultReturnDelaySeconds, false);
   } else {
     CompleteBattleConclusion();
@@ -569,117 +569,43 @@ void ATurnManager::HandleGridBattleEnded(ESkaldFaction /*WinningFaction*/, int32
 void ATurnManager::CompleteBattleConclusion() {
   UWorld *World = GetWorld();
   if (World) {
-    World->GetTimerManager().ClearTimer(BattleReturnDelayHandle);
+    World->GetTimerManager().ClearTimer(BattleConclusionDelayHandle);
   }
 
   USkaldGameInstance *GI = GetGameInstance<USkaldGameInstance>();
   if (GI && !GI->bIsInBattleMap) {
     UE_LOG(LogSkald, Verbose,
-           TEXT("CompleteBattleConclusion aborted: battle map already inactive."));
-    bBattleReturnPending = false;
+           TEXT("CompleteBattleConclusion aborted: streamed battle map already inactive."));
+    bBattleConclusionPending = false;
     return;
   }
-
-  if (GI && GI->bTravelPending) {
-    UE_LOG(LogSkald, Warning,
-           TEXT("CompleteBattleConclusion aborted: travel already pending."));
-    bBattleReturnPending = false;
-    return;
-  }
-
-  FString ReturnMapName;
-  FString ReturnMapSource;
-  if (!ResolveBattleReturnMapName(ReturnMapName, ReturnMapSource)) {
-    const FString PendingBattleValue = PendingBattle.ReturnMap;
-    const FString GameInstanceValue = GI ? GI->PendingBattle.ReturnMap : FString();
-    const TCHAR *PendingValueForLog =
-        PendingBattleValue.IsEmpty() ? TEXT("<Empty>") : *PendingBattleValue;
-    const TCHAR *GameInstanceValueForLog =
-        GameInstanceValue.IsEmpty() ? TEXT("<Empty>") : *GameInstanceValue;
-    UE_LOG(LogSkald, Error,
-           TEXT("HandleGridBattleEnded: unable to resolve return map (Pending='%s', GI='%s')."),
-           PendingValueForLog, GameInstanceValueForLog);
-    bBattleReturnPending = false;
-    return;
-  }
-
-  if (ReturnMapSource == TEXT("FallbackOverviewMap") && GI) {
-    GI->SetPendingReturnMap(ReturnMapName);
-  }
-
-  UE_LOG(LogSkald, Verbose,
-         TEXT("HandleGridBattleEnded: resolved return map '%s' from %s."),
-         *ReturnMapName, *ReturnMapSource);
 
   const bool bHasPendingResolution =
       GI && GI->bPendingBattleResolution && GI->PendingBattleResolution.bValid;
   if (bHasPendingResolution) {
     UE_LOG(LogSkald, Verbose,
-           TEXT("HandleGridBattleEnded: reusing already captured pending battle resolution."));
+           TEXT("CompleteBattleConclusion: reusing already captured pending battle resolution."));
   } else {
     ResolveGridBattleResult();
   }
 
   if (GI) {
-    GI->SetTravelPending(true);
+    if (USkaldBattleLevelManager *BattleLevelManager =
+            GI->GetBattleLevelManager()) {
+      BattleLevelManager->ReleaseBattleLevel();
+    }
+
+    GI->SetTravelPending(false);
   }
 
-  if (!World) {
-    World = GetWorld();
+  if (HasAuthority()) {
+    MulticastSetBattleMapActive(false);
   }
 
-  if (World) {
-    const ENetMode NetMode = World->GetNetMode();
-    auto NetModeToString = [](ENetMode InNetMode) {
-      switch (InNetMode) {
-      case NM_Standalone:
-        return TEXT("NM_Standalone");
-      case NM_DedicatedServer:
-        return TEXT("NM_DedicatedServer");
-      case NM_ListenServer:
-        return TEXT("NM_ListenServer");
-      case NM_Client:
-        return TEXT("NM_Client");
-      case NM_MAX:
-        return TEXT("NM_MAX");
-      default:
-        return TEXT("Unknown");
-      }
-    };
-    const TCHAR *NetModeStringPtr = NetModeToString(NetMode);
+  UE_LOG(LogSkald, Log,
+         TEXT("CompleteBattleConclusion: resolved battle and released streamed battle sublevel without map travel."));
 
-    UE_LOG(LogSkald, Log,
-           TEXT("HandleGridBattleEnded: travelling to '%s' (source=%s, NetMode=%s)."),
-           *ReturnMapName, *ReturnMapSource,
-           NetModeStringPtr);
-
-    switch (NetMode) {
-    case NM_Standalone: {
-      const FName LevelName(*ReturnMapName);
-      UGameplayStatics::OpenLevel(World, LevelName, /*bAbsolute=*/true);
-      break;
-    }
-    case NM_DedicatedServer:
-    case NM_ListenServer: {
-      FString ListenTarget = ReturnMapName;
-      if (!ListenTarget.Contains(TEXT("?listen"))) {
-        ListenTarget.Append(TEXT("?listen"));
-      }
-      World->ServerTravel(ListenTarget);
-      break;
-    }
-    case NM_Client:
-      // Clients should wait for the server's travel notification instead of
-      // loading the map locally with an incomplete URL. The pending server
-      // travel initiated above will automatically move connected clients.
-      break;
-    default:
-      World->ServerTravel(ReturnMapName);
-      break;
-    }
-  }
-
-  bBattleReturnPending = false;
+  bBattleConclusionPending = false;
 }
 
 bool ATurnManager::ResolveBattleReturnMapName(FString &OutReturnMapName,
@@ -2408,11 +2334,11 @@ void ATurnManager::TriggerGridBattle(const FS_BattlePayload &Battle) {
     DeferredPendingBattle = SeededBattle;
 
     if (UWorld *World = GetWorld()) {
-      if (!World->GetTimerManager().IsTimerActive(PendingBattleTravelRetryHandle)) {
+      if (!World->GetTimerManager().IsTimerActive(PendingBattleStreamRetryHandle)) {
         FTimerDelegate RetryDelegate =
-            FTimerDelegate::CreateUObject(this, &ATurnManager::RetryPendingBattleTravel);
+            FTimerDelegate::CreateUObject(this, &ATurnManager::RetryPendingBattleStream);
         constexpr float RetryDelaySeconds = 0.1f;
-        World->GetTimerManager().SetTimer(PendingBattleTravelRetryHandle, RetryDelegate,
+        World->GetTimerManager().SetTimer(PendingBattleStreamRetryHandle, RetryDelegate,
                                           RetryDelaySeconds, false);
       }
     }
@@ -2422,7 +2348,7 @@ void ATurnManager::TriggerGridBattle(const FS_BattlePayload &Battle) {
   bool bGameModeHasSnapshotAfterCall = GI && GI->CachedWorldMapTerritories.Num() > 0;
 
   if (UWorld *ExistingWorld = GetWorld()) {
-    ExistingWorld->GetTimerManager().ClearTimer(PendingBattleTravelRetryHandle);
+    ExistingWorld->GetTimerManager().ClearTimer(PendingBattleStreamRetryHandle);
   }
 
   if (UWorld *World = GetWorld()) {
@@ -2443,7 +2369,7 @@ void ATurnManager::TriggerGridBattle(const FS_BattlePayload &Battle) {
              *SeededBattle.ReturnMap);
     } else {
       UE_LOG(LogSkald, Log,
-             TEXT("TriggerGridBattle: storing return map '%s' before travelling to battle."),
+             TEXT("TriggerGridBattle: storing overview map '%s' before streaming battle sublevel."),
              *SeededBattle.ReturnMap);
       if (GI) {
         GI->SetPendingReturnMap(SeededBattle.ReturnMap);
@@ -2507,9 +2433,8 @@ void ATurnManager::TriggerGridBattle(const FS_BattlePayload &Battle) {
     }
 
     const bool bIsCapitalAttack = SeededBattle.IsCapitalAttack;
-    // Prefer in-world streamed battle transitions so turn/payload state remains
-    // in the same persistent world rather than relying on map travel.
-    bool bShouldStreamSelectedMap = true;
+    // Battle transitions are always in-world streamed sublevels so turn/payload
+    // state remains in the same persistent world.
     TSoftObjectPtr<UWorld> SelectedBattleMap;
     if (bIsCapitalAttack && CapitalMaps.Num() > 0) {
       const int32 Index = FMath::RandRange(0, CapitalMaps.Num() - 1);
@@ -2533,18 +2458,10 @@ void ATurnManager::TriggerGridBattle(const FS_BattlePayload &Battle) {
           FSoftObjectPath(TEXT("/Game/Blueprints/Maps/BattleMap.BattleMap")));
     }
 
-    // Keep this guard for environments where streaming may be disabled and we
-    // need to fall back to travel.
     const ENetMode NetMode = World->GetNetMode();
     UE_LOG(LogSkald, Log,
-           TEXT("TriggerGridBattle: streaming battle map transition enabled (net mode %d)."),
+           TEXT("TriggerGridBattle: streaming battle sublevel transition required (net mode %d)."),
            static_cast<int32>(NetMode));
-
-    FString MapToLoad =
-        SelectedBattleMap.ToSoftObjectPath().GetLongPackageName();
-    if (MapToLoad.IsEmpty()) {
-      MapToLoad = TEXT("/Game/Blueprints/Maps/BattleMap");
-    }
 
     ASkaldGameState *GS = World->GetGameState<ASkaldGameState>();
 
@@ -2755,7 +2672,7 @@ void ATurnManager::TriggerGridBattle(const FS_BattlePayload &Battle) {
 
     if (TravelState.CachedTerritories.Num() == 0) {
       UE_LOG(LogSkald, Warning,
-             TEXT("TriggerGridBattle deferred: territory snapshot unavailable; retrying before travel."));
+             TEXT("TriggerGridBattle deferred: territory snapshot unavailable; retrying before streaming."));
 
       if (GI) {
         GI->SetTravelPending(false);
@@ -2763,11 +2680,11 @@ void ATurnManager::TriggerGridBattle(const FS_BattlePayload &Battle) {
         GI->bResumeTurns = false;
       }
 
-      if (World && !World->GetTimerManager().IsTimerActive(PendingBattleTravelRetryHandle)) {
+      if (World && !World->GetTimerManager().IsTimerActive(PendingBattleStreamRetryHandle)) {
         FTimerDelegate RetryDelegate = FTimerDelegate::CreateUObject(
-            this, &ATurnManager::RetryPendingBattleTravel);
+            this, &ATurnManager::RetryPendingBattleStream);
         constexpr float RetryDelaySeconds = 0.1f;
-        World->GetTimerManager().SetTimer(PendingBattleTravelRetryHandle, RetryDelegate,
+        World->GetTimerManager().SetTimer(PendingBattleStreamRetryHandle, RetryDelegate,
                                           RetryDelaySeconds, false);
       }
 
@@ -2775,7 +2692,7 @@ void ATurnManager::TriggerGridBattle(const FS_BattlePayload &Battle) {
     }
 
     if (World) {
-      World->GetTimerManager().ClearTimer(PendingBattleTravelRetryHandle);
+      World->GetTimerManager().ClearTimer(PendingBattleStreamRetryHandle);
     }
 
     FS_BattlePayload PendingPayload = SeededBattle;
@@ -2868,33 +2785,17 @@ void ATurnManager::TriggerGridBattle(const FS_BattlePayload &Battle) {
 
       if (USkaldBattleLevelManager *BattleLevelManager =
               GI->GetBattleLevelManager()) {
-        if (bShouldStreamSelectedMap) {
-          bStreamingBattle = BattleLevelManager->RequestBattleLevel(
-              World, SelectedBattleMap, PendingPayload);
-        }
+        bStreamingBattle = BattleLevelManager->RequestBattleLevel(
+            World, SelectedBattleMap, PendingPayload);
       }
 
-      if (bShouldStreamSelectedMap) {
-        if (bStreamingBattle) {
-          if (World->GetNetMode() != NM_Standalone) {
-            MulticastStreamBattleLevel(SelectedBattleMap.ToSoftObjectPath(),
-                                       TravelState, PendingPayload);
-          }
-        } else {
-          GI->SetTravelPending(true);
+      if (bStreamingBattle) {
+        if (World->GetNetMode() != NM_Standalone) {
+          MulticastStreamBattleLevel(SelectedBattleMap.ToSoftObjectPath(),
+                                     TravelState, PendingPayload);
         }
       } else {
         GI->SetTravelPending(true);
-      }
-
-      // Streamed battle-map activation is owned by the battle level manager as
-      // soon as its sublevel request is accepted. Non-streamed travel still
-      // needs the turn manager to publish the active battle-map flag directly.
-      if (!bShouldStreamSelectedMap) {
-        GI->SetBattleMapActive(true);
-        if (World->GetNetMode() != NM_Standalone) {
-          MulticastSetBattleMapActive(true);
-        }
       }
     }
 
@@ -2907,40 +2808,22 @@ void ATurnManager::TriggerGridBattle(const FS_BattlePayload &Battle) {
            TravelState.HumanOwnedTerritories.Num(),
            TravelState.CachedTerritories.Num());
 
-    if (bShouldStreamSelectedMap && !bStreamingBattle) {
+    if (!bStreamingBattle) {
       UE_LOG(LogSkald, Warning,
-             TEXT("TriggerGridBattle: battle level streaming failed for %s; scheduling retry instead of map travel."),
+             TEXT("TriggerGridBattle: battle sublevel streaming failed for %s; scheduling retry."),
              *SelectedBattleMap.ToSoftObjectPath().ToString());
       if (GI) {
-        // Clear the in-flight travel gate before scheduling a retry. Streaming
-        // failure marks travel pending earlier in this function to block
-        // premature battle flow, but leaving it set would cause the retry path
-        // to immediately defer again at the TriggerGridBattle guard.
+        // Clear the in-flight streaming gate before scheduling a retry.
         GI->SetTravelPending(false);
       }
       DeferredPendingBattle = PendingPayload;
       if (World &&
-          !World->GetTimerManager().IsTimerActive(PendingBattleTravelRetryHandle)) {
+          !World->GetTimerManager().IsTimerActive(PendingBattleStreamRetryHandle)) {
         FTimerDelegate RetryDelegate = FTimerDelegate::CreateUObject(
-            this, &ATurnManager::RetryPendingBattleTravel);
+            this, &ATurnManager::RetryPendingBattleStream);
         constexpr float RetryDelaySeconds = 0.15f;
-        World->GetTimerManager().SetTimer(PendingBattleTravelRetryHandle,
+        World->GetTimerManager().SetTimer(PendingBattleStreamRetryHandle,
                                           RetryDelegate, RetryDelaySeconds, false);
-      }
-    } else if (!bShouldStreamSelectedMap) {
-      if (World->GetNetMode() != NM_Standalone) {
-        MulticastPrepareBattleTravel(TravelState, PendingPayload);
-      }
-      if (IsRunningDedicatedServer() ||
-          World->GetNetMode() != NM_Standalone) {
-        FString ListenMap = MapToLoad;
-        if (!ListenMap.Contains(TEXT("?"))) {
-          ListenMap.Append(TEXT("?listen"));
-        }
-        World->ServerTravel(ListenMap);
-      } else {
-        const FName LevelName = FName(*MapToLoad);
-        UGameplayStatics::OpenLevel(World, LevelName, /*bAbsolute=*/true);
       }
     }
   }
@@ -3560,7 +3443,7 @@ bool ATurnManager::TryAdvanceFromReadyToBattle(const TCHAR *Context) {
   CommitPendingBattleReadyState(TEXT("TryAdvanceFromReadyToBattle_Clear"));
 
   UE_LOG(LogSkaldReady, Log,
-         TEXT("AllReady=true -> StartBattleTravel Battle=%d->%d (Context=%s)"),
+         TEXT("AllReady=true -> StartBattleStream Battle=%d->%d (Context=%s)"),
          BattleToLaunch.FromTerritoryID, BattleToLaunch.TargetTerritoryID,
          Context ? Context : TEXT("TryAdvanceFromReadyToBattle"));
 
@@ -3568,9 +3451,9 @@ bool ATurnManager::TryAdvanceFromReadyToBattle(const TCHAR *Context) {
   return true;
 }
 
-void ATurnManager::RetryPendingBattleTravel() {
+void ATurnManager::RetryPendingBattleStream() {
   if (UWorld *World = GetWorld()) {
-    World->GetTimerManager().ClearTimer(PendingBattleTravelRetryHandle);
+    World->GetTimerManager().ClearTimer(PendingBattleStreamRetryHandle);
   }
 
   const FS_BattlePayload PendingPayload = DeferredPendingBattle;
@@ -3619,22 +3502,6 @@ void ATurnManager::MulticastStreamBattleLevel_Implementation(
   }
 }
 
-void ATurnManager::MulticastPrepareBattleTravel_Implementation(
-    const FSkaldTravelState &TravelState,
-    const FS_BattlePayload &BattlePayload) {
-  if (HasAuthority()) {
-    return;
-  }
-
-  if (USkaldGameInstance *GI = GetGameInstance<USkaldGameInstance>()) {
-    GI->SetTravelState(TravelState);
-    GI->PendingBattle = BattlePayload;
-    GI->SetBattleMapActive(true);
-    GI->SetPendingReturnMap(TravelState.ReturnMap);
-    GI->SetTravelPending(true);
-  }
-}
-
 void ATurnManager::MulticastOnReadyStateChanged_Implementation(
     const FSkaldBattleReadyState &ReadyState,
     const FS_BattlePayload &BattlePayload) {
@@ -3661,6 +3528,12 @@ void ATurnManager::MulticastSetBattleMapActive_Implementation(bool bInBattleMap)
   }
 
   if (USkaldGameInstance *GI = GetGameInstance<USkaldGameInstance>()) {
+    if (!bInBattleMap) {
+      if (USkaldBattleLevelManager *BattleLevelManager =
+              GI->GetBattleLevelManager()) {
+        BattleLevelManager->ReleaseBattleLevel();
+      }
+    }
     GI->SetBattleMapActive(bInBattleMap);
   }
 }
@@ -3698,7 +3571,7 @@ void ATurnManager::ResolveGridBattleResult_Implementation() {
     UWorld *World = GetWorld();
     if (!World) {
       UE_LOG(LogSkald, Verbose,
-             TEXT("ResolveGridBattleResult: World unavailable; awaiting travel completion before retry."));
+             TEXT("ResolveGridBattleResult: World unavailable; awaiting streaming completion before retry."));
       return;
     }
 
@@ -3713,9 +3586,8 @@ void ATurnManager::ResolveGridBattleResult_Implementation() {
   };
 
   if (GameMode && GameMode->IsA(ASkald_BattleGameMode::StaticClass())) {
-    // Still on the battle map; wait for travel to finish before updating the
-    // overworld. The pending resolution will be applied once the world map
-    // has been rebuilt.
+    // Still inside a standalone battle game mode; wait until the persistent
+    // overworld is available before applying the pending resolution.
     QueueRetry();
     return;
   }
@@ -3998,7 +3870,7 @@ void ATurnManager::ResolveGridBattleResult_Implementation() {
 
   // Ensure no stale retry timers trigger another battle after resolution
   if (UWorld *World = GetWorld()) {
-    World->GetTimerManager().ClearTimer(PendingBattleTravelRetryHandle);
+    World->GetTimerManager().ClearTimer(PendingBattleStreamRetryHandle);
   }
   DeferredPendingBattle = FS_BattlePayload();
 

--- a/Source/Skald/Skald_TurnManager.h
+++ b/Source/Skald/Skald_TurnManager.h
@@ -19,16 +19,11 @@ struct FBattleMapDescriptor {
   GENERATED_BODY()
 
 public:
-  // Battle maps are travelled to rather than streamed as sub-levels.
-  FBattleMapDescriptor() : bStreamAsSubLevel(false) {}
+  // Battle maps are always streamed as sub-levels of the persistent overworld.
+  FBattleMapDescriptor() = default;
 
   UPROPERTY(EditAnywhere, BlueprintReadWrite)
   TSoftObjectPtr<UWorld> Map;
-
-  UPROPERTY(EditAnywhere, BlueprintReadWrite, meta =
-                (Tooltip =
-                     "If true the map will be streamed instead of travelling"))
-  bool bStreamAsSubLevel;
 };
 
 // Broadcast whenever the overall world state changes so HUDs can refresh.
@@ -56,7 +51,7 @@ public:
 
   void RestoreControllerOrderFromSnapshots(const TArray<FS_PlayerData> &Snapshots);
 
-  /** Attempt to resume the saved turn state captured before travelling. */
+  /** Attempt to resume the saved turn state captured before battle streaming. */
   bool AttemptResumeSavedTurnState();
 
   /** Begin the pre-game army placement phase. */
@@ -108,7 +103,7 @@ public:
   /** Query the number of remaining movement actions for the specified player. */
   int32 GetMovementActionsRemaining(int32 PlayerID) const;
 
-  /** Request that both players confirm readiness before travelling to battle. */
+  /** Request that both players confirm readiness before streaming the battle sublevel. */
   UFUNCTION(BlueprintCallable, Category = "Battle")
   void RequestPrepareBattle(const FS_BattlePayload &Battle);
 
@@ -135,12 +130,6 @@ public:
   void MulticastStreamBattleLevel(const FSoftObjectPath &BattleLevelPath,
                                   const FSkaldTravelState &TravelState,
                                   const FS_BattlePayload &BattlePayload);
-
-  /** Multicast notification to prepare clients for travelling to a battle map
-   *  when a streaming level is not being used. */
-  UFUNCTION(NetMulticast, Reliable)
-  void MulticastPrepareBattleTravel(const FSkaldTravelState &TravelState,
-                                    const FS_BattlePayload &BattlePayload);
 
   /** Multicast notification whenever the pending battle readiness changes. */
   UFUNCTION(NetMulticast, Reliable)
@@ -231,7 +220,7 @@ public:
   /** Restore the cached ready state from a saved game. */
   void SetPendingBattleReadyState(const FSkaldBattleReadyState &ReadyState);
 
-  /** Mark the specified player as ready to travel to the battle map. */
+  /** Mark the specified player as ready to stream the battle sublevel. */
   UFUNCTION(BlueprintCallable, Category = "Battle")
   void NotifyPlayerReadyForBattle(int32 PlayerID, bool bReady);
 
@@ -247,7 +236,7 @@ public:
   UPROPERTY(EditAnywhere, BlueprintReadWrite, Replicated, Category = "Battle")
   TArray<TSoftObjectPtr<UWorld>> CapitalMaps;
 
-  /** Optional per-map configuration including streaming preferences. */
+  /** Optional per-map configuration; every battle map is streamed as a sublevel. */
   UPROPERTY(EditAnywhere, BlueprintReadWrite, Replicated, Category = "Battle",
             meta = (TitleProperty = "Map"))
   TArray<FBattleMapDescriptor> BattleMapEntries;
@@ -277,7 +266,7 @@ protected:
   bool TryAutoReadyAI(const TCHAR *Context);
   ASkaldPlayerController *FindControllerByPlayerId(int32 PlayerId) const;
   void ClearActiveRetreatContext();
-  /** Payload for the next battle waiting on travel/resolution to finish. */
+  /** Payload for the next battle waiting on streaming/resolution to finish. */
   FS_BattlePayload DeferredPendingBattle;
   /** Last battle payload hash processed by TriggerGridBattle for duplicate suppression. */
   uint32 LastTriggeredBattlePayloadHash = 0;
@@ -288,14 +277,14 @@ protected:
   /** Retry handle used when deferring battle resolution until the world map has been restored. */
   FTimerHandle PendingBattleResolutionRetryHandle;
 
-  /** Retry handle used when a battle travel request must wait for a territory snapshot. */
-  FTimerHandle PendingBattleTravelRetryHandle;
+  /** Retry handle used when a battle stream request must wait for a territory snapshot. */
+  FTimerHandle PendingBattleStreamRetryHandle;
 
-  /** Retry handle used when waiting for the battle manager to become available on the battle map. */
+  /** Retry handle used when waiting for the battle manager in the streamed battle map. */
   FTimerHandle BattleEndBindingRetryHandle;
 
-  /** Delay handle ensuring the battle result remains visible before returning to the overworld. */
-  FTimerHandle BattleReturnDelayHandle;
+  /** Delay handle ensuring the battle result remains visible before unloading the battle sublevel. */
+  FTimerHandle BattleConclusionDelayHandle;
 
   /** Retry handle used when a phase broadcast must wait for initialization gates to clear. */
   FTimerHandle PhaseBroadcastRetryHandle;
@@ -352,8 +341,8 @@ protected:
   /** Returns true if the currently active controller represents an AI. */
   bool IsCurrentControllerAI() const;
 
-  /** Attempt to continue travelling to the battle map after capturing the world snapshot. */
-  void RetryPendingBattleTravel();
+  /** Attempt to continue streaming the battle sublevel after capturing the world snapshot. */
+  void RetryPendingBattleStream();
 
   UFUNCTION()
   void HandleGridBattleEnded(ESkaldFaction WinningFaction, int32 AttackerCasualties, int32 DefenderCasualties);
@@ -393,16 +382,16 @@ protected:
   /** Internal: set GameState.CurrentTurnIndex (and broadcast) to match CurrentIndex. */
   void SyncGameStateTurnIndex();
 
-  /** Attempt to restore a saved turn state captured before travelling. */
+  /** Attempt to restore a saved turn state captured before battle streaming. */
   bool TryResumeSavedTurnState(USkaldGameInstance *GameInstance = nullptr);
 
   /** Ensure the cached world map pointer references a valid actor. */
   AWorldMap *ResolveWorldMap();
 
-  /** Capture the most recent grid battle resolution before travelling back. */
+  /** Capture the most recent grid battle resolution before unloading the battle sublevel. */
   bool CapturePendingBattleResolution(USkaldGameInstance *GameInstance);
 
-  bool bBattleReturnPending = false;
+  bool bBattleConclusionPending = false;
 
   /** True when an AI-controlled turn must pause for player acknowledgements. */
   bool bAwaitingBattleResultAcknowledgements = false;

--- a/Source/Skald/UI/PrepareForBattleWidget.h
+++ b/Source/Skald/UI/PrepareForBattleWidget.h
@@ -14,7 +14,7 @@ DECLARE_DYNAMIC_MULTICAST_DELEGATE(FPrepareForBattleRetreatClicked);
 
 /**
  * Confirmation widget shown after an attack is approved on the world map.
- * Allows both participants to confirm they are ready before travelling to
+ * Allows both participants to confirm they are ready before streaming to
  * the grid battle map.
  */
 UCLASS(BlueprintType, Blueprintable)


### PR DESCRIPTION
### Motivation
- Consolidate battle transitions to in-world streamed sublevels and remove the legacy travel/ServerTravel fallback flow so the overworld remains persistent during combat.
- Ensure all systems (turn manager, game instance, player controllers) treat battles as streamed sublevels and update state/flags accordingly.
- Keep player camera/pawn actors alive during streamed battles and provide a reliable camera centring behaviour so local players immediately have a usable view when a sublevel activates.

### Description
- Stream-only battle flow: `FBattleMapDescriptor` now holds only the `Map` asset and the turn manager always requests a streamed battle level via `USkaldBattleLevelManager::RequestBattleLevel` instead of optionally travelling to a separate map, and the fallback `MulticastPrepareBattleTravel`/travel flow was removed; retry logic was preserved but renamed to reflect streaming (`PendingBattleStreamRetryHandle`, `RetryPendingBattleStream`).
- End-of-battle cleanup: `ATurnManager::CompleteBattleConclusion` and related handlers now resolve results, clear pending state and instruct the `USkaldBattleLevelManager` to `ReleaseBattleLevel` rather than issuing `OpenLevel`/`ServerTravel` back to an overview map, and `MulticastSetBattleMapActive` was updated to release client-side streamed levels when deactivating.
- Battle level manager camera integration: `USkaldBattleLevelManager` now keeps persistent camera/player actors ticking (skips hiding player camera pawns/controllers while hiding overworld actors), computes streamed battle-level bounds (`CalculateActiveBattleLevelBounds`), and recenters local battle cameras onto the streamed level when activation completes (`RecenterLocalBattleCameras`), improving immediate camera usability for streamed sublevels.
- API and comment updates: various variables and comments were updated to reflect the stream-only model (e.g. `bIsInBattleMap` semantics, `ReturnMap` description, travel-related names and comments), and `FS_BattlePayload` text was adjusted to reference streaming/overview context rather than travel.

### Testing
- Ran `./Build/validate.sh`; the script executed but `UnrealBuildTool` and `UnrealEditor` were not present in this environment so compile and automation test steps were skipped (no compile/run results available).
- Performed static/source checks including `git diff --check` and repository greps for travel/streaming symbols to ensure the travel fallback paths were removed or replaced; those checks completed without flagged diffs.
- Basic local sanity: exercised the main changed flows in code (stream request, release, camera recenter logic) via static inspection; runtime behavior and full integration need verification in-editor/with UnrealEditor and multiplayer playtests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a187f06c4f08324b00a819d168d5f5b)