### PR TITLE
Decouple battle input from overworld turn flow

### DIFF
--- a/Source/Skald/FighterPawn.cpp
+++ b/Source/Skald/FighterPawn.cpp
@@ -74,6 +74,10 @@ AFighterPawn::AFighterPawn() : MaxHealth(0) {
   CollisionComponent->InitCapsuleSize(40.f, 88.f);
   CollisionComponent->SetCollisionProfileName(
       UCollisionProfile::Pawn_ProfileName);
+  // Battle selection uses visibility traces from the player controller. Make
+  // fighter capsules explicit visibility blockers so clicking the displayed
+  // pawn is not lost to the terrain/grid plane behind it on streamed sublevels.
+  CollisionComponent->SetCollisionResponseToChannel(ECC_Visibility, ECR_Block);
   CollisionComponent->SetCanEverAffectNavigation(false);
   RootComponent = CollisionComponent;
 

--- a/Source/Skald/Skald_BattleGameMode.cpp
+++ b/Source/Skald/Skald_BattleGameMode.cpp
@@ -502,7 +502,14 @@ void ASkald_BattleGameMode::InitGame(const FString &Map, const FString &Options,
 
 void ASkald_BattleGameMode::BeginPlay() {
   if (const USkaldGameInstance* GI = GetGameInstance<USkaldGameInstance>()) { UE_LOG(LogSkaldBattle, Log, TEXT("[TravelToken] Token=%s Stage=BattleGM.BeginPlay World=%s Ctx=BeginPlay PayloadValid=%d"), *GI->GetTravelSessionToken(), *GetNameSafe(GetWorld()), GI->GetTravelState().bValid ? 1 : 0); }
-  Super::BeginPlay();
+
+  // Intentionally bypass ASkaldGameMode::BeginPlay here. The overworld mode
+  // registers controllers with ATurnManager during BeginPlay, but tactical
+  // battles are driven by UGridBattleManager. Registering battle participants
+  // with the overworld turn manager creates a second authority over the same
+  // controllers and can desync activation/turn flow on streamed battle maps.
+  AGameModeBase::BeginPlay();
+  TurnManager = nullptr;
 
   if (!BattleManager) {
     UClass *ClassToUse = BattleManagerClass ? *BattleManagerClass
@@ -2103,7 +2110,7 @@ void ASkald_BattleGameMode::HandleStartingNewPlayer_Implementation(
          TEXT("HandleStartingNewPlayer: %s (HasAuthority=%d)"),
          *GetNameSafe(NewPlayer), HasAuthority() ? 1 : 0);
 
-  Super::HandleStartingNewPlayer_Implementation(NewPlayer);
+  AGameModeBase::HandleStartingNewPlayer_Implementation(NewPlayer);
 
   if (!HasAuthority()) {
     return;
@@ -2143,7 +2150,7 @@ void ASkald_BattleGameMode::HandleSeamlessTravelPlayer(AController *&C) {
          TEXT("HandleSeamlessTravelPlayer: %s (HasAuthority=%d)"),
          *GetNameSafe(C), HasAuthority() ? 1 : 0);
 
-  Super::HandleSeamlessTravelPlayer(C);
+  AGameModeBase::HandleSeamlessTravelPlayer(C);
 
   if (!HasAuthority()) {
     return;
@@ -2159,7 +2166,7 @@ void ASkald_BattleGameMode::HandleSeamlessTravelPlayer(AController *&C) {
 }
 
 void ASkald_BattleGameMode::PostLogin(APlayerController *NewPlayer) {
-  Super::PostLogin(NewPlayer);
+  AGameModeBase::PostLogin(NewPlayer);
 
   UE_LOG(LogSkaldBattle, Log, TEXT("PostLogin: %s"), *GetNameSafe(NewPlayer));
   if (ASkaldPlayerState *PS = NewPlayer->GetPlayerState<ASkaldPlayerState>()) {

--- a/Source/Skald/Skald_PlayerController.cpp
+++ b/Source/Skald/Skald_PlayerController.cpp
@@ -2168,6 +2168,25 @@ void ASkaldPlayerController::TryBindWorldMap() {
     return;
   }
 
+  if (!CachedGameInstance) {
+    CachedGameInstance = GetGameInstance<USkaldGameInstance>();
+  }
+  const bool bBattleMapActive =
+      bIsBattleMap || (CachedGameInstance && CachedGameInstance->bIsInBattleMap);
+  if (bBattleMapActive) {
+    if (AWorldMap *WorldMap = CachedWorldMap.Get()) {
+      if (WorldMap->OnTerritorySelected.IsAlreadyBound(
+              this, &ASkaldPlayerController::HandleTerritorySelected)) {
+        WorldMap->OnTerritorySelected.RemoveDynamic(
+            this, &ASkaldPlayerController::HandleTerritorySelected);
+      }
+    }
+    CachedWorldMap.Reset();
+    World->GetTimerManager().ClearTimer(WorldMapSearchHandle);
+    bPendingLocalSelectionRefresh = false;
+    return;
+  }
+
   if (CachedWorldMap.IsValid()) {
     World->GetTimerManager().ClearTimer(WorldMapSearchHandle);
     return;
@@ -5392,6 +5411,18 @@ void ASkaldPlayerController::ClientHandleMoveOutcome_Implementation(
 }
 
 bool ASkaldPlayerController::EnsureTurnManager(const TCHAR *Caller) {
+  if (!CachedGameInstance) {
+    CachedGameInstance = GetGameInstance<USkaldGameInstance>();
+  }
+  const bool bBattleMapActive =
+      bIsBattleMap || (CachedGameInstance && CachedGameInstance->bIsInBattleMap);
+  if (bBattleMapActive) {
+    UE_LOG(LogSkaldBattle, Verbose,
+           TEXT("%s ignored while battle map flow is active; GridBattleManager owns tactical turns."),
+           Caller);
+    return false;
+  }
+
   if (TurnManager) {
     return true;
   }
@@ -6597,19 +6628,66 @@ void ASkaldPlayerController::HandleGridClick() {
   }
 
   // Terrain/grid clicks can arrive while the viewport is in Game+UI mode and no
-  // visible actor blocks the cursor trace.  Fall back to intersecting the mouse
-  // ray with the grid plane so empty movement cells are still valid targets
-  // instead of turning into a viewport-capture/cursor-hide click.
+  // visible actor blocks the cursor trace. Trace the whole cursor ray so fighter
+  // capsules on streamed battle sublevels win over terrain, while stale
+  // overworld WorldMap/Territory hits are ignored during tactical play. If the
+  // ray does not hit usable battle geometry, fall back to intersecting the grid
+  // plane so empty movement cells remain valid targets.
+  FVector MouseWorldLocation = FVector::ZeroVector;
+  FVector MouseWorldDirection = FVector::ZeroVector;
+  if (!DeprojectMousePositionToWorld(MouseWorldLocation, MouseWorldDirection)) {
+    ApplyBattleInteractionInputState(TEXT("HandleGridClickTraceFailed"));
+    return;
+  }
+
+  FVector TraceStart = MouseWorldLocation;
+  if (APlayerCameraManager *CameraManager = PlayerCameraManager) {
+    TraceStart = CameraManager->GetCameraLocation();
+  }
+  const FVector TraceEnd = TraceStart + MouseWorldDirection * 100000.f;
+
+  AFighterPawn *DirectHitFighter = nullptr;
   FVector WorldLocation = FVector::ZeroVector;
-  const bool bHasCursorHit =
-      GetHitResultUnderCursor(ECC_Visibility, /*bTraceComplex*/ false, Hit);
-  if (bHasCursorHit) {
-    WorldLocation = Hit.bBlockingHit ? Hit.ImpactPoint : Hit.Location;
-  } else {
-    FVector MouseWorldLocation = FVector::ZeroVector;
-    FVector MouseWorldDirection = FVector::ZeroVector;
-    if (!DeprojectMousePositionToWorld(MouseWorldLocation, MouseWorldDirection) ||
-        FMath::IsNearlyZero(MouseWorldDirection.Z)) {
+  bool bHasUsableBattleHit = false;
+
+  if (UWorld *World = GetWorld()) {
+    TArray<FHitResult> CursorHits;
+    FCollisionQueryParams QueryParams(SCENE_QUERY_STAT(HandleGridClickBattle),
+                                      /*bTraceComplex*/ false);
+    if (World->LineTraceMultiByChannel(CursorHits, TraceStart, TraceEnd,
+                                       ECC_Visibility, QueryParams)) {
+      for (const FHitResult &CandidateHit : CursorHits) {
+        AActor *HitActor = CandidateHit.GetActor();
+        if (!HitActor) {
+          continue;
+        }
+
+        if (!DirectHitFighter) {
+          if (AFighterPawn *Fighter = Cast<AFighterPawn>(HitActor)) {
+            if (Fighter->IsAlive()) {
+              DirectHitFighter = Fighter;
+            }
+          }
+        }
+
+        if (!bHasUsableBattleHit &&
+            !HitActor->IsA<AWorldMap>() &&
+            !HitActor->IsA<ATerritory>()) {
+          Hit = CandidateHit;
+          WorldLocation = CandidateHit.bBlockingHit ? CandidateHit.ImpactPoint
+                                                    : CandidateHit.Location;
+          bHasUsableBattleHit = true;
+        }
+
+        if (DirectHitFighter && bHasUsableBattleHit) {
+          break;
+        }
+      }
+    }
+  }
+
+  if (!bHasUsableBattleHit) {
+    if (FMath::IsNearlyZero(MouseWorldDirection.Z)) {
       ApplyBattleInteractionInputState(TEXT("HandleGridClickTraceFailed"));
       return;
     }
@@ -6623,13 +6701,20 @@ void ASkaldPlayerController::HandleGridClick() {
     }
 
     WorldLocation = MouseWorldLocation + MouseWorldDirection * DistanceAlongRay;
+    Hit.TraceStart = TraceStart;
+    Hit.TraceEnd = TraceEnd;
+    Hit.Location = WorldLocation;
+    Hit.ImpactPoint = WorldLocation;
   }
-  const FIntPoint Cell = Grid->WorldToGrid(WorldLocation);
+
+  FIntPoint Cell = DirectHitFighter ? DirectHitFighter->GetCurrentCell()
+                                   : Grid->WorldToGrid(WorldLocation);
   if (!Grid->IsCellInBounds(Cell)) {
     return;
   }
 
-  AFighterPawn *CellFighter = FindFighterAtCell(Cell);
+  AFighterPawn *CellFighter = DirectHitFighter ? DirectHitFighter
+                                               : FindFighterAtCell(Cell);
 
   switch (CurrentCommandMode) {
   case EBattleCommandMode::Move: {


### PR DESCRIPTION
### Motivation
- Prevent the overworld turn flow and streamed battle sublevel flow from conflicting by keeping tactical battle controllers and input separate from the overworld `ATurnManager` and world-map selection handling.
- Ensure left-click selection/hit-detection on streamed battle maps reliably selects fighter pawns and grid cells (not stale world-map actors) while preserving HUD interactions and right-mouse camera rotation.

### Description
- Modified `ASkald_BattleGameMode::BeginPlay`, `HandleStartingNewPlayer`, `HandleSeamlessTravelPlayer`, and `PostLogin` to avoid running the overworld `ASkaldGameMode` registration paths (call `AGameModeBase` variants and clear `TurnManager`) so battle bootstrapping does not register controllers with the overworld turn manager.
- Changed `ASkaldPlayerController::TryBindWorldMap` to unbind/avoid binding overworld `WorldMap` selection callbacks when a battle-map context is active and early-return when battle mode is detected.
- Guarded `ASkaldPlayerController::EnsureTurnManager` to refuse reacquisition of the overworld `TurnManager` while a grid/battle map flow is active, logging a verbose message and returning false.
- Reworked `ASkaldPlayerController::HandleGridClick` to perform a full cursor-ray `LineTraceMultiByChannel`, prioritize `AFighterPawn` hits (so pawn capsules win over terrain), ignore `AWorldMap`/`ATerritory` hits during tactical play, and fall back to intersecting the grid plane when no usable battle geometry is hit.
- Made fighter pawn capsule collision explicitly block `ECC_Visibility` so visibility traces used for selection hit the pawn reliably on streamed sublevels.

### Testing
- Ran `./Build/validate.sh`; the script executed but compile/tests were skipped because `UnrealBuildTool` and `UnrealEditor` were not available in the environment.
- Ran `git diff --check` and `git status` to validate the workspace diffs; checks reported clean diffs (no whitespace/patch errors).
- Manual code inspection and local trace-path reasoning performed to verify: world-map binding is bypassed in battle context, `HandleGridClick` now prioritizes fighters and falls back to grid plane, and fighter capsules block visibility traces as intended.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a199f9d69b88324af7873db7e1821ca)