### PR TITLE
Fix seamless battle return streaming

### DIFF
--- a/Source/Skald/Skald_BattleGameMode.cpp
+++ b/Source/Skald/Skald_BattleGameMode.cpp
@@ -1910,6 +1910,11 @@ void ASkald_BattleGameMode::SpawnFighterSide(const TArray<FFighterDefinition> &R
     FActorSpawnParameters Params;
     Params.SpawnCollisionHandlingOverride =
         ESpawnActorCollisionHandlingMethod::AdjustIfPossibleButAlwaysSpawn;
+    // Spawn tactical fighters into the streamed battle level, not the persistent
+    // overworld. Without an override, SpawnActor places them in the persistent
+    // root, so unloading the battle sublevel leaves fighters behind on the
+    // overview map.
+    Params.OverrideLevel = GetLevel();
 
     AFighterPawn *Pawn = GetWorld()->SpawnActor<AFighterPawn>(
         DesiredClass, SpawnLoc, FRotator::ZeroRotator, Params);

--- a/Source/Skald/Skald_BattleLevelManager.cpp
+++ b/Source/Skald/Skald_BattleLevelManager.cpp
@@ -278,6 +278,9 @@ void USkaldBattleLevelManager::ReleaseBattleLevel() {
   if (ULevelStreaming *StreamingLevel = ActiveStreamingLevel.Get()) {
     StreamingLevel->SetShouldBeVisible(false);
     StreamingLevel->SetShouldBeLoaded(false);
+    if (UWorld *World = StreamingLevel->GetWorld()) {
+      World->UpdateLevelStreaming();
+    }
   }
 
   bActiveLevelShouldBeLoaded = false;
@@ -762,11 +765,16 @@ void USkaldBattleLevelManager::HideNonBattleLevels() {
       LevelLabel = OtherLevel->GetWorldAsset().ToSoftObjectPath().ToString();
     }
 
-    OtherLevel->SetShouldBeLoaded(false);
+    // Keep overworld streaming levels loaded while the battle map is visible.
+    // Runtime territories are spawned/owned by the overview map and unloading the
+    // overview level destroys them, causing the return transition to briefly show
+    // an empty table and forcing reconstruction from cached snapshots.  Hiding
+    // visibility/collision is enough to make the tactical map feel isolated, and
+    // restoring visibility after the battle is immediate/seamless.
     OtherLevel->SetShouldBeVisible(false);
     UE_LOG(LogSkald, Verbose,
-           TEXT("BattleLevelManager: Hiding streaming level %s while battle map active"),
-           *LevelLabel);
+           TEXT("BattleLevelManager: Hiding streaming level %s while battle map active (kept loaded=%d)"),
+           *LevelLabel, State.bWasLoaded ? 1 : 0);
   }
 
   HiddenPersistentLevel.Reset();
@@ -865,6 +873,10 @@ void USkaldBattleLevelManager::RestoreNonBattleLevels() {
       Actor->SetActorEnableCollision(State.bHadCollision);
       Actor->SetActorTickEnabled(State.bWasTickEnabled);
     }
+  }
+
+  if (StreamingWorld) {
+    StreamingWorld->UpdateLevelStreaming();
   }
 
   HiddenPersistentActors.Reset();

--- a/Source/Skald/WorldMap.cpp
+++ b/Source/Skald/WorldMap.cpp
@@ -275,6 +275,9 @@ bool AWorldMap::GenerateTerritoriesFromTable() {
 
     FActorSpawnParameters Params;
     Params.Owner = this;
+    // Keep generated territory actors in the same level as their WorldMap so
+    // overview visibility/streaming transitions move the map as one unit.
+    Params.OverrideLevel = GetLevel();
     ATerritory *Territory = GetWorld()->SpawnActor<ATerritory>(
         TerritoryClass, SpawnLocation, FRotator::ZeroRotator, Params);
     if (Territory) {


### PR DESCRIPTION
### Motivation
- Prevent streamed battle unload from destroying overview actors and leaving stray `AFighterPawn` instances on the world map by ensuring actors are spawned into the correct streamed level and by keeping non-battle streaming levels loaded while a battle is active.

### Description
- In `USkaldBattleLevelManager::HideNonBattleLevels` keep non-battle streaming levels loaded and only hide their visibility, and log that they are kept loaded instead of unloaded to preserve runtime world-map state (`Source/Skald/Skald_BattleLevelManager.cpp`).
- Call `World->UpdateLevelStreaming()` after clearing `ShouldBeLoaded`/`ShouldBeVisible` when releasing the active battle streaming level and after restoring non-battle levels so visibility/streaming state applies immediately (`USkaldBattleLevelManager::ReleaseBattleLevel` and `RestoreNonBattleLevels`).
- Spawn tactical fighters into the streamed battle level by setting `Params.OverrideLevel = GetLevel()` in `ASkald_BattleGameMode::SpawnFighterSide` so fighter pawns are created in the battle sublevel and are removed when that sublevel unloads (`Source/Skald/Skald_BattleGameMode.cpp`).
- Ensure territories generated by `AWorldMap::GenerateTerritoriesFromTable` are spawned into the same level as their `WorldMap` via `Params.OverrideLevel = GetLevel()` so overview map actors remain grouped during visibility/streaming transitions (`Source/Skald/WorldMap.cpp`).

### Testing
- Ran `git diff --check` to validate no whitespace/patch errors and committed the changes successfully; commit succeeded.
- Verified repository status with `git status`/`git diff --stat` to confirm intended files were modified; these commands succeeded.
- Attempted to run `command -v UnrealEditor || command -v UnrealEditor-Cmd || command -v ue4editor` to run engine-level tests, but the Unreal editor command was not available in this environment so no runtime build/test was executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1a36f332d483249a6b12efb6a1a93e)