### PR TITLE
Fix streamed battle activation sync and AI activation during streamed battles

### DIFF
--- a/Source/Skald/Skald_AIController.cpp
+++ b/Source/Skald/Skald_AIController.cpp
@@ -3302,11 +3302,13 @@ void ASkaldAIController::TryActivateNextFighter() {
 
   DetermineControlledBattleSide();
 
-  if (!IsMyTurn()) {
+  const bool bAttackerTurn = CachedBattleManager->IsAttackerTurn();
+  const bool bControlsCurrentSide =
+      bAttackerTurn ? bAIControlsAttackerSide : bAIControlsDefenderSide;
+  if (!bControlsCurrentSide) {
     return;
   }
 
-  const bool bAttackerTurn = CachedBattleManager->IsAttackerTurn();
   AFighterPawn *NextFighter = FindNextFriendlyFighter(bAttackerTurn);
   if (!NextFighter) {
     CachedBattleManager->AdvanceTurn();

--- a/Source/Skald/Skald_BattleLevelManager.cpp
+++ b/Source/Skald/Skald_BattleLevelManager.cpp
@@ -366,9 +366,11 @@ void USkaldBattleLevelManager::HandleLevelLoaded() {
   UE_LOG(LogSkald, Log, TEXT("BattleLevelManager: Battle level streamed and visible"));
 
   if (USkaldGameInstance *GI = OwningInstance.Get()) {
-    GI->SetTravelPending(false);
-    GI->SetBattleMapActive(true);
-
+    // Do not publish the battle map as active until after the streamed level
+    // has a battle game mode and activation callbacks have run.  Several
+    // controllers immediately reconcile input/turn state when bIsInBattleMap
+    // flips; doing that before the sublevel BattleGameMode bootstraps leaves
+    // fighter selection and AI automation observing a half-initialized battle.
     if (!GI->GetActiveBattleGameMode() && ActiveStreamingLevel.IsValid()) {
       UWorld *OwningWorld = ActiveStreamingLevel->GetWorld();
       ULevel *LoadedLevel = ActiveStreamingLevel->GetLoadedLevel();
@@ -502,6 +504,11 @@ void USkaldBattleLevelManager::HandleLevelLoaded() {
   }
 
   bActiveLevelActivationComplete = true;
+
+  if (USkaldGameInstance *GI = OwningInstance.Get()) {
+    GI->SetTravelPending(false);
+    GI->SetBattleMapActive(true);
+  }
 }
 
 void USkaldBattleLevelManager::HandleLevelUnloaded() {


### PR DESCRIPTION
### Motivation
- Prevent local controllers from reconciling input/turn state before a streamed battle sublevel has finished initializing its `BattleGameMode`, which caused cursor/input flip-flopping and fighter-selection churn when the map was streamed in. 
- Ensure tactical AI actually acts during streamed sublevel battles by decoupling its activation logic from overworld `IsMyTurn()` state so AI drives activations based on the grid side it controls.

### Description
- In `USkaldBattleLevelManager::HandleLevelLoaded` delay publishing travel-complete/battle-map-active flags and calling `GI->SetBattleMapActive(true)` until after the streamed level’s `BattleGameMode` has been found/created and `NotifyBattleLevelActivated` has run, and added explanatory comments describing the race being avoided. (file: `Source/Skald/Skald_BattleLevelManager.cpp`)
- In `ASkaldAIController::TryActivateNextFighter` stop gating AI activation on `IsMyTurn()` and instead determine the current initiative side with `CachedBattleManager->IsAttackerTurn()` and skip unless the AI actually controls that side (`bAIControlsAttackerSide` / `bAIControlsDefenderSide`). (file: `Source/Skald/Skald_AIController.cpp`)
- Minor bookkeeping: moved the `SetTravelPending(false)` / `SetBattleMapActive(true)` call site to follow the activation-complete path to avoid exposing a half-initialized battle context to controllers and UI.

### Testing
- Ran `git diff --check` which reported no whitespace/patch errors and completed successfully. 
- Verified environment did not have `UnrealBuildTool` in `PATH`, so a full engine build/test run could not be executed in this environment (no automated engine build was run).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1994801f64832499f12dbd1b626147)