### PR TITLE
Restore overview camera & HUD input after battle; fix duplicate territory delegate bindings

### DIFF
--- a/Source/Skald/Skald_BattleLevelManager.cpp
+++ b/Source/Skald/Skald_BattleLevelManager.cpp
@@ -7,12 +7,14 @@
 #include "Containers/Ticker.h"
 #include "Engine/Level.h"
 #include "Engine/LevelStreamingDynamic.h"
+#include "EngineUtils.h"
 #include "Misc/PackageName.h"
 #include "GameFramework/Actor.h"
 #include "GameFramework/Controller.h"
 #include "GameFramework/GameModeBase.h"
 #include "GameFramework/Pawn.h"
 #include "GameFramework/PlayerController.h"
+#include "GameFramework/PlayerStart.h"
 #include "GameFramework/WorldSettings.h"
 #include "Skald_BattleGameMode.h"
 #include "Skald_GameInstance.h"
@@ -42,6 +44,42 @@ static ULevelStreaming *FindStreamingLevelFor(ULevel *Level)
   }
 
   return nullptr;
+}
+
+
+static APlayerStart *FindOverviewPlayerStart(UWorld *World, const TSoftObjectPtr<UWorld> &ConfiguredOverviewLevel)
+{
+  if (!World) {
+    return nullptr;
+  }
+
+  const FString OverviewPackage = ConfiguredOverviewLevel.ToSoftObjectPath().GetLongPackageName();
+  APlayerStart *FallbackStart = nullptr;
+
+  for (TActorIterator<APlayerStart> It(World); It; ++It) {
+    APlayerStart *Start = *It;
+    if (!Start) {
+      continue;
+    }
+
+    if (!FallbackStart) {
+      FallbackStart = Start;
+    }
+
+    if (OverviewPackage.IsEmpty()) {
+      continue;
+    }
+
+    const ULevel *StartLevel = Start->GetLevel();
+    const UPackage *LevelPackage = StartLevel ? StartLevel->GetOutermost() : nullptr;
+    const FString StartPackage = LevelPackage ? LevelPackage->GetName() : FString();
+    if (StartPackage.Equals(OverviewPackage, ESearchCase::IgnoreCase) ||
+        StartPackage.StartsWith(OverviewPackage + TEXT("."), ESearchCase::IgnoreCase)) {
+      return Start;
+    }
+  }
+
+  return FallbackStart;
 }
 
 static FString ResolveStreamingLevelPackageName(const ULevelStreaming *Level)
@@ -1038,9 +1076,24 @@ void USkaldBattleLevelManager::RestoreLocalBattleCameraStates() {
     }
 
     CameraPawn->SetBattleCameraActive(false);
