### PR TITLE
Fix post-battle resolution and improve AI movement/targeting (abilities & coordinated attacks)

### DIFF
--- a/Source/Skald/Skald_AIController.cpp
+++ b/Source/Skald/Skald_AIController.cpp
@@ -1831,6 +1831,51 @@ AFighterPawn *ASkaldAIController::FindNearestEnemy(AFighterPawn *Fighter) const 
   return BestEnemy;
 }
 
+
+AFighterPawn *ASkaldAIController::FindBestTacticalEnemy(
+    AFighterPawn *Fighter) const {
+  if (!Fighter) {
+    return nullptr;
+  }
+
+  UWorld *World = GetWorld();
+  if (!World) {
+    return nullptr;
+  }
+
+  AFighterPawn *BestEnemy = nullptr;
+  float BestScore = TNumericLimits<float>::Lowest();
+  for (TActorIterator<AFighterPawn> It(World); It; ++It) {
+    AFighterPawn *Candidate = *It;
+    if (!Candidate || Candidate == Fighter || !Candidate->IsAlive() ||
+        ControlsFighter(Candidate)) {
+      continue;
+    }
+
+    const int32 Distance = Fighter->GetFootprintDistanceToFighter(Candidate);
+    const int32 AlliesThreatening = CountAlliesThreateningTarget(Candidate);
+    const int32 ThreatenedAllies =
+        CountEnemiesThreateningAllyNearTarget(Candidate);
+    const float ThreatScore =
+        static_cast<float>(Candidate->Stats.AttackDamage) * 5.f +
+        Candidate->Stats.Strength * 3.f + Candidate->Stats.Health;
+    float Score = ThreatScore - Distance * 8.f;
+    Score += AlliesThreatening * 45.f;
+    Score += ThreatenedAllies * 35.f;
+
+    if (Candidate->Stats.Health <= Fighter->Stats.AttackDamage) {
+      Score += 60.f;
+    }
+
+    if (!BestEnemy || Score > BestScore) {
+      BestScore = Score;
+      BestEnemy = Candidate;
+    }
+  }
+
+  return BestEnemy ? BestEnemy : FindNearestEnemy(Fighter);
+}
+
 bool ASkaldAIController::GatherEnemiesInRange(
     AFighterPawn *Fighter, TArray<AFighterPawn *> &OutTargets) const {
   OutTargets.Reset();
@@ -1874,6 +1919,69 @@ bool ASkaldAIController::GatherEnemiesInRange(
   }
 
   return bFoundTarget;
+}
+
+
+int32 ASkaldAIController::CountAlliesThreateningTarget(
+    const AFighterPawn *Target) const {
+  if (!Target) {
+    return 0;
+  }
+
+  UWorld *World = GetWorld();
+  if (!World) {
+    return 0;
+  }
+
+  int32 Count = 0;
+  for (TActorIterator<AFighterPawn> It(World); It; ++It) {
+    AFighterPawn *Candidate = *It;
+    if (!Candidate || Candidate == Target || !Candidate->IsAlive() ||
+        !ControlsFighter(Candidate)) {
+      continue;
+    }
+
+    const int32 Range = FMath::Max(1, Candidate->Stats.AttackRange);
+    if (Candidate->GetFootprintDistanceToFighter(Target) > Range) {
+      continue;
+    }
+
+    UGridOverlayComponent *Grid = Candidate->GetGrid();
+    if (Grid && !Candidate->HasLineOfSightToFighter(Target, Range, Grid)) {
+      continue;
+    }
+
+    ++Count;
+  }
+
+  return Count;
+}
+
+int32 ASkaldAIController::CountEnemiesThreateningAllyNearTarget(
+    const AFighterPawn *Target) const {
+  if (!Target) {
+    return 0;
+  }
+
+  UWorld *World = GetWorld();
+  if (!World) {
+    return 0;
+  }
+
+  int32 Count = 0;
+  for (TActorIterator<AFighterPawn> It(World); It; ++It) {
+    AFighterPawn *Ally = *It;
+    if (!Ally || !Ally->IsAlive() || !ControlsFighter(Ally)) {
+      continue;
+    }
+
+    const int32 AllyThreatRange = FMath::Max(1, Target->Stats.AttackRange);
+    if (Target->GetFootprintDistanceToFighter(Ally) <= AllyThreatRange) {
+      ++Count;
+    }
+  }
+
+  return Count;
 }
 
 float ASkaldAIController::EvaluateAttackTargetScore(
@@ -1933,6 +2041,16 @@ float ASkaldAIController::EvaluateAttackTargetScoreInternal(
   Score += EffectiveAttackerStats.AttackDice * 5.f;
   Score += EffectiveAttackerStats.Strength * 2.f;
   Score += FMath::Min(Attacker->ActionsRemaining, 3) * 6.f;
+
+  const int32 AlliesThreatening = CountAlliesThreateningTarget(Target);
+  if (AlliesThreatening > 0) {
+    Score += AlliesThreatening * 30.f;
+  }
+
+  const int32 ThreatenedAllies = CountEnemiesThreateningAllyNearTarget(Target);
+  if (ThreatenedAllies > 0) {
+    Score += ThreatenedAllies * 20.f;
+  }
   Score += FMath::Min(Target->ActionsRemaining, 3) * 4.f;
 
   if (bIncludeRandom) {
@@ -2123,13 +2241,22 @@ ASkaldAIController::TryUseFactionAbilityBeforeAttack(AFighterPawn *Fighter,
       ResolveAIAbilityTargeting(AbilityId);
 
   FText FailureReason;
+  if (Targeting.CommandMode == EBattleCommandMode::AbilityTargetEnemy) {
+    FSkaldAbilityContext AbilityContext;
+    AbilityContext.AbilityId = AbilityId;
+    AbilityContext.TargetFighter = Target;
+    AbilityComponent->SetPendingAbilityContext(AbilityContext);
+  }
+
   if (!AbilityComponent->CanActivateAbility(ESkaldAbilitySlot::Ability1,
                                             &FailureReason)) {
+    AbilityComponent->ClearPendingAbilityContext();
     return EAIAttackAbilityResult::None;
   }
 
   if (!ShouldTriggerAbilityForAttack(Fighter, Target, *AbilityState,
                                      Targeting)) {
+    AbilityComponent->ClearPendingAbilityContext();
     return EAIAttackAbilityResult::None;
   }
 
@@ -2139,6 +2266,7 @@ ASkaldAIController::TryUseFactionAbilityBeforeAttack(AFighterPawn *Fighter,
            TEXT("[AI] Failed to trigger ability %s for %s: %s"),
            *AbilityId.ToString(), *Fighter->GetHumanReadableName(),
            *FailureReason.ToString());
+    AbilityComponent->ClearPendingAbilityContext();
     return EAIAttackAbilityResult::None;
   }
 
@@ -2187,7 +2315,8 @@ bool ASkaldAIController::TryUseMovementAbility(AFighterPawn *Fighter,
 
   const FSkaldAbilityTargetingInfo Targeting =
       ResolveAIAbilityTargeting(AbilityId);
-  if (Targeting.CommandMode != EBattleCommandMode::None) {
+  if (Targeting.CommandMode != EBattleCommandMode::None &&
+      Targeting.CommandMode != EBattleCommandMode::AbilityTargetEnemy) {
     return false;
   }
 
@@ -2211,13 +2340,21 @@ bool ASkaldAIController::TryUseMovementAbility(AFighterPawn *Fighter,
     ExpectedBonus = 2;
   }
 
-  if (Distance > Fighter->Stats.Movement + ExpectedBonus) {
+  if (Distance > Fighter->Stats.Movement + ExpectedBonus + AttackRange) {
     return false;
+  }
+
+  if (Targeting.CommandMode == EBattleCommandMode::AbilityTargetEnemy) {
+    FSkaldAbilityContext AbilityContext;
+    AbilityContext.AbilityId = AbilityId;
+    AbilityContext.TargetFighter = Target;
+    AbilityComponent->SetPendingAbilityContext(AbilityContext);
   }
 
   FText FailureReason;
   if (!AbilityComponent->CanActivateAbility(ESkaldAbilitySlot::Ability1,
                                             &FailureReason)) {
+    AbilityComponent->ClearPendingAbilityContext();
     return false;
   }
 
@@ -2227,6 +2364,7 @@ bool ASkaldAIController::TryUseMovementAbility(AFighterPawn *Fighter,
            TEXT("[AI] Failed to trigger movement ability %s for %s: %s"),
            *AbilityId.ToString(), *Fighter->GetHumanReadableName(),
            *FailureReason.ToString());
+    AbilityComponent->ClearPendingAbilityContext();
     return false;
   }
 
@@ -2504,7 +2642,7 @@ bool ASkaldAIController::TryMoveTowardsNearestEnemy(AFighterPawn *Fighter) {
     return false;
   }
 
-  AFighterPawn *Enemy = FindNearestEnemy(Fighter);
+  AFighterPawn *Enemy = FindBestTacticalEnemy(Fighter);
   if (!Enemy) {
     return false;
   }

--- a/Source/Skald/Skald_AIController.h
+++ b/Source/Skald/Skald_AIController.h
@@ -162,6 +162,7 @@ private:
 
   AFighterPawn *FindNextFriendlyFighter(bool bExpectAttacker) const;
   AFighterPawn *FindNearestEnemy(AFighterPawn *Fighter) const;
+  AFighterPawn *FindBestTacticalEnemy(AFighterPawn *Fighter) const;
   AFighterPawn *FindBestAttackTarget(AFighterPawn *Fighter) const;
   float EvaluateAttackTargetScore(const AFighterPawn *Attacker,
                                   const AFighterPawn *Target) const;
@@ -170,6 +171,8 @@ private:
                                           bool bIncludeRandom) const;
   bool GatherEnemiesInRange(AFighterPawn *Fighter,
                             TArray<AFighterPawn *> &OutTargets) const;
+  int32 CountAlliesThreateningTarget(const AFighterPawn *Target) const;
+  int32 CountEnemiesThreateningAllyNearTarget(const AFighterPawn *Target) const;
   bool TryAttackNearestEnemy(AFighterPawn *Fighter);
   bool TryMoveTowardsNearestEnemy(AFighterPawn *Fighter);
   bool TryMoveTowardsSupportAlly(AFighterPawn *Fighter);

--- a/Source/Skald/Skald_PlayerController.cpp
+++ b/Source/Skald/Skald_PlayerController.cpp
@@ -159,6 +159,16 @@ constexpr const TCHAR *PendingBattlePhaseError =
     TEXT("Cannot end the phase while a battle is awaiting confirmation.");
 
 constexpr float FighterDeathEffectHeightOffset = 120.f;
+
+namespace {
+
+bool IsImmediateMovementAbilityId(const FName &AbilityId) {
+  return AbilityId == TEXT("Ability_Orc_Skirmish") ||
+         AbilityId == TEXT("Ability_Goblin_Elite");
+}
+
+} // namespace
+
 constexpr int32 VeilStepRange = 3;
 const FColor VeilStepHighlightColor(128, 64, 255, 215);
 const FName VeilStepAbilityId(TEXT("Ability_Elf_Skirmish"));
@@ -509,7 +519,26 @@ bool ASkaldPlayerController::TryUseAbilitySlot(ESkaldAbilitySlot Slot) {
                                "Cannot trigger abilities on enemy fighters.");
   } else if (USkaldAbilityComponent *AbilityComponent =
                  SelectedFighter->GetAbilityComponent()) {
+    const FSkaldAbilityState *AbilityState =
+        AbilityComponent->FindAbilityState(Slot);
+    const FName AbilityId = AbilityState && AbilityState->Definition.IsValid()
+                                ? AbilityState->Definition.AbilityId
+                                : NAME_None;
+    const ESkaldAbilityCostType CostType =
+        AbilityState && AbilityState->Definition.IsValid()
+            ? AbilityState->Definition.CostType
+            : ESkaldAbilityCostType::Free;
+
     if (AbilityComponent->TryBeginAbility(Slot, FailureReason)) {
+      if (IsImmediateMovementAbilityId(AbilityId)) {
+        if (CostType == ESkaldAbilityCostType::Action) {
+          SelectedFighter->TryRestoreAction();
+        }
+        if (SelectedFighter->IsCurrentlyActive()) {
+          LockedActiveFighter = SelectedFighter;
+          BeginMoveMode();
+        }
+      }
       UpdateBattleHUDButtons();
       return true;
     }
@@ -1081,8 +1110,10 @@ FSkaldAbilityTargetingInfo ASkaldPlayerController::GetAbilityTargetingInfo(
        {EBattleCommandMode::AbilityTargetAlly, 1, false}},
       {TEXT("Ability_Human_Elite"),
        {EBattleCommandMode::AbilityTargetAlly, 5, false, false, false, false}},
+      // Brutal Charge is consumed first, then immediately hands the fighter
+      // back to normal movement with its temporary Movement bonus applied.
       {TEXT("Ability_Orc_Skirmish"),
-       {EBattleCommandMode::AbilityTargetEnemy, INDEX_NONE}},
+       {EBattleCommandMode::None, INDEX_NONE}},
       {TEXT("Ability_Inflicted_Skirmish"),
        {EBattleCommandMode::AbilityTargetEnemy, INDEX_NONE}},
       {TEXT("Ability_Ravpack_Skirmish"),

--- a/Source/Skald/Skald_TurnManager.cpp
+++ b/Source/Skald/Skald_TurnManager.cpp
@@ -573,15 +573,15 @@ void ATurnManager::CompleteBattleConclusion() {
   }
 
   USkaldGameInstance *GI = GetGameInstance<USkaldGameInstance>();
-  if (GI && !GI->bIsInBattleMap) {
+  const bool bHasPendingResolution =
+      GI && GI->bPendingBattleResolution && GI->PendingBattleResolution.bValid;
+  if (GI && !GI->bIsInBattleMap && !bHasPendingResolution) {
     UE_LOG(LogSkald, Verbose,
-           TEXT("CompleteBattleConclusion aborted: streamed battle map already inactive."));
+           TEXT("CompleteBattleConclusion aborted: streamed battle map already inactive and no pending resolution was captured."));
     bBattleConclusionPending = false;
     return;
   }
 
-  const bool bHasPendingResolution =
-      GI && GI->bPendingBattleResolution && GI->PendingBattleResolution.bValid;
   if (bHasPendingResolution) {
     UE_LOG(LogSkald, Verbose,
            TEXT("CompleteBattleConclusion: reusing already captured pending battle resolution."));


### PR DESCRIPTION
### Motivation
- Prevent a previously-observed fatal/blocked post-battle return path when the streamed battle map is already inactive but a pending battle resolution exists.\
- Make AI fighters more tactically aware of teammates when choosing movement/attack targets and when deciding to consume movement-granting abilities.\
- Ensure certain movement-type abilities behave as immediate movement grants (restore an action and transition into move mode) when used by players.

### Description
- Turn manager: updated `CompleteBattleConclusion()` to still apply a captured pending battle resolution even if the streamed battle map has been marked inactive, but only abort when no pending resolution exists. (`Source/Skald/Skald_TurnManager.cpp`)\
- AI targeting: added `FindBestTacticalEnemy()`, `CountAlliesThreateningTarget()` and `CountEnemiesThreateningAllyNearTarget()` to let AI evaluate enemies by distance, threat, how many allies can focus-fire them, and how many allies they threaten; integrated these scores into `EvaluateAttackTargetScoreInternal()` and used tactical selection in movement decision-making. (`Source/Skald/Skald_AIController.cpp`, `Source/Skald/Skald_AIController.h`)\
- AI abilities: allowed the AI to set pending ability context for movement abilities that target enemies, improved guard/clearup of pending contexts on failures, relaxed checks so movement-buff abilities can be triggered with enemy context, and restored action balance when abilities are action-cost. (`Source/Skald/Skald_AIController.cpp`)\
- Player flow for immediate movement abilities: added a small helper `IsImmediateMovementAbilityId()` and changed player ability handling so immediate movement actives (e.g. `Ability_Orc_Skirmish`, `Ability_Goblin_Elite`) consume then hand the fighter back into movement mode and restore actions when appropriate; also adjusted the targeting preset for `Ability_Orc_Skirmish` so it is consumed first and then movement is used. (`Source/Skald/Skald_PlayerController.cpp`)\
- Defensive cleanup: ensure the AI/ability pending context is cleared on failure paths to avoid stale pending contexts. (`Source/Skald/Skald_AIController.cpp`)\
- Small behavioral tweaks to AI movement heuristics so they prefer coordinated targets and use movement abilities more appropriately. (`Source/Skald/Skald_AIController.cpp`)

### Testing
- Ran repository checks: `git diff --check` (no whitespace/diff issues found) — success.\
- Performed quick repository inspections (`rg`/`sed`/`nl`) to validate the edits and ensure new symbols are referenced — success.\
- Could not perform a full Unreal Engine build or automated engine tests inside the container because Unreal build tooling is not available here, so runtime/engine integration tests were not executed; recommend running the project compile and the existing automation tests (`Source/Skald/Tests/*`) in the engine CI to validate runtime behaviour and multiplayer/battle streaming scenarios.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1a3e71ddec83248376d6da829c7eca)