### PR TITLE
Forward Battle HUD empty-space clicks to grid handler

### DIFF
--- a/Source/Skald/Skald_PlayerController.cpp
+++ b/Source/Skald/Skald_PlayerController.cpp
@@ -58,6 +58,7 @@
 #include "Sound/SoundBase.h"
 
 #include "Misc/EngineVersionComparison.h"
+#include "Misc/ScopeExit.h"
 #include "Misc/CoreDelegates.h"
 #if UE_VERSION_OLDER_THAN(5, 5, 0)
 #include "UObject/CoreUObjectDelegates.h"
@@ -3327,16 +3328,15 @@ void ASkaldPlayerController::EnsureBattleHUDVisible() {
     return;
   }
 
-  // The battle HUD spans the viewport, so the widget itself must not be a
-  // hit-test target.  Keeping only its children hit-testable lets HUD buttons
-  // consume clicks while empty HUD space still falls through to grid/fighter
-  // traces.
-  BattleHudWidget->SetVisibility(ESlateVisibility::SelfHitTestInvisible);
+  // The battle HUD spans the viewport. Keep it hit-testable so empty-space
+  // clicks that Slate routes to the HUD can be forwarded explicitly into the
+  // tactical grid handler, while child buttons still consume their own clicks.
+  BattleHudWidget->SetVisibility(ESlateVisibility::Visible);
   bBattleHUDVisible = true;
 
   // After selection lock-in/deploy, restore the battle input policy. This keeps
-  // Game+UI active for HUD buttons while allowing empty HUD space to fall through
-  // to grid/fighter traces and camera controls.
+  // Game+UI active for HUD buttons while letting the HUD forward empty-space
+  // clicks to grid/fighter traces and preserve camera controls.
   ApplyBattleInteractionInputState(TEXT("EnsureBattleHUDVisible"));
 }
 
@@ -6342,9 +6342,9 @@ bool ASkaldPlayerController::ApplyBattleInteractionInputState(
   } else {
     // Normal battle play still needs a live Game+UI input mode: unhandled WASD,
     // mouse-axis, and wheel input fall through to the camera pawn, while the
-    // visible UBattleHUDWidget buttons continue to receive UI clicks.  The HUD
-    // root is made SelfHitTestInvisible when shown, so empty HUD space still
-    // falls through to grid/fighter traces.
+    // visible UBattleHUDWidget buttons continue to receive UI clicks. Empty
+    // HUD-space left clicks are forwarded by the HUD into HandleGridClick(),
+    // which keeps grid/fighter traces alive even when Slate owns the click.
     //
     // Keep the viewport in NoCapture for battle interaction.  Using
     // CaptureDuringMouseDown makes landscape/empty-grid clicks capture the PIE
@@ -6623,6 +6623,15 @@ void ASkaldPlayerController::BeginAttackMode() {
   }
 }
 
