### PR TITLE
Fix post-battle resolution flow

### DIFF
--- a/Source/Skald/Skald_PlayerController.cpp
+++ b/Source/Skald/Skald_PlayerController.cpp
@@ -2101,7 +2101,11 @@ void ASkaldPlayerController::ShowBattleResultWidget(
     VictoryWidgetClass = UBattleResultWidget::StaticClass();
   }
 
-  ClearBattleResultWidget();
+  // Replacing an existing result widget as part of showing/re-showing results
+  // must not acknowledge the result. Acknowledgement is reserved for the
+  // player's explicit close action; acknowledging here can let AI turns resume
+  // while the modal is still being constructed.
+  ClearBattleResultWidget(/*bNotifyAcknowledgement=*/false);
 
   if (!VictoryWidgetClass) {
     return;
@@ -2130,7 +2134,7 @@ void ASkaldPlayerController::ShowBattleResultWidget(
   }
 }
 
-void ASkaldPlayerController::ClearBattleResultWidget() {
+void ASkaldPlayerController::ClearBattleResultWidget(bool bNotifyAcknowledgement) {
   if (UBattleResultWidget *ResultWidget =
           Cast<UBattleResultWidget>(BattleResultWidget)) {
     ResultWidget->OnBattleResultClosed.RemoveAll(this);
@@ -2141,7 +2145,7 @@ void ASkaldPlayerController::ClearBattleResultWidget() {
     BattleResultWidget = nullptr;
   }
 
-  if (bAwaitingBattleResultCloseAck) {
+  if (bAwaitingBattleResultCloseAck && bNotifyAcknowledgement) {
     bAwaitingBattleResultCloseAck = false;
     CachedBattleResultDisplayData = FBattleResultDisplayData();
     ServerAcknowledgeBattleResults();

--- a/Source/Skald/Skald_PlayerController.h
+++ b/Source/Skald/Skald_PlayerController.h
@@ -578,7 +578,7 @@ protected:
   bool bWasHoveringInteractable = false;
 
   virtual void ShowBattleResultWidget(const FBattleResultDisplayData &DisplayData);
-  void ClearBattleResultWidget();
+  void ClearBattleResultWidget(bool bNotifyAcknowledgement = true);
 
   UFUNCTION()
   void HandleBattleResultWidgetClosed();

--- a/Source/Skald/Skald_TurnManager.cpp
+++ b/Source/Skald/Skald_TurnManager.cpp
@@ -584,9 +584,18 @@ void ATurnManager::CompleteBattleConclusion() {
 
   if (bHasPendingResolution) {
     UE_LOG(LogSkald, Verbose,
-           TEXT("CompleteBattleConclusion: reusing already captured pending battle resolution."));
-  } else {
-    ResolveGridBattleResult();
+           TEXT("CompleteBattleConclusion: applying already captured pending battle resolution."));
+  }
+
+  ResolveGridBattleResult();
+
+  const bool bResolutionStillPending =
+      GI && GI->bPendingBattleResolution && GI->PendingBattleResolution.bValid;
+  if (bResolutionStillPending) {
+    UE_LOG(LogSkald, Verbose,
+           TEXT("CompleteBattleConclusion: battle resolution is still pending; deferring level cleanup until the retry resolves it."));
+    bBattleConclusionPending = false;
+    return;
   }
 
   if (GI) {
@@ -3917,6 +3926,10 @@ void ATurnManager::ResolveGridBattleResult_Implementation() {
   const int32 NewOwnerPlayerID = Resolution.NewOwnerPlayerID;
   const int32 AttackerCasualties = Resolution.AttackerCasualties;
   const int32 DefenderCasualties = Resolution.DefenderCasualties;
+  const int32 ResolvedFromTerritoryID = Source->TerritoryID;
+  const int32 ResolvedTargetTerritoryID = Target->TerritoryID;
+  const int32 ResolvedSourceArmy = Source->ArmyUnits;
+  const int32 ResolvedTargetArmy = Target->ArmyUnits;
 
   GI->bPendingBattleResolution = false;
   GI->PendingBattleResolution = FGridBattleResolution();
@@ -3931,19 +3944,27 @@ void ATurnManager::ResolveGridBattleResult_Implementation() {
     ClearBattleResultAcknowledgements();
   }
 
-  if (ASkaldGameMode *GM = GetWorld()->GetAuthGameMode<ASkaldGameMode>()) {
+  // Push the resolved world-state values before checking victory conditions.
+  // CheckVictoryConditions can ServerTravel to the end screen, so do not touch
+  // Source/Target actors or issue the resolution RPC after that point.
+  ClientBattleResolved(WinningPlayerID, AttackerCasualties, DefenderCasualties,
+                       ResolvedFromTerritoryID, ResolvedTargetTerritoryID,
+                       NewOwnerPlayerID, ResolvedSourceArmy, ResolvedTargetArmy);
+
+  if (ASkaldGameMode *GM = World->GetAuthGameMode<ASkaldGameMode>()) {
     GM->CheckVictoryConditions();
   }
-
-  ClientBattleResolved(WinningPlayerID, AttackerCasualties, DefenderCasualties,
-                       Source->TerritoryID, Target->TerritoryID,
-                       NewOwnerPlayerID, Source->ArmyUnits, Target->ArmyUnits);
 }
 
 void ATurnManager::ClientBattleResolved_Implementation(
     int32 WinningPlayerID, int32 AttackerCasualties, int32 DefenderCasualties,
     int32 FromTerritoryID, int32 TargetTerritoryID, int32 NewOwnerPlayerID,
     int32 SourceArmy, int32 TargetArmy) {
+  UWorld *World = GetWorld();
+  if (!World || World->bIsTearingDown) {
+    return;
+  }
+
   if (AWorldMap *WorldMapForClient = ResolveWorldMap()) {
     ATerritory *Source = WorldMapForClient->GetTerritoryById(FromTerritoryID);
     ATerritory *Target = WorldMapForClient->GetTerritoryById(TargetTerritoryID);
@@ -3953,7 +3974,7 @@ void ATurnManager::ClientBattleResolved_Implementation(
     }
     if (IsValid(Target)) {
       ASkaldPlayerState *NewOwner = nullptr;
-      if (ASkaldGameState *GS = GetWorld()->GetGameState<ASkaldGameState>()) {
+      if (ASkaldGameState *GS = World->GetGameState<ASkaldGameState>()) {
         NewOwner = GS->GetPlayerById(NewOwnerPlayerID);
       }
       Target->OwningPlayer = NewOwner;
@@ -3963,13 +3984,13 @@ void ATurnManager::ClientBattleResolved_Implementation(
   }
 
   for (FConstPlayerControllerIterator It =
-           GetWorld()->GetPlayerControllerIterator();
+           World->GetPlayerControllerIterator();
        It; ++It) {
     if (ASkaldPlayerController *PC = Cast<ASkaldPlayerController>(It->Get())) {
       if (USkaldMainHUDWidget *HUD = PC->GetHUDWidget()) {
         FString WinnerName = TEXT("Unknown");
         if (ASkaldGameState *GSLocal =
-                GetWorld()->GetGameState<ASkaldGameState>()) {
+                World->GetGameState<ASkaldGameState>()) {
           if (ASkaldPlayerState *WinnerPS =
                   GSLocal->GetPlayerById(WinningPlayerID)) {
             WinnerName =


### PR DESCRIPTION
### Motivation

- Post-battle cleanup and client update ordering could touch world/map actors after a `ServerTravel` or while the world is tearing down, causing fatal access/teardown races. 
- Replacing the battle-result UI could inadvertently acknowledge results and let AI continue while the modal was still being constructed, breaking the acknowledgement flow.

### Description

- Ensure pending resolutions are applied before battle-level cleanup by always calling `ResolveGridBattleResult()` from `ATurnManager::CompleteBattleConclusion()` and deferring cleanup when `GI->bPendingBattleResolution` remains set. (`Source/Skald/Skald_TurnManager.cpp`)
- Capture resolved territory IDs and army counts into locals and call `ClientBattleResolved(...)` with those captured values before calling `CheckVictoryConditions()` so `ServerTravel` cannot race with actor use. (`Source/Skald/Skald_TurnManager.cpp`)
- Harden `ClientBattleResolved_Implementation` against world teardown by validating `GetWorld()` early and reusing the `World` pointer for client-side updates. (`Source/Skald/Skald_TurnManager.cpp`)
- Prevent automatic acknowledgement when replacing an existing battle-result widget by changing `ClearBattleResultWidget()` to accept a `bool bNotifyAcknowledgement` and calling it with `false` when re-showing the widget; acknowledgements now only happen when explicitly requested/cleared. (`Source/Skald/Skald_PlayerController.cpp` and `Source/Skald/Skald_PlayerController.h`)

### Testing

- Ran `git diff --check` to validate whitespace/patch issues and it produced no warnings.
- Executed `bash Build/validate.sh`; the script ran but skipped compile and automation runs because `UnrealBuildTool`/`UnrealEditor` are not available in this environment, so engine-level automation tests were not executed here.
- Performed repository-wide static inspection (searches and diffs) to verify the updated callsites for `ClearBattleResultWidget(...)` and the guarded `ClientBattleResolved` usage.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1c6dee91f4832488dd49b7925cc8e5)