### PR TITLE
Fix battle initiative and side ownership gating

### DIFF
--- a/Source/Skald/GridBattleManager.cpp
+++ b/Source/Skald/GridBattleManager.cpp
@@ -1261,6 +1261,13 @@ bool UGridBattleManager::CanActivateFighter(AFighterPawn* Fighter) const
         return false;
     }
 
+    if (CurrentRound <= 0 || InitiativeWinnerFaction == ESkaldFaction::None)
+    {
+        UE_LOG(LogSkaldBattle, Verbose, TEXT("[Battle] CanActivateFighter rejected (Initiative not resolved. Round=%d Winner=%s) -> %s"),
+            CurrentRound, *UEnum::GetValueAsString(InitiativeWinnerFaction), *DescribeFighter(Fighter));
+        return false;
+    }
+
     if (!Fighter->IsAlive() || !InitiativeOrder.Contains(Fighter))
     {
         UE_LOG(LogSkaldBattle, Verbose, TEXT("[Battle] CanActivateFighter rejected (Alive=%s, InOrder=%s) -> %s"),
@@ -1747,17 +1754,11 @@ bool UGridBattleManager::IsSideAIControlled(bool bForAttackers) const
             return true;
         }
 
-        if (TargetPlayerId <= 0)
+        if (TargetPlayerId <= 0 && ParticipantDisplayName.IsEmpty() && ParticipantFaction == ESkaldFaction::None)
         {
-            const int32 OpponentPlayerId = bForAttackers ? Battle.DefenderPlayerID : Battle.AttackerPlayerID;
-            const FString& OpponentDisplayName = bForAttackers ? Battle.DefenderDisplayName : Battle.AttackerDisplayName;
-            const bool bOpponentIdentified = OpponentPlayerId > 0 || !OpponentDisplayName.IsEmpty();
-
-            if (bOpponentIdentified)
-            {
-                return true;
-            }
-
+            UE_LOG(LogSkaldBattle, Verbose,
+                TEXT("[Battle] Unable to resolve controller identity for %s; assuming player control until payload is populated."),
+                bForAttackers ? TEXT("attackers") : TEXT("defenders"));
             return false;
         }
     }

--- a/Source/Skald/Skald_PlayerController.cpp
+++ b/Source/Skald/Skald_PlayerController.cpp
@@ -10276,14 +10276,18 @@ void ASkaldPlayerController::DetermineControlledBattleSide() {
     PlayerName = PS->GetResolvedPlayerName(TEXT("DetermineControlledBattleSide"));
   }
 
