### PR TITLE
Fix post-battle overview input state

### DIFF
--- a/Source/Skald/Skald_PlayerController.cpp
+++ b/Source/Skald/Skald_PlayerController.cpp
@@ -2602,14 +2602,9 @@ void ASkaldPlayerController::PlayerTick(float DeltaTime) {
     CachedGameState = GetWorld()->GetGameState<ASkaldGameState>();
   }
 
-  const FS_BattlePayload TickBattle = CachedGameState
-                                          ? CachedGameState->GetActiveBattlePayload()
-                                          : CachedGameInstance
-                                                ? CachedGameInstance->PendingBattle
-                                                : FS_BattlePayload();
-  const bool bHasTickBattlePayload =
-      TickBattle.AttackerPlayerID > 0 || TickBattle.DefenderPlayerID > 0 ||
-      TickBattle.FromTerritoryID > 0 || TickBattle.TargetTerritoryID > 0;
+  const bool bTickPendingBattleTravelContext =
+      CachedGameInstance && CachedGameInstance->IsTravelPending() &&
+      CachedGameInstance->HasPendingBattleTravelContext();
   const USkaldBattleLevelManager* TickBattleLevelManager =
       CachedGameInstance ? CachedGameInstance->GetBattleLevelManager() : nullptr;
   const bool bTickStreamedBattleContext =
@@ -2617,8 +2612,7 @@ void ASkaldPlayerController::PlayerTick(float DeltaTime) {
                                  TickBattleLevelManager->IsBattleLevelFullyReady());
   const bool bTickBattleContext =
       bIsBattleMap || (CachedGameInstance && CachedGameInstance->bIsInBattleMap) ||
-      (CachedGameState && CachedGameState->BattlePhase != EBattlePhase::None) ||
-      bHasTickBattlePayload || bTickStreamedBattleContext ||
+      bTickStreamedBattleContext || bTickPendingBattleTravelContext ||
       (CachedGameInstance && CachedGameInstance->GridBattleManager) ||
       bBattleHUDReadyToShow || bBattleHUDVisible ||
       (FighterSelectionWidget && FighterSelectionWidget->IsInViewport()) ||
