### PR TITLE
Fix battle result acknowledgement pending state

### DIFF
--- a/Source/Skald/Skald_AIController.cpp
+++ b/Source/Skald/Skald_AIController.cpp
@@ -203,9 +203,10 @@ void ASkaldAIController::HideMainHUD() {
   // AI controllers do not own local HUD/UI.
 }
 
-void ASkaldAIController::ShowBattleResultWidget(
+bool ASkaldAIController::ShowBattleResultWidget(
     const FBattleResultDisplayData & /*DisplayData*/) {
   // AI controllers do not display local battle-result widgets.
+  return false;
 }
 
 void ASkaldAIController::InitializeBattleHUD() {

--- a/Source/Skald/Skald_AIController.h
+++ b/Source/Skald/Skald_AIController.h
@@ -44,7 +44,7 @@ public:
   virtual void InitializeHUDWidget() override;
   virtual void ShowMainHUD() override;
   virtual void HideMainHUD() override;
-  virtual void ShowBattleResultWidget(
+  virtual bool ShowBattleResultWidget(
       const FBattleResultDisplayData &DisplayData) override;
   virtual void InitializeBattleHUD() override;
   virtual void ShowFighterSelectionUI(

--- a/Source/Skald/Skald_PlayerController.cpp
+++ b/Source/Skald/Skald_PlayerController.cpp
@@ -2117,11 +2117,11 @@ void ASkaldPlayerController::HideMainHUD() {
   }
 }
 
-void ASkaldPlayerController::ShowBattleResultWidget(
+bool ASkaldPlayerController::ShowBattleResultWidget(
     const FBattleResultDisplayData &DisplayData) {
   if (IsAIControllerIdentity_PlayerController(this) || !Player || !GetLocalPlayer() ||
       !CanCreateLocalUIWidget() || !DisplayData.bValid) {
-    return;
+    return false;
   }
 
   if (!VictoryWidgetClass) {
@@ -2135,11 +2135,11 @@ void ASkaldPlayerController::ShowBattleResultWidget(
   ClearBattleResultWidget(/*bNotifyAcknowledgement=*/false);
 
   if (!VictoryWidgetClass) {
-    return;
+    return false;
   }
 
   if (!CanCreateLocalUIWidget()) {
-    return;
+    return false;
   }
 
   if (UUserWidget *Widget = CreateWidget<UUserWidget>(this, VictoryWidgetClass)) {
@@ -2165,7 +2165,10 @@ void ASkaldPlayerController::ShowBattleResultWidget(
     bShowMouseCursor = true;
     bEnableClickEvents = true;
     bEnableMouseOverEvents = true;
+    return true;
   }
+
+  return false;
 }
 
 void ASkaldPlayerController::ClearBattleResultWidget(bool bNotifyAcknowledgement) {
@@ -6231,7 +6234,10 @@ void ASkaldPlayerController::HandleWorldStateChanged() {
 
   if (!bIsBattleMap && bPendingOverworldBattleResults &&
       CachedBattleResultDisplayData.bValid) {
-    bPendingOverworldBattleResults = false;
+    const bool bResultWidgetShown =
+        ShowBattleResultWidget(CachedBattleResultDisplayData);
+    bPendingOverworldBattleResults = !bResultWidgetShown;
+    bAwaitingBattleResultCloseAck = bResultWidgetShown;
   }
 
   // Update territory info for the currently selected territory if available.
@@ -10686,9 +10692,9 @@ void ASkaldPlayerController::HandleBattleEnded(ESkaldFaction WinningFaction,
   DisplayData.EnemyFactionText = EnemyFactionText;
 
   CachedBattleResultDisplayData = DisplayData;
-  bPendingOverworldBattleResults = false;
-  bAwaitingBattleResultCloseAck = true;
-  ShowBattleResultWidget(DisplayData);
+  const bool bResultWidgetShown = ShowBattleResultWidget(DisplayData);
+  bPendingOverworldBattleResults = !bResultWidgetShown;
+  bAwaitingBattleResultCloseAck = bResultWidgetShown;
 
   if (!CachedGameInstance)
   {

--- a/Source/Skald/Skald_PlayerController.h
+++ b/Source/Skald/Skald_PlayerController.h
@@ -577,7 +577,7 @@ protected:
   /** Tracks whether the cursor was hovering an interactable widget last tick. */
   bool bWasHoveringInteractable = false;
 
-  virtual void ShowBattleResultWidget(const FBattleResultDisplayData &DisplayData);
+  virtual bool ShowBattleResultWidget(const FBattleResultDisplayData &DisplayData);
   void ClearBattleResultWidget(bool bNotifyAcknowledgement = true);
 
   UFUNCTION()


### PR DESCRIPTION
### Motivation
- Prevent entering the acknowledgement wait state when `ShowBattleResultWidget()` returns early due to unavailable local UI, which left `bAwaitingBattleResultCloseAck` true with no widget to close. 
- Ensure overworld battle-result data remains queued and is retried when UI becomes available instead of getting stuck and never sending `ServerAcknowledgeBattleResults()`.

### Description
- Change `ShowBattleResultWidget(const FBattleResultDisplayData&)` to return `bool` indicating whether the widget was actually created and shown, and update the declaration in `Skald_PlayerController.h` and the AI override in `Skald_AIController.*` to match. 
- Only set `bAwaitingBattleResultCloseAck` when `ShowBattleResultWidget()` returns `true`, and set `bPendingOverworldBattleResults` to `true` when the widget could not be created so the UI creation will be retried later. 
- Update call sites in `HandleBattleEnded()` and `HandleWorldStateChanged()` to use the new return value and to preserve/clear `bPendingOverworldBattleResults` appropriately.

### Testing
- Ran code checks with `git diff --check`, which completed without reported issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1c954f55748324a85417980091f0f0)