### PR TITLE
Avoid duplicate attack dice presentation

### DIFF
--- a/Source/Skald/FighterPawn.cpp
+++ b/Source/Skald/FighterPawn.cpp
@@ -3238,6 +3238,7 @@ void AFighterPawn::ProcessPhysicalDiceRollResults(
   FDiceRollResult DiceResult =
       UGridBattleManager::ResolveAttackDice(AttackerStats, DefenderStatsSnapshot,
                                             *RandomStream, Results);
+  DiceResult.bResolvedFromPhysicalRoll = true;
 
   TArray<int32> SanitizedResults = Results;
   if (SanitizedResults.Num() > DiceResult.DiceOutcomes.Num()) {
@@ -3267,6 +3268,7 @@ void AFighterPawn::ProcessPhysicalDiceRollResults(
             : (Target ? Target->Stats : FFighterStats());
 
     PendingAttackDiceResult.HighStakesFaction = Faction;
+    PendingAttackDiceResult.bResolvedFromPhysicalRoll = true;
     bPendingPhysicalRollValuesApplied = false;
     ApplyPendingPhysicalRollValues();
 

--- a/Source/Skald/GridBattleManager.h
+++ b/Source/Skald/GridBattleManager.h
@@ -102,6 +102,10 @@ struct FDiceRollResult
     UPROPERTY(BlueprintReadOnly, Category="Skald|Battle|Dice")
     bool bHighStakesCritical = false;
 
+    /** True when the displayed combat dice were already rolled through the physical dice arena. */
+    UPROPERTY(BlueprintReadOnly, Category="Skald|Battle|Dice")
+    bool bResolvedFromPhysicalRoll = false;
+
     UPROPERTY(BlueprintReadOnly, Category="Skald|Battle|Dice")
     ESkaldFaction HighStakesFaction = ESkaldFaction::None;
 };

--- a/Source/Skald/Skald_PlayerController.cpp
+++ b/Source/Skald/Skald_PlayerController.cpp
@@ -8807,11 +8807,18 @@ void ASkaldPlayerController::HandleAttackResolved(AFighterPawn *Attacker,
       return;
     }
 
+    if (Result.bResolvedFromPhysicalRoll) {
+      ProcessAttackResolutionPresentation(Attacker, Defender, Result);
+      return;
+    }
+
     StartAttackDiceSequence(Attacker, Defender, Result);
     return;
   }
 
-  TriggerAttackDicePresentation(Attacker, Defender, Result);
+  if (!Result.bResolvedFromPhysicalRoll) {
+    TriggerAttackDicePresentation(Attacker, Defender, Result);
+  }
   ProcessAttackResolutionPresentation(Attacker, Defender, Result);
 }
 


### PR DESCRIPTION
### Motivation
- Prevent AI-initiated attacks from spawning a second scripted dice arena when the physical dice arena already produced the roll, which caused duplicate dice presentation during battle.

### Description
- Add `bResolvedFromPhysicalRoll` to `FDiceRollResult` to mark results produced by the physical dice arena (`Source/Skald/GridBattleManager.h`).
- Set `bResolvedFromPhysicalRoll` when processing completed physical rolls and preserve it when merging into an existing queued attack (`Source/Skald/FighterPawn.cpp`).
- Update player-controller presentation flow to skip spawning the scripted dice arena when `Result.bResolvedFromPhysicalRoll` is true while still running resolution UI/feedback (`Source/Skald/Skald_PlayerController.cpp`).

### Testing
- Ran `git diff --check` to validate patch formatting and found no issues (passed).
- Verified Unreal build tooling was not available in the environment, so a full Unreal build/test could not be run here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1a1e0f1d4c832494809698e5b03c00)