### PR TITLE
Fix battle result duplication, add off‑turn territory preview, and make deployment float reliable

### DIFF
--- a/Source/Skald/Skald_PlayerController.cpp
+++ b/Source/Skald/Skald_PlayerController.cpp
@@ -4948,6 +4948,30 @@ void ASkaldPlayerController::RequestSelectTerritory(ATerritory *Territory) {
                                                  *Territory->GetName(),
                                                  Territory->TerritoryID)
                                : FString(TEXT("None"));
+
+  if (!IsMyTurn()) {
+    if (ATerritory *PreviousVisual = VisualOnlySelectedTerritory.Get()) {
+      PreviousVisual->SetLocalVisualSelection(false);
+    }
+
+    ATerritory *NewVisualSelection = nullptr;
+    if (IsValid(Territory) && VisualOnlySelectedTerritory.Get() != Territory) {
+      NewVisualSelection = Territory;
+      NewVisualSelection->SetLocalVisualSelection(true);
+    }
+    VisualOnlySelectedTerritory = NewVisualSelection;
+
+    UE_LOG(LogSkald, Verbose,
+           TEXT("RequestSelectTerritory applied visual-only off-turn selection of %s for %s"),
+           *TerrDesc, *GetName());
+    return;
+  }
+
+  if (ATerritory *PreviousVisual = VisualOnlySelectedTerritory.Get()) {
+    PreviousVisual->SetLocalVisualSelection(false);
+    VisualOnlySelectedTerritory.Reset();
+  }
+
   UE_LOG(LogSkald, Log,
          TEXT("RequestSelectTerritory forwarding %s from client controller %s"),
          *TerrDesc, *GetName());
@@ -5973,6 +5997,13 @@ void ASkaldPlayerController::HandleReplicatedTurnOwnership() {
     return;
   }
 
