### PR TITLE
Fix implicit FBox::IsValid uint8-to-bool conversions to avoid MSVC C4800

### DIFF
--- a/Source/Skald/GridObstacleComponent.cpp
+++ b/Source/Skald/GridObstacleComponent.cpp
@@ -10,7 +10,7 @@ FBox CalculateRelevantBounds(const AActor *Actor) {
   }
 
   FBox Bounds = Actor->GetComponentsBoundingBox(false);
-  if (!Bounds.IsValid) {
+  if (Bounds.IsValid == 0) {
     Bounds = Actor->GetComponentsBoundingBox(true);
   }
   return Bounds;
@@ -60,7 +60,7 @@ bool UGridObstacleComponent::GetCustomGridFootprint(const UGridOverlayComponent 
   }
 
   const FBox Bounds = Skald::GridObstacle::CalculateRelevantBounds(Owner);
-  const FVector AnchorLocation = Bounds.IsValid
+  const FVector AnchorLocation = Bounds.IsValid != 0
                                      ? Bounds.GetCenter()
                                      : Owner->GetActorLocation();
 

--- a/Source/Skald/GridOverlayActor.cpp
+++ b/Source/Skald/GridOverlayActor.cpp
@@ -253,7 +253,7 @@ void AGridOverlayActor::SpawnRandomObstacles() {
 
     if (!bHasCustomFootprint) {
       const FBox Bounds = Skald::GridObstacle::CalculateRelevantBounds(Obstacle);
-      if (Bounds.IsValid) {
+      if (Bounds.IsValid != 0) {
         const FIntPoint RawMin = LocalGridComponent->WorldToGrid(Bounds.Min);
         const FIntPoint RawMax = LocalGridComponent->WorldToGrid(Bounds.Max);
         Min.X = FMath::Min(RawMin.X, RawMax.X);

--- a/Source/Skald/GridOverlayComponent.cpp
+++ b/Source/Skald/GridOverlayComponent.cpp
@@ -1407,7 +1407,7 @@ void UGridOverlayComponent::UnregisterObstacle(UGridObstacleComponent *Obstacle)
 
     if (!bHasCustomFootprint) {
       const FBox Bounds = Skald::GridObstacle::CalculateRelevantBounds(Owner);
-      if (Bounds.IsValid) {
+      if (Bounds.IsValid != 0) {
         const FIntPoint RawMin = WorldToGrid(Bounds.Min);
         const FIntPoint RawMax = WorldToGrid(Bounds.Max);
         Min.X = FMath::Min(RawMin.X, RawMax.X);

--- a/Source/Skald/Skald_BattleLevelManager.cpp
+++ b/Source/Skald/Skald_BattleLevelManager.cpp
@@ -949,12 +949,12 @@ bool USkaldBattleLevelManager::CalculateActiveBattleLevelBounds(FBox& OutBounds)
     }
 
     const FBox ActorBounds = Actor->GetComponentsBoundingBox(/*bNonColliding=*/true);
-    if (ActorBounds.IsValid) {
+    if (ActorBounds.IsValid != 0) {
       OutBounds += ActorBounds;
     }
   }
 
-  return OutBounds.IsValid;
+  return OutBounds.IsValid != 0;
 }
 
 void USkaldBattleLevelManager::RecenterLocalBattleCameras() {


### PR DESCRIPTION
### Motivation
- MSVC raised C4800 errors due to implicit conversion from `uint8` (`FBox::IsValid`) to `bool`, causing builds with warnings-as-errors to fail. 
- Ensure explicit comparisons against zero to make intent clear and avoid information-loss warnings on Windows toolchains.

### Description
- Changed checks that used `FBox::IsValid` as a boolean to explicit comparisons against zero (`...IsValid != 0` or `...IsValid == 0`) in four files. 
- Updated `CalculateActiveBattleLevelBounds` in `Source/Skald/Skald_BattleLevelManager.cpp` to explicitly compare `ActorBounds.IsValid` and `OutBounds.IsValid`. 
- Updated `Skald::GridObstacle::CalculateRelevantBounds` and anchor selection in `Source/Skald/GridObstacleComponent.cpp` to compare `Bounds.IsValid` explicitly. 
- Updated obstacle footprint validity checks in `Source/Skald/GridOverlayActor.cpp` and `Source/Skald/GridOverlayComponent.cpp` to use explicit `FBox::IsValid` comparisons.

### Testing
- Ran `git diff --check` to ensure no trivial whitespace or diff errors and it passed. 
- Ran a Python scan that searches `Source/Skald` for remaining `ActorBounds/Bounds/OutBounds.IsValid` usages lacking explicit comparisons and found no unmatched instances. 
- Performed repository-wide `rg` checks for modified patterns and reviewed the diffs; these static checks succeeded. 
- Could not run the Unreal build (`RunUBT`) in this container because the Unreal Engine toolchain / RunUBT is not available, so a full compile wasn't executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a189cf171d88324b90720ecaffbbe2a)