@@ -3391,7 +3385,14 @@ void ASkaldPlayerController::InitializeBattleHUD() {
 }
 
 void ASkaldPlayerController::ShowOverworldHUD() {
-  ShowMainHUD();
+  const bool bBattleResultVisible =
+      BattleResultWidget && BattleResultWidget->IsInViewport() &&
+      BattleResultWidget->GetVisibility() != ESlateVisibility::Collapsed &&
+      BattleResultWidget->GetVisibility() != ESlateVisibility::Hidden;
+
+  if (!bAwaitingBattleResultCloseAck && !bBattleResultVisible) {
+    ShowMainHUD();
+  }
 
   if (BattleHudWidget) {
     BattleHudWidget->RemoveFromParent();
@@ -6353,14 +6354,9 @@ void ASkaldPlayerController::UpdateBattleCameraMode() {
     return;
   }
 
-  const FS_BattlePayload ActiveBattle = CachedGameState
-                                            ? CachedGameState->GetActiveBattlePayload()
-                                            : CachedGameInstance
-                                                  ? CachedGameInstance->PendingBattle
-                                                  : FS_BattlePayload();
-  const bool bHasBattlePayload =
-      ActiveBattle.AttackerPlayerID > 0 || ActiveBattle.DefenderPlayerID > 0 ||
-      ActiveBattle.FromTerritoryID > 0 || ActiveBattle.TargetTerritoryID > 0;
+  const bool bPendingBattleTravelContext =
+      CachedGameInstance && CachedGameInstance->IsTravelPending() &&
+      CachedGameInstance->HasPendingBattleTravelContext();
   USkaldBattleLevelManager* BattleLevelManager =
       CachedGameInstance ? CachedGameInstance->GetBattleLevelManager() : nullptr;
   const bool bStreamedBattleLevelActive =
@@ -6370,8 +6366,7 @@ void ASkaldPlayerController::UpdateBattleCameraMode() {
       BattleLevelManager && BattleLevelManager->IsBattleLevelFullyReady();
   const bool bBattleCameraContext =
       bIsBattleMap || (CachedGameInstance && CachedGameInstance->bIsInBattleMap) ||
-      (CachedGameState && CachedGameState->BattlePhase != EBattlePhase::None) ||
-      bHasBattlePayload || bStreamedBattleLevelActive ||
+      bStreamedBattleLevelActive || bPendingBattleTravelContext ||
       (CachedGameInstance && CachedGameInstance->GridBattleManager) ||
       bBattleHUDReadyToShow || bBattleHUDVisible ||
       (FighterSelectionWidget && FighterSelectionWidget->IsInViewport()) ||
@@ -6422,14 +6417,6 @@ bool ASkaldPlayerController::ApplyBattleInteractionInputState(
     CachedGameState = GetWorld()->GetGameState<ASkaldGameState>();
   }
 
-  const FS_BattlePayload ActiveBattle = CachedGameState
-                                            ? CachedGameState->GetActiveBattlePayload()
-                                            : CachedGameInstance
-                                                  ? CachedGameInstance->PendingBattle
-                                                  : FS_BattlePayload();
-  const bool bHasBattlePayload =
-      ActiveBattle.AttackerPlayerID > 0 || ActiveBattle.DefenderPlayerID > 0 ||
-      ActiveBattle.FromTerritoryID > 0 || ActiveBattle.TargetTerritoryID > 0;
   const USkaldBattleLevelManager* BattleLevelManager =
       CachedGameInstance ? CachedGameInstance->GetBattleLevelManager() : nullptr;
   const bool bStreamedBattleMapActive =

--- a/Source/Skald/Skald_TurnManager.cpp
+++ b/Source/Skald/Skald_TurnManager.cpp
@@ -3951,6 +3951,17 @@ void ATurnManager::ResolveGridBattleResult_Implementation() {
                        ResolvedFromTerritoryID, ResolvedTargetTerritoryID,
                        NewOwnerPlayerID, ResolvedSourceArmy, ResolvedTargetArmy);
 
+  // The battle result multicast above is the final consumer of the replicated
+  // battle context. Clear it before normal overworld play resumes so local
+  // controllers do not continue treating the post-battle overview as an active
+  // battle map because BattlePhase/ActiveBattlePayload are still set to Deploy.
+  if (ASkaldGameState *ResolvedGameState =
+          World->GetGameState<ASkaldGameState>()) {
+    ResolvedGameState->SetActiveBattlePayload(FS_BattlePayload());
+    ResolvedGameState->SetBattlePhase(EBattlePhase::None);
+    ResolvedGameState->ResetBattleParticipants();
+  }
+
   if (ASkaldGameMode *GM = World->GetAuthGameMode<ASkaldGameMode>()) {
     GM->CheckVictoryConditions();
   }


### PR DESCRIPTION
### Motivation
- Prevent stale replicated battle state from keeping the player controller in battle input/camera mode after a battle concludes, which made the post-battle overview UI unresponsive to clicks.
- Ensure the battle result modal retains focus when the overworld HUD is rebuilt so the player can close/continue the overview.
- Clear replicated battle payload/phase/participant state once results are broadcast so normal overworld input resumes.

### Description
- Update tick context in `ASkaldPlayerController::PlayerTick` to treat pending travel/streaming and active battle runtime/UI as the source of battle input context instead of relying on `BattlePhase`/replicated payload presence.
- Adjust `UpdateBattleCameraMode` and `ApplyBattleInteractionInputState` in `Skald_PlayerController.cpp` to ignore stale `BattlePhase`/payload and rely on actual streaming/travel/UI state (`CachedGameInstance->IsTravelPending()`, `BattleLevelManager` and HUD/widget visibility).
- Prevent `ShowOverworldHUD()` from calling `ShowMainHUD()` when a battle result modal is visible or awaiting close acknowledgement so the modal stays interactive.
- After `ClientBattleResolved` is multicast, clear the replicated battle context in `ResolveGridBattleResult_Implementation` by calling `SetActiveBattlePayload(FS_BattlePayload())`, `SetBattlePhase(EBattlePhase::None)`, and `ResetBattleParticipants()` in `Skald_TurnManager.cpp`.

### Testing
- Ran `git diff --check` to validate no whitespace/patch issues; the check succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1ceac9f4ec8324a133a000d8e1116e)