### PR TITLE
Fix TObjectPtr validity checks in Skald_PlayerController

### DIFF
--- a/Source/Skald/Skald_PlayerController.cpp
+++ b/Source/Skald/Skald_PlayerController.cpp
@@ -3387,7 +3387,7 @@ void ASkaldPlayerController::HandleActiveFighterChanged(
   if (UGridOverlayComponent *Grid = FindGridOverlay()) {
     if (bHasValidNewFighter) {
       Grid->HighlightSelection(NewFighter);
-    } else if (bHadActiveFighter || !SelectedFighter.IsValid()) {
+    } else if (bHadActiveFighter || SelectedFighter == nullptr) {
       Grid->ClearSelectionHighlight();
     }
   }
@@ -7171,7 +7171,7 @@ void ASkaldPlayerController::HandleRoundStarted(int32 RoundNumber,
   LastBattleTurnSoundAvailableCount = INDEX_NONE;
 
   LockedActiveFighter = nullptr;
-  if (SelectedFighter.IsValid() && !SelectedFighter->IsAlive()) {
+  if (SelectedFighter && !SelectedFighter->IsAlive()) {
     ClearSelectedFighter();
   }
   CancelCommandMode();


### PR DESCRIPTION
### Motivation
- Resolve Windows/MSVC compile failures caused by calling `IsValid()` on `TObjectPtr<AFighterPawn>`, which is not a member and broke the build under UBT.

### Description
- Replace unsupported `TObjectPtr` usage by switching `SelectedFighter.IsValid()` checks to supported pointer/boolean checks (`SelectedFighter == nullptr` and `SelectedFighter && !SelectedFighter->IsAlive()`) in `Source/Skald/Skald_PlayerController.cpp` to preserve existing behavior.

### Testing
- Ran `git diff --check` and `rg -n "SelectedFighter\.IsValid\(\)|LockedActiveFighter\.IsValid\(\)" Source/Skald/Skald_PlayerController.cpp Source/Skald/Skald_PlayerController.h` and both commands reported no remaining issues, indicating the invalid usages were removed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a199049c07083249ed380c0caa94de8)