### PR TITLE
Fix physical dice roll broadcast and restore battle camera rotation

### DIFF
--- a/Config/DefaultInput.ini
+++ b/Config/DefaultInput.ini
@@ -86,6 +86,8 @@ DoubleClickTime=0.200000
 +AxisMappings=(AxisName="MoveUp",Scale=-1.000000,Key=LeftControl)
 +AxisMappings=(AxisName="Turn",Scale=1.000000,Key=MouseX)
 +AxisMappings=(AxisName="LookUp",Scale=-1.000000,Key=MouseY)
++AxisMappings=(AxisName="BattleRotate",Scale=-1.000000,Key=Q)
++AxisMappings=(AxisName="BattleRotate",Scale=1.000000,Key=E)
 +AxisMappings=(AxisName="BattleZoom",Scale=1.000000,Key=MouseWheelAxis)
 DefaultPlayerInputClass=/Script/EnhancedInput.EnhancedPlayerInput
 DefaultInputComponentClass=/Script/EnhancedInput.EnhancedInputComponent

--- a/Source/Skald/Skald_PlayerCharacter.cpp
+++ b/Source/Skald/Skald_PlayerCharacter.cpp
@@ -192,6 +192,52 @@ bool ASkald_PlayerCharacter::ShouldProcessBattleMouseInput() const
         return false;
 }
 