-  if (!PlayerName.IsEmpty()) {
-    if (!bControlsAttackerSide && !Battle.AttackerDisplayName.IsEmpty() &&
-        PlayerName.Equals(Battle.AttackerDisplayName, ESearchCase::IgnoreCase)) {
-      bControlsAttackerSide = true;
-    }
-    if (!bControlsDefenderSide && !Battle.DefenderDisplayName.IsEmpty() &&
-        PlayerName.Equals(Battle.DefenderDisplayName, ESearchCase::IgnoreCase)) {
-      bControlsDefenderSide = true;
+  if (!PlayerName.IsEmpty() && !bControlsAttackerSide &&
+      !bControlsDefenderSide) {
+    const bool bDisplayNameMatchesAttacker =
+        !Battle.AttackerDisplayName.IsEmpty() &&
+        PlayerName.Equals(Battle.AttackerDisplayName, ESearchCase::IgnoreCase);
+    const bool bDisplayNameMatchesDefender =
+        !Battle.DefenderDisplayName.IsEmpty() &&
+        PlayerName.Equals(Battle.DefenderDisplayName, ESearchCase::IgnoreCase);
+
+    if (bDisplayNameMatchesAttacker != bDisplayNameMatchesDefender) {
+      bControlsAttackerSide = bDisplayNameMatchesAttacker;
+      bControlsDefenderSide = bDisplayNameMatchesDefender;
     }
   }
 

--- a/Source/Skald/Skald_PlayerController.cpp
+++ b/Source/Skald/Skald_PlayerController.cpp
@@ -10240,16 +10240,61 @@ void ASkaldPlayerController::DetermineControlledBattleSide() {
     return;
 
   FS_BattlePayload Battle = CachedGameInstance->PendingBattle;
-  if (CachedGameState)
-  {
-    Battle = CachedGameState->GetActiveBattlePayload();
+  if (CachedGameState) {
+    const FS_BattlePayload &ReplicatedBattle = CachedGameState->GetActiveBattlePayload();
+    const bool bReplicatedBattleValid =
+        ReplicatedBattle.AttackerPlayerID > 0 ||
+        ReplicatedBattle.DefenderPlayerID > 0 ||
+        ReplicatedBattle.AttackerFaction != ESkaldFaction::None ||
+        ReplicatedBattle.DefenderFaction != ESkaldFaction::None ||
+        !ReplicatedBattle.AttackerDisplayName.IsEmpty() ||
+        !ReplicatedBattle.DefenderDisplayName.IsEmpty();
+    if (bReplicatedBattleValid) {
+      Battle = ReplicatedBattle;
+    }
   }
-  const int32 PlayerID = ResolveStablePlayerId(PS);
-  if (PlayerID == Battle.AttackerPlayerID) {
+
+  const int32 StablePlayerID = ResolveStablePlayerId(PS);
+  const int32 RuntimePlayerID = PS->GetPlayerId();
+  const int32 AuthoritativePlayerID = PS->GetAuthoritativePlayerId();
+
+  auto MatchesPlayerId = [&](int32 CandidateId) {
+    return CandidateId > 0 &&
+           (CandidateId == StablePlayerID || CandidateId == RuntimePlayerID ||
+            CandidateId == AuthoritativePlayerID);
+  };
+
+  if (MatchesPlayerId(Battle.AttackerPlayerID)) {
     bControlsAttackerSide = true;
   }
-  if (PlayerID == Battle.DefenderPlayerID) {
+  if (MatchesPlayerId(Battle.DefenderPlayerID)) {
     bControlsDefenderSide = true;
+  }
+
+  FString PlayerName = PS->PlayerDisplayName;
+  if (PlayerName.IsEmpty()) {
+    PlayerName = PS->GetResolvedPlayerName(TEXT("DetermineControlledBattleSide"));
+  }
+
+  if (!PlayerName.IsEmpty()) {
+    if (!bControlsAttackerSide && !Battle.AttackerDisplayName.IsEmpty() &&
+        PlayerName.Equals(Battle.AttackerDisplayName, ESearchCase::IgnoreCase)) {
+      bControlsAttackerSide = true;
+    }
+    if (!bControlsDefenderSide && !Battle.DefenderDisplayName.IsEmpty() &&
+        PlayerName.Equals(Battle.DefenderDisplayName, ESearchCase::IgnoreCase)) {
+      bControlsDefenderSide = true;
+    }
+  }
+
+  if (!bControlsAttackerSide && !bControlsDefenderSide &&
+      PS->Faction != ESkaldFaction::None) {
+    const bool bFactionMatchesAttacker = Battle.AttackerFaction == PS->Faction;
+    const bool bFactionMatchesDefender = Battle.DefenderFaction == PS->Faction;
+    if (bFactionMatchesAttacker != bFactionMatchesDefender) {
+      bControlsAttackerSide = bFactionMatchesAttacker;
+      bControlsDefenderSide = bFactionMatchesDefender;
+    }
   }
 }
 


### PR DESCRIPTION
### Motivation
- Prevent fighter activation and AI automation from running before the tactical round has fully started and initiative has resolved, which could allow AI moves or block player input during battle startup.
- Stop treating an incompletely-populated battle payload as evidence that a side is AI-controlled, which caused local players to lose selection/control of their fighters.
- Make local side-ownership resolution more robust so the controller can correctly determine whether the local player controls attackers/defenders and re-enable grid interaction.

### Description
- Added a guard in `UGridBattleManager::CanActivateFighter` to reject activations when `CurrentRound <= 0` or `InitiativeWinnerFaction == ESkaldFaction::None`, preventing activations before initiative is resolved (`Source/Skald/GridBattleManager.cpp`).
- Modified `UGridBattleManager::IsSideAIControlled` to avoid defaulting to AI control when the participant payload is incomplete by checking for an empty `TargetPlayerId`, `ParticipantDisplayName`, and `ParticipantFaction` and returning player control until payload data arrives (`Source/Skald/GridBattleManager.cpp`).
- Reworked `ASkaldPlayerController::DetermineControlledBattleSide` to prefer a valid replicated payload, resolve player ownership using stable/runtime/authoritative IDs, match display names, and fall back to unique faction matches, improving resilience of local ownership detection and restoring correct friendly/enemy classification (`Source/Skald/Skald_PlayerController.cpp`).

### Testing
- Ran `git diff --check` to validate the workspace formatting and diffs and committed the changes successfully; no unit test run was performed in this rollout.
- Verified via local compile/inspection that the new gating and matching logic are present in `GridBattleManager.cpp` and `Skald_PlayerController.cpp` and that the commit recorded changes to both files.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a19b766ec788324b2487447ae89b22f)