-    CameraPawn->SetActorLocationAndRotation(State.Location, State.ActorRotation, false,
+
+    FVector RestoreLocation = State.Location;
+    FRotator RestoreRotation = State.ActorRotation;
+    FRotator RestoreControlRotation = State.ControlRotation;
+
+    if (APlayerStart *OverviewStart =
+            FindOverviewPlayerStart(PC->GetWorld(), ConfiguredOverviewLevel)) {
+      RestoreLocation = OverviewStart->GetActorLocation();
+      RestoreRotation = OverviewStart->GetActorRotation();
+      RestoreControlRotation = RestoreRotation;
+      UE_LOG(LogSkald, Verbose,
+             TEXT("BattleLevelManager: restoring local overview camera for %s to PlayerStart %s"),
+             *GetNameSafe(PC), *GetNameSafe(OverviewStart));
+    }
+
+    CameraPawn->SetActorLocationAndRotation(RestoreLocation, RestoreRotation, false,
                                             nullptr, ETeleportType::TeleportPhysics);
-    PC->SetControlRotation(State.ControlRotation);
+    PC->SetControlRotation(RestoreControlRotation);
 
     AActor* DesiredViewTarget = State.ViewTarget.Get();
     PC->SetViewTarget(DesiredViewTarget ? DesiredViewTarget : CameraPawn);

--- a/Source/Skald/Skald_PlayerController.cpp
+++ b/Source/Skald/Skald_PlayerController.cpp
@@ -2008,6 +2008,7 @@ void ASkaldPlayerController::EndPlay(const EEndPlayReason::Type EndPlayReason) {
     BattleHudWidget->RemoveFromParent();
     BattleHudWidget = nullptr;
   }
+  BattleHUD = nullptr;
 
   if (DiceOverlayWidget) {
     DiceOverlayWidget->RemoveFromParent();
@@ -2095,7 +2096,13 @@ void ASkaldPlayerController::ShowMainHUD() {
   bShowMouseCursor = true;
   bEnableClickEvents = true;
   bEnableMouseOverEvents = true;
+  SetIgnoreMoveInput(false);
+  SetIgnoreLookInput(false);
   DefaultMouseCaptureMode = EMouseCaptureMode::NoCapture;
+  if (UGameViewportClient *GameViewport =
+          GetWorld() ? GetWorld()->GetGameViewport() : nullptr) {
+    GameViewport->SetMouseCaptureMode(DefaultMouseCaptureMode);
+  }
 }
 
 void ASkaldPlayerController::HideMainHUD() {
@@ -2150,7 +2157,14 @@ void ASkaldPlayerController::ShowBattleResultWidget(
 
     BattleResultWidget = Widget;
     BattleResultWidget->AddToViewport();
-    HideMainHUD();
+    if (MainHUD) {
+      MainHUD->SetVisibility(ESlateVisibility::Collapsed);
+    }
+    UWidgetBlueprintLibrary::SetInputMode_UIOnlyEx(
+        this, BattleResultWidget, EMouseLockMode::DoNotLock, false);
+    bShowMouseCursor = true;
+    bEnableClickEvents = true;
+    bEnableMouseOverEvents = true;
   }
 }
 
@@ -3380,6 +3394,7 @@ void ASkaldPlayerController::ShowOverworldHUD() {
     BattleHudWidget->RemoveFromParent();
     BattleHudWidget = nullptr;
   }
+  BattleHUD = nullptr;
 
   if (FighterSelectionWidget) {
     FighterSelectionWidget->RemoveFromParent();

--- a/Source/Skald/Territory.cpp
+++ b/Source/Skald/Territory.cpp
@@ -117,6 +117,12 @@ void ATerritory::BeginPlay() {
   }
 
   if (MeshComponent) {
+    MeshComponent->OnBeginCursorOver.RemoveDynamic(
+        this, &ATerritory::HandleMouseEnter);
+    MeshComponent->OnEndCursorOver.RemoveDynamic(
+        this, &ATerritory::HandleMouseLeave);
+    MeshComponent->OnClicked.RemoveDynamic(this, &ATerritory::HandleClicked);
+
     MeshComponent->OnBeginCursorOver.AddDynamic(this,
                                                 &ATerritory::HandleMouseEnter);
     MeshComponent->OnEndCursorOver.AddDynamic(this,
@@ -197,6 +203,14 @@ void ATerritory::Deselect() {
 }
 
 void ATerritory::EndPlay(const EEndPlayReason::Type Reason) {
+  if (MeshComponent) {
+    MeshComponent->OnBeginCursorOver.RemoveDynamic(
+        this, &ATerritory::HandleMouseEnter);
+    MeshComponent->OnEndCursorOver.RemoveDynamic(
+        this, &ATerritory::HandleMouseLeave);
+    MeshComponent->OnClicked.RemoveDynamic(this, &ATerritory::HandleClicked);
+  }
+
   if (AWorldMap *Map = Cast<AWorldMap>(GetOwner())) {
     if (Map->SelectedTerritory == this) {
       Map->SelectTerritory(nullptr, false);


### PR DESCRIPTION
### Motivation
- After a streamed battle sublevel unload the local camera/input should be restored to the overview map `PlayerStart`, and the overworld HUD/input must be fully interactive again.
- Rebuilding the main HUD after battle sometimes left the game in the wrong input/cursor state and broke UI interaction.
- A runtime ensure was observed from duplicate `OnBeginCursorOver`/`OnClicked` delegate bindings on `ATerritory` when the overview level was reloaded.

### Description
- Restore overview camera: added `FindOverviewPlayerStart` and updated `USkaldBattleLevelManager::RestoreLocalBattleCameraStates` to teleport local `ASkald_PlayerCharacter` pawns back to the overview `PlayerStart` (if found) and restore control/view rotations instead of always using the saved battle-world actor location; updated includes (`EngineUtils.h`, `PlayerStart`). (`Source/Skald/Skald_BattleLevelManager.cpp`)
- Reassert HUD/input state: in `ASkaldPlayerController::ShowMainHUD` ensure move/look input is enabled, set viewport mouse capture back to `NoCapture`, and force proper cursor/click state so the main HUD is fully interactive after returning from battle. (`Source/Skald/Skald_PlayerController.cpp`)
- Keep battle-result modal in UI-only mode: when showing the battle result widget we now set input mode to UI-only and leave the main HUD hidden rather than calling `HideMainHUD()` which switched to Game-only and hid the cursor. (`Source/Skald/Skald_PlayerController.cpp`)
- Clear stale HUD references: clear the cached `BattleHUD` reference when tearing down/rebuilding the overworld HUD to avoid lingering stale pointers after battle unloads. (`Source/Skald/Skald_PlayerController.cpp`)
- Prevent duplicate territory delegate bindings: remove existing `MeshComponent` dynamic bindings in `ATerritory::BeginPlay` before re-adding them and remove them in `ATerritory::EndPlay` to avoid duplicate `AddDynamic` causes and the ENSURE from `ScriptDelegates`. (`Source/Skald/Territory.cpp`)
- Small logging and safety tweaks around the above changes; all edits are in `Source/Skald/Skald_BattleLevelManager.cpp`, `Source/Skald/Skald_PlayerController.cpp`, and `Source/Skald/Territory.cpp`.

### Testing
- Ran `git diff --check` to validate no whitespace/patch issues (passed).
- Attempted an editor build with `UnrealBuildTool` to compile the changes, but the environment lacks `UnrealBuildTool` so a full compile/run could not be executed here (tool unavailable).
- Committed the changes (`git commit`) locally and validated repository status and diffs; no further automated tests were available in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1c7dfcc8308324a961c7ade8b6bce1)