+  if (bIsMyTurn) {
+    if (ATerritory *PreviousVisual = VisualOnlySelectedTerritory.Get()) {
+      PreviousVisual->SetLocalVisualSelection(false);
+      VisualOnlySelectedTerritory.Reset();
+    }
+  }
+
   if (bIsMyTurn && !bLocalTurnActive) {
     UE_LOG(LogSkald, Log,
            TEXT("[TurnState] Controller %s starting local turn from replicated state."),
@@ -6201,8 +6232,6 @@ void ASkaldPlayerController::HandleWorldStateChanged() {
   if (!bIsBattleMap && bPendingOverworldBattleResults &&
       CachedBattleResultDisplayData.bValid) {
     bPendingOverworldBattleResults = false;
-    bAwaitingBattleResultCloseAck = true;
-    ShowBattleResultWidget(CachedBattleResultDisplayData);
   }
 
   // Update territory info for the currently selected territory if available.
@@ -10657,9 +10686,9 @@ void ASkaldPlayerController::HandleBattleEnded(ESkaldFaction WinningFaction,
   DisplayData.EnemyFactionText = EnemyFactionText;
 
   CachedBattleResultDisplayData = DisplayData;
+  bPendingOverworldBattleResults = false;
+  bAwaitingBattleResultCloseAck = true;
   ShowBattleResultWidget(DisplayData);
-  bPendingOverworldBattleResults = true;
-  bAwaitingBattleResultCloseAck = false;
 
   if (!CachedGameInstance)
   {

--- a/Source/Skald/Skald_PlayerController.h
+++ b/Source/Skald/Skald_PlayerController.h
@@ -1060,6 +1060,9 @@ private:
   /** Queued territory selection to replay once the world map finishes spawning. */
   int32 PendingTerritorySelectionId = INDEX_NONE;
 
+  /** Territory highlighted locally while inspecting the map outside our turn. */
+  TWeakObjectPtr<ATerritory> VisualOnlySelectedTerritory;
+
   /** Timer used to poll for world map readiness after an early selection arrives. */
   FTimerHandle PendingTerritorySelectionHandle;
 

--- a/Source/Skald/Territory.cpp
+++ b/Source/Skald/Territory.cpp
@@ -235,18 +235,30 @@ void ATerritory::Select(int32 SelectingPlayerId) {
   }
 
   bIsSelected = true;
-  UpdateSelectionVisuals(bShouldShow);
+  UpdateSelectionVisuals(bShouldShow || bLocalVisualSelectionActive);
 }
 
 void ATerritory::Deselect() {
   bIsSelected = false;
   LastSelectingPlayerId = INDEX_NONE;
-  UpdateSelectionVisuals(false);
+  UpdateSelectionVisuals(bLocalVisualSelectionActive);
   if (AWorldMap *Map = Cast<AWorldMap>(GetOwner())) {
     if (Map->SelectedTerritory == this) {
       Map->SelectedTerritory = nullptr;
     }
   }
+}
+
+void ATerritory::SetLocalVisualSelection(bool bEnabled) {
+  if (bLocalVisualSelectionActive == bEnabled) {
+    return;
+  }
+
+  bLocalVisualSelectionActive = bEnabled;
+  const bool bReplicatedSelectionVisible =
+      bIsSelected && ShouldShowSelectionVisuals(LastSelectingPlayerId);
+  UpdateSelectionVisuals(bLocalVisualSelectionActive ||
+                         bReplicatedSelectionVisible);
 }
 
 void ATerritory::EndPlay(const EEndPlayReason::Type Reason) {
@@ -551,6 +563,10 @@ bool ATerritory::ShouldShowSelectionVisuals(int32 SelectingPlayerId) const {
 }
 
 bool ATerritory::IsSelectionVisibleToLocalPlayer() const {
+  if (bLocalVisualSelectionActive) {
+    return true;
+  }
+
   if (!bIsSelected) {
     return false;
   }

--- a/Source/Skald/Territory.h
+++ b/Source/Skald/Territory.h
@@ -93,6 +93,9 @@ public:
     UFUNCTION(BlueprintCallable, Category = "Territory")
     void Deselect();
 
+    /** Toggle a local-only selection preview without changing replicated selection. */
+    void SetLocalVisualSelection(bool bEnabled);
+
     /** True if the local player should currently see selection visuals. */
     bool IsSelectionVisibleToLocalPlayer() const;
 
@@ -153,7 +156,7 @@ public:
     void ShowDeploymentFloat(int32 UnitsAdded);
 
     /** Broadcast a deployment float to every client viewing this territory. */
-    UFUNCTION(NetMulticast, Unreliable)
+    UFUNCTION(NetMulticast, Reliable)
     void MulticastShowDeploymentFloat(int32 UnitsAdded);
 
     UFUNCTION()
@@ -227,6 +230,9 @@ protected:
 
     /** Base color of the territory mesh. */
     FLinearColor DefaultColor;
+
+    /** Local-only visual preview used for off-turn inspection clicks. */
+    bool bLocalVisualSelectionActive = false;
 
     /** Whether the territory has been selected. */
     bool bIsSelected = false;


### PR DESCRIPTION
### Motivation
- Prevent the battle result UI from being spawned twice (immediately after combat and again during the overworld unload/rebuild path). 
- Allow players to visually inspect territory selections during enemy turns without changing replicated selection, camera, or pawn state. 
- Ensure deployed-unit floating text reliably arrives on clients so deployment feedback is not silently dropped.

### Description
- Stop recreating the overworld result widget by treating the first post-battle widget as the authoritative one and clearing the pending-overworld flag instead of re-showing in `ASkaldPlayerController::HandleBattleEnded` and `HandleWorldStateChanged` (`bPendingOverworldBattleResults` / `bAwaitingBattleResultCloseAck` ordering). 
- Add an off-turn visual-only selection flow: `ASkaldPlayerController` now keeps `VisualOnlySelectedTerritory` and in `RequestSelectTerritory` toggles a local preview when `!IsMyTurn()` (calling `ATerritory::SetLocalVisualSelection`) and skips `ServerSelectTerritory` until the player is on-turn. 
- Add `ATerritory::SetLocalVisualSelection` plus `bLocalVisualSelectionActive` and adjust `Select`/`Deselect`/`IsSelectionVisibleToLocalPlayer`/`UpdateSelectionVisuals` so local previews co-exist with replicated selection visuals. 
- Clear any visual-only preview when the player regains their turn in turn ownership handling so previews do not persist. 
- Make deployment float multicast reliable by changing `MulticastShowDeploymentFloat` to `NetMulticast, Reliable` so deployed-unit floaters are less likely to be dropped.

### Testing
- Ran `./Build/validate.sh`; the script detected missing `UnrealBuildTool`/`UnrealEditor` in the environment so compile and automation tests were skipped and no engine tests were executed (script completed but could not run the automated test suite).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1c8e9c7f3883248a6bfdc22df67865)