### PR TITLE
Fix attack trace variable shadowing in HandleGridClick

### DIFF
--- a/Source/Skald/Skald_PlayerController.cpp
+++ b/Source/Skald/Skald_PlayerController.cpp
@@ -6970,18 +6970,20 @@ void ASkaldPlayerController::HandleGridClick() {
     if (!IsValidEnemyTarget(TargetPawn)) {
       TargetPawn = nullptr;
 
-      FVector TraceStart = Hit.TraceStart;
-      FVector TraceEnd = Hit.TraceEnd;
+      FVector AttackTraceStart = Hit.TraceStart;
+      FVector AttackTraceEnd = Hit.TraceEnd;
 
-      if (TraceStart == TraceEnd) {
-        FVector MouseWorldLocation, MouseWorldDirection;
-        if (DeprojectMousePositionToWorld(MouseWorldLocation, MouseWorldDirection)) {
+      if (AttackTraceStart == AttackTraceEnd) {
+        FVector AttackMouseWorldLocation = FVector::ZeroVector;
+        FVector AttackMouseWorldDirection = FVector::ZeroVector;
+        if (DeprojectMousePositionToWorld(AttackMouseWorldLocation,
+                                          AttackMouseWorldDirection)) {
           if (APlayerCameraManager *CameraManager = PlayerCameraManager) {
-            TraceStart = CameraManager->GetCameraLocation();
+            AttackTraceStart = CameraManager->GetCameraLocation();
           } else {
-            TraceStart = MouseWorldLocation;
+            AttackTraceStart = AttackMouseWorldLocation;
           }
-          TraceEnd = TraceStart + MouseWorldDirection * 100000.f;
+          AttackTraceEnd = AttackTraceStart + AttackMouseWorldDirection * 100000.f;
         }
       }
 
@@ -6993,8 +6995,9 @@ void ASkaldPlayerController::HandleGridClick() {
           QueryParams.AddIgnoredActor(LockedActiveFighter);
         }
 
-        if (World->LineTraceMultiByChannel(AdditionalHits, TraceStart, TraceEnd,
-                                           ECC_Visibility, QueryParams)) {
+        if (World->LineTraceMultiByChannel(AdditionalHits, AttackTraceStart,
+                                           AttackTraceEnd, ECC_Visibility,
+                                           QueryParams)) {
           for (const FHitResult &CandidateHit : AdditionalHits) {
             AFighterPawn *CandidatePawn =
                 Cast<AFighterPawn>(CandidateHit.GetActor());


### PR DESCRIPTION
### Motivation
- Resolve C4456 shadowing errors in `ASkaldPlayerController::HandleGridClick` where attack-path local trace variables hid earlier cursor-trace locals, causing compile failures.

### Description
- Renamed attack-mode fallback trace locals from `TraceStart`/`TraceEnd` to `AttackTraceStart`/`AttackTraceEnd` to avoid name collisions with the outer battle-click trace variables.
- Renamed the fallback deprojection locals from `MouseWorldLocation`/`MouseWorldDirection` to `AttackMouseWorldLocation`/`AttackMouseWorldDirection` and preserved the original fallback logic.
- Updated the additional enemy-target `LineTraceMultiByChannel` call to use the attack-specific trace variables so behavior is unchanged except for variable names.

### Testing
- Ran `git diff --check` and observed no whitespace or diff-check issues, which succeeded.
- Verified variable occurrences with `rg -n "FVector (TraceStart|TraceEnd|MouseWorldLocation|MouseWorldDirection|AttackTraceStart|AttackTraceEnd|AttackMouseWorldLocation|AttackMouseWorldDirection)" Source/Skald/Skald_PlayerController.cpp` and confirmed the new names are present and the old local names no longer conflict.
- No automated build was run in this environment as part of this PR, but the change is targeted to eliminate the compiler C4456 shadowing errors seen previously.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a19a15726048324a49bdaa04dd1bfcc)