### PR TITLE
Fix TurnManager World shadowing compile error

### DIFF
--- a/Source/Skald/Skald_TurnManager.cpp
+++ b/Source/Skald/Skald_TurnManager.cpp
@@ -3894,9 +3894,7 @@ void ATurnManager::ResolveGridBattleResult_Implementation() {
   GI->ClearPendingReturnMap();
 
   // Ensure no stale retry timers trigger another battle after resolution
-  if (UWorld *World = GetWorld()) {
-    World->GetTimerManager().ClearTimer(PendingBattleStreamRetryHandle);
-  }
+  World->GetTimerManager().ClearTimer(PendingBattleStreamRetryHandle);
   DeferredPendingBattle = FS_BattlePayload();
 
   const int32 WinningPlayerID = Resolution.WinningPlayerID;


### PR DESCRIPTION
### Motivation

- Fix MSVC C4456 compile error caused by an inner `UWorld *World` redeclaration in `ResolveGridBattleResult_Implementation` that shadowed the earlier validated `World` pointer.

### Description

- Removed the inner `UWorld *World = GetWorld()` declaration and reused the existing `World` when calling `World->GetTimerManager().ClearTimer(PendingBattleStreamRetryHandle)` in `Source/Skald/Skald_TurnManager.cpp`.

### Testing

- Ran `git diff --check` and `rg -n "if (UWorld *World = GetWorld())" Source/Skald/Skald_TurnManager.cpp || true`, both completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1a4bf30fcc8324ab9ecdd1a89370c5)