### PR TITLE
Show enemy territory selections and deployment floats

### DIFF
--- a/Source/Skald/Skald_AIController.cpp
+++ b/Source/Skald/Skald_AIController.cpp
@@ -939,6 +939,7 @@ void ASkaldAIController::HandleArmyPlacementAnimationStep() {
     if (UnitsToDeploy > 0) {
       Target->ArmyUnits += UnitsToDeploy;
       Target->RefreshAppearance();
+      Target->MulticastShowDeploymentFloat(UnitsToDeploy);
       AnimatedPlayerState->DeployableUnits -= UnitsToDeploy;
       AnimatedPlayerState->AddArmyPlacementDeployment(
           Target->GetTerritoryId(), UnitsToDeploy);

--- a/Source/Skald/Skald_PlayerController.cpp
+++ b/Source/Skald/Skald_PlayerController.cpp
@@ -4918,6 +4918,7 @@ void ASkaldPlayerController::ServerDeployUnits_Implementation(int32 TerritoryID,
 
   Terr->ArmyUnits += Amount;
   Terr->RefreshAppearance();
+  Terr->MulticastShowDeploymentFloat(Amount);
 
   PS->DeployableUnits -= Amount;
 

--- a/Source/Skald/Territory.cpp
+++ b/Source/Skald/Territory.cpp
@@ -17,6 +17,7 @@
 #include "Skald_PlayerController.h"
 #include "Skald_PlayerState.h"
 #include "Skald_GameInstance.h"
+#include "Skald_GameState.h"
 #include "UObject/ConstructorHelpers.h"
 #include "WorldMap.h"
 
@@ -35,7 +36,8 @@ FLinearColor ResolveFactionColor(const UObject *WorldContext,
 } // namespace
 
 ATerritory::ATerritory() {
-  PrimaryActorTick.bCanEverTick = false;
+  PrimaryActorTick.bCanEverTick = true;
+  PrimaryActorTick.bStartWithTickEnabled = false;
   bReplicates = true;
   MeshComponent = CreateDefaultSubobject<UStaticMeshComponent>(TEXT("Mesh"));
   MeshComponent->SetCollisionEnabled(ECollisionEnabled::QueryOnly);
@@ -69,6 +71,18 @@ ATerritory::ATerritory() {
   LabelComponent->SetRelativeLocation(FVector(0.f, 0.f, 100.f));
   LabelComponent->SetText(FText::GetEmpty());
 
+  DeploymentFloatComponent =
+      CreateDefaultSubobject<UTextRenderComponent>(TEXT("DeploymentFloat"));
+  DeploymentFloatComponent->SetupAttachment(RootComponent);
+  DeploymentFloatComponent->SetHorizontalAlignment(EHTA_Center);
+  DeploymentFloatComponent->SetVerticalAlignment(EVRTA_TextCenter);
+  DeploymentFloatComponent->SetRelativeLocation(DeploymentFloatBaseOffset);
+  DeploymentFloatComponent->SetWorldSize(24.f);
+  DeploymentFloatComponent->SetText(FText::GetEmpty());
+  DeploymentFloatComponent->SetTextRenderColor(FColor::Green);
+  DeploymentFloatComponent->SetVisibility(false);
+  DeploymentFloatComponent->SetHiddenInGame(true);
+
   SelectionDecal = CreateDefaultSubobject<UDecalComponent>(TEXT("SelectionDecal"));
   if (SelectionDecal) {
     SelectionDecal->SetupAttachment(RootComponent);
@@ -101,6 +115,11 @@ void ATerritory::BeginPlay() {
   Super::BeginPlay();
 
   ApplySelectionDecalMaterial();
+  if (DeploymentFloatComponent) {
+    DeploymentFloatComponent->SetRelativeLocation(DeploymentFloatBaseOffset);
+    DeploymentFloatComponent->SetVisibility(false);
+    DeploymentFloatComponent->SetHiddenInGame(true);
+  }
 
   if (!CapitalMesh) {
     CapitalMesh = NewObject<UStaticMeshComponent>(this, TEXT("CapitalMesh"));
@@ -159,6 +178,34 @@ void ATerritory::BeginPlay() {
     if (!WorldMap->Territories.Contains(this)) {
       WorldMap->RegisterTerritory(this);
     }
+  }
+}
+
+void ATerritory::Tick(float DeltaSeconds) {
+  Super::Tick(DeltaSeconds);
+
+  if (!bDeploymentFloatActive || !DeploymentFloatComponent) {
+    SetActorTickEnabled(false);
+    return;
+  }
+
+  const float Duration = FMath::Max(DeploymentFloatDuration, KINDA_SMALL_NUMBER);
+  DeploymentFloatElapsed += DeltaSeconds;
+  const float Alpha = FMath::Clamp(DeploymentFloatElapsed / Duration, 0.f, 1.f);
+
+  FVector FloatOffset = DeploymentFloatBaseOffset;
+  FloatOffset.Z += DeploymentFloatRiseDistance * Alpha;
+  DeploymentFloatComponent->SetRelativeLocation(FloatOffset);
+
+  const uint8 TextAlpha =
+      static_cast<uint8>(FMath::RoundToInt(255.f * (1.f - Alpha)));
+  DeploymentFloatComponent->SetTextRenderColor(FColor(80, 255, 80, TextAlpha));
+
+  if (DeploymentFloatElapsed >= Duration) {
+    bDeploymentFloatActive = false;
+    DeploymentFloatComponent->SetVisibility(false);
+    DeploymentFloatComponent->SetHiddenInGame(true);
+    SetActorTickEnabled(false);
   }
 }
 
@@ -360,6 +407,28 @@ void ATerritory::RefreshAppearance() {
   }
 }
 
+void ATerritory::ShowDeploymentFloat(int32 UnitsAdded) {
+  if (UnitsAdded <= 0 || !DeploymentFloatComponent ||
+      GetNetMode() == NM_DedicatedServer) {
+    return;
+  }
+
+  DeploymentFloatElapsed = 0.f;
+  bDeploymentFloatActive = true;
+
+  DeploymentFloatComponent->SetText(
+      FText::FromString(FString::Printf(TEXT("+%d"), UnitsAdded)));
+  DeploymentFloatComponent->SetRelativeLocation(DeploymentFloatBaseOffset);
+  DeploymentFloatComponent->SetTextRenderColor(FColor(80, 255, 80, 255));
+  DeploymentFloatComponent->SetVisibility(true);
+  DeploymentFloatComponent->SetHiddenInGame(false);
+  SetActorTickEnabled(true);
+}
+
+void ATerritory::MulticastShowDeploymentFloat_Implementation(int32 UnitsAdded) {
+  ShowDeploymentFloat(UnitsAdded);
+}
+
 void ATerritory::OnRep_OwningPlayer() { RefreshAppearance(); }
 
 void ATerritory::OnRep_IsCapital() { RefreshAppearance(); }
@@ -451,6 +520,10 @@ bool ATerritory::ShouldShowSelectionVisuals(int32 SelectingPlayerId) const {
     return false;
   }
 
+  const ASkaldGameState *SkaldGameState = World->GetGameState<ASkaldGameState>();
+  const bool bSelectingPlayerHasTurn =
+      SkaldGameState && SkaldGameState->ActivePlayerId == SelectingPlayerId;
+
   for (FConstPlayerControllerIterator It = World->GetPlayerControllerIterator(); It;
        ++It) {
     const APlayerController *PC = It->Get();
@@ -463,7 +536,13 @@ bool ATerritory::ShouldShowSelectionVisuals(int32 SelectingPlayerId) const {
       continue;
     }
 
-    if (PS->GetStablePlayerId() == SelectingPlayerId) {
+    const int32 LocalStableId = PS->GetStablePlayerId();
+    if (LocalStableId == SelectingPlayerId) {
+      return true;
+    }
+
+    if (bSelectingPlayerHasTurn && LocalStableId != INDEX_NONE &&
+        LocalStableId != SelectingPlayerId) {
       return true;
     }
   }

--- a/Source/Skald/Territory.h
+++ b/Source/Skald/Territory.h
@@ -33,6 +33,8 @@ public:
 
     virtual void EndPlay(const EEndPlayReason::Type Reason) override;
 
+    virtual void Tick(float DeltaSeconds) override;
+
     virtual void GetLifetimeReplicatedProps(
         TArray<FLifetimeProperty>& OutLifetimeProps) const override;
 
@@ -146,6 +148,14 @@ public:
     UFUNCTION(BlueprintCallable, Category = "Territory")
     void RefreshAppearance();
 
+    /** Show a short-lived floating text label for newly deployed units. */
+    UFUNCTION(BlueprintCallable, Category = "Territory|Deployment")
+    void ShowDeploymentFloat(int32 UnitsAdded);
+
+    /** Broadcast a deployment float to every client viewing this territory. */
+    UFUNCTION(NetMulticast, Unreliable)
+    void MulticastShowDeploymentFloat(int32 UnitsAdded);
+
     UFUNCTION()
     void OnRep_OwningPlayer();
 
@@ -172,6 +182,10 @@ protected:
     UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "Territory|Selection")
     UDecalComponent* SelectionDecal = nullptr;
 
+    /** Text that briefly displays the number of units deployed here. */
+    UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "Territory|Deployment")
+    UTextRenderComponent* DeploymentFloatComponent = nullptr;
+
     /** Material applied to the territory selection decal. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Territory|Selection")
     TObjectPtr<UMaterialInterface> SelectionDecalMaterial = nullptr;
@@ -195,6 +209,18 @@ protected:
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Territory|Selection", meta = (ClampMin = "0.0"))
     float SelectionSoundVolumeMultiplier = 1.f;
 
+    /** How long deployed-unit floating text remains visible. */
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Territory|Deployment", meta = (ClampMin = "0.01"))
+    float DeploymentFloatDuration = 0.6f;
+
+    /** Position of the deployed-unit floating text above the territory label. */
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Territory|Deployment")
+    FVector DeploymentFloatBaseOffset = FVector(0.f, 0.f, 145.f);
+
+    /** How far the deployed-unit text drifts upward while visible. */
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Territory|Deployment", meta = (ClampMin = "0.0"))
+    float DeploymentFloatRiseDistance = 30.f;
+
     /** Dynamic material used for highlighting. */
     UPROPERTY()
     UMaterialInstanceDynamic* DynamicMaterial = nullptr;
@@ -216,4 +242,7 @@ protected:
     void SetSelectionDecalVisible(bool bVisible);
     void UpdateSelectionVisuals(bool bVisible);
     bool ShouldShowSelectionVisuals(int32 SelectingPlayerId) const;
+
+    float DeploymentFloatElapsed = 0.f;
+    bool bDeploymentFloatActive = false;
 };

--- a/Source/Skald/WorldMap.cpp
+++ b/Source/Skald/WorldMap.cpp
@@ -850,6 +850,7 @@ int32 AWorldMap::AutoPlaceUnitsForAI(ASkaldPlayerState *PlayerState) {
   int32 Remaining = PlayerState->DeployableUnits;
   int32 Index = 0;
   int32 ConsecutiveSkips = 0;
+  TMap<ATerritory *, int32> DeploymentsByTerritory;
 
   const int32 MaxPerTerritory = Skald::ArmyPlacement::DeployPerTerritoryLimit;
 
@@ -880,10 +881,17 @@ int32 AWorldMap::AutoPlaceUnitsForAI(ASkaldPlayerState *PlayerState) {
 
     ++Target->ArmyUnits;
     Target->RefreshAppearance();
+    DeploymentsByTerritory.FindOrAdd(Target) += 1;
     ++UnitsPlaced;
     --Remaining;
     PlayerState->AddArmyPlacementDeployment(TerritoryId, 1);
     ++Index;
+  }
+
+  for (const TPair<ATerritory *, int32> &Deployment : DeploymentsByTerritory) {
+    if (Deployment.Key) {
+      Deployment.Key->MulticastShowDeploymentFloat(Deployment.Value);
+    }
   }
 
   PlayerState->DeployableUnits = Remaining;
@@ -1009,6 +1017,7 @@ int32 AWorldMap::DistributeUnplacedArmyPlacementUnits(
 
     Territory->ArmyUnits += Assignment.Value;
     Territory->RefreshAppearance();
+    Territory->MulticastShowDeploymentFloat(Assignment.Value);
   }
 
   Remaining = FMath::Max(Remaining, 0);


### PR DESCRIPTION
### Motivation
- Make enemy selections visible to players during enemy turns so players can see which territories the active (enemy) player chooses. 
- Provide immediate visual feedback when troops are deployed by showing a short floating +N indicator above the territory name.

### Description
- Territory selection visibility: `ATerritory::ShouldShowSelectionVisuals` now checks the game state `ActivePlayerId` and treats selections from the active-turn player as visible to local controllers so enemy-turn selections highlight locally (changes in `Source/Skald/Territory.cpp`).
- Deployment float visuals: added a `UTextRenderComponent* DeploymentFloatComponent`, configurable properties (`DeploymentFloatDuration` default 0.6s, `DeploymentFloatBaseOffset`, `DeploymentFloatRiseDistance`), tick-driven rise+fade logic, `ShowDeploymentFloat` and an unreliable `MulticastShowDeploymentFloat` RPC to broadcast the float to clients (changes in `Source/Skald/Territory.h` and `Source/Skald/Territory.cpp`).
- Hooked float triggers into deployment paths so the float plays when units are added from player deploy (`ASkaldPlayerController::ServerDeployUnits`), AI animated placement (`ASkaldAIController`), AI auto-placement and unplaced distribution (`AWorldMap::AutoPlaceUnitsForAI` and `AWorldMap::DistributeUnplacedArmyPlacementUnits`).
- Small runtime/tick change: territories now enable ticking only while a deployment float is active to animate the float without enabling continuous tick.

### Testing
- Ran `clang-format -i` on modified files to ensure formatting (succeeded). 
- Ran `git diff --check` to validate no whitespace/patch issues (no errors).
- Noted that `UnrealBuildTool` / full engine build is not available in this environment, so runtime build/QA was not executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1c88a4dc448324be1b28e6c0d70964)