+void ASkaldPlayerController::HandleBattleHudWorldClick() {
+  if (!IsLocalController()) {
+    return;
+  }
+
+  TGuardValue<bool> ForwardedClickGuard(bHandlingBattleHudForwardedClick, true);
+  HandleGridClick();
+}
+
 void ASkaldPlayerController::HandleGridClick() {
   if (!IsLocalController())
     return;
@@ -6631,7 +6640,8 @@ void ASkaldPlayerController::HandleGridClick() {
   const bool bBattleMapActive =
       bIsBattleMap || (CachedGameInstance && CachedGameInstance->bIsInBattleMap);
 
-  if (IsCursorOverInteractableSlateWidget()) {
+  if (!bHandlingBattleHudForwardedClick &&
+      IsCursorOverInteractableSlateWidget()) {
     return;
   }
 

--- a/Source/Skald/Skald_PlayerController.h
+++ b/Source/Skald/Skald_PlayerController.h
@@ -618,6 +618,9 @@ protected:
   /** Ensures ServerInitPlayerState and lock-in handling run only once. */
   bool bHasInitialized;
 
+  /** True while the Battle HUD is explicitly forwarding an empty-space world click. */
+  bool bHandlingBattleHudForwardedClick = false;
+
   /** Default mouse capture behavior for this controller. */
   UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Input")
   EMouseCaptureMode DefaultMouseCaptureMode;
@@ -679,6 +682,9 @@ protected:
   void HandleRightClick();
 
 public:
+  /** Forward an empty-space Battle HUD click into the tactical grid handler. */
+  void HandleBattleHudWorldClick();
+
   /** Handle HUD attack submissions.
    *  Bound to USkaldMainHUDWidget::OnAttackRequested in the HUD.
    *  Blueprint widgets invoke this when an attack is submitted.

--- a/Source/Skald/UI/BattleHUDWidget.cpp
+++ b/Source/Skald/UI/BattleHUDWidget.cpp
@@ -16,6 +16,7 @@
 #include "Engine/World.h"
 #include "FighterPawn.h"
 #include "GridOverlayComponent.h"
+#include "InputCoreTypes.h"
 #include "UI/CombatFloaterPoolSubsystem.h"
 #include "UI/LockedInFighterEntryWidget.h"
 #include "UI/SkaldTooltipStatics.h"
@@ -242,6 +243,21 @@ void UBattleHUDWidget::NativeConstruct() {
   CacheDefaultTextColor(EnemyAttackDiceText);
 
   UpgradeStatIconTooltips();
+}
+
+FReply UBattleHUDWidget::NativeOnMouseButtonDown(
+    const FGeometry &InGeometry, const FPointerEvent &InMouseEvent) {
+  if (InMouseEvent.GetEffectingButton() == EKeys::LeftMouseButton &&
+      !IsInitiativePromptActive() && !IsManualAttackRollPromptActive() &&
+      !IsManualDiceResolutionActive() && !IsCombatPresentationActive()) {
+    if (ASkaldPlayerController *SkaldPC =
+            Cast<ASkaldPlayerController>(GetOwningPlayer())) {
+      SkaldPC->HandleBattleHudWorldClick();
+      return FReply::Handled();
+    }
+  }
+
+  return Super::NativeOnMouseButtonDown(InGeometry, InMouseEvent);
 }
 
 void UBattleHUDWidget::NativeTick(const FGeometry &MyGeometry,

--- a/Source/Skald/UI/BattleHUDWidget.h
+++ b/Source/Skald/UI/BattleHUDWidget.h
@@ -94,6 +94,8 @@ public:
   virtual void NativeTick(const FGeometry &MyGeometry,
                           float InDeltaTime) override;
   virtual void NativeDestruct() override;
+  virtual FReply NativeOnMouseButtonDown(
+      const FGeometry &InGeometry, const FPointerEvent &InMouseEvent) override;
 
   /** Refresh all stat text from the currently bound fighter. */
   UFUNCTION(BlueprintCallable, Category = "Skald|Battle")


### PR DESCRIPTION
### Motivation
- Empty-space clicks routed to the Battle HUD were being swallowed by Slate after HUD button interactions, preventing grid cells from receiving move/attack clicks during tactical play.
- The intent is to allow HUD buttons to remain interactive while ensuring clicks on empty HUD area still perform grid/fighter traces and trigger existing `HandleGridClick()` behavior.

### Description
- Make the battle HUD widget hit-testable (`SetVisibility(ESlateVisibility::Visible)`) so it can receive empty-space mouse events and forward them instead of relying on hit-test invisibility to let clicks fall through. (changed in `ASkaldPlayerController::EnsureBattleHUDVisible`) 
- Add a `NativeOnMouseButtonDown` override in `UBattleHUDWidget` that forwards non-modal left-clicks into the player controller via a new `ASkaldPlayerController::HandleBattleHudWorldClick()` entrypoint, while ignoring clicks when initiative/manual-roll/dice-resolution/combat-presentation is active. (`Source/Skald/UI/BattleHUDWidget.*`)
- Add a guarded forwarding flag `bHandlingBattleHudForwardedClick` to the player controller so forwarded HUD clicks bypass the Slate-interactable early-out (`IsCursorOverInteractableSlateWidget()`), letting the existing `HandleGridClick()` logic process the click as a world/grid hit. (`Source/Skald/Skald_PlayerController.*`)
- Use `TGuardValue<bool>` to ensure the guard is scoped only while forwarding a HUD click and does not affect normal UI input paths.

### Testing
- Ran `git diff --check` to verify there are no whitespace/patch issues; this check passed.
- Attempted local syntax-only checks with `clang++ -fsyntax-only` for the modified translation units, but these checks could not complete because Unreal Engine headers (e.g. `CoreMinimal.h`, `Blueprint/UserWidget.h`) are not available in this container; therefore full compilation checks were blocked.
- Performed repository grep/search and basic static validation commands to confirm the new APIs are wired into the existing HUD/controller flow and committed the changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a19beedef508324b2e94514ad8b6f4f)