### PR TITLE
Restore overview camera & reconnect controllers after streamed battles; ensure AI attack overview pans before rolling

### DIFF
--- a/Source/Skald/Skald_BattleLevelManager.cpp
+++ b/Source/Skald/Skald_BattleLevelManager.cpp
@@ -264,6 +264,7 @@ void USkaldBattleLevelManager::ReleaseBattleLevel() {
     UnregisterWorldDelegates();
     UnregisterStreamingTicker();
     RestoreNonBattleLevels();
+    RestoreLocalBattleCameraStates();
     bActiveLevelShouldBeLoaded = false;
     bActiveLevelVisibilityRequested = false;
     bActiveLevelActivationComplete = false;
@@ -517,6 +518,7 @@ void USkaldBattleLevelManager::HandleLevelUnloaded() {
   UnregisterWorldDelegates();
   UnregisterStreamingTicker();
   RestoreNonBattleLevels();
+  RestoreLocalBattleCameraStates();
 
   bActiveLevelShouldBeLoaded = false;
   bActiveLevelVisibilityRequested = false;
@@ -964,6 +966,67 @@ bool USkaldBattleLevelManager::CalculateActiveBattleLevelBounds(FBox& OutBounds)
   return OutBounds.IsValid != 0;
 }
 
+
+void USkaldBattleLevelManager::CacheLocalBattleCameraStates(UWorld* World) {
+  if (!World) {
+    return;
+  }
+
+  for (FConstPlayerControllerIterator It = World->GetPlayerControllerIterator(); It; ++It) {
+    APlayerController* PC = It->Get();
+    if (!PC || !PC->IsLocalController()) {
+      continue;
+    }
+
+    ASkald_PlayerCharacter* CameraPawn = Cast<ASkald_PlayerCharacter>(PC->GetPawn());
+    if (!CameraPawn) {
+      CameraPawn = Cast<ASkald_PlayerCharacter>(PC->GetViewTarget());
+    }
+    if (!CameraPawn) {
+      continue;
+    }
+
+    const bool bAlreadyCached = LocalBattleCameraStates.ContainsByPredicate(
+        [PC](const FLocalBattleCameraState& State) {
+          return State.Controller.Get() == PC;
+        });
+    if (bAlreadyCached) {
+      continue;
+    }
+
+    FLocalBattleCameraState State;
+    State.Controller = PC;
+    State.CameraPawn = CameraPawn;
+    State.ViewTarget = PC->GetViewTarget();
+    State.Location = CameraPawn->GetActorLocation();
+    State.ActorRotation = CameraPawn->GetActorRotation();
+    State.ControlRotation = PC->GetControlRotation();
+    LocalBattleCameraStates.Add(State);
+  }
+}
+
+void USkaldBattleLevelManager::RestoreLocalBattleCameraStates() {
+  for (const FLocalBattleCameraState& State : LocalBattleCameraStates) {
+    APlayerController* PC = State.Controller.Get();
+    ASkald_PlayerCharacter* CameraPawn = State.CameraPawn.Get();
+    if (!PC || !CameraPawn) {
+      continue;
+    }
+
+    CameraPawn->SetBattleCameraActive(false);
+    CameraPawn->SetActorLocationAndRotation(State.Location, State.ActorRotation, false,
+                                            nullptr, ETeleportType::TeleportPhysics);
+    PC->SetControlRotation(State.ControlRotation);
+
+    AActor* DesiredViewTarget = State.ViewTarget.Get();
+    PC->SetViewTarget(DesiredViewTarget ? DesiredViewTarget : CameraPawn);
+    PC->SetIgnoreMoveInput(false);
+    PC->SetIgnoreLookInput(false);
+  }
+
+  LocalBattleCameraStates.Reset();
+}
+
 void USkaldBattleLevelManager::RecenterLocalBattleCameras() {
   UWorld* World = nullptr;
   if (ULevelStreaming* StreamingLevel = ActiveStreamingLevel.Get()) {
@@ -972,6 +1035,8 @@ void USkaldBattleLevelManager::RecenterLocalBattleCameras() {
   if (!World) {
     return;
   }
+
+  CacheLocalBattleCameraStates(World);
 
   FBox BattleBounds;
   const bool bHasBounds = CalculateActiveBattleLevelBounds(BattleBounds);

--- a/Source/Skald/Skald_BattleLevelManager.h
+++ b/Source/Skald/Skald_BattleLevelManager.h
@@ -13,6 +13,8 @@ class ULevel;
 class UWorld;
 class ASkald_BattleGameMode;
 class AActor;
+class APlayerController;
+class ASkald_PlayerCharacter;
 
 /**
  * Helper object responsible for loading and unloading tactical battle levels
@@ -54,6 +56,8 @@ private:
   void ApplyVisibilityForCurrentMode();
   bool IsStreamingLevelPartOfDiceBoard(ULevelStreaming* Level) const;
   bool ShouldKeepPersistentActorForBattle(AActor* Actor) const;
+  void CacheLocalBattleCameraStates(UWorld* World);
+  void RestoreLocalBattleCameraStates();
   void RecenterLocalBattleCameras();
   bool CalculateActiveBattleLevelBounds(FBox& OutBounds) const;
 
@@ -98,6 +102,16 @@ private:
     bool bWasTickEnabled = false;
   };
 
+  struct FLocalBattleCameraState {
+    TWeakObjectPtr<APlayerController> Controller;
+    TWeakObjectPtr<ASkald_PlayerCharacter> CameraPawn;
+    TWeakObjectPtr<AActor> ViewTarget;
+    FVector Location = FVector::ZeroVector;
+    FRotator ActorRotation = FRotator::ZeroRotator;
+    FRotator ControlRotation = FRotator::ZeroRotator;
+  };
+
+  TArray<FLocalBattleCameraState> LocalBattleCameraStates;
   TArray<FHiddenStreamingLevelState> HiddenStreamingLevels;
   TWeakObjectPtr<ULevel> HiddenPersistentLevel;
   TWeakObjectPtr<UWorld> CachedStreamingWorld;

--- a/Source/Skald/Skald_PlayerController.cpp
+++ b/Source/Skald/Skald_PlayerController.cpp
@@ -8866,6 +8866,9 @@ bool ASkaldPlayerController::BeginManualDiceSequence(AFighterPawn *Attacker) {
 
   ASkald_PlayerCharacter *CameraPawn =
       Cast<ASkald_PlayerCharacter>(GetPawn());
+  if (!CameraPawn) {
+    CameraPawn = Cast<ASkald_PlayerCharacter>(GetViewTarget());
+  }
   const USkaldBattleLevelManager* BattleLevelManager =
       CachedGameInstance ? CachedGameInstance->GetBattleLevelManager() : nullptr;
   const bool bBattleMapActive =
@@ -8977,6 +8980,9 @@ void ASkaldPlayerController::HandleManualDiceCleanupFinished() {
 
   ASkald_PlayerCharacter *CameraPawn =
       Cast<ASkald_PlayerCharacter>(GetPawn());
+  if (!CameraPawn) {
+    CameraPawn = Cast<ASkald_PlayerCharacter>(GetViewTarget());
+  }
   if (!CameraPawn || !PendingManualSequence.bHadBattleCamera) {
     HandleManualDiceReturnComplete();
     return;
@@ -9011,6 +9017,9 @@ void ASkaldPlayerController::HandleManualDiceReturnComplete() {
 
   ASkald_PlayerCharacter *CameraPawn =
       Cast<ASkald_PlayerCharacter>(GetPawn());
+  if (!CameraPawn) {
+    CameraPawn = Cast<ASkald_PlayerCharacter>(GetViewTarget());
+  }
   if (CameraPawn) {
     if (PendingManualSequence.Attacker.IsValid()) {
       CameraPawn->FocusCameraOnActor(PendingManualSequence.Attacker.Get());
@@ -10615,9 +10624,19 @@ void ASkaldPlayerController::ClientShowAttackRollButton_Implementation(
         return;
     }
 
-    // AI-triggered attack rolls are resolved by the authoritative fighter pawn.
-    // Human presenter clients should acknowledge camera/presentation readiness,
-    // not invoke the manual roll RPC that requires fighter ownership.
+    // AI-triggered attack rolls use the same camera overview sequence as a
+    // player-initiated manual roll. The sequence acknowledges the authoritative
+    // fighter only after the local camera has panned/zoomed out, preventing the
+    // dice arena from spawning before the presenter has reached the battlefield
+    // overview.
+    if (BeginManualDiceSequence(Attacker))
+    {
+        return;
+    }
+
+    UE_LOG(LogTemp, Warning,
+        TEXT("[ManualDice] Auto-trigger requested for %s but no camera overview sequence could start; acknowledging directly."),
+        *GetNameSafe(Attacker));
     ServerNotifyAIAttackOverviewComplete(Attacker);
 }
 


### PR DESCRIPTION
### Motivation
- Returning from streamed tactical battles did not reliably restore the local overview camera, view target, and input state so players were left detached from the overworld and turn flow.
- AI-initiated manual attack rolls could trigger dice presentation before the presenter camera panned/zoomed to the overview, causing missing/incorrect presentation sequencing.

### Description
- Cache/restore local camera/controller state: introduce `FLocalBattleCameraState`, `CacheLocalBattleCameraStates` and `RestoreLocalBattleCameraStates` to `USkaldBattleLevelManager` and persist them in `LocalBattleCameraStates`. 
- Call `CacheLocalBattleCameraStates` before recentering battle cameras and call `RestoreLocalBattleCameraStates` when a streamed battle level is released or unloaded so pawns, view targets, rotations, and input flags are restored. 
- Route AI attack presentation through the existing manual dice overview sequence by calling `BeginManualDiceSequence(Attacker)` in `ClientShowAttackRollButton_Implementation` and falling back to direct acknowledgement only if the overview sequence cannot start. 
- Make manual-dice camera code more robust by falling back to the controller's `GetViewTarget()` when resolving the camera pawn for overview/return transitions.

### Testing
- Ran `git diff --check` to ensure there are no whitespace/format errors and it passed successfully. 
- Verified repository changes and created a commit containing the edits to `Skald_BattleLevelManager.*` and `Skald_PlayerController.cpp`. 
- Attempted to run an Unreal build presence check (`test -x .../Build.sh`) but the engine build scripts were not available in the container so a full engine compile/test could not be executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1a2e3b5b4483249399887e1197ccb7)