### PR TITLE
Use StablePlayerId for player matching, refresh AI side, and require RMB for battle camera rotation

### DIFF
--- a/Source/Skald/GridBattleManager.cpp
+++ b/Source/Skald/GridBattleManager.cpp
@@ -1831,7 +1831,10 @@ bool UGridBattleManager::IsSideAIControlled(bool bForAttackers) const
         {
             if (const ASkaldPlayerState* SkaldPlayerState = Cast<ASkaldPlayerState>(PlayerState))
             {
-                if (TargetPlayerId > 0 && SkaldPlayerState->GetPlayerId() == TargetPlayerId)
+                const int32 StablePlayerId = SkaldPlayerState->GetStablePlayerId();
+                const int32 RuntimePlayerId = SkaldPlayerState->GetPlayerId();
+                if (TargetPlayerId > 0 &&
+                    (StablePlayerId == TargetPlayerId || RuntimePlayerId == TargetPlayerId))
                 {
                     bMatchedPlayerState = true;
                     return SkaldPlayerState->bIsAI;

--- a/Source/Skald/Skald_AIController.cpp
+++ b/Source/Skald/Skald_AIController.cpp
@@ -1621,7 +1621,8 @@ void ASkaldAIController::DetermineControlledBattleSide() {
   }
 
   FS_BattlePayload &Battle = GameInstance->PendingBattle;
-  const int32 PlayerId = PS->GetPlayerId();
+  const int32 StablePlayerId = PS->GetStablePlayerId();
+  const int32 PlayerId = StablePlayerId > 0 ? StablePlayerId : PS->GetPlayerId();
   FString PlayerName = PS->PlayerDisplayName;
   if (PlayerName.IsEmpty()) {
     PlayerName = PS->GetResolvedPlayerName(TEXT("SkaldAIController"));
@@ -3286,6 +3287,8 @@ void ASkaldAIController::TryActivateNextFighter() {
   if (CachedBattleManager->GetActiveFighter()) {
     return;
   }
+
+  DetermineControlledBattleSide();
 
   if (!IsMyTurn()) {
     return;

--- a/Source/Skald/Skald_PlayerCharacter.cpp
+++ b/Source/Skald/Skald_PlayerCharacter.cpp
@@ -176,6 +176,22 @@ void ASkald_PlayerCharacter::RefreshOverviewPivot()
         }
 }
 
+
+bool ASkald_PlayerCharacter::ShouldProcessBattleMouseInput() const
+{
+        if (!bBattleCameraActive)
+        {
+                return false;
+        }
+
+        if (const APlayerController* PlayerController = Cast<APlayerController>(Controller))
+        {
+                return PlayerController->IsInputKeyDown(EKeys::RightMouseButton);
+        }
+
+        return false;
+}
+
 bool ASkald_PlayerCharacter::ShouldProcessOverviewMouseInput() const
 {
         if (bBattleCameraActive)
@@ -376,7 +392,7 @@ void ASkald_PlayerCharacter::Turn(float Value)
 {
 	if (bBattleCameraActive)
         {
-                if (!FMath::IsNearlyZero(Value))
+                if (!FMath::IsNearlyZero(Value) && ShouldProcessBattleMouseInput())
                 {
                         if (bBattleCameraLocked)
                         {
@@ -408,7 +424,7 @@ void ASkald_PlayerCharacter::LookUp(float Value)
 {
 	if (bBattleCameraActive)
         {
-                if (!FMath::IsNearlyZero(Value))
+                if (!FMath::IsNearlyZero(Value) && ShouldProcessBattleMouseInput())
                 {
                         if (bBattleCameraLocked)
                         {

--- a/Source/Skald/Skald_PlayerCharacter.h
+++ b/Source/Skald/Skald_PlayerCharacter.h
@@ -348,6 +348,7 @@ private:
         void InitializeOverviewCamera();
         FVector ComputeOverviewPivotLocation() const;
         void RefreshOverviewPivot();
+        bool ShouldProcessBattleMouseInput() const;
         bool ShouldProcessOverviewMouseInput() const;
         FVector2D GetLockedOverviewPitchRange() const;
 


### PR DESCRIPTION
### Motivation

- Ensure player matching and AI-side resolution are stable across runtime changes by preferring a persistent `GetStablePlayerId()` when available.
- Ensure the AI controller recomputes which side it controls immediately before attempting activations so activation decisions use up-to-date ownership state.
- Prevent accidental camera rotations in battle mode by requiring the right mouse button to be held for mouse-driven rotation.

### Description

- Updated player lookup in `UGridBattleManager::IsSideAIControlled` to compare both `GetStablePlayerId()` and `GetPlayerId()` against the provided `TargetPlayerId` when resolving matches.  
- Changed `ASkaldAIController::DetermineControlledBattleSide` to prefer `GetStablePlayerId()` and fall back to `GetPlayerId()`, and added a call to `DetermineControlledBattleSide()` at the start of `TryActivateNextFighter()` so the AI side flags are refreshed before turn/activation checks.  
- Added `ASkald_PlayerCharacter::ShouldProcessBattleMouseInput()` and updated `Turn()` and `LookUp()` to only apply mouse-driven battle camera rotation when the right mouse button (`EKeys::RightMouseButton`) is pressed.  
- Added the `ShouldProcessBattleMouseInput()` declaration to the header file and implemented the function in the player character source.

### Testing

- Project compiles successfully after the changes.  
- Automated unit/CI tests covering gameplay and player/AI resolution were executed and passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a18c28229948324a61f696d62b30539)