+
+void ASkald_PlayerCharacter::ApplyBattleMouseDragInput()
+{
+        APlayerController* PlayerController = Cast<APlayerController>(Controller);
+        if (!bBattleCameraActive || !PlayerController || !PlayerController->IsInputKeyDown(EKeys::RightMouseButton))
+        {
+                bBattleRightMouseDragActive = false;
+                return;
+        }
+
+        float MouseX = 0.f;
+        float MouseY = 0.f;
+        if (!PlayerController->GetMousePosition(MouseX, MouseY))
+        {
+                bBattleRightMouseDragActive = false;
+                return;
+        }
+
+        const FVector2D CurrentMousePosition(MouseX, MouseY);
+        if (!bBattleRightMouseDragActive)
+        {
+                LastBattleRightMousePosition = CurrentMousePosition;
+                bBattleRightMouseDragActive = true;
+                return;
+        }
+
+        const FVector2D MouseDelta = CurrentMousePosition - LastBattleRightMousePosition;
+        LastBattleRightMousePosition = CurrentMousePosition;
+
+        if (MouseDelta.IsNearlyZero())
+        {
+                return;
+        }
+
+        if (bBattleCameraLocked)
+        {
+                bHasManuallyRotatedWhileLocked = true;
+        }
+
+        DesiredBattleRotation.Yaw = FRotator::NormalizeAxis(
+                DesiredBattleRotation.Yaw + (MouseDelta.X * BattleMouseYawSpeed));
+        DesiredBattleRotation.Pitch = FMath::Clamp(
+                DesiredBattleRotation.Pitch + (MouseDelta.Y * BattleMousePitchSpeed),
+                MinBattlePitch, MaxBattlePitch);
+}
+
 bool ASkald_PlayerCharacter::ShouldProcessOverviewMouseInput() const
 {
         if (bBattleCameraActive)
@@ -298,6 +344,7 @@ void ASkald_PlayerCharacter::SetupPlayerInputComponent(UInputComponent* PlayerIn
         PlayerInputComponent->BindAxis("MoveUp", this, &ASkald_PlayerCharacter::MoveUp);
         PlayerInputComponent->BindAxis("Turn", this, &ASkald_PlayerCharacter::Turn);
         PlayerInputComponent->BindAxis("LookUp", this, &ASkald_PlayerCharacter::LookUp);
+        PlayerInputComponent->BindAxis("BattleRotate", this, &ASkald_PlayerCharacter::BattleRotateCamera);
         PlayerInputComponent->BindAxis("BattleZoom", this, &ASkald_PlayerCharacter::AdjustZoom);
 
         PlayerInputComponent->BindAction("Ability1", IE_Pressed, this, &ASkald_PlayerCharacter::AbilityOne);
@@ -392,16 +439,9 @@ void ASkald_PlayerCharacter::Turn(float Value)
 {
 	if (bBattleCameraActive)
         {
-                if (!FMath::IsNearlyZero(Value) && ShouldProcessBattleMouseInput())
-                {
-                        if (bBattleCameraLocked)
-                        {
-                                bHasManuallyRotatedWhileLocked = true;
-                        }
-
-                        DesiredBattleRotation.Yaw = FRotator::NormalizeAxis(
-                                DesiredBattleRotation.Yaw + (Value * BattleMouseYawSpeed));
-                }
+                // Battle RMB drag rotation is sampled in UpdateBattleCamera so it
+                // still works while the battle HUD keeps the viewport in
+                // NoCapture/Game+UI mode for clickable widgets.
                 return;
         }
 
@@ -424,16 +464,9 @@ void ASkald_PlayerCharacter::LookUp(float Value)
 {
 	if (bBattleCameraActive)
         {
-                if (!FMath::IsNearlyZero(Value) && ShouldProcessBattleMouseInput())
-                {
-                        if (bBattleCameraLocked)
-                        {
-                                bHasManuallyRotatedWhileLocked = true;
-                        }
-
-                        const float NewPitch = DesiredBattleRotation.Pitch + (Value * BattleMousePitchSpeed);
-                        DesiredBattleRotation.Pitch = FMath::Clamp(NewPitch, MinBattlePitch, MaxBattlePitch);
-                }
+                // Battle RMB drag rotation is sampled in UpdateBattleCamera so it
+                // still works while the battle HUD keeps the viewport in
+                // NoCapture/Game+UI mode for clickable widgets.
                 return;
         }
 
@@ -458,6 +491,29 @@ void ASkald_PlayerCharacter::LookUp(float Value)
         {
                 OverviewDefaultPitch = NewPitch;
         }
+}
+
+
+void ASkald_PlayerCharacter::BattleRotateCamera(float Value)
+{
+        if (!bBattleCameraActive || FMath::IsNearlyZero(Value))
+        {
+                return;
+        }
+
+        const float DeltaTime = GetWorld() ? GetWorld()->GetDeltaSeconds() : 0.f;
+        if (DeltaTime <= 0.f)
+        {
+                return;
+        }
+
+        if (bBattleCameraLocked)
+        {
+                bHasManuallyRotatedWhileLocked = true;
+        }
+
+        const float YawDelta = Value * BattleKeyboardYawSpeed * DeltaTime;
+        DesiredBattleRotation.Yaw = FRotator::NormalizeAxis(DesiredBattleRotation.Yaw + YawDelta);
 }
 
 void ASkald_PlayerCharacter::Select()
@@ -809,6 +865,7 @@ void ASkald_PlayerCharacter::SetBattleCameraActive(bool bActive)
 
                 BattleMoveInput = FVector2D::ZeroVector;
                 BattleCameraVelocity = FVector::ZeroVector;
+                bBattleRightMouseDragActive = false;
 
                 if (UCharacterMovementComponent* MovementComponent = GetCharacterMovement())
                 {
@@ -840,6 +897,7 @@ void ASkald_PlayerCharacter::SetBattleCameraActive(bool bActive)
 
                 BattleMoveInput = FVector2D::ZeroVector;
                 BattleCameraVelocity = FVector::ZeroVector;
+                bBattleRightMouseDragActive = false;
 
                 bBattleCameraActive = false;
         }
@@ -960,6 +1018,8 @@ void ASkald_PlayerCharacter::UpdateBattleCamera(float DeltaTime)
                 MovementComponent->Velocity = FVector::ZeroVector;
         }
 
+        ApplyBattleMouseDragInput();
+
         CurrentBattleRotation = FMath::RInterpTo(CurrentBattleRotation, DesiredBattleRotation, DeltaTime, BattleRotationInterpSpeed);
         CameraBoom->SetWorldRotation(CurrentBattleRotation);
 
@@ -1013,6 +1073,7 @@ void ASkald_PlayerCharacter::ClearBattleCameraLock()
         LockedBattleActor = nullptr;
         BattleCameraVelocity = FVector::ZeroVector;
         bHasManuallyRotatedWhileLocked = false;
+        bBattleRightMouseDragActive = false;
 
         DesiredBattleZoom = FMath::Clamp(DefaultBattleZoom, MinBattleZoom, MaxBattleZoom);
         const float ClampedPitch = FMath::Clamp(DefaultBattlePitch, MinBattlePitch, MaxBattlePitch);

--- a/Source/Skald/Skald_PlayerCharacter.h
+++ b/Source/Skald/Skald_PlayerCharacter.h
@@ -122,6 +122,10 @@ public:
         UFUNCTION(BlueprintCallable, Category="Input")
         void LookUp(float Value);
 
+        /** Rotate the battle camera with keyboard input. */
+        UFUNCTION(BlueprintCallable, Category="Input")
+        void BattleRotateCamera(float Value);
+
         /** Adjust zoom level when the battle camera is active. */
         UFUNCTION(BlueprintCallable, Category="Input")
         void AdjustZoom(float Value);
@@ -349,6 +353,7 @@ private:
         FVector ComputeOverviewPivotLocation() const;
         void RefreshOverviewPivot();
         bool ShouldProcessBattleMouseInput() const;
+        void ApplyBattleMouseDragInput();
         bool ShouldProcessOverviewMouseInput() const;
         FVector2D GetLockedOverviewPitchRange() const;
 
@@ -412,6 +417,12 @@ private:
 
         /** Tracks if the player has manually rotated the camera while locked on. */
         bool bHasManuallyRotatedWhileLocked = false;
+
+        /** Tracks RMB drag deltas while viewport mouse capture is disabled. */
+        bool bBattleRightMouseDragActive = false;
+
+        /** Last observed mouse position for the battle RMB drag camera. */
+        FVector2D LastBattleRightMousePosition = FVector2D::ZeroVector;
 
         /** Convert the configured relative lock offset into world space. */
         FVector GetBattleLockWorldOffset(const AActor* FocusActor) const;

--- a/Source/Skald/Skald_PlayerController.cpp
+++ b/Source/Skald/Skald_PlayerController.cpp
@@ -244,6 +244,18 @@ void ASkaldPlayerController::BroadcastPhysicalDiceRoll(
          TEXT("[DiceArena] Broadcasting roll %s (PlayerDice=%d EnemyDice=%d)"),
          *RollId.ToString(), PlayerDice, EnemyDice);
 
+  // Drive the authoritative dice manager with the same RollId/results that are
+  // sent to clients.  The previous server path only broadcast the client RPC,
+  // while authority-side listeners such as AFighterPawn waited on
+  // OnDiceRollCompleted forever.  That left physical attack rolls stuck after
+  // the arena spawned because ProcessPhysicalDiceRollResults never ran.
+  if (DiceManager) {
+    const FGuid ServerRollId = DiceManager->PlayScriptedRoll(
+        PlayerResults, EnemyResults, bForInitiative, -1.f, PlayerColor,
+        EnemyColor, RollId);
+    ensure(!ServerRollId.IsValid() || ServerRollId == RollId);
+  }
+
   for (FConstPlayerControllerIterator It = World->GetPlayerControllerIterator(); It;
        ++It) {
     if (ASkaldPlayerController *PC = Cast<ASkaldPlayerController>(*It)) {


### PR DESCRIPTION
### Motivation
- Physical attack rolls were being broadcast to clients but not driven through the authoritative dice manager on the server, leaving server-side listeners (e.g., AFighterPawn) waiting on `OnDiceRollCompleted` and preventing attack resolution. 
- Players could not rotate the battle camera using `Q`/`E` or RMB drag while battle UI was active because rotation relied on viewport capture which the HUD intentionally disables in Game+UI/NoCapture mode.

### Description
- Route server-side broadcasts through the authoritative dice subsystem by calling `USkaldDiceManager::PlayScriptedRoll(...)` with the same `RollId`/results sent to clients so the server receives `OnDiceRollCompleted` and resolves queued physical attacks (`Source/Skald/Skald_PlayerController.cpp`).
- Add a new input axis `BattleRotate` mapped to `Q` (negative) and `E` (positive) in `Config/DefaultInput.ini` and bind it to a new `BattleRotateCamera` handler on the player character to support keyboard rotation while in battle mode.
- Implement `BattleRotateCamera(float)` to yaw the battle camera via keyboard when the battle camera is active and mark manual rotation so auto-facing does not override it (`Source/Skald/Skald_PlayerCharacter.h/.cpp`).
- Implement polling-based RMB drag rotation via `ApplyBattleMouseDragInput()` and sample mouse deltas during `UpdateBattleCamera()` so RMB drag works even when the HUD keeps the viewport in `NoCapture` Game+UI mode; add small per-player state (`bBattleRightMouseDragActive`, `LastBattleRightMousePosition`) to support this flow (`Source/Skald/Skald_PlayerCharacter.h/.cpp`).

### Testing
- Ran `git diff --check` to validate workspace diffs and found no whitespace/merge errors (succeeded).
- Searched for relevant symbols and new call-sites with `rg -n "BattleRotate|ApplyBattleMouseDragInput|PlayScriptedRoll\("` to confirm the new bindings and authoritative roll usage are present (succeeded).
- Attempted to run the editor automation (`UnrealEditor Skald.uproject -run=AutomationTool -help`) to exercise runtime behavior but the `UnrealEditor` binary is not available in this environment, so no automated gameplay/engine tests were executed (environment limitation).
- Manual static verification confirms the server now drives the authoritative dice manager with the same `RollId`, and player-character code binds `BattleRotate` and polls RMB delta during battle updates; runtime QA in-editor is still required to fully validate in-game behaviour (not run here).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a19ea7c70b483248cfdbe28c80dabd1)