### PR TITLE
Fix battle HUD -> grid click handoff (prevent viewport capture hiding cursor)

### DIFF
--- a/Config/DefaultInput.ini
+++ b/Config/DefaultInput.ini
@@ -74,8 +74,8 @@ bAlwaysShowTouchInterface=False
 bShowConsoleOnFourFingerTap=True
 bEnableGestureRecognizer=False
 bUseAutocorrect=False
-DefaultViewportMouseCaptureMode=CapturePermanently_IncludingInitialMouseDown
-DefaultViewportMouseLockMode=LockOnCapture
+DefaultViewportMouseCaptureMode=NoCapture
+DefaultViewportMouseLockMode=DoNotLock
 FOVScale=0.011110
 DoubleClickTime=0.200000
 +ActionMappings=(ActionName="Select",bShift=False,bCtrl=False,bAlt=False,bCmd=False,Key=LeftMouseButton)

--- a/Source/Skald/Skald_PlayerController.cpp
+++ b/Source/Skald/Skald_PlayerController.cpp
@@ -6386,6 +6386,31 @@ void ASkaldPlayerController::ReconcileBattleInputState(const TCHAR* Context) {
   ApplyBattleInteractionInputState(Context);
 }
 
+void ASkaldPlayerController::ReconcileBattleInputStateNextTick() {
+  ApplyBattleInteractionInputState(TEXT("BattleHudCommandNextTick"));
+}
+
+void ASkaldPlayerController::ReconcileBattleInputStateAfterHudCommand(
+    const TCHAR* Context) {
+  if (!IsLocalController()) {
+    return;
+  }
+
+  ApplyBattleInteractionInputState(Context);
+
+  // Slate/PIE can restore the project default viewport capture policy after a
+  // UButton click finishes its press/release sequence.  In battle this is fatal
+  // because the very next empty-grid click is interpreted as viewport capture:
+  // the cursor hides and the click never reaches HandleGridClick().  Re-assert
+  // the battle interaction policy on the next tick, after Slate has unwound, so
+  // HUD button clicks can safely hand off to world/grid clicks.
+  if (UWorld* World = GetWorld()) {
+    FTimerDelegate ReconcileDelegate = FTimerDelegate::CreateUObject(
+        this, &ASkaldPlayerController::ReconcileBattleInputStateNextTick);
+    World->GetTimerManager().SetTimerForNextTick(ReconcileDelegate);
+  }
+}
+
 void ASkaldPlayerController::SchedulePostLockInBattleInputReconcile() {
   UWorld* World = GetWorld();
   if (!World || !IsLocalController()) {
@@ -6551,6 +6576,8 @@ void ASkaldPlayerController::SetupInputComponent() {
 }
 
 void ASkaldPlayerController::BeginMoveMode() {
+  ReconcileBattleInputStateAfterHudCommand(TEXT("BeginMoveMode"));
+
   if (!LockedActiveFighter || !IsFriendlyFighter(LockedActiveFighter))
     return;
   if (LockedActiveFighter->IsEngaged()) {
@@ -6567,6 +6594,8 @@ void ASkaldPlayerController::BeginMoveMode() {
 }
 
 void ASkaldPlayerController::BeginDisengageMode() {
+  ReconcileBattleInputStateAfterHudCommand(TEXT("BeginDisengageMode"));
+
   if (!LockedActiveFighter || !IsFriendlyFighter(LockedActiveFighter))
     return;
   if (!LockedActiveFighter->IsEngaged()) {
@@ -6584,6 +6613,8 @@ void ASkaldPlayerController::BeginDisengageMode() {
 }
 
 void ASkaldPlayerController::BeginAttackMode() {
+  ReconcileBattleInputStateAfterHudCommand(TEXT("BeginAttackMode"));
+
   if (!LockedActiveFighter || !IsFriendlyFighter(LockedActiveFighter))
     return;
   CurrentCommandMode = EBattleCommandMode::Attack;
@@ -7120,7 +7151,12 @@ void ASkaldPlayerController::HandleGridClick() {
 }
 
 void ASkaldPlayerController::HandleActivatePressed() {
-  if (!IsLocalController() || !SelectedFighter)
+  if (!IsLocalController())
+    return;
+
+  ReconcileBattleInputStateAfterHudCommand(TEXT("HandleActivatePressed"));
+
+  if (!SelectedFighter)
     return;
 
   UE_LOG(LogSkaldBattle, Log,
@@ -7195,6 +7231,8 @@ void ASkaldPlayerController::HandleActivatePressed() {
 }
 
 void ASkaldPlayerController::HandleEndTurnPressed() {
+  ReconcileBattleInputStateAfterHudCommand(TEXT("HandleEndTurnPressed"));
+
   UE_LOG(LogSkaldBattle, Log,
          TEXT("[BattleHUD] End Turn pressed. Locked=%s"),
          LockedActiveFighter ? *LockedActiveFighter->GetHumanReadableName()

--- a/Source/Skald/Skald_PlayerController.h
+++ b/Source/Skald/Skald_PlayerController.h
@@ -1096,6 +1096,8 @@ private:
   void RequestBattleStateIfNeeded();
   bool ApplyBattleInteractionInputState(const TCHAR* Context);
   void ReconcileBattleInputState(const TCHAR* Context);
+  void ReconcileBattleInputStateNextTick();
+  void ReconcileBattleInputStateAfterHudCommand(const TCHAR* Context);
   void SchedulePostLockInBattleInputReconcile();
   void HandlePostLockInBattleInputReconcileTick();
 


### PR DESCRIPTION
### Motivation
- Player clicks on battle HUD buttons were sometimes causing the PIE viewport to capture the mouse (hiding the cursor) and swallow the next intended grid click, blocking fighter movement selection.  The change ensures HUD button presses reliably hand off to world/grid clicks.

### Description
- Change default viewport capture/lock policy in `Config/DefaultInput.ini` from `CapturePermanently_IncludingInitialMouseDown`/`LockOnCapture` to `NoCapture`/`DoNotLock` to avoid automatic capture of tactical clicks.
- Add two reconciler helpers to `ASkaldPlayerController`: `ReconcileBattleInputStateNextTick()` and `ReconcileBattleInputStateAfterHudCommand(const TCHAR*)`, which re-apply the battle Game+UI input policy immediately and again on the next tick to counter Slate/PIE restoring capture after a button release.
- Call `ReconcileBattleInputStateAfterHudCommand(...)` from battle HUD-driven controller actions so UI button presses (Move/Disengage/Attack/Activate/EndTurn) re-assert battle input state and allow the following world click to reach `HandleGridClick()`.
- Add declarations for the new helpers to `Source/Skald/Skald_PlayerController.h` and wire up the timer-based next-tick re-assertion using `FTimerManager`.

### Testing
- Ran `git diff --check` to validate whitespace/patch issues; the check succeeded.
- Changes were committed as `Fix battle HUD grid click capture` (no full engine build or runtime automation was executed in this rollout).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a19a328a5288324a199ffb7c8f648c0)