### PR TITLE
Keep battle cursor visible on grid clicks

### DIFF
--- a/Source/Skald/Skald_PlayerController.cpp
+++ b/Source/Skald/Skald_PlayerController.cpp
@@ -6299,6 +6299,11 @@ bool ASkaldPlayerController::ApplyBattleInteractionInputState(
     // visible UBattleHUDWidget buttons continue to receive UI clicks.  The HUD
     // root is made SelfHitTestInvisible when shown, so empty HUD space still
     // falls through to grid/fighter traces.
+    //
+    // Keep the viewport in NoCapture for battle interaction.  Using
+    // CaptureDuringMouseDown makes landscape/empty-grid clicks capture the PIE
+    // viewport when Slate does not consume the press, which hides the cursor
+    // and drops the first intended grid click until input is reconciled again.
     UWidget* BattleFocusWidget =
         IsVisibleInViewport(BattleHudWidget) ? BattleHudWidget.Get() : nullptr;
     UWidgetBlueprintLibrary::SetInputMode_GameAndUIEx(
@@ -6307,7 +6312,7 @@ bool ASkaldPlayerController::ApplyBattleInteractionInputState(
     bShowMouseCursor = true;
     bEnableClickEvents = true;
     bEnableMouseOverEvents = true;
-    DefaultMouseCaptureMode = EMouseCaptureMode::CaptureDuringMouseDown;
+    DefaultMouseCaptureMode = EMouseCaptureMode::NoCapture;
   }
 
   if (UGameViewportClient* GameViewport =


### PR DESCRIPTION
### Motivation
- World clicks on the battle grid were sometimes not consumed by Slate and caused the PIE viewport to capture the mouse, hiding the cursor and dropping the intended first click.  The input reconciliation must keep clicks delivered to grid/fighter traces without losing cursor visibility.

### Description
- Change: in `ApplyBattleInteractionInputState` (file `Source/Skald/Skald_PlayerController.cpp`) set `DefaultMouseCaptureMode` to `EMouseCaptureMode::NoCapture` for normal battle interaction instead of `CaptureDuringMouseDown` so unconsumed landscape/grid presses do not capture the viewport.
- Documentation: added a brief explanatory comment next to the change describing why battle play keeps `NoCapture` while still using `Game+UI` input so HUD buttons and world traces both work.
- Behavior: preserves `Game+UI` input mode for HUD buttons while preventing the viewport from stealing the cursor on empty-grid clicks, ensuring the first grid click is handled as intended.

### Testing
- Ran `git diff --check` to validate the working tree changes (no issues reported).
- Attempted to locate the Unreal build tool with `command -v UnrealBuildTool`, but `UnrealBuildTool` is not available in this environment so a full engine build/test could not be performed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1992741d748324867650a5dc320a60)