### PR TITLE
Avoid reentrant streaming update on battle-level unload

### DIFF
--- a/Source/Skald/Skald_BattleLevelManager.cpp
+++ b/Source/Skald/Skald_BattleLevelManager.cpp
@@ -522,12 +522,12 @@ void USkaldBattleLevelManager::HandleLevelLoaded() {
   }
 }
 
-void USkaldBattleLevelManager::HandleLevelUnloaded() {
+void USkaldBattleLevelManager::HandleLevelUnloaded(bool bRequestStreamingUpdate) {
   UE_LOG(LogSkald, Log, TEXT("BattleLevelManager: Battle level unloaded"));
 
   UnregisterWorldDelegates();
   UnregisterStreamingTicker();
-  RestoreNonBattleLevels();
+  RestoreNonBattleLevels(bRequestStreamingUpdate);
   RestoreLocalBattleCameraStates();
 
   bActiveLevelShouldBeLoaded = false;
@@ -568,7 +568,12 @@ void USkaldBattleLevelManager::HandleLevelRemovedFromWorld(ULevel *InLevel,
     return;
   }
 
-  HandleLevelUnloaded();
+  // This delegate is broadcast while UWorld::RemoveFromWorld is already
+  // inside a level-streaming update.  Requesting another UpdateLevelStreaming
+  // from the restore path re-enters RemoveFromWorld and can leave the engine
+  // unregistering components against an invalid world pointer.  Restore the
+  // desired flags now and let the in-flight streaming update continue naturally.
+  HandleLevelUnloaded(false);
 }
 
 bool USkaldBattleLevelManager::DoesEventMatchActiveLevel(ULevel *InLevel,
@@ -829,7 +834,7 @@ void USkaldBattleLevelManager::HideNonBattleLevels() {
   }
 }
 
-void USkaldBattleLevelManager::RestoreNonBattleLevels() {
+void USkaldBattleLevelManager::RestoreNonBattleLevels(bool bRequestStreamingUpdate) {
   if (!HiddenStreamingLevels.Num() && !HiddenPersistentLevel.IsValid() &&
       !HiddenPersistentActors.Num()) {
     CachedStreamingWorld.Reset();
@@ -882,7 +887,7 @@ void USkaldBattleLevelManager::RestoreNonBattleLevels() {
     }
   }
 
-  if (StreamingWorld) {
+  if (bRequestStreamingUpdate && StreamingWorld) {
     StreamingWorld->UpdateLevelStreaming();
   }
 

--- a/Source/Skald/Skald_BattleLevelManager.h
+++ b/Source/Skald/Skald_BattleLevelManager.h
@@ -49,7 +49,7 @@ public:
 
 private:
   void HideNonBattleLevels();
-  void RestoreNonBattleLevels();
+  void RestoreNonBattleLevels(bool bRequestStreamingUpdate = true);
   bool IsStreamingLevelPartOfBattleMap(ULevelStreaming *Level) const;
   bool ResolveOrStreamLevel(UWorld* World, const TSoftObjectPtr<UWorld>& LevelAsset,
                             ULevelStreaming*& OutStreamingLevel, const TCHAR* ContextLabel);
@@ -62,7 +62,7 @@ private:
   bool CalculateActiveBattleLevelBounds(FBox& OutBounds) const;
 
   void HandleLevelLoaded();
-  void HandleLevelUnloaded();
+  void HandleLevelUnloaded(bool bRequestStreamingUpdate = true);
   void HandleLevelAddedToWorld(ULevel *InLevel, UWorld *InWorld);
   void HandleLevelRemovedFromWorld(ULevel *InLevel, UWorld *InWorld);
   bool DoesEventMatchActiveLevel(ULevel *InLevel, UWorld *InWorld) const;


### PR DESCRIPTION
### Motivation
- Prevent a crash caused by re-entering `UWorld::RemoveFromWorld` when `UpdateLevelStreaming()` is requested during an in-flight level removal by allowing restore paths to skip an immediate streaming update.

### Description
- Add an optional `bool bRequestStreamingUpdate = true` parameter to `RestoreNonBattleLevels` and `HandleLevelUnloaded` so callers can restore state without forcing `UpdateLevelStreaming()`.
- Guard the explicit `StreamingWorld->UpdateLevelStreaming()` call behind the new flag in `RestoreNonBattleLevels`.
- Change the `LevelRemovedFromWorld` delegate handler to call `HandleLevelUnloaded(false)` so the restore path does not trigger a reentrant streaming update while the engine is inside `RemoveFromWorld`.
- Modified files: `Source/Skald/Skald_BattleLevelManager.h` and `Source/Skald/Skald_BattleLevelManager.cpp`.

### Testing
- Ran repository checks including `git diff --check` and observed no diff-check warnings, and `git status` showed only the intended two files modified.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1c7a800d348324a11a0e38ea76215a)