### PR TITLE
Keep AI battle activation retry alive

### DIFF
--- a/Source/Skald/Skald_AIController.cpp
+++ b/Source/Skald/Skald_AIController.cpp
@@ -3224,27 +3224,23 @@ void ASkaldAIController::HandleBattleMapExit() {
 }
 
 void ASkaldAIController::ScheduleTryActivateNextFighter() {
-  if (CachedBattleManager.IsValid() &&
-      CachedBattleManager->IsAwaitingAttackPresentation()) {
-    if (UWorld *World = GetWorld()) {
-      World->GetTimerManager().ClearTimer(ActivationGapTimerHandle);
-    }
-    return;
-  }
+  float Delay = ActivationGapDelay;
 
   if (CachedBattleManager.IsValid() &&
-      CachedBattleManager->IsAwaitingInitiativeRoll()) {
-    if (UWorld *World = GetWorld()) {
-      World->GetTimerManager().ClearTimer(ActivationGapTimerHandle);
-    }
-    return;
+      (CachedBattleManager->IsAwaitingAttackPresentation() ||
+       CachedBattleManager->IsAwaitingInitiativeRoll())) {
+    // Battle startup can race delegate binding against the initiative and
+    // presentation phases. Keep a lightweight retry alive so an AI side that
+    // wins initiative cannot miss the single OnRoundStarted notification and
+    // leave the battle waiting with no active fighter.
+    Delay = FMath::Max(0.1f, FMath::Min(ActivationGapDelay, 0.25f));
   }
 
   if (UWorld *World = GetWorld()) {
     World->GetTimerManager().ClearTimer(ActivationGapTimerHandle);
     World->GetTimerManager().SetTimer(
         ActivationGapTimerHandle, this, &ASkaldAIController::TryActivateNextFighter,
-        ActivationGapDelay, false);
+        Delay, false);
   }
 }
 
@@ -3278,10 +3274,12 @@ void ASkaldAIController::TryActivateNextFighter() {
   }
 
   if (CachedBattleManager->IsAwaitingAttackPresentation()) {
+    ScheduleTryActivateNextFighter();
     return;
   }
 
   if (CachedBattleManager->IsAwaitingInitiativeRoll()) {
+    ScheduleTryActivateNextFighter();
     return;
   }
 


### PR DESCRIPTION
### Motivation
- Prevent a race during battle startup where an AI that won initiative could miss the `OnRoundStarted`/activation window and never make a move because the AI cleared its activation timer while the battle was still presenting initiative or attack animations.
- Make the AI resilient to delegate/timer ordering during the initiative/presentation phases so the enemy side continues trying to activate until the battle is ready.

### Description
- Modified `ASkaldAIController::ScheduleTryActivateNextFighter` to keep a short retry timer alive instead of clearing it while the battle is awaiting initiative or attack presentation, using a bounded short `Delay` when those wait states are detected (in `Source/Skald/Skald_AIController.cpp`).
- Changed `ASkaldAIController::TryActivateNextFighter` to reschedule `ScheduleTryActivateNextFighter()` and return when it fires while `CachedBattleManager->IsAwaitingAttackPresentation()` or `IsAwaitingInitiativeRoll()`, ensuring repeated retry attempts until the battle is ready.
- Added explanatory comments and a small clamp on the retry `Delay` to avoid excessively tight polling while ensuring responsiveness during startup races.

### Testing
- Ran `bash Build/validate.sh`; the script executed but `UnrealBuildTool` and `UnrealEditor` were not available in the environment so compile and automation tests were skipped by the script (reported by the script).
- Ran `git diff --check` and basic repo checks; no issues reported.
- Changes were committed locally (`Keep AI battle activation retry alive`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a18bf5594ac832499988dde7ee79ebf)