### PR TITLE
Fix dice presentation on hosts and stabilize battle->overview resume

### DIFF
--- a/Source/Skald/Skald_PlayerController.cpp
+++ b/Source/Skald/Skald_PlayerController.cpp
@@ -247,12 +247,17 @@ void ASkaldPlayerController::BroadcastPhysicalDiceRoll(
   // If another authoritative flow already started this RollId (for example
   // initiative via RollDice_D6), leave that roll alone. Replaying it here would
   // spawn a second server-side arena and overwrite the active roll, causing
-  // duplicate dice in overview/battle initiative and orphaned actors. For attack
-  // broadcasts that only render on clients, schedule server callbacks without
-  // spawning presentation actors so AFighterPawn still receives completion.
+  // duplicate dice in overview/battle initiative and orphaned actors. Dedicated
+  // servers only need authoritative callbacks, but standalone/listen hosts also
+  // need visible physical dice because their authority RPC implementation skips
+  // the client-side duplicate presentation below.
   if (DiceManager && !DiceManager->IsRollActive(RollId)) {
-    const FGuid ServerRollId = DiceManager->PlayScriptedRollWithoutPresentation(
-        PlayerResults, EnemyResults, bForInitiative, -1.f, RollId);
+    const bool bCanPresentOnAuthority = World->GetNetMode() != NM_DedicatedServer;
+    const FGuid ServerRollId = bCanPresentOnAuthority
+        ? DiceManager->PlayScriptedRoll(PlayerResults, EnemyResults, bForInitiative,
+                                        -1.f, PlayerColor, EnemyColor, RollId)
+        : DiceManager->PlayScriptedRollWithoutPresentation(
+              PlayerResults, EnemyResults, bForInitiative, -1.f, RollId);
     ensure(!ServerRollId.IsValid() || ServerRollId == RollId);
   }
 
@@ -3739,10 +3744,16 @@ void ASkaldPlayerController::DetectBattleMap() {
     bDetectedBattleMap = CachedGameInstance->bIsInBattleMap;
 
     if (!bDetectedBattleMap) {
-      if (USkaldBattleLevelManager* BattleLevelManager =
-              CachedGameInstance->GetBattleLevelManager()) {
-        bDetectedBattleMap = BattleLevelManager->PromoteLoadedBattleLevelIfReady(
-            TEXT("DetectBattleMap"));
+      const bool bBattleTravelOrResolutionPending =
+          CachedGameInstance->IsTravelPending() ||
+          CachedGameInstance->bPendingBattleResolution ||
+          CachedGameInstance->PendingBattleResolution.bValid;
+      if (!bBattleTravelOrResolutionPending) {
+        if (USkaldBattleLevelManager* BattleLevelManager =
+                CachedGameInstance->GetBattleLevelManager()) {
+          bDetectedBattleMap = BattleLevelManager->PromoteLoadedBattleLevelIfReady(
+              TEXT("DetectBattleMap"));
+        }
       }
     }
 

--- a/Source/Skald/Skald_TurnManager.cpp
+++ b/Source/Skald/Skald_TurnManager.cpp
@@ -3558,13 +3558,17 @@ void ATurnManager::ResolveGridBattleResult_Implementation() {
     return;
   }
 
-  GI->SetBattleMapActive(false);
-  if (HasAuthority()) {
-    MulticastSetBattleMapActive(false);
-  }
+  // Start unloading before clearing the battle-map flag. Otherwise local
+  // controllers can observe a still-visible, fully-ready streamed battle level
+  // and immediately promote the flag back to active while the conclusion is
+  // trying to return to the overworld.
   if (USkaldBattleLevelManager *BattleLevelManager =
           GI->GetBattleLevelManager()) {
     BattleLevelManager->ReleaseBattleLevel();
+  }
+  GI->SetBattleMapActive(false);
+  if (HasAuthority()) {
+    MulticastSetBattleMapActive(false);
   }
 
   // Always mirror the pending payload locally for reference.


### PR DESCRIPTION
### Motivation

- Players reported no visible dice presentation for some attack rolls while results still applied, and logs showed physical roll values being received but not presented (`ProcessPhysicalDiceRollResults`).
- After battle conclusion the streamed battle sublevel was being released but the client sometimes re-promoted the battle-map flag and failed to resume overworld turn state correctly.
- The authoritative flow for battle conclusion could let controllers observe a still-ready streamed sublevel and re-enter battle HUD/input before the overworld resume applied.

### Description

- Present authoritative physical dice on non-dedicated authoritative hosts by calling `PlayScriptedRoll` (physical presentation) when the server is not a dedicated server, while retaining `PlayScriptedRollWithoutPresentation` on dedicated servers to keep callback-only behavior (`Source/Skald/Skald_PlayerController.cpp`).
- Prevent `DetectBattleMap()` from promoting a loaded streamed battle level while travel or a pending battle resolution is in progress by checking `IsTravelPending()` and pending-resolution flags before calling `PromoteLoadedBattleLevelIfReady` (`Source/Skald/Skald_PlayerController.cpp`).
- During battle conclusion, begin unloading the battle sublevel via the `USkaldBattleLevelManager::ReleaseBattleLevel()` call before clearing the game-instance battle-map active flag so clients cannot prematurely re-promote battle state; then clear the flag and multicast the change (`Source/Skald/Skald_TurnManager.cpp`).

### Testing

- Ran the project validation script `bash Build/validate.sh` which executed but could not perform compile or automation tests because `UnrealBuildTool` and `UnrealEditor` were not available in the environment (script skipped those steps).
- Ran `git diff --check` and `git diff --stat` to verify the working changes; no whitespace or diff-check issues reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1a11a316008324ba94229ea3a0520c)