### PR TITLE
Fix battle conclusion unload race

### DIFF
--- a/Source/Skald/Skald_AIController.cpp
+++ b/Source/Skald/Skald_AIController.cpp
@@ -13,6 +13,7 @@
 #include "Skald.h"
 #include "SkaldLogging.h"
 #include "Skald_BattleGameMode.h"
+#include "Skald_BattleLevelManager.h"
 #include "Skald_GameInstance.h"
 #include "Skald_GameState.h"
 #include "Skald_GameUserSettings.h"
@@ -383,6 +384,20 @@ void ASkaldAIController::ProcessCurrentPhase() {
     BroadcastEnemyTurnStatus(FString(EnemyAwaitingResultsMessage));
     ScheduleNextDecisionStep(EnemyBattleTransitionPollDelay);
     return;
+  }
+
+  if (const USkaldGameInstance *GI = GetGameInstance<USkaldGameInstance>()) {
+    const USkaldBattleLevelManager *BattleLevelManager =
+        GI->GetBattleLevelManager();
+    const bool bBattleLevelActive =
+        BattleLevelManager &&
+        (BattleLevelManager->IsBattleLevelActive() ||
+         BattleLevelManager->IsBattleLevelFullyReady());
+    if (GI->bTravelPending || GI->bIsInBattleMap || bBattleLevelActive) {
+      BroadcastEnemyTurnStatus(FString(EnemyBattleTransitionMessage));
+      ScheduleNextDecisionStep(EnemyBattleTransitionPollDelay);
+      return;
+    }
   }
 
   if (bPendingPhaseAdvance) {

--- a/Source/Skald/Skald_BattleLevelManager.cpp
+++ b/Source/Skald/Skald_BattleLevelManager.cpp
@@ -271,6 +271,13 @@ void USkaldBattleLevelManager::ReleaseBattleLevel() {
     return;
   }
 
+  if (!bActiveLevelShouldBeLoaded && !bActiveLevelVisibilityRequested &&
+      !bActiveLevelActivationComplete) {
+    UE_LOG(LogSkald, Verbose,
+           TEXT("BattleLevelManager: ReleaseBattleLevel ignored; battle level is already unloading"));
+    return;
+  }
+
   if (USkaldGameInstance *GI = OwningInstance.Get()) {
     GI->SetTravelPending(true);
   }

--- a/Source/Skald/Skald_TurnManager.cpp
+++ b/Source/Skald/Skald_TurnManager.cpp
@@ -590,12 +590,16 @@ void ATurnManager::CompleteBattleConclusion() {
   }
 
   if (GI) {
+    bool bBattleLevelStillActive = false;
     if (USkaldBattleLevelManager *BattleLevelManager =
             GI->GetBattleLevelManager()) {
       BattleLevelManager->ReleaseBattleLevel();
+      bBattleLevelStillActive = BattleLevelManager->IsBattleLevelActive();
     }
 
-    GI->SetTravelPending(false);
+    if (!bBattleLevelStillActive) {
+      GI->SetTravelPending(false);
+    }
   }
 
   if (HasAuthority()) {
@@ -3582,10 +3586,22 @@ void ATurnManager::ResolveGridBattleResult_Implementation() {
   // Always mirror the pending payload locally for reference.
   PendingBattle = GI->PendingBattle;
 
+  auto HasActiveBattleLevel = [&]() {
+    const USkaldBattleLevelManager *BattleLevelManager =
+        GI ? GI->GetBattleLevelManager() : nullptr;
+    return BattleLevelManager && BattleLevelManager->IsBattleLevelActive();
+  };
+
+  auto ClearTravelPendingIfBattleLevelReleased = [&]() {
+    if (!HasActiveBattleLevel()) {
+      GI->SetTravelPending(false);
+    }
+  };
+
   const bool bHasResolution = CapturePendingBattleResolution(GI);
 
   if (!bHasResolution) {
-    GI->SetTravelPending(false);
+    ClearTravelPendingIfBattleLevelReleased();
     return;
   }
 
@@ -3619,7 +3635,7 @@ void ATurnManager::ResolveGridBattleResult_Implementation() {
   }
 
   if (!GI->bPendingBattleResolution || !GI->PendingBattleResolution.bValid) {
-    GI->SetTravelPending(false);
+    ClearTravelPendingIfBattleLevelReleased();
     return;
   }
   if (GameMode && !GameMode->IsWorldInitialized()) {
@@ -3904,7 +3920,7 @@ void ATurnManager::ResolveGridBattleResult_Implementation() {
 
   GI->bPendingBattleResolution = false;
   GI->PendingBattleResolution = FGridBattleResolution();
-  GI->SetTravelPending(false);
+  ClearTravelPendingIfBattleLevelReleased();
 
   // Resume the saved turn sequence now that the battle has been resolved.
   TryResumeSavedTurnState(GI);


### PR DESCRIPTION
### Motivation
- A race during battle conclusion could release the streamed battle sublevel and clear travel state too early, allowing AI and controllers to resume overworld processing while the world map or streaming level was not yet available and triggering "missing world map; ending turn" paths.
- The change aims to ensure travel/streaming state is consistently observed during teardown so AI pauses and duplicate unload requests do not cause invalid state transitions.

### Description
- Pause AI overworld decision processing in `ASkaldAIController::ProcessCurrentPhase` while `USkaldGameInstance` indicates travel/battle activity or the `USkaldBattleLevelManager` reports an active/ready battle level, causing the AI to poll until teardown completes (`Source/Skald/Skald_AIController.cpp`).
- Make `USkaldBattleLevelManager::ReleaseBattleLevel` idempotent by early-returning when the level is already being unloaded, preventing duplicate/unnecessary unload operations (`Source/Skald/Skald_BattleLevelManager.cpp`).
- Defer clearing `bTravelPending` during battle conclusion and pending-resolution paths in `ATurnManager` so `GI->SetTravelPending(false)` is only called after the `USkaldBattleLevelManager` reports the battle level is no longer active (`Source/Skald/Skald_TurnManager.cpp`).
- Add required include (`Skald_BattleLevelManager.h`) to the AI controller to reference the level manager checks (`Source/Skald/Skald_AIController.cpp`).

### Testing
- Ran `git diff --check` to validate whitespace/patch issues, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1a537379f48324b36686402d5ec080)