### PR TITLE
Fix battle AI turn sync and prevent camera/selection resets

### DIFF
--- a/Source/Skald/GridBattleManager.cpp
+++ b/Source/Skald/GridBattleManager.cpp
@@ -1726,7 +1726,17 @@ bool UGridBattleManager::IsSideAIControlled(bool bForAttackers) const
 
     if (GameInstance)
     {
-        const FS_BattlePayload& Battle = GameInstance->PendingBattle;
+        FS_BattlePayload Battle = GameInstance->PendingBattle;
+        if (const ASkaldGameState* SkaldGameState = World->GetGameState<ASkaldGameState>())
+        {
+            const FS_BattlePayload& ReplicatedBattle = SkaldGameState->GetActiveBattlePayload();
+            if (ReplicatedBattle.AttackerPlayerID > 0 || ReplicatedBattle.DefenderPlayerID > 0 ||
+                ReplicatedBattle.AttackerFaction != ESkaldFaction::None || ReplicatedBattle.DefenderFaction != ESkaldFaction::None)
+            {
+                Battle = ReplicatedBattle;
+            }
+        }
+
         TargetPlayerId = bForAttackers ? Battle.AttackerPlayerID : Battle.DefenderPlayerID;
         bPendingBattleAIFlag = bForAttackers ? Battle.bAttackerIsAI : Battle.bDefenderIsAI;
         ParticipantDisplayName = bForAttackers ? Battle.AttackerDisplayName : Battle.DefenderDisplayName;

--- a/Source/Skald/Skald_AIController.cpp
+++ b/Source/Skald/Skald_AIController.cpp
@@ -14,6 +14,7 @@
 #include "SkaldLogging.h"
 #include "Skald_BattleGameMode.h"
 #include "Skald_GameInstance.h"
+#include "Skald_GameState.h"
 #include "Skald_GameUserSettings.h"
 #include "Skald_GameMode.h"
 #include "Skald_PlayerState.h"
@@ -1620,7 +1621,18 @@ void ASkaldAIController::DetermineControlledBattleSide() {
     return;
   }
 
-  FS_BattlePayload &Battle = GameInstance->PendingBattle;
+  FS_BattlePayload Battle = GameInstance->PendingBattle;
+  if (const UWorld *World = GetWorld()) {
+    if (const ASkaldGameState *GameState = World->GetGameState<ASkaldGameState>()) {
+      const FS_BattlePayload &ReplicatedBattle = GameState->GetActiveBattlePayload();
+      if (ReplicatedBattle.AttackerPlayerID > 0 ||
+          ReplicatedBattle.DefenderPlayerID > 0 ||
+          ReplicatedBattle.AttackerFaction != ESkaldFaction::None ||
+          ReplicatedBattle.DefenderFaction != ESkaldFaction::None) {
+        Battle = ReplicatedBattle;
+      }
+    }
+  }
   const int32 StablePlayerId = PS->GetStablePlayerId();
   const int32 PlayerId = StablePlayerId > 0 ? StablePlayerId : PS->GetPlayerId();
   FString PlayerName = PS->PlayerDisplayName;
@@ -1714,11 +1726,11 @@ void ASkaldAIController::DetermineControlledBattleSide() {
   }
 
   if (bAIControlsAttackerSide && bIsAIPlayer) {
-    Battle.bAttackerIsAI = true;
+    GameInstance->PendingBattle.bAttackerIsAI = true;
   }
 
   if (bAIControlsDefenderSide && bIsAIPlayer) {
-    Battle.bDefenderIsAI = true;
+    GameInstance->PendingBattle.bDefenderIsAI = true;
   }
 
   if (!bAIControlsAttackerSide && !bAIControlsDefenderSide && bIsAIPlayer) {

--- a/Source/Skald/Skald_PlayerController.cpp
+++ b/Source/Skald/Skald_PlayerController.cpp
@@ -3362,7 +3362,12 @@ UGridBattleManager *ASkaldPlayerController::GetBattleManager() const {
 
 void ASkaldPlayerController::HandleActiveFighterChanged(
     AFighterPawn *NewFighter) {
-  if (NewFighter && NewFighter->IsAlive()) {
+  AFighterPawn *PreviousActiveFighter = LockedActiveFighter.Get();
+  const bool bHasValidNewFighter = NewFighter && NewFighter->IsAlive();
+  const bool bHadActiveFighter = PreviousActiveFighter != nullptr;
+  const bool bActiveFighterChanged = PreviousActiveFighter != NewFighter;
+
+  if (bHasValidNewFighter) {
     LockedActiveFighter = NewFighter;
     SetSelectedFighter(NewFighter, true);
     if (bBattleHUDReadyToShow && !bBattleHUDVisible) {
@@ -3375,23 +3380,23 @@ void ASkaldPlayerController::HandleActiveFighterChanged(
   CancelCommandMode();
   UpdateBattleHUDButtons();
   UpdateBattlePlayersTurnDisplay();
-  if (!NewFighter) {
+  if (!bHasValidNewFighter) {
     UpdateBattleHUDSelection();
   }
 
   if (UGridOverlayComponent *Grid = FindGridOverlay()) {
-    if (NewFighter && NewFighter->IsAlive()) {
+    if (bHasValidNewFighter) {
       Grid->HighlightSelection(NewFighter);
-    } else {
+    } else if (bHadActiveFighter || !SelectedFighter.IsValid()) {
       Grid->ClearSelectionHighlight();
     }
   }
 
   if (IsLocalController()) {
     if (ASkald_PlayerCharacter *CameraPawn = Cast<ASkald_PlayerCharacter>(GetPawn())) {
-      if (bIsBattleMap && NewFighter && NewFighter->IsAlive()) {
+      if (bIsBattleMap && bHasValidNewFighter) {
         CameraPawn->FocusCameraOnActor(NewFighter);
-      } else {
+      } else if (bHadActiveFighter && bActiveFighterChanged) {
         CameraPawn->ClearCameraFocus();
       }
     }
@@ -7166,7 +7171,9 @@ void ASkaldPlayerController::HandleRoundStarted(int32 RoundNumber,
   LastBattleTurnSoundAvailableCount = INDEX_NONE;
 
   LockedActiveFighter = nullptr;
-  ClearSelectedFighter();
+  if (SelectedFighter.IsValid() && !SelectedFighter->IsAlive()) {
+    ClearSelectedFighter();
+  }
   CancelCommandMode();
   UpdateBattleRoundDisplay(RoundNumber, InitiativeWinner);
   UpdateBattlePlayersTurnDisplay();


### PR DESCRIPTION
### Motivation

- Battle camera and selection were repeatedly reset on active-fighter transitions and AI sides sometimes failed to take their activations after initiative, suggesting turn/participant identity was out-of-sync between replicated and pending battle payloads and the UI was clearing focus too aggressively.

### Description

- Prefer the replicated active battle payload when resolving which side is AI-controlled in `ASkaldAIController::DetermineControlledBattleSide` so AI ownership matches the authoritative game state at battle start.  
- Mirror the same replicated-payload fallback in `UGridBattleManager::IsSideAIControlled` so initiative/activation logic uses the same identity source as AI decision code.  
- Stop clearing camera focus and selection highlights on redundant null active-fighter notifications by tracking previous active-fighter state in `ASkaldPlayerController::HandleActiveFighterChanged` and only clearing focus/highlights when the active fighter actually changed.  
- Preserve a living `SelectedFighter` when a new round starts by only clearing selection if the selected fighter is dead, and add the required `Skald_GameState` include to access the replicated payload.  

### Testing

- Ran `bash Build/validate.sh`; the script executed but `UnrealBuildTool` and `UnrealEditor` were not available in the environment so compile and automation tests were skipped.  
- Ran lightweight repository checks including `git diff --check` which reported no whitespace issues.  
- Manual code inspection and local file validation of modified logic paths were performed to ensure the replicated-payload fallback and camera/selection guards are applied consistently.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a18d8be730483248cfc3737a8